### PR TITLE
make slow tests run in travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ ignore=
 usedevelop=True
 passenv =
     PYTEST_ADDOPTS
+    TRAVIS_EVENT_TYPE
 commands=
     core: py.test {posargs:tests/core}
     p2p: py.test {posargs:evm/p2p}


### PR DESCRIPTION
fixes #186 

### What was wrong?

By default, tox does not pass through environment variables.  This was causing the `TRAVIS_EVENT_TYPE` environment variable to not be present when the test suite checked if it should run the slow tests.

### How was it fixed?

Added it to the whitelist in `tox.ini`

#### Cute Animal Picture

![f1e063886f9bee5381ca63277f183f87--dachshund-puppies-weenie-dogs](https://user-images.githubusercontent.com/824194/33567490-a361b84a-d8e0-11e7-9149-1121a31c1ce5.jpg)

