### PR TITLE
p2p and rpc: a few misc fixes

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -86,3 +86,18 @@ The methods available on the block are variable. They depend on what fork you're
 The mainnet follows "Frontier" rules at the beginning, then Homestead, and so on.
 To see block features for Frontier, see the API for
 :class:`~evm.vm.forks.frontier.blocks.FrontierBlock`.
+
+
+The JSON-RPC API
+----------------
+
+Like all ethereum clients, Py-EVM will eventually provide a JSON-RPC API with all the
+methods defined in https://github.com/ethereum/wiki/wiki/JSON-RPC, but for now only
+a few of them are supported. To start the JSON-RPC server, simply run:
+
+::
+
+  $ python -i -m evm.rpc.server -db /tmp/testnet.db
+
+That will start a server listening on port 8080, with a LightChain syncing block headers on the
+Ropsten network. You can then use curl as described on the wikipage above to interact with it.

--- a/evm/lightchain_shell.py
+++ b/evm/lightchain_shell.py
@@ -7,6 +7,7 @@ See docs/quickstart.rst for more info on how to use this.
 import argparse
 import asyncio
 import atexit
+import logging
 import threading
 
 from evm.db.chain import BaseChainDB
@@ -17,9 +18,18 @@ from evm.p2p.lightchain import LightChain
 from evm.db.backends.level import LevelDB
 
 
+LOGFILE = '/tmp/lightchain-shell.log'
+LOGLEVEL = logging.INFO
+
 parser = argparse.ArgumentParser()
 parser.add_argument('-db', type=str, required=True)
+parser.add_argument('-debug', action='store_true')
 args = parser.parse_args()
+
+print("Logging to", LOGFILE)
+if args.debug:
+    LOGLEVEL = logging.DEBUG
+logging.basicConfig(level=LOGLEVEL, filename=LOGFILE)
 
 DemoLightChain = LightChain.configure(
     name='Demo LightChain',
@@ -28,11 +38,9 @@ DemoLightChain = LightChain.configure(
     network_id=ROPSTEN_NETWORK_ID,
 )
 
-
 chain = DemoLightChain(BaseChainDB(LevelDB(args.db)))
 loop = asyncio.get_event_loop()
-t = threading.Thread(target=loop.run_until_complete, args=(chain.run(),))
-t.setDaemon(True)
+t = threading.Thread(target=loop.run_until_complete, args=(chain.run(),), daemon=True)
 t.start()
 
 

--- a/evm/p2p/test_lightchain.py
+++ b/evm/p2p/test_lightchain.py
@@ -219,8 +219,8 @@ async def get_client_and_server_peer_pair(
 
     def finalizer():
         async def afinalizer():
-            await client.stop_and_wait_until_finished()
-            await server.stop_and_wait_until_finished()
+            await client.stop()
+            await server.stop()
         event_loop.run_until_complete(afinalizer())
     request.addfinalizer(finalizer)
 

--- a/evm/rpc/server.py
+++ b/evm/rpc/server.py
@@ -13,15 +13,8 @@ from aiohttp.web_exceptions import HTTPMethodNotAllowed
 
 from eth_utils import decode_hex, encode_hex
 
-from evm.chains.mainnet import (
-    MAINNET_GENESIS_HEADER, MAINNET_VM_CONFIGURATION, MAINNET_NETWORK_ID)
 from evm.p2p.lightchain import LightChain
 from evm.utils.numeric import int_to_big_endian
-
-
-# Change the values below to connect to a node on a different network or IP address.
-GENESIS_HEADER = MAINNET_GENESIS_HEADER
-NETWORK_ID = MAINNET_NETWORK_ID
 
 
 class App(web.Application):
@@ -91,6 +84,9 @@ class App(web.Application):
 
 if __name__ == '__main__':
     import argparse
+    from evm.chains.mainnet import (
+        MAINNET_GENESIS_HEADER, MAINNET_VM_CONFIGURATION, MAINNET_NETWORK_ID)
+    from evm.chains.ropsten import ROPSTEN_GENESIS_HEADER, ROPSTEN_NETWORK_ID
     from evm.db.backends.level import LevelDB
     from evm.db.chain import BaseChainDB
     from evm.exceptions import CanonicalHeadNotFound
@@ -100,8 +96,14 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-db', type=str, required=True)
+    parser.add_argument('-mainnet', action="store_true")
     args = parser.parse_args()
 
+    GENESIS_HEADER = ROPSTEN_GENESIS_HEADER
+    NETWORK_ID = ROPSTEN_NETWORK_ID
+    if args.mainnet:
+        GENESIS_HEADER = MAINNET_GENESIS_HEADER
+        NETWORK_ID = MAINNET_NETWORK_ID
     DemoLightChain = LightChain.configure(
         'RPCDemoLightChain',
         vm_configuration=MAINNET_VM_CONFIGURATION,


### PR DESCRIPTION
- Log to a file in lightchain_shell
- Rename Peer.stop_and_wait_until_finished() to stop()
- lightchain.py, lightchain_shell.py and rpc/server.py now connect to ropsten by default
- peer.py no longer takes a db/mainnet arg as it no longer handles sync