### PR TITLE
Making Chain asynchronous

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -74,13 +74,17 @@ For example:
 
 ::
 
+  loop = asyncio.get_event_loop()
+
   highest_block_num = chain.get_canonical_head().block_number
 
-  block1 = chain.get_canonical_block_by_number(1)
+  block1 = loop.run_until_complete(chain.get_canonical_block_by_number(1))
   assert block1.number() == 1
 
   blockhash = block1.hash()
   blockgas = block1.get_cumulative_gas_used()
+
+  loop.close()
 
 The methods available on the block are variable. They depend on what fork you're on.
 The mainnet follows "Frontier" rules at the beginning, then Homestead, and so on.

--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -85,7 +85,7 @@ class Chain(object):
     #
     # Convenience and Helpers
     #
-    def get_block(self):
+    async def get_block(self):
         """
         Passthrough helper to the current VM class.
         """
@@ -179,10 +179,7 @@ class Chain(object):
     # Chain Initialization
     #
     @classmethod
-    def from_genesis(cls,
-                     chaindb,
-                     genesis_params,
-                     genesis_state=None):
+    async def from_genesis(cls, chaindb, genesis_params, genesis_state=None):
         """
         Initialize the Chain from a genesis state.
         """
@@ -216,7 +213,8 @@ class Chain(object):
 
         genesis_header = BlockHeader(**genesis_params)
         genesis_chain = cls(chaindb, genesis_header)
-        chaindb.persist_block_to_db(genesis_chain.get_block())
+        block = await genesis_chain.get_block()
+        chaindb.persist_block_to_db(block)
         return cls.from_genesis_header(chaindb, genesis_header)
 
     @classmethod

--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -162,9 +162,9 @@ class Chain(object):
         canonical chain.
         """
         validate_uint256(block_number, title="Block Number")
-        return self.get_block_by_hash(self.chaindb.lookup_block_hash(block_number))
+        return await self.get_block_by_hash(self.chaindb.lookup_block_hash(block_number))
 
-    def get_block_by_hash(self, block_hash):
+    async def get_block_by_hash(self, block_hash):
         """
         Returns the requested block as specified by block hash.
         """

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -41,7 +41,8 @@ async def test_import_block(chain_without_block_validation):  # noqa: F811
     assert not computation.is_error
     block = chain.import_block(vm.block)
     assert block.transactions == [tx]
-    assert chain.get_block_by_hash(block.hash) == block
+    block_by_hash = await chain.get_block_by_hash(block.hash)
+    assert block_by_hash == block
     block_by_number = await chain.get_canonical_block_by_number(block.number)
     assert block_by_number == block
 

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -30,7 +30,7 @@ def test_import_block_validation(chain):  # noqa: F811
             chain.funded_address_initial_balance - tx.value - tx_gas)
 
 
-def test_import_block(chain_without_block_validation):  # noqa: F811
+async def test_import_block(chain_without_block_validation):  # noqa: F811
     chain = chain_without_block_validation  # noqa: F811
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
@@ -42,7 +42,8 @@ def test_import_block(chain_without_block_validation):  # noqa: F811
     block = chain.import_block(vm.block)
     assert block.transactions == [tx]
     assert chain.get_block_by_hash(block.hash) == block
-    assert chain.get_canonical_block_by_number(block.number) == block
+    block_by_number = await chain.get_canonical_block_by_number(block.number)
+    assert block_by_number == block
 
 
 def test_canonical_chain(chain):  # noqa: F811

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -15,7 +15,7 @@ from evm.vm.forks.frontier import FrontierVM
 
 
 @pytest.fixture
-def chain():
+async def chain():
     """
     Return a Chain object containing just the genesis block.
 
@@ -64,7 +64,7 @@ def chain():
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
         ))
-    chain = klass.from_genesis(BaseChainDB(get_db_backend()), genesis_params, genesis_state)
+    chain = await klass.from_genesis(BaseChainDB(get_db_backend()), genesis_params, genesis_state)
     chain.funded_address = funded_addr
     chain.funded_address_initial_balance = initial_balance
     return chain
@@ -82,7 +82,7 @@ def import_block_without_validation(chain, block):
 
 
 @pytest.fixture
-def chain_without_block_validation():
+async def chain_without_block_validation():
     """
     Return a Chain object containing just the genesis block.
 
@@ -129,7 +129,7 @@ def chain_without_block_validation():
             'storage': {},
         }
     }
-    chain = klass.from_genesis(BaseChainDB(get_db_backend()), genesis_params, genesis_state)
+    chain = await klass.from_genesis(BaseChainDB(get_db_backend()), genesis_params, genesis_state)
     chain.funded_address = funded_addr
     chain.funded_address_initial_balance = initial_balance
     chain.funded_address_private_key = private_key

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -146,7 +146,7 @@ def chain_vm_configuration(fixture_data, fixture):
         )
 
 
-def test_blockchain_fixtures(fixture, chain_vm_configuration):
+async def test_blockchain_fixtures(fixture, chain_vm_configuration):
     genesis_params = {
         'parent_hash': fixture['genesisBlockHeader']['parentHash'],
         'uncles_hash': fixture['genesisBlockHeader']['uncleHash'],
@@ -176,7 +176,7 @@ def test_blockchain_fixtures(fixture, chain_vm_configuration):
         vm_configuration=chain_vm_configuration,
     )
 
-    chain = ChainForTesting.from_genesis(
+    chain = await ChainForTesting.from_genesis(
         db,
         genesis_params=genesis_params,
         genesis_state=fixture['pre'],

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -182,7 +182,7 @@ async def test_blockchain_fixtures(fixture, chain_vm_configuration):
         genesis_state=fixture['pre'],
     )
 
-    genesis_block = chain.get_canonical_block_by_number(0)
+    genesis_block = await chain.get_canonical_block_by_number(0)
     genesis_header = genesis_block.header
 
     assert_rlp_equal(genesis_header, expected_genesis_header)
@@ -224,7 +224,9 @@ async def test_blockchain_fixtures(fixture, chain_vm_configuration):
             assert_rlp_equal(mined_block, block)
             assert should_be_good_block, "Block should have caused a validation error"
 
-    latest_block_hash = chain.get_canonical_block_by_number(chain.get_block().number - 1).hash
+    block = await chain.get_block()
+    block_by_number = await chain.get_canonical_block_by_number(block.number - 1)
+    latest_block_hash = block_by_number.hash
     assert latest_block_hash == fixture['lastblockhash']
 
     with chain.get_vm().state_db(read_only=True) as state_db:


### PR DESCRIPTION
### What was wrong?

LightChain is already async, and Chain is going to be. Better do it now before too many other modules are written on top of it.

_I think that I would like challenge the presumption that all the Chain things should be async and that all the synchronous methods should go away. But I don't feel informed enough to make an alternate proposal yet. I'm taking it as given for now and marching on._

### How was it fixed?

Make all-the-things async. I dislike how async seems to infect everything around it, but maybe I just don't grok async yet... Seeking feedback.

Todo:

- [x] make get_block() async
- [x] make get_canonical_block_by_number() async
- [x] make get_block_by_hash() async
- [ ] make a list of methods to turn async

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/c8/77/f2/c877f2c1c720aacfc3a8ad89a4a8e4ab--cute-giraffe-little-giraffe.jpg)
