### PR TITLE
docstrings: a bit more mine_block info

### DIFF
--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -266,7 +266,8 @@ class Chain(object):
 
     def mine_block(self, *args, **kwargs):
         """
-        Mines the current block.
+        Mines the current block. Proxies to the current Virtual Machine.
+        See VM. :meth:`~evm.vm.base.VM.mine_block`
         """
         mined_block = self.get_vm().mine_block(*args, **kwargs)
 

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -181,7 +181,8 @@ class VM(object):
 
     def mine_block(self, *args, **kwargs):
         """
-        Mine the current block.
+        Mine the current block. Proxies to the current block's mine method.
+        See example with FrontierBlock. :meth:`~evm.vm.forks.frontier.blocks.FrontierBlock.mine`
         """
         block = self.block
         block.mine(*args, **kwargs)

--- a/evm/vm/forks/frontier/blocks.py
+++ b/evm/vm/forks/frontier/blocks.py
@@ -288,16 +288,16 @@ class FrontierBlock(BaseBlock):
 
     def mine(self, **kwargs):
         """
-        - `coinbase`
-        - `uncles_hash`
-        - `state_root`
-        - `transaction_root`
-        - `receipt_root`
-        - `bloom`
-        - `gas_used`
-        - `extra_data`
-        - `mix_hash`
-        - `nonce`
+        :param bytes coinbase: 20-byte public address to receive block reward
+        :param bytes uncles_hash: 32 bytes
+        :param bytes state_root: 32 bytes
+        :param bytes transaction_root: 32 bytes
+        :param bytes receipt_root: 32 bytes
+        :param int bloom:
+        :param int gas_used:
+        :param bytes extra_data: 32 bytes
+        :param bytes mix_hash: 32 bytes
+        :param bytes nonce: 8 bytes
         """
         if 'uncles' in kwargs:
             self.uncles = kwargs.pop('uncles')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 bumpversion==0.5.3
+flake8==3.5.0
 hypothesis==3.30.0
 pytest-asyncio==0.8.0
 pytest-cov==2.5.1


### PR DESCRIPTION
### What was wrong?

Type info about the keyword args to `mine_block` was not apparent in the low-level api docs.

### How was it fixed?

Adding the docstrings with parameter type info, to autopopulate the low-level api docs on RTD.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.therooster.com/sites/default/files/styles/hero/public/rooster_micropig.png?itok=NOq4fTeR)
