### PR TITLE
Introduce a new exception to signal handshake failures

### DIFF
--- a/evm/p2p/exceptions.py
+++ b/evm/p2p/exceptions.py
@@ -1,3 +1,11 @@
+from typing import TYPE_CHECKING
+
+# Workaround for import cycles caused by type annotations:
+# http://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
+if TYPE_CHECKING:
+    from evm.p2p.p2p_proto import DisconnectReason  # noqa: F401
+
+
 class AuthenticationError(Exception):
     pass
 
@@ -40,3 +48,12 @@ class TooManyTimeouts(Exception):
 
 class StopRequested(Exception):
     pass
+
+
+class HandshakeFailure(Exception):
+
+    def __init__(self, reason: 'DisconnectReason') -> None:
+        self.reason = reason
+
+    def __str__(self):
+        return self.reason.name

--- a/evm/p2p/protocol.py
+++ b/evm/p2p/protocol.py
@@ -120,14 +120,16 @@ class Protocol:
         raise NotImplementedError()
 
     def process_handshake(self, decoded_msg: _DecodedMsgType) -> None:
-        """Process the handshake msg for this protocol."""
+        """Process the handshake msg for this protocol.
+
+        Should raise HandshakeFailure if the handshake fails for any reason.
+        """
         raise NotImplementedError()
 
     def process(self, cmd_id: int, msg: bytes) -> Tuple[Command, _DecodedMsgType]:
         cmd = self.cmd_by_id[cmd_id]
         decoded = cmd.handle(self, msg)
-        self.logger.debug("Successfully processed {}(cmd_id={}) msg: {}".format(
-            cmd.__class__.__name__, cmd_id, decoded))
+        self.logger.debug("Successfully processed %s msg: %s", cmd, decoded)
         if isinstance(cmd, self.handshake_msg_type):
             self.process_handshake(decoded)
         return cmd, decoded


### PR DESCRIPTION
Protocol.process_handshake() must now raise that exception to signal a
handshake failure, which will then cause the peer to be disconnected.