### PR TITLE
Account redesign

### DIFF
--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -25,7 +25,7 @@ from evm.db.journal import (
 )
 from evm.db.state import (
     State,
-    TwoLayerBackend,
+    NestedTrieBackend,
 )
 from evm.rlp.headers import (
     BlockHeader,
@@ -48,7 +48,7 @@ CANONICAL_HEAD_HASH_DB_KEY = b'v1:canonical_head_hash'
 
 class BaseChainDB:
 
-    def __init__(self, db, state_backend_class=TwoLayerBackend):
+    def __init__(self, db, state_backend_class=NestedTrieBackend):
         self.db = JournalDB(db)
         self.state_backend_class = state_backend_class
 

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -25,6 +25,7 @@ from evm.db.journal import (
 )
 from evm.db.state import (
     State,
+    TwoLayerBackend,
 )
 from evm.rlp.headers import (
     BlockHeader,
@@ -47,8 +48,9 @@ CANONICAL_HEAD_HASH_DB_KEY = b'v1:canonical_head_hash'
 
 class BaseChainDB:
 
-    def __init__(self, db):
+    def __init__(self, db, state_backend_class=TwoLayerBackend):
         self.db = JournalDB(db)
+        self.state_backend_class = state_backend_class
 
     def exists(self, key):
         return self.db.exists(key)
@@ -247,5 +249,6 @@ class BaseChainDB:
             db=self.db,
             root_hash=state_root,
             read_only=read_only,
-            access_list=access_list
+            access_list=access_list,
+            backend_class=self.state_backend_class
         )

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -236,10 +236,7 @@ class FlatTrieBackend:
             return 0
 
     def delete_storage(self, address):
-        key = self.full_storage_key(address)
-        self._check_accessibility(key)
-
-        self._trie.delete_branch(key)
+        raise NotImplementedError("Full storage deletion not supported in flat trie state")
 
     def set_balance(self, address, balance):
         key = self.balance_key(address)
@@ -296,19 +293,10 @@ class FlatTrieBackend:
     # Account Methods
     #
     def delete_account(self, address):
-        keys = [
-            self.nonce_key(address),
-            self.balance_key(address),
-            self.code_key(address)
-        ]
-        for key in keys:
-            self._check_accessibility(key)
-            del self._trie[key]
-        self.delete_storage(address)
+        raise NotImplementedError("Account deletion not supported in flat trie state")
 
     def account_exists(self, address):
-        key = keccak(address)
-        return self._trie.branch_exists(key)
+        raise NotImplementedError("Account existence check not supported in flat trie")
 
     def account_has_code_or_nonce(self, address):
         return self.get_code(address) != b'' or self.get_nonce(address) != 0

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -46,7 +46,7 @@ from evm.utils.padding import (
 from .hash_trie import HashTrie
 
 
-class TwoLayerBackend:
+class NestedTrieBackend:
 
     def __init__(self, db, root_hash=BLANK_ROOT_HASH, access_list=None):
         self.db = db
@@ -174,7 +174,7 @@ class TwoLayerBackend:
         self._trie[address] = rlp.encode(account, sedes=Account)
 
 
-class OneLayerBackend:
+class FlatTrieBackend:
 
     def __init__(self, db, root_hash=BLANK_ROOT_HASH, access_list=None):
         self._trie = Trie(db, root_hash)
@@ -335,7 +335,7 @@ class State:
         root_hash=BLANK_ROOT_HASH,
         read_only=False,
         access_list=None,
-        backend_class=TwoLayerBackend
+        backend_class=NestedTrieBackend
     ):
         if read_only:
             self.db = ImmutableDB(db)

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -36,6 +36,7 @@ from evm.utils.keccak import (
     keccak,
 )
 from evm.utils.numeric import (
+    big_endian_to_int,
     int_to_big_endian,
 )
 from evm.utils.padding import (
@@ -221,8 +222,7 @@ class OneLayerBackend:
         self._check_accessibility(key)
 
         if value:
-            encoded_value = rlp.encode(value)
-            self._trie[key] = encoded_value
+            self._trie[key] = int_to_big_endian(value)
         else:
             del self._trie[key]
 
@@ -231,8 +231,7 @@ class OneLayerBackend:
         self._check_accessibility(key)
 
         if key in self._trie:
-            encoded_value = self._trie[key]
-            return rlp.decode(encoded_value, sedes=rlp.sedes.big_endian_int)
+            return big_endian_to_int(self._trie[key])
         else:
             return 0
 
@@ -246,15 +245,14 @@ class OneLayerBackend:
         key = self.balance_key(address)
         self._check_accessibility(key)
 
-        self._trie[key] = rlp.encode(balance)
+        self._trie[key] = int_to_big_endian(balance)
 
     def get_balance(self, address):
         key = self.balance_key(address)
         self._check_accessibility(key)
 
         if key in self._trie:
-            encoded_value = self._trie[key]
-            return rlp.decode(encoded_value, sedes=rlp.sedes.big_endian_int)
+            return big_endian_to_int(self._trie[key])
         else:
             return 0
 
@@ -262,15 +260,14 @@ class OneLayerBackend:
         key = self.nonce_key(address)
         self._check_accessibility(key)
 
-        self._trie[key] = rlp.encode(nonce)
+        self._trie[key] = int_to_big_endian(nonce)
 
     def get_nonce(self, address):
         key = self.nonce_key(address)
         self._check_accessibility(key)
 
         if key in self._trie:
-            encoded_value = self._trie[key]
-            return rlp.decode(encoded_value, sedes=rlp.sedes.big_endian_int)
+            return big_endian_to_int(self._trie[key])
         else:
             return 0
 
@@ -278,15 +275,14 @@ class OneLayerBackend:
         key = self.code_key(address)
         self._check_accessibility(key)
 
-        self._trie[key] = rlp.encode(code)
+        self._trie[key] = code
 
     def get_code(self, address):
         key = self.code_key(address)
         self._check_accessibility(key)
 
         if key in self._trie:
-            encoded_value = self._trie[key]
-            return rlp.decode(encoded_value)
+            return self._trie[key]
         else:
             return b''
 

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -12,6 +12,7 @@ from evm.constants import (
     BALANCE_TRIE_PREFIX,
     CODE_TRIE_PREFIX,
     NONCE_TRIE_PREFIX,
+    STORAGE_TRIE_PREFIX,
 )
 from evm.exceptions import (
     UnannouncedStateAccess,
@@ -44,34 +45,20 @@ from evm.utils.padding import (
 from .hash_trie import HashTrie
 
 
-class State:
-    """
-    High level API around account storage.
-    """
-    db = None
-    _trie = None
+class TwoLayerBackend:
 
-    logger = logging.getLogger('evm.state.State')
-
-    def __init__(
-        self,
-        db,
-        root_hash=BLANK_ROOT_HASH,
-        read_only=False,
-        access_list=None
-    ):
-        if read_only:
-            self.db = ImmutableDB(db)
-        else:
+    def __init__(self, db, root_hash=BLANK_ROOT_HASH, access_list=None):
             self.db = db
         self._trie = HashTrie(Trie(self.db, root_hash))
+        if access_list is not None:
+            raise NotImplementedError(
+                "State access restriction not implemented for two layer trie"
+            )
 
-        self.is_access_restricted = access_list is not None
-        self.access_list = access_list
+    def decommission(self):
+        self.db = None
+        self._trie = None
 
-    #
-    # Base API
-    #
     @property
     def root_hash(self):
         return self._trie.root_hash
@@ -81,20 +68,10 @@ class State:
         self._trie.root_hash = value
 
     def set_storage(self, address, slot, value):
-        validate_uint256(value, title="Storage Value")
-        validate_uint256(slot, title="Storage Slot")
-        validate_canonical_address(address, title="Storage Address")
-
-        slot_as_key = pad32(int_to_big_endian(slot))
-
-        if self.is_access_restricted:
-            if not is_accessible(address, slot_as_key, self.access_list):
-                raise UnannouncedStateAccess(
-                    "Attempted writing to storage slot outside of access list"
-                )
-
         account = self._get_account(address)
         storage = HashTrie(Trie(self.db, account.storage_root))
+
+        slot_as_key = pad32(int_to_big_endian(slot))
 
         if value:
             encoded_value = rlp.encode(value)
@@ -106,19 +83,10 @@ class State:
         self._set_account(address, account)
 
     def get_storage(self, address, slot):
-        validate_canonical_address(address, title="Storage Address")
-        validate_uint256(slot, title="Storage Slot")
-
-        slot_as_key = pad32(int_to_big_endian(slot))
-
-        if self.is_access_restricted:
-            if not is_accessible(address, slot_as_key, self.access_list):
-                raise UnannouncedStateAccess(
-                    "Attempted reading from storage slot outside of access list"
-                )
-
         account = self._get_account(address)
         storage = HashTrie(Trie(self.db, account.storage_root))
+
+        slot_as_key = pad32(int_to_big_endian(slot))
 
         if slot_as_key in storage:
             encoded_value = storage[slot_as_key]
@@ -127,90 +95,31 @@ class State:
             return 0
 
     def delete_storage(self, address):
-        validate_canonical_address(address, title="Storage Address")
-
-        if self.is_access_restricted:
-            if not is_accessible(address, b'', self.access_list):
-                raise UnannouncedStateAccess(
-                    "Attempted writing to storage slot outside of access list"
-                )
-
         account = self._get_account(address)
         account.storage_root = BLANK_ROOT_HASH
         self._set_account(address, account)
 
     def set_balance(self, address, balance):
-        validate_canonical_address(address, title="Storage Address")
-        validate_uint256(balance, title="Account Balance")
-
-        if self.is_access_restricted:
-            if keccak(address) + BALANCE_TRIE_PREFIX not in self.access_list:
-                # TODO: use is_accessible once two layer trie is implemented
-                raise UnannouncedStateAccess(
-                    "Attempted setting balance of account outside of access list"
-                )
-
         account = self._get_account(address)
         account.balance = balance
 
         self._set_account(address, account)
 
-    def delta_balance(self, address, delta):
-        self.set_balance(address, self.get_balance(address) + delta)
-
     def get_balance(self, address):
-        validate_canonical_address(address, title="Storage Address")
-
-        if self.is_access_restricted:
-            # TODO: use is_accessible once two layer trie is implemented
-            if keccak(address) + BALANCE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted reading balance of account outside of access list"
-                )
-
         account = self._get_account(address)
         return account.balance
 
     def set_nonce(self, address, nonce):
-        validate_canonical_address(address, title="Storage Address")
-        validate_uint256(nonce, title="Nonce")
-
-        if self.is_access_restricted:
-            # TODO: use is_accessible once two layer trie is implemented
-            if keccak(address) + NONCE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted setting nonce of account outside of access list"
-                )
-
         account = self._get_account(address)
         account.nonce = nonce
 
         self._set_account(address, account)
 
     def get_nonce(self, address):
-        validate_canonical_address(address, title="Storage Address")
-
-        if self.is_access_restricted:
-            # TODO: use is_accessible once two layer trie is implemented
-            if keccak(address) + NONCE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted reading nonce of account outside of access list"
-                )
-
         account = self._get_account(address)
         return account.nonce
 
     def set_code(self, address, code):
-        validate_canonical_address(address, title="Storage Address")
-        validate_is_bytes(code, title="Code")
-
-        if self.is_access_restricted:
-            # TODO: use is_accessible once two layer trie is implemented
-            if keccak(address) + CODE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted setting code of account outside of access list"
-                )
-
         account = self._get_account(address)
 
         account.code_hash = keccak(code)
@@ -224,28 +133,10 @@ class State:
             return b''
 
     def get_code_hash(self, address):
-        validate_canonical_address(address, title="Storage Address")
-
-        if self.is_access_restricted:
-            # TODO: use is_accessible once two layer trie is implemented
-            if keccak(address) + CODE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted reading code hash of account outside of access list"
-                )
-
         account = self._get_account(address)
         return account.code_hash
 
     def delete_code(self, address):
-        validate_canonical_address(address, title="Storage Address")
-
-        if self.is_access_restricted:
-            # TODO: use is_accessible once two layer trie is implemented
-            if keccak(address) + CODE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted setting code of account outside of access list"
-                )
-
         account = self._get_account(address)
         account.code_hash = EMPTY_SHA3
         self._set_account(address, account)
@@ -254,87 +145,14 @@ class State:
     # Account Methods
     #
     def delete_account(self, address):
-        if self.is_access_restricted:
-            if not is_accessible(address, b'', self.access_list):
-                raise UnannouncedStateAccess(
-                    'Attempted deleting account without full storage access'
-                )
-            # TODO: use is_accessible once two layer trie is implemented
-            if keccak(address) + CODE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted deleting code of account outside of access list"
-                )
-            if keccak(address) + BALANCE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted deleting balance of account outside of access list"
-                )
-            if keccak(address) + NONCE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted deleting nonce of account outside of access list"
-                )
-
         del self._trie[address]
 
     def account_exists(self, address):
-        validate_canonical_address(address, title="Storage Address")
         return bool(self._trie[address])
-
-    def account_has_code_or_nonce(self, address):
-        if self.is_access_restricted:
-            # TODO: use is_accessible once two layer trie is implemented
-            if keccak(address) + CODE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted reading code of account outside of access list"
-                )
-            if keccak(address) + NONCE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted reading nonce of account outside of access list"
-                )
-
-        if not self.account_exists(address):
-            return False
-        account = self._get_account(address)
-        if account.nonce != 0:
-            return True
-        elif account.code_hash != EMPTY_SHA3:
-            return True
-        else:
-            return False
-
-    def account_is_empty(self, address):
-        if self.is_access_restricted:
-            # TODO: use is_accessible once two layer trie is implemented
-            if keccak(address) + CODE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted reading code of account outside of access list"
-                )
-            if keccak(address) + BALANCE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted reading balance of account outside of access list"
-                )
-            if keccak(address) + NONCE_TRIE_PREFIX not in self.access_list:
-                raise UnannouncedStateAccess(
-                    "Attempted reading nonce of account outside of access list"
-                )
-
-        validate_canonical_address(address, title="Storage Address")
-        account = self._get_account(address)
-        if account.code_hash != EMPTY_SHA3:
-            return False
-        elif account.balance != 0:
-            return False
-        elif account.nonce != 0:
-            return False
-        else:
-            return True
 
     def touch_account(self, address):
         account = self._get_account(address)
         self._set_account(address, account)
-
-    def increment_nonce(self, address):
-        current_nonce = self.get_nonce(address)
-        self.set_nonce(address, current_nonce + 1)
 
     #
     # Internal
@@ -350,3 +168,120 @@ class State:
 
     def _set_account(self, address, account):
         self._trie[address] = rlp.encode(account, sedes=Account)
+
+
+class State:
+    """
+    High level API around account storage.
+    """
+    db = None
+    _trie = None
+
+    logger = logging.getLogger('evm.state.State')
+
+    def __init__(
+        self,
+        db,
+        root_hash=BLANK_ROOT_HASH,
+        read_only=False,
+        access_list=None,
+        backend_class=TwoLayerBackend
+    ):
+        if read_only:
+            self.db = ImmutableDB(db)
+        else:
+            self.db = db
+        self.backend = backend_class(self.db, root_hash, access_list)
+
+    def decommission(self):
+        self.backend.decommission()
+        self.db = None
+
+    #
+    # Base API
+    #
+    @property
+    def root_hash(self):
+        return self.backend.root_hash
+
+    @root_hash.setter
+    def root_hash(self, value):
+        self.backend.root_hash = value
+
+    def set_storage(self, address, slot, value):
+        validate_uint256(value, title="Storage Value")
+        validate_uint256(slot, title="Storage Slot")
+        validate_canonical_address(address, title="Storage Address")
+        self.backend.set_storage(address, slot, value)
+
+    def get_storage(self, address, slot):
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(slot, title="Storage Slot")
+        return self.backend.get_storage(address, slot)
+
+    def delete_storage(self, address):
+        validate_canonical_address(address, title="Storage Address")
+        self.backend.delete_storage(address)
+
+    def set_balance(self, address, balance):
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(balance, title="Account Balance")
+        self.backend.set_balance(address, balance)
+
+    def delta_balance(self, address, delta):
+        self.set_balance(address, self.get_balance(address) + delta)
+
+    def get_balance(self, address):
+        validate_canonical_address(address, title="Storage Address")
+        return self.backend.get_balance(address)
+
+    def set_nonce(self, address, nonce):
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(nonce, title="Nonce")
+        self.backend.set_nonce(address, nonce)
+
+    def get_nonce(self, address):
+        validate_canonical_address(address, title="Storage Address")
+        return self.backend.get_nonce(address)
+
+    def set_code(self, address, code):
+        validate_canonical_address(address, title="Storage Address")
+        validate_is_bytes(code, title="Code")
+        self.backend.set_code(address, code)
+
+    def get_code(self, address):
+        validate_canonical_address(address, title="Storage Address")
+        return self.backend.get_code(address)
+
+    def get_code_hash(self, address):
+        validate_canonical_address(address, title="Storage Address")
+        return self.backend.get_code_hash(address)
+
+    def delete_code(self, address):
+        validate_canonical_address(address, title="Storage Address")
+        self.backend.delete_code(address)
+
+    #
+    # Account Methods
+    #
+    def delete_account(self, address):
+        validate_canonical_address(address, title="Storage Address")
+        self.backend.delete_account(address)
+
+    def account_exists(self, address):
+        validate_canonical_address(address, title="Storage Address")
+        return self.backend.account_exists(address)
+
+    def account_has_code_or_nonce(self, address):
+        return self.get_code_hash(address) != EMPTY_SHA3 or self.get_nonce(address) != 0
+
+    def account_is_empty(self, address):
+        return not self.account_has_code_or_nonce(address) and self.get_balance(address) != 0
+
+    def touch_account(self, address):
+        validate_canonical_address(address, title="Storage Address")
+        self.backend.touch_account(address)
+
+    def increment_nonce(self, address):
+        current_nonce = self.get_nonce(address)
+        self.set_nonce(address, current_nonce + 1)

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -311,7 +311,8 @@ class OneLayerBackend:
         self.delete_storage(address)
 
     def account_exists(self, address):
-        return self._trie.branch_exists(address)
+        key = keccak(address)
+        return self._trie.branch_exists(key)
 
     def account_has_code_or_nonce(self, address):
         return self.get_code(address) != b'' or self.get_nonce(address) != 0

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -48,7 +48,7 @@ from .hash_trie import HashTrie
 class TwoLayerBackend:
 
     def __init__(self, db, root_hash=BLANK_ROOT_HASH, access_list=None):
-            self.db = db
+        self.db = db
         self._trie = HashTrie(Trie(self.db, root_hash))
         if access_list is not None:
             raise NotImplementedError(
@@ -150,6 +150,9 @@ class TwoLayerBackend:
     def account_exists(self, address):
         return bool(self._trie[address])
 
+    def account_has_code_or_nonce(self, address):
+        return self.get_code_hash(address) != EMPTY_SHA3 or self.get_nonce(address) != 0
+
     def touch_account(self, address):
         account = self._get_account(address)
         self._set_account(address, account)
@@ -168,6 +171,156 @@ class TwoLayerBackend:
 
     def _set_account(self, address, account):
         self._trie[address] = rlp.encode(account, sedes=Account)
+
+
+class OneLayerBackend:
+
+    def __init__(self, db, root_hash=BLANK_ROOT_HASH, access_list=None):
+        self._trie = Trie(db, root_hash)
+        self.is_access_restricted = access_list is not None
+        self.access_list = access_list
+
+    def decommission(self):
+        self._trie = None
+
+    @property
+    def root_hash(self):
+        return self._trie.root_hash
+
+    @root_hash.setter
+    def root_hash(self, value):
+        self._trie.root_hash = value
+
+    @staticmethod
+    def storage_key(address, slot):
+        return keccak(address) + STORAGE_TRIE_PREFIX + pad32(int_to_big_endian(slot))
+
+    @staticmethod
+    def full_storage_key(address):
+        return keccak(address) + STORAGE_TRIE_PREFIX
+
+    @staticmethod
+    def balance_key(address):
+        return keccak(address) + BALANCE_TRIE_PREFIX
+
+    @staticmethod
+    def nonce_key(address):
+        return keccak(address) + NONCE_TRIE_PREFIX
+
+    @staticmethod
+    def code_key(address):
+        return keccak(address) + CODE_TRIE_PREFIX
+
+    def _check_accessibility(self, key):
+        if self.is_access_restricted:
+            if not is_accessible(key, self.access_list):
+                raise UnannouncedStateAccess("Attempted state access outside of access set")
+
+    def set_storage(self, address, slot, value):
+        key = self.storage_key(address, slot)
+        self._check_accessibility(key)
+
+        if value:
+            encoded_value = rlp.encode(value)
+            self._trie[key] = encoded_value
+        else:
+            del self._trie[key]
+
+    def get_storage(self, address, slot):
+        key = self.storage_key(address, slot)
+        self._check_accessibility(key)
+
+        if key in self._trie:
+            encoded_value = self._trie[key]
+            return rlp.decode(encoded_value, sedes=rlp.sedes.big_endian_int)
+        else:
+            return 0
+
+    def delete_storage(self, address):
+        key = self.full_storage_key(address)
+        self._check_accessibility(key)
+
+        self._trie.delete_branch(key)
+
+    def set_balance(self, address, balance):
+        key = self.balance_key(address)
+        self._check_accessibility(key)
+
+        self._trie[key] = rlp.encode(balance)
+
+    def get_balance(self, address):
+        key = self.balance_key(address)
+        self._check_accessibility(key)
+
+        if key in self._trie:
+            encoded_value = self._trie[key]
+            return rlp.decode(encoded_value, sedes=rlp.sedes.big_endian_int)
+        else:
+            return 0
+
+    def set_nonce(self, address, nonce):
+        key = self.nonce_key(address)
+        self._check_accessibility(key)
+
+        self._trie[key] = rlp.encode(nonce)
+
+    def get_nonce(self, address):
+        key = self.nonce_key(address)
+        self._check_accessibility(key)
+
+        if key in self._trie:
+            encoded_value = self._trie[key]
+            return rlp.decode(encoded_value, sedes=rlp.sedes.big_endian_int)
+        else:
+            return 0
+
+    def set_code(self, address, code):
+        key = self.code_key(address)
+        self._check_accessibility(key)
+
+        self._trie[key] = rlp.encode(code)
+
+    def get_code(self, address):
+        key = self.code_key(address)
+        self._check_accessibility(key)
+
+        if key in self._trie:
+            encoded_value = self._trie[key]
+            return rlp.decode(encoded_value)
+        else:
+            return b''
+
+    def delete_code(self, address):
+        key = self.code_key(address)
+        self._check_accessibility(key)
+
+        del self._trie[key]
+
+    #
+    # Account Methods
+    #
+    def delete_account(self, address):
+        keys = [
+            self.nonce_key(address),
+            self.balance_key(address),
+            self.code_key(address)
+        ]
+        for key in keys:
+            self._check_accessibility(key)
+            del self._trie[key]
+        self.delete_storage(address)
+
+    def account_exists(self, address):
+        return self._trie.branch_exists(address)
+
+    def account_has_code_or_nonce(self, address):
+        return self.get_code(address) != b'' or self.get_nonce(address) != 0
+
+    def touch_account(self, address):
+        if not self.account_exists(address):
+            self.set_nonce(address, 0)
+            self.set_balance(address, 0)
+            self.set_code(address, b'')
 
 
 class State:
@@ -253,10 +406,6 @@ class State:
         validate_canonical_address(address, title="Storage Address")
         return self.backend.get_code(address)
 
-    def get_code_hash(self, address):
-        validate_canonical_address(address, title="Storage Address")
-        return self.backend.get_code_hash(address)
-
     def delete_code(self, address):
         validate_canonical_address(address, title="Storage Address")
         self.backend.delete_code(address)
@@ -273,10 +422,11 @@ class State:
         return self.backend.account_exists(address)
 
     def account_has_code_or_nonce(self, address):
-        return self.get_code_hash(address) != EMPTY_SHA3 or self.get_nonce(address) != 0
+        validate_canonical_address(address, title="Storage Address")
+        return self.backend.account_has_code_or_nonce(address)
 
     def account_is_empty(self, address):
-        return not self.account_has_code_or_nonce(address) and self.get_balance(address) != 0
+        return not self.account_has_code_or_nonce(address) and self.get_balance(address) == 0
 
     def touch_account(self, address):
         validate_canonical_address(address, title="Storage Address")

--- a/evm/utils/state_access_restriction.py
+++ b/evm/utils/state_access_restriction.py
@@ -14,9 +14,8 @@ from evm.utils.keccak import (
 )
 
 
-def is_accessible(address, slot_as_key, access_prefix_list):
-    """Check if a storage slot is specified in an access prefix list."""
-    key = keccak(address) + STORAGE_TRIE_PREFIX + slot_as_key
+def is_accessible(key, access_prefix_list):
+    """Check if a key is specified in an access prefix list."""
     for prefix in access_prefix_list:
         if key.startswith(prefix):
             return True

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -69,11 +69,9 @@ class VM(object):
         elif self.block.header.state_root != state.root_hash:
             self.block.header.state_root = state.root_hash
 
-        # remove the reference to the underlying `db` object to ensure that no
-        # further modifications can occur using the `State` object after
-        # leaving the context.
-        state.db = None
-        state._trie = None
+        # ensure that no further modifications can occure using the `State`
+        # object  after leaving the context
+        state.decommission()
 
     @property
     def precompiles(self):

--- a/tests/core/access-restrictions-utils/test_checks_and_conversion.py
+++ b/tests/core/access-restrictions-utils/test_checks_and_conversion.py
@@ -1,5 +1,12 @@
 import pytest
 
+from evm.constants import (
+    STORAGE_TRIE_PREFIX,
+)
+
+from evm.utils.keccak import (
+    keccak,
+)
 from evm.utils.state_access_restriction import (
     is_accessible,
     remove_redundant_prefixes,
@@ -35,10 +42,12 @@ TEST_PREFIX_LIST = to_prefix_list_form([
     )
 )
 def test_accessibility(prefix_list, address, slot, accessible):
+    assert len(slot) == 32
+    key = keccak(address) + STORAGE_TRIE_PREFIX + slot
     if accessible:
-        assert is_accessible(address, slot, prefix_list)
+        assert is_accessible(key, prefix_list)
     else:
-        assert not is_accessible(address, slot, prefix_list)
+        assert not is_accessible(key, prefix_list)
 
 
 @pytest.mark.parametrize(

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -10,6 +10,7 @@ from evm.vm.forks.frontier.blocks import FrontierBlock
 from tests.core.fixtures import (  # noqa: F401
     chain,
     chain_without_block_validation,
+    chaindb,
     valid_block_rlp,
 )
 from tests.core.helpers import new_transaction

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -11,7 +11,7 @@ from evm import Chain
 from evm import constants
 from evm.db import get_db_backend
 from evm.db.chain import BaseChainDB
-from evm.db.state import OneLayerBackend
+from evm.db.state import FlatTrieBackend
 from evm.vm.forks.frontier import FrontierVM
 
 
@@ -79,7 +79,7 @@ def chain(chaindb):
 
 @pytest.fixture
 def shard_chain():
-    shard_chaindb = BaseChainDB(get_db_backend(), state_backend_class=OneLayerBackend)
+    shard_chaindb = BaseChainDB(get_db_backend(), state_backend_class=FlatTrieBackend)
     return chain(shard_chaindb)
 
 

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -11,11 +11,17 @@ from evm import Chain
 from evm import constants
 from evm.db import get_db_backend
 from evm.db.chain import BaseChainDB
+from evm.db.state import OneLayerBackend
 from evm.vm.forks.frontier import FrontierVM
 
 
 @pytest.fixture
-def chain():
+def chaindb():
+    return BaseChainDB(get_db_backend())
+
+
+@pytest.fixture
+def chain(chaindb):
     """
     Return a Chain object containing just the genesis block.
 
@@ -41,8 +47,9 @@ def chain():
             "0000000000000000000000000000000000000000000000000000000000000000"),
         "receipt_root": decode_hex(
             "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
-        "state_root": decode_hex(
-            "cafd881ab193703b83816c49ff6c2bf6ba6f464a1be560c42106128c8dbc35e7"),
+        # TODO: uncomment when there's a dedicated shard chain object with separate fixture
+        # "state_root": decode_hex(
+        #     "cafd881ab193703b83816c49ff6c2bf6ba6f464a1be560c42106128c8dbc35e7"),
         "timestamp": 1422494849,
         "transaction_root": decode_hex(
             "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
@@ -64,10 +71,16 @@ def chain():
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
         ))
-    chain = klass.from_genesis(BaseChainDB(get_db_backend()), genesis_params, genesis_state)
+    chain = klass.from_genesis(chaindb, genesis_params, genesis_state)
     chain.funded_address = funded_addr
     chain.funded_address_initial_balance = initial_balance
     return chain
+
+
+@pytest.fixture
+def shard_chain():
+    shard_chaindb = BaseChainDB(get_db_backend(), state_backend_class=OneLayerBackend)
+    return chain(shard_chaindb)
 
 
 # This block is a child of the genesis defined in the chain fixture above and contains a single tx

--- a/tests/core/vm/test_state_access_restrictions.py
+++ b/tests/core/vm/test_state_access_restrictions.py
@@ -9,12 +9,12 @@ from evm.utils.state_access_restriction import (
     to_prefix_list_form,
 )
 
-from tests.core.fixtures import chain  # noqa: F401
+from tests.core.fixtures import shard_chain  # noqa: F401
 
 
-def test_balance_restriction(chain):  # noqa: F811
-    vm = chain.get_vm()
-    address = chain.funded_address
+def test_balance_restriction(shard_chain):  # noqa: F811
+    vm = shard_chain.get_vm()
+    address = shard_chain.funded_address
     access_list = to_prefix_list_form([[address]])
 
     method_and_args = (
@@ -31,9 +31,9 @@ def test_balance_restriction(chain):  # noqa: F811
                 getattr(state_db, method)(*args)
 
 
-def test_nonce_restriction(chain):  # noqa: F811
-    vm = chain.get_vm()
-    address = chain.funded_address
+def test_nonce_restriction(shard_chain):  # noqa: F811
+    vm = shard_chain.get_vm()
+    address = shard_chain.funded_address
     access_list = to_prefix_list_form([[address]])
 
     method_and_args = (
@@ -50,9 +50,9 @@ def test_nonce_restriction(chain):  # noqa: F811
                 getattr(state_db, method)(*args)
 
 
-def test_code_restriction(chain):  # noqa: F811
-    vm = chain.get_vm()
-    address = chain.funded_address
+def test_code_restriction(shard_chain):  # noqa: F811
+    vm = shard_chain.get_vm()
+    address = shard_chain.funded_address
     access_list = to_prefix_list_form([[address]])
 
     method_and_args = (
@@ -69,9 +69,9 @@ def test_code_restriction(chain):  # noqa: F811
                 getattr(state_db, method)(*args)
 
 
-def test_storage_read_restriction(chain):  # noqa: F811
-    vm = chain.get_vm()
-    address = chain.funded_address
+def test_storage_restriction(shard_chain):  # noqa: F811
+    vm = shard_chain.get_vm()
+    address = shard_chain.funded_address
     other_address = b'\xaa' * 20
     access_list = to_prefix_list_form([[address, b'\x00', b'\xff' * 32]])
 

--- a/tests/core/vm/test_state_access_restrictions.py
+++ b/tests/core/vm/test_state_access_restrictions.py
@@ -87,8 +87,6 @@ def test_storage_restriction(shard_chain):  # noqa: F811
         (True, 'set_storage', [address, big_endian_to_int(b'\xff' * 32), 0]),
         (False, 'set_storage', [address, big_endian_to_int(b'\xaa' * 32), 0]),
         (False, 'set_storage', [other_address, big_endian_to_int(b'\x00' * 32), 0]),
-
-        (False, 'delete_storage', [address]),
     )
 
     for valid, method, args in tests:
@@ -104,6 +102,3 @@ def test_storage_restriction(shard_chain):  # noqa: F811
         with pytest.raises(UnannouncedStateAccess):
             with vm.state_db(access_list=[]) as state_db:
                 getattr(state_db, method)(*args)
-
-    with vm.state_db(access_list=to_prefix_list_form([[address, b'']])) as state_db:
-        state_db.delete_storage(address)

--- a/tests/database/test_state.py
+++ b/tests/database/test_state.py
@@ -6,8 +6,8 @@ from evm.exceptions import (
 
 from evm.db.state import (
     State,
-    OneLayerBackend,
-    TwoLayerBackend,
+    FlatTrieBackend,
+    NestedTrieBackend,
 )
 
 
@@ -17,8 +17,8 @@ INVALID_ADDRESS = b'aa' * 20
 
 
 @pytest.fixture(params=[
-    OneLayerBackend,
-    TwoLayerBackend,
+    FlatTrieBackend,
+    NestedTrieBackend,
 ])
 def state(request):
     return State({}, backend_class=request.param)

--- a/tests/database/test_state.py
+++ b/tests/database/test_state.py
@@ -1,0 +1,136 @@
+import pytest
+
+from evm.exceptions import (
+    ValidationError,
+)
+
+from evm.db.state import (
+    State,
+    OneLayerBackend,
+    TwoLayerBackend,
+)
+
+
+ADDRESS = b'\xaa' * 20
+OTHER_ADDRESS = b'\xbb' * 20
+INVALID_ADDRESS = b'aa' * 20
+
+
+@pytest.fixture(params=[
+    OneLayerBackend,
+    TwoLayerBackend,
+])
+def state(request):
+    return State({}, backend_class=request.param)
+
+
+def test_balance(state):
+    assert state.get_balance(ADDRESS) == 0
+
+    state.set_balance(ADDRESS, 1)
+    assert state.get_balance(ADDRESS) == 1
+    assert state.get_balance(OTHER_ADDRESS) == 0
+
+    state.delta_balance(ADDRESS, 2)
+    assert state.get_balance(ADDRESS) == 3
+    assert state.get_balance(OTHER_ADDRESS) == 0
+
+    with pytest.raises(ValidationError):
+        state.get_balance(INVALID_ADDRESS)
+    with pytest.raises(ValidationError):
+        state.set_balance(INVALID_ADDRESS, 1)
+    with pytest.raises(ValidationError):
+        state.delta_balance(INVALID_ADDRESS, 1)
+    with pytest.raises(ValidationError):
+        state.set_balance(ADDRESS, 1.0)
+    with pytest.raises(ValidationError):
+        state.delta_balance(ADDRESS, 1.0)
+
+
+def test_nonce(state):
+    assert state.get_nonce(ADDRESS) == 0
+
+    state.set_nonce(ADDRESS, 5)
+    assert state.get_nonce(ADDRESS) == 5
+    assert state.get_nonce(OTHER_ADDRESS) == 0
+
+    state.increment_nonce(ADDRESS)
+    assert state.get_nonce(ADDRESS) == 6
+    assert state.get_nonce(OTHER_ADDRESS) == 0
+
+    with pytest.raises(ValidationError):
+        state.get_nonce(INVALID_ADDRESS)
+    with pytest.raises(ValidationError):
+        state.set_nonce(INVALID_ADDRESS, 1)
+    with pytest.raises(ValidationError):
+        state.increment_nonce(INVALID_ADDRESS)
+    with pytest.raises(ValidationError):
+        state.set_nonce(ADDRESS, 1.0)
+
+
+def test_code(state):
+    assert state.get_code(ADDRESS) == b''
+
+    state.set_code(ADDRESS, b'code')
+    assert state.get_code(ADDRESS) == b'code'
+    assert state.get_code(OTHER_ADDRESS) == b''
+
+    with pytest.raises(ValidationError):
+        state.get_code(INVALID_ADDRESS)
+    with pytest.raises(ValidationError):
+        state.set_code(INVALID_ADDRESS, b'code')
+    with pytest.raises(ValidationError):
+        state.set_code(ADDRESS, 'code')
+
+
+def test_storage(state):
+    assert state.get_storage(ADDRESS, 0) == 0
+
+    state.set_storage(ADDRESS, 0, 123)
+    assert state.get_storage(ADDRESS, 0) == 123
+    assert state.get_storage(ADDRESS, 1) == 0
+    assert state.get_storage(OTHER_ADDRESS, 0) == 0
+
+    state.set_storage(OTHER_ADDRESS, 1, 321)
+    state.delete_storage(ADDRESS)
+    assert state.get_storage(ADDRESS, 0) == 0
+    assert state.get_storage(OTHER_ADDRESS, 1) == 321
+
+    with pytest.raises(ValidationError):
+        state.get_storage(INVALID_ADDRESS, 0)
+    with pytest.raises(ValidationError):
+        state.set_storage(INVALID_ADDRESS, 0, 0)
+    with pytest.raises(ValidationError):
+        state.delete_storage(INVALID_ADDRESS)
+    with pytest.raises(ValidationError):
+        state.get_storage(ADDRESS, b'\x00')
+    with pytest.raises(ValidationError):
+        state.set_storage(ADDRESS, b'\x00', 0)
+    with pytest.raises(ValidationError):
+        state.set_storage(ADDRESS, 0, b'asdf')
+
+
+def test_accounts(state):
+    assert not state.account_exists(ADDRESS)
+    assert not state.account_has_code_or_nonce(ADDRESS)
+
+    state.touch_account(ADDRESS)
+    assert state.account_exists(ADDRESS)
+    assert state.get_nonce(ADDRESS) == 0
+    assert state.get_balance(ADDRESS) == 0
+    assert state.get_code(ADDRESS) == b''
+
+    assert not state.account_has_code_or_nonce(ADDRESS)
+    state.increment_nonce(ADDRESS)
+    assert state.account_has_code_or_nonce(ADDRESS)
+
+    state.delete_account(ADDRESS)
+    assert not state.account_exists(ADDRESS)
+    assert not state.account_has_code_or_nonce(ADDRESS)
+
+    with pytest.raises(ValidationError):
+        state.account_exists(INVALID_ADDRESS)
+    with pytest.raises(ValidationError):
+        state.delete_account(INVALID_ADDRESS)
+    with pytest.raises(ValidationError):
+        state.account_has_code_or_nonce(INVALID_ADDRESS)


### PR DESCRIPTION
This PR adds an alternative way of storing state as described in #191.

It depends on two not yet implemented trie methods:

- `Trie.delete_branch(key)` that should delete all keys that start with `key` (to delete the whole storage of an account)
- `Trie.branch_exists(key)` that checks if there is a key that starts with `key` (to check if an account exists)

State is always stored RLP encoded as that's the way it used to be in the two layer design. However, I don't really see a good motivation for that anymore as all entries are either integers (nonces, balances, storage entries) or binary (code), whereas in the old design we had a slightly more complex object (account).