### PR TITLE
Misc cleanup

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,23 @@
+[bumpversion]
+current_version = 0.2.0-alpha.6
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
+serialize = 
+	{major}.{minor}.{patch}-{stage}.{devnum}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:stage]
+optional_value = stable
+first_value = stable
+values = 
+	alpha
+	beta
+	stable
+
+[bumpversion:part:devnum]
+
+[bumpversion:file:setup.py]
+search = version='{current_version}',
+replace = version='{new_version}',
+

--- a/README.md
+++ b/README.md
@@ -1,16 +1,87 @@
 # Python Implementation of the EVM
 
+- [![Join the chat at https://gitter.im/pipermerriam/py-evm](https://badges.gitter.im/pipermerriam/py-evm.svg)](https://gitter.im/pipermerriam/py-evm?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+
 ## Introducing Py-EVM
-Py-EVM is a new implementation of the Ethereum Virtual Machine written in python. It is currently in active development but is quickly progressing through the test suite provided by ethereum/tests. I have Vitalik, and the existing PyEthereum code to thank for the quick progress I’ve made as many design decisions were inspired, or even directly ported from the PyEthereum codebase.
-Py-EVM aims to eventually become the defacto python implementation of the EVM, enabling a wide array of use cases for both public and private chains. Development will focus on creating an EVM with a well defined API, friendly and easy to digest documentation which can be run as a fully functional mainnet node.
+
+Py-EVM is a new implementation of the Ethereum Virtual Machine written in
+python. It is currently in active development but is quickly progressing
+through the test suite provided by ethereum/tests. I have Vitalik, and the
+existing PyEthereum code to thank for the quick progress I’ve made as many
+design decisions were inspired, or even directly ported from the PyEthereum
+codebase.
+
+Py-EVM aims to eventually become the defacto python implementation of the EVM,
+enabling a wide array of use cases for both public and private chains.
+Development will focus on creating an EVM with a well defined API, friendly and
+easy to digest documentation which can be run as a fully functional mainnet
+node.
 
 ### Step 1: Alpha Release
-The plan is to begin with an MVP, alpha-level release that is suitable for testing purposes. We’ll be looking for early adopters to provide feedback on our architecture and API choices as well as general feedback and bug finding.
+
+The plan is to begin with an MVP, alpha-level release that is suitable for
+testing purposes. We’ll be looking for early adopters to provide feedback on
+our architecture and API choices as well as general feedback and bug finding.
 
 #### Blog posts:
 
 - https://medium.com/@pipermerriam/py-evm-part-1-origins-25d9ad390b
 
-#### Join the chat on gitter:
 
-- [![Join the chat at https://gitter.im/pipermerriam/py-evm](https://badges.gitter.im/pipermerriam/py-evm.svg)](https://gitter.im/pipermerriam/py-evm?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+## Development
+
+```sh
+pip install -e . -r requirements-dev.txt
+```
+
+
+### Running the tests
+
+You can run the tests with:
+
+```sh
+py.test tests
+```
+
+Or you can install `tox` to run the full test suite.
+
+
+### Releasing
+
+Pandoc is required for transforming the markdown README to the proper format to
+render correctly on pypi.
+
+For Debian-like systems:
+
+```
+apt install pandoc
+```
+
+Or on OSX:
+
+```sh
+brew install pandoc
+```
+
+To release a new version:
+
+```sh
+bumpversion $$VERSION_PART_TO_BUMP$$
+git push && git push --tags
+make release
+```
+
+
+#### How to bumpversion
+
+The version format for this repo is `{major}.{minor}.{patch}` for stable, and
+`{major}.{minor}.{patch}-{stage}.{devnum}` for unstable (`stage` can be alpha or beta).
+
+To issue the next version in line, use bumpversion and specify which part to bump,
+like `bumpversion minor` or `bumpversion devnum`.
+
+If you are in a beta version, `bumpversion stage` will switch to a stable.
+
+To issue an unstable version when the current version is stable, specify the
+new version explicitly, like `bumpversion --new-version 4.0.0-alpha.1 devnum`

--- a/evm/__init__.py
+++ b/evm/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import pkg_resources
 import sys
 
 from evm.utils.logging import (
@@ -15,18 +16,6 @@ from evm.chains import (  # noqa: F401
     MainnetTesterChain,
 )
 
-from .__version__ import (  # noqa: F401
-    __title__,
-    __description__,
-    __url__,
-    __version__,
-    __copyright__,
-    __author__,
-    __author_email__,
-    __license__,
-    __build__
-)
-
 #
 #  Setup TRACE level logging.
 #
@@ -39,3 +28,6 @@ logging.Logger.trace = trace
 #  Ensure we can reach 1024 frames of recursion
 #
 sys.setrecursionlimit(1024 * 10)
+
+
+__version__ = pkg_resources.get_distribution("web3").version

--- a/evm/__init__.py
+++ b/evm/__init__.py
@@ -30,4 +30,4 @@ logging.Logger.trace = trace
 sys.setrecursionlimit(1024 * 10)
 
 
-__version__ = pkg_resources.get_distribution("web3").version
+__version__ = pkg_resources.get_distribution("py-evm").version

--- a/evm/__version__.py
+++ b/evm/__version__.py
@@ -1,9 +1,0 @@
-__title__ = 'py-evm'
-__description__ = 'Python implementation of the Ethereum Virtual Machine'
-__url__ = 'https://github.com/pipermerriam/py-evm'
-__version__ = "0.2.0-alpha.6"
-__author__ = 'Piper Merriam'
-__author_email__ = 'pipermerriam@gmail.com'
-__license__ = 'MIT'
-__copyright__ = 'Copyright 2017 %s' % __author__
-__build__ = '[TODO] STUB'

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
-
 from setuptools import setup, find_packages
 
-DIR = os.path.dirname(os.path.abspath(__file__))
-
-
-readme = open(os.path.join(DIR, 'README.md')).read()
-
-# By definition, we can't depend on evm being installed yet,
-# so pull this information in via read, not import.
-about = {}
-with open(os.path.join(DIR, 'evm', '__version__.py'), 'r') as f:
-    exec(f.read(), about)
 
 setup(
-    name=about['__title__'],
-    version=about['__version__'],
-    description=about['__description__'],
-    long_description=readme,
-    author=about['__author__'],
-    author_email=about['__author_email__'],
-    url=about['__url__'],
+    name='py-evm',
+    # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
+    version='0.2.0-alpha.6',
+    description='Python implementation of the Ethereum Virtual Machine',
+    long_description_markdown_filename='README.md',
+    author='Piper Merriam',
+    author_email='piper@pipermerriam.com',
+    url='https://github.com/ethereum/py-evm',
     include_package_data=True,
     py_modules=['evm'],
     install_requires=[
@@ -30,20 +19,20 @@ setup(
         "async_lru>=0.1.0",
         "cryptography>=2.0.3",
         "cytoolz==0.8.2",
-        "ethereum-bloom>=0.4.0",
-        "ethereum-utils>=0.2.0",
+        "eth-bloom>=0.5.2",
+        "eth-utils>=0.7.1",
         "pyethash>=0.1.27",
         "py-ecc==1.4.2",
         "rlp==0.4.7",
-        "ethereum-keys==0.1.0a7",
-        "trie>=0.3.0",
+        "eth-keys==0.1.0b3",
+        "trie>=0.3.1",
     ],
     extra_require={
         'leveldb': [
             "leveldb>=0.194",
         ]
     },
-    license=about['__license__'],
+    license='MIT',
     zip_safe=False,
     keywords='ethereum blockchain evm',
     packages=find_packages(exclude=["tests", "tests.*"]),
@@ -52,10 +41,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
 )


### PR DESCRIPTION
### What was wrong?

* Some meta information was wrong after the recent migration to the ethereum foundation github
* No docs for how to cut a release.
* Upstream dependency library names have changed

### How was it fixed?

* Removed the `__version__.py` in favor of embedding all information in `setup.py`
* fixed dependency names `ethereum-` to be `eth-`
* Added bumpversion based release process
* Fixed markdown rendering for pypi


#### Cute Animal Picture

![1daa63ce8e379109a058c7600fec4b20](https://user-images.githubusercontent.com/824194/33336325-be025244-d42c-11e7-9ed6-87e0f3781465.jpg)
