### PR TITLE
docs: build more consistent with readthedocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,7 @@ coverage:
 	open htmlcov/index.html
 
 build-docs:
-	sphinx-apidoc -o docs/ -d 2 evm/
-	$(MAKE) -C docs clean
-	$(MAKE) -C docs html
+	cd docs/; sphinx-build -T -E . _build/html
 
 docs: build-docs
 	open docs/_build/html/index.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,7 @@ exclude_patterns = [
     '_build',
     'Thumbs.db',
     '.DS_Store',
+    'modules.rst',
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.
@@ -175,3 +176,28 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.5', None),
 }
+
+# -- autodoc on any sphinx-build, to support RTD ---------------------------
+
+
+def run_apidoc(_):
+    from sphinx.apidoc import main
+    import os
+    import sys
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+    cur_dir = os.path.abspath(os.path.dirname(__file__))
+    package = os.path.join(cur_dir, "..")
+    main([
+        None,
+        '-o',
+        cur_dir,
+        '--force',
+        package,
+        package + "/tests/*",
+        package + "/setup.py",
+        package + '/.eggs/*',
+    ])
+
+
+def setup(app):
+    app.connect('builder-inited', run_apidoc)

--- a/docs/low_level.rst
+++ b/docs/low_level.rst
@@ -4,5 +4,6 @@ Low-Level API Docs
 These docs are auto-generated from docstrings in the code.
 
 .. toctree::
-   evm.rst
-   modules.rst
+   :maxdepth: 5
+
+   evm


### PR DESCRIPTION
### What was wrong?

The autodocs weren't building, which meant that the low-level API page was empty, and the deep links to class docs were broken.

### How was it fixed?

Build locally the same way RTD builds. Hook autodoc into the vanilla `sphinx-build` process via docs/conf.py.

I tested this branch against the live RTD site. It works.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://talenthounds.ca/wp-content/uploads/2015/05/TH-Buster-puppy-640x865.jpg)