### PR TITLE
Pure apply_transaction

### DIFF
--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import copy
 import logging
 
 from cytoolz import (
@@ -233,12 +232,10 @@ class Chain(object):
         Apply the transaction to the current head block of the Chain.
         """
         vm = self.get_vm()
-        # return vm.apply_transaction(transaction)
-
+        # [FIXME]: replace with the real pure function
         return vm.apply_transaction_to_block(
             transaction,
-            copy.deepcopy(self.chaindb),
-            copy.deepcopy(vm.block),
+            vm.block,
         )
 
     def import_block(self, block, perform_validation=True):
@@ -255,9 +252,7 @@ class Chain(object):
             )
 
         parent_chain = self.get_chain_at_block_parent(block)
-        chaindb = self.chaindb
-        imported_block = parent_chain.get_vm().apply_block(block, chaindb)
-        # imported_block = parent_chain.get_vm().import_block(block)
+        imported_block = parent_chain.get_vm().import_block(block)
 
         # Validate the imported block.
         if perform_validation:

--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import copy
 import logging
 
 from cytoolz import (
@@ -232,7 +233,13 @@ class Chain(object):
         Apply the transaction to the current head block of the Chain.
         """
         vm = self.get_vm()
-        return vm.apply_transaction(transaction)
+        # return vm.apply_transaction(transaction)
+
+        return vm.apply_transaction_to_block(
+            transaction,
+            copy.deepcopy(self.chaindb),
+            copy.deepcopy(vm.block),
+        )
 
     def import_block(self, block, perform_validation=True):
         """
@@ -248,7 +255,9 @@ class Chain(object):
             )
 
         parent_chain = self.get_chain_at_block_parent(block)
-        imported_block = parent_chain.get_vm().import_block(block)
+        chaindb = self.chaindb
+        imported_block = parent_chain.get_vm().apply_block(block, chaindb)
+        # imported_block = parent_chain.get_vm().import_block(block)
 
         # Validate the imported block.
         if perform_validation:

--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -25,7 +25,9 @@ from evm.validation import (
     validate_uint256,
     validate_word,
 )
-
+from evm.vm.state_transition_helper import (
+    apply_transaction
+)
 from evm.rlp.headers import (
     BlockHeader,
 )
@@ -232,10 +234,11 @@ class Chain(object):
         Apply the transaction to the current head block of the Chain.
         """
         vm = self.get_vm()
-        # [FIXME]: replace with the real pure function
-        return vm.apply_transaction_to_block(
+        return apply_transaction(
             transaction,
             vm.block,
+            vm,
+            self.chaindb,
         )
 
     def import_block(self, block, perform_validation=True):

--- a/evm/db/backends/memory.py
+++ b/evm/db/backends/memory.py
@@ -6,8 +6,8 @@ from .base import (
 class MemoryDB(BaseDB):
     kv_store = None
 
-    def __init__(self):
-        self.kv_store = {}
+    def __init__(self, kv_store=None):
+        self.kv_store = {} if kv_store is None else kv_store
 
     def get(self, key):
         return self.kv_store[key]

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -23,6 +23,9 @@ from evm.exceptions import (
 from evm.db.journal import (
     JournalDB,
 )
+from evm.db.tracked import (
+    TrackedDB
+)
 from evm.db.state import (
     State,
     NestedTrieBackend,
@@ -244,9 +247,10 @@ class BaseChainDB:
     def clear(self):
         self.db.clear()
 
-    def get_state_db(self, state_root, read_only, access_list=None):
+    def get_state_db(self, state_root, read_only, access_list=None, is_stateless=False):
+        db = TrackedDB(self.db) if is_stateless else self.db
         return State(
-            db=self.db,
+            db=db,
             root_hash=state_root,
             read_only=read_only,
             access_list=access_list,

--- a/evm/rlp/blocks.py
+++ b/evm/rlp/blocks.py
@@ -58,12 +58,6 @@ class BaseBlock(rlp.Serializable):
     def validate(self):
         pass
 
-    def add_transaction(self, transaction, computation):
-        """
-        Adds the given transaction to the current block.
-        """
-        raise NotImplementedError("Must be implemented by subclasses")
-
     def mine(self, *args, **kwargs):
         """
         Mines the block.

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -97,7 +97,7 @@ class VM(object):
         # [FIXME]: initialize self.block?
         # [FIXME]: don't mutate the given block
 
-        receipt = block.make_receipt(transaction, computation)
+        receipt = self.make_receipt(transaction, computation, block)
 
         transaction_idx = len(block.transactions)
 
@@ -187,6 +187,12 @@ class VM(object):
     def apply_message(self, message):
         """
         Execution of an VM message.
+        """
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    def make_receipt(self, transaction, computation, block):
+        """
+        Make receipt.
         """
         raise NotImplementedError("Must be implemented by subclasses")
 

--- a/evm/vm/forks/byzantium/__init__.py
+++ b/evm/vm/forks/byzantium/__init__.py
@@ -4,6 +4,9 @@ from cytoolz import (
 
 from evm import precompiles
 from evm.constants import MAX_UNCLE_DEPTH
+from evm.rlp.receipts import (
+    Receipt,
+)
 from evm.utils.address import (
     force_bytes_to_address,
 )
@@ -11,7 +14,10 @@ from evm.validation import (
     validate_lte,
 )
 
-from ..frontier import FRONTIER_PRECOMPILES
+from ..frontier import (
+    FRONTIER_PRECOMPILES,
+    _make_frontier_receipt,
+)
 from ..spurious_dragon import SpuriousDragonVM
 
 from .constants import EIP649_BLOCK_REWARD
@@ -44,6 +50,16 @@ def _byzantium_get_uncle_reward(block_number, uncle):
     return (8 - block_number_delta) * EIP649_BLOCK_REWARD // 8
 
 
+def make_byzantium_receipt(vm, transaction, computation, block):
+    old_receipt = _make_frontier_receipt(vm, transaction, computation, block)
+    receipt = Receipt(
+        state_root=b'' if computation.is_error else b'\x01',
+        gas_used=old_receipt.gas_used,
+        logs=old_receipt.logs,
+    )
+    return receipt
+
+
 ByzantiumVM = SpuriousDragonVM.configure(
     name='ByzantiumVM',
     # precompiles
@@ -57,4 +73,5 @@ ByzantiumVM = SpuriousDragonVM.configure(
     configure_header=configure_byzantium_header,
     get_block_reward=staticmethod(_byzantium_get_block_reward),
     get_uncle_reward=staticmethod(_byzantium_get_uncle_reward),
+    make_receipt=make_byzantium_receipt,
 )

--- a/evm/vm/forks/byzantium/__init__.py
+++ b/evm/vm/forks/byzantium/__init__.py
@@ -50,8 +50,8 @@ def _byzantium_get_uncle_reward(block_number, uncle):
     return (8 - block_number_delta) * EIP649_BLOCK_REWARD // 8
 
 
-def make_byzantium_receipt(vm, transaction, computation, block):
-    old_receipt = _make_frontier_receipt(vm, transaction, computation, block)
+def make_byzantium_receipt(vm, transaction, computation):
+    old_receipt = _make_frontier_receipt(vm, transaction, computation)
     receipt = Receipt(
         state_root=b'' if computation.is_error else b'\x01',
         gas_used=old_receipt.gas_used,

--- a/evm/vm/forks/byzantium/blocks.py
+++ b/evm/vm/forks/byzantium/blocks.py
@@ -4,9 +4,6 @@ from rlp.sedes import (
 from evm.rlp.headers import (
     BlockHeader,
 )
-from evm.rlp.receipts import (
-    Receipt,
-)
 from evm.vm.forks.spurious_dragon.blocks import (
     SpuriousDragonBlock,
 )
@@ -23,12 +20,3 @@ class ByzantiumBlock(SpuriousDragonBlock):
         ('transactions', CountableList(transaction_class)),
         ('uncles', CountableList(BlockHeader))
     ]
-
-    def make_receipt(self, transaction, computation):
-        old_receipt = super(ByzantiumBlock, self).make_receipt(transaction, computation)
-        receipt = Receipt(
-            state_root=b'' if computation.is_error else b'\x01',
-            gas_used=old_receipt.gas_used,
-            logs=old_receipt.logs,
-        )
-        return receipt

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -254,7 +254,7 @@ def _apply_frontier_create_message(vm, message):
         return computation
 
 
-def _make_frontier_receipt(vm, transaction, computation, block):
+def _make_frontier_receipt(vm, transaction, computation):
     logs = [
         Log(address, topics, data)
         for address, topics, data
@@ -270,10 +270,10 @@ def _make_frontier_receipt(vm, transaction, computation, block):
         (transaction.gas - gas_remaining) // 2,
     )
 
-    gas_used = block.header.gas_used + tx_gas_used
+    gas_used = vm.block.header.gas_used + tx_gas_used
 
     receipt = Receipt(
-        state_root=block.header.state_root,
+        state_root=vm.block.header.state_root,
         gas_used=gas_used,
         logs=logs,
     )

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -11,7 +11,12 @@ from evm.exceptions import (
     ContractCreationCollision,
 )
 from evm import precompiles
-
+from evm.rlp.logs import (
+    Log,
+)
+from evm.rlp.receipts import (
+    Receipt,
+)
 from evm.vm.message import (
     Message,
 )
@@ -249,6 +254,32 @@ def _apply_frontier_create_message(vm, message):
         return computation
 
 
+def _make_frontier_receipt(vm, transaction, computation, block):
+    logs = [
+        Log(address, topics, data)
+        for address, topics, data
+        in computation.get_log_entries()
+    ]
+
+    gas_remaining = computation.get_gas_remaining()
+    gas_refund = computation.get_gas_refund()
+    tx_gas_used = (
+        transaction.gas - gas_remaining
+    ) - min(
+        gas_refund,
+        (transaction.gas - gas_remaining) // 2,
+    )
+
+    gas_used = block.header.gas_used + tx_gas_used
+
+    receipt = Receipt(
+        state_root=block.header.state_root,
+        gas_used=gas_used,
+        logs=logs,
+    )
+    return receipt
+
+
 FrontierVM = VM.configure(
     name='FrontierVM',
     # VM logic
@@ -265,4 +296,5 @@ FrontierVM = VM.configure(
     execute_transaction=_execute_frontier_transaction,
     apply_create_message=_apply_frontier_create_message,
     apply_message=_apply_frontier_message,
+    make_receipt=_make_frontier_receipt,
 )

--- a/evm/vm/forks/frontier/blocks.py
+++ b/evm/vm/forks/frontier/blocks.py
@@ -260,27 +260,6 @@ class FrontierBlock(BaseBlock):
     #
     # Execution API
     #
-    def add_transaction(self, transaction, computation):
-        receipt = self.make_receipt(transaction, computation)
-
-        transaction_idx = len(self.transactions)
-
-        index_key = rlp.encode(transaction_idx, sedes=rlp.sedes.big_endian_int)
-
-        self.transactions.append(transaction)
-
-        tx_root_hash = self.chaindb.add_transaction(self.header, index_key, transaction)
-        receipt_root_hash = self.chaindb.add_receipt(self.header, index_key, receipt)
-
-        self.bloom_filter |= receipt.bloom
-
-        self.header.transaction_root = tx_root_hash
-        self.header.receipt_root = receipt_root_hash
-        self.header.bloom = int(self.bloom_filter)
-        self.header.gas_used = receipt.gas_used
-
-        return self
-
     def add_uncle(self, uncle):
         self.uncles.append(uncle)
         self.header.uncles_hash = keccak(rlp.encode(self.uncles))

--- a/evm/vm/forks/frontier/blocks.py
+++ b/evm/vm/forks/frontier/blocks.py
@@ -71,6 +71,10 @@ class FrontierBlock(BaseBlock):
         )
         # TODO: should perform block validation at this point?
 
+    @property
+    def transaction_count(self):
+        return len(self.transactions)
+
     def validate_gas_limit(self):
         gas_limit = self.header.gas_limit
         if gas_limit < GAS_LIMIT_MINIMUM:
@@ -198,7 +202,7 @@ class FrontierBlock(BaseBlock):
         Note return value of this function can be cached based on
         `self.receipt_db.root_hash`
         """
-        if len(self.transactions):
+        if self.transaction_count:
             return self.receipts[-1].gas_used
         else:
             return 0

--- a/evm/vm/forks/frontier/blocks.py
+++ b/evm/vm/forks/frontier/blocks.py
@@ -18,9 +18,6 @@ from evm.exceptions import (
     BlockNotFound,
     ValidationError,
 )
-from evm.rlp.logs import (
-    Log,
-)
 from evm.rlp.receipts import (
     Receipt,
 )
@@ -213,31 +210,6 @@ class FrontierBlock(BaseBlock):
     @property
     def receipts(self):
         return self.chaindb.get_receipts(self.header, Receipt)
-
-    def make_receipt(self, transaction, computation):
-        logs = [
-            Log(address, topics, data)
-            for address, topics, data
-            in computation.get_log_entries()
-        ]
-
-        gas_remaining = computation.get_gas_remaining()
-        gas_refund = computation.get_gas_refund()
-        tx_gas_used = (
-            transaction.gas - gas_remaining
-        ) - min(
-            gas_refund,
-            (transaction.gas - gas_remaining) // 2,
-        )
-
-        gas_used = self.header.gas_used + tx_gas_used
-
-        receipt = Receipt(
-            state_root=self.header.state_root,
-            gas_used=gas_used,
-            logs=logs,
-        )
-        return receipt
 
     #
     # Header API

--- a/evm/vm/state_transition_helper.py
+++ b/evm/vm/state_transition_helper.py
@@ -1,0 +1,47 @@
+import copy
+import logging
+import traceback
+
+
+logger = logging.getLogger("evm.research.state_transition_helper")
+
+
+def apply_transaction(transaction, block, prev_vm, chaindb):
+    """
+    Apply transaction to the block, return the result with a new block object
+
+    Original Goal: apply_transaction(stateobj, db, blockdata, transaction)
+    -> state_obj', reads, writes
+    """
+    # TODO: try to use simplier StateObj object instead of VM as the
+    # state transition container?
+
+    # init vm
+    vm = copy.deepcopy(prev_vm)
+    vm.chaindb = chaindb
+
+    # result
+    success = True
+    reads = None
+    writes = None
+
+    try:
+        vm.set_stateless(True)
+        computation = vm.apply_transaction_to_block(
+            transaction,
+            block,
+            vm.chaindb,
+        )
+        vm.set_stateless(False)
+        if computation.is_error:
+            success = False
+    except Exception as e:
+        # FIXME: any specific exception type in this function?
+        logger.error(
+            "Unexpected error when handling remote msg: {}".format(traceback.format_exc()))
+        success = False
+
+    reads = vm.reads
+    writes = vm.writes
+
+    return success, reads, writes, vm.block

--- a/evm/vm/state_transition_helper.py
+++ b/evm/vm/state_transition_helper.py
@@ -13,7 +13,7 @@ def apply_transaction(transaction, block, prev_vm, chaindb):
     Original Goal: apply_transaction(stateobj, db, blockdata, transaction)
     -> state_obj', reads, writes
     """
-    # TODO: try to use simplier StateObj object instead of VM as the
+    # TODO: try to use simpler StateObj object instead of VM as the
     # state transition container?
 
     # init vm

--- a/tests/core/vm/test_state_transition_helper.py
+++ b/tests/core/vm/test_state_transition_helper.py
@@ -48,9 +48,11 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     assert block.transactions[tx_idx] == tx
     assert block.header.gas_used == constants.GAS_TX
 
-    # Check if no side effect, state trie in chain.chaindb haven't been changed
+    # Check if no side effect, state trie in `chain.chaindb` haven't been changed
     with chain.get_vm().state_db(read_only=True) as chain_state_db:
         assert chain_state_db.root_hash == original_root_hash
+        with vm.state_db(read_only=True) as state_db:
+            assert state_db.root_hash == original_root_hash
 
     # Try again - Simulate apply the given transaction package with witness data
     vm = chain.get_vm()

--- a/tests/core/vm/test_state_transition_helper.py
+++ b/tests/core/vm/test_state_transition_helper.py
@@ -1,0 +1,76 @@
+from eth_utils import (
+    decode_hex,
+)
+
+from evm import constants
+from evm.db.backends.memory import MemoryDB
+from evm.db.chain import BaseChainDB
+from evm.vm.state_transition_helper import (
+    apply_transaction,
+)
+
+from tests.core.fixtures import chain_without_block_validation  # noqa: F401
+from tests.core.helpers import new_transaction
+
+
+def test_apply_transaction(chain_without_block_validation):  # noqa: F811
+    chain = chain_without_block_validation  # noqa: F811
+
+    # Get original_root_hash for assertion
+    original_root_hash = None
+    with chain.get_vm().state_db(read_only=True) as state_db:
+        original_root_hash = state_db.root_hash
+    assert original_root_hash is not None
+
+    vm = chain.get_vm()
+
+    # Prepare a transaction
+    tx_idx = len(vm.block.transactions)
+    recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
+    amount = 100
+    from_ = chain.funded_address
+    tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
+    tx_gas = tx.gas_price * constants.GAS_TX
+
+    # Apply transaction to vm.block and also return vm.block
+    success, reads, writes, block = apply_transaction(
+        tx,
+        vm.block,
+        vm,
+        chain.chaindb,
+    )
+
+    # Store the witness data in memory
+    db = MemoryDB(reads)
+    witness_db = BaseChainDB(db)
+
+    assert success
+    assert block.transactions[tx_idx] == tx
+    assert block.header.gas_used == constants.GAS_TX
+
+    # Check if no side effect, state trie in chain.chaindb haven't been changed
+    with chain.get_vm().state_db(read_only=True) as chain_state_db:
+        assert chain_state_db.root_hash == original_root_hash
+
+    # Try again - Simulate apply the given transaction package with witness data
+    vm = chain.get_vm()
+
+    assert vm.block.transaction_count == 0
+
+    success, reads, writes, block = apply_transaction(
+        tx,
+        vm.block,
+        vm,
+        witness_db,
+    )
+    assert success
+    assert block.transactions[tx_idx] == tx
+    assert block.header.gas_used == constants.GAS_TX
+
+    # Check if block can be apply to a chain
+    chain.import_block(block)
+    vm = chain.get_vm()
+    with vm.state_db(read_only=True) as state_db:
+        assert state_db.get_balance(from_) == (
+            chain.funded_address_initial_balance - amount - tx_gas)
+        assert state_db.get_balance(recipient) == amount

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -22,13 +22,9 @@ def test_add_transaction_to_block(chain_without_block_validation):  # noqa: F811
     tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
     tx_gas = tx.gas_price * constants.GAS_TX
 
-    # Use add_transaction_to_block as a pure function
     computation = vm.execute_transaction(tx)
     prev_block = copy.deepcopy(vm.block)
     block = vm.add_transaction_to_block(tx, prev_block, computation)
-
-    # Check if no side effect
-    assert prev_block.hash != block.hash
 
     # Check if the result is right
     with vm.state_db(read_only=True) as state_db:
@@ -94,42 +90,25 @@ def test_apply_transaction_semi_pure(chain_without_block_validation):  # noqa: F
     tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
     tx_gas = tx.gas_price * constants.GAS_TX
 
-    # chaindb: a db object, TODO: use TrackedDB
-    # block: the current block blocked
-    chaindb = copy.deepcopy(chain.chaindb)
-    block = copy.deepcopy(vm.block)
+    # block: the current block
+    block = vm.block
 
-    computation, block = vm.apply_transaction_to_block(tx, chaindb, block)
+    vm.set_stateless(True)
+    computation = vm.apply_transaction_to_block(tx, block)
+    vm.set_stateless(False)
 
     # result:
     # 1. computation
-    assert computation.error is None
+    assert not computation.is_error
     # 2. vm.state_db
     with vm.state_db(read_only=True) as state_db:
         assert state_db.get_balance(from_) == (
             chain.funded_address_initial_balance - amount - tx_gas)
         assert state_db.get_balance(recipient) == amount
+        # [TODO]: verify reads and writes dicts
     # 3. vm.block
-    assert block.transactions[tx_idx] == tx
-    assert block.header.gas_used == constants.GAS_TX
-
-
-# def test_apply_block(chain_without_block_validation):  # noqa: F811
-#     chain = chain_without_block_validation  # noqa: F811
-#     vm = chain.get_vm()
-#     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
-#     amount = 100
-#     from_ = chain.funded_address
-#     tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
-#     computation = vm.apply_transaction(tx)
-#     assert computation.error is None
-
-#     parent_vm = chain.get_chain_at_block_parent(vm.block).get_vm()
-#     chaindb = copy.deepcopy(chain.chaindb)
-#     block = parent_vm.apply_block(vm.block, chaindb)
-#     assert block.transactions == [tx]
-
-#     # [TODO]: more tests
+    assert vm.block.transactions[tx_idx] == tx
+    assert vm.block.header.gas_used == constants.GAS_TX
 
 
 def test_mine_block(chain_without_block_validation):  # noqa: F811

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -25,9 +25,7 @@ def test_add_transaction_to_block(chain_without_block_validation):  # noqa: F811
     # Use add_transaction_to_block as a pure function
     computation = vm.execute_transaction(tx)
     prev_block = copy.deepcopy(vm.block)
-    block = copy.deepcopy(
-        vm.add_transaction_to_block(tx, prev_block, computation)
-    )
+    block = vm.add_transaction_to_block(tx, prev_block, computation)
 
     # Check if no side effect
     assert prev_block.hash != block.hash
@@ -47,25 +45,91 @@ def test_add_transaction_to_block(chain_without_block_validation):  # noqa: F811
             assert state_db.get_balance(from_) != prev_state_db.get_balance(from_)
             assert state_db.get_balance(recipient) != prev_state_db.get_balance(recipient)
 
+    # Block can be apply to a chain
+    chain.import_block(block)
+    vm = chain.get_vm()
+    with vm.state_db(read_only=True) as state_db:
+        assert state_db.get_balance(from_) == (
+            chain.funded_address_initial_balance - amount - tx_gas)
+        assert state_db.get_balance(recipient) == amount
+
 
 def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     chain = chain_without_block_validation  # noqa: F811
     vm = chain.get_vm()
+
+    # Prepare a transaction
     tx_idx = len(vm.block.transactions)
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
     from_ = chain.funded_address
     tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
-    computation = vm.apply_transaction(tx)
-    assert not computation.is_error
     tx_gas = tx.gas_price * constants.GAS_TX
+
+    computation = vm.apply_transaction(tx)
+
+    # result:
+    # 1. computation
+    assert not computation.is_error
+    # 2. vm.state_db
     with vm.state_db(read_only=True) as state_db:
         assert state_db.get_balance(from_) == (
             chain.funded_address_initial_balance - amount - tx_gas)
         assert state_db.get_balance(recipient) == amount
+    # 3. vm.block
     block = vm.block
     assert block.transactions[tx_idx] == tx
     assert block.header.gas_used == constants.GAS_TX
+
+
+def test_apply_transaction_semi_pure(chain_without_block_validation):  # noqa: F811
+    chain = chain_without_block_validation  # noqa: F811
+    vm = copy.deepcopy(chain.get_vm())  # Use vm as a temporary container
+
+    # Prepare a transaction
+    tx_idx = len(vm.block.transactions)
+    recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
+    amount = 100
+    from_ = chain.funded_address
+    tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
+    tx_gas = tx.gas_price * constants.GAS_TX
+
+    # chaindb: a db object, TODO: use TrackedDB
+    # block: the current block blocked
+    chaindb = copy.deepcopy(chain.chaindb)
+    block = copy.deepcopy(vm.block)
+
+    computation, block = vm.apply_transaction_to_block(tx, chaindb, block)
+
+    # result:
+    # 1. computation
+    assert computation.error is None
+    # 2. vm.state_db
+    with vm.state_db(read_only=True) as state_db:
+        assert state_db.get_balance(from_) == (
+            chain.funded_address_initial_balance - amount - tx_gas)
+        assert state_db.get_balance(recipient) == amount
+    # 3. vm.block
+    assert block.transactions[tx_idx] == tx
+    assert block.header.gas_used == constants.GAS_TX
+
+
+# def test_apply_block(chain_without_block_validation):  # noqa: F811
+#     chain = chain_without_block_validation  # noqa: F811
+#     vm = chain.get_vm()
+#     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
+#     amount = 100
+#     from_ = chain.funded_address
+#     tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
+#     computation = vm.apply_transaction(tx)
+#     assert computation.error is None
+
+#     parent_vm = chain.get_chain_at_block_parent(vm.block).get_vm()
+#     chaindb = copy.deepcopy(chain.chaindb)
+#     block = parent_vm.apply_block(vm.block, chaindb)
+#     assert block.transactions == [tx]
+
+#     # [TODO]: more tests
 
 
 def test_mine_block(chain_without_block_validation):  # noqa: F811


### PR DESCRIPTION
#### Description

#195 subtask
Pure apply_transaction function

1. Moved the logic of `Block.make_receipt(transaction, computation)` to `VM.make_receipt(transaction, computation)` 
2. I found that it’s easier to using `VM` as a container for state transition than separating input `block.chaindb`, `vm.block.chaindb`, and `vm.chaindb`. So I only moved the logic of  `Block.add_transaction(Block)` to `VM.add_transaction(transaction, computation)`.
3. Added `VM.apply_transaction_to_block(transaction, block, chaindb)` method. This method has similar function as `VM.apply_transaction(tx)`, but instead of using the member variable, it `deepcopy` and apply the given `block` and `chaindb`.
4. Added `vm.state_transition_helper.apply_transaction` function. It’s a pure function that won’t mutate the given input and returns `success, reads, writes, block`, where:
	* `success`: check if the state transition succeeded
	* `reads`: the reads dict during state transition
	* `writes`: the writes dict during state transition
	* `block`: the applied block

#### TODO
- Add more tests to verify  `reads` and `writes` dicts.
- Our original goal is `apply_transaction(stateobj, db, blockdata, tx) -> state_obj', reads, writes`, so I'm still looking for using simpler StateObj object instead of VM as the state transition container.
	1. Should we remove `self.block` from `VM`?
	2. Should we remove `self.chaindb` from `Block`?
	3. Risk of using too many `deepcopy` (Looking for other method) 

#### Cute Animal Picture

![cute-animal-red-panda-2](https://user-images.githubusercontent.com/9263930/34218206-81b47740-e5e8-11e7-9c90-e4edc1909bc1.jpg)
