### PR TITLE
State.touch_account(): don't call _set_account() for existing accounts

### DIFF
--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -197,8 +197,8 @@ class State:
             return True
 
     def touch_account(self, address):
-        account = self._get_account(address)
-        self._set_account(address, account)
+        if not self.account_exists(address):
+            self._set_account(address, Account())
 
     def increment_nonce(self, address):
         current_nonce = self.get_nonce(address)
@@ -208,8 +208,9 @@ class State:
     # Internal
     #
     def _get_account(self, address):
-        if address in self._trie:
-            account = rlp.decode(self._trie[address], sedes=Account)
+        rlp_account = self._trie[address]
+        if rlp_account:
+            account = rlp.decode(rlp_account, sedes=Account)
             account._mutable = True
         else:
             account = Account()

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -208,8 +208,7 @@ def _apply_frontier_message(vm, message):
         )
 
     with vm.state_db() as state_db:
-        if not state_db.account_exists(message.storage_address):
-            state_db.touch_account(message.storage_address)
+        state_db.touch_account(message.storage_address)
 
     computation = vm.apply_computation(message)
 


### PR DESCRIPTION
Should speed up the Byzantium tests