### PR TITLE
Move header-syncing code from LESPeer to LightChain

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -18,12 +18,12 @@ Installation
 Syncing with Mainnet
 ---------------------
 
-Run the peer for a little while, saving the blockchain to a file of your chioce:
+Run the LightChain for a little while, saving the blockchain to a file of your chioce:
 
 .. code:: sh
 
-  $ python -m evm.p2p.peer --db /tmp/mychain.db --mainnet
-  
+  $ python -m evm.p2p.lightchain -db /tmp/mainnet.db
+
 After syncing some blocks, you can close out the process
 to explore the chain directly with py-evm.
 

--- a/evm/p2p/exceptions.py
+++ b/evm/p2p/exceptions.py
@@ -28,3 +28,15 @@ class UnreachablePeer(Exception):
 
 class EmptyGetBlockHeadersReply(Exception):
     pass
+
+
+class LESAnnouncementProcessingError(Exception):
+    pass
+
+
+class TooManyTimeouts(Exception):
+    pass
+
+
+class StopRequested(Exception):
+    pass


### PR DESCRIPTION
This allows us to avoid unnecessarily fetching the same headers from
all peers we're connected to.

Now we also retry a few times if we get a timeout when fetching headers
from a peer.