### PR TITLE
upstream changes to py-trie

### DIFF
--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -3,7 +3,7 @@ import itertools
 import rlp
 
 from trie import (
-    Trie,
+    HexaryTrie,
 )
 
 from eth_utils import (
@@ -146,7 +146,7 @@ class BaseChainDB:
 
     @to_list
     def get_receipts(self, header, receipt_class):
-        receipt_db = Trie(db=self.db, root_hash=header.receipt_root)
+        receipt_db = HexaryTrie(db=self.db, root_hash=header.receipt_root)
         for receipt_idx in itertools.count():
             receipt_key = rlp.encode(receipt_idx)
             if receipt_key in receipt_db:
@@ -157,7 +157,7 @@ class BaseChainDB:
 
     @to_list
     def get_block_transactions(self, block_header, transaction_class):
-        transaction_db = Trie(self.db, root_hash=block_header.transaction_root)
+        transaction_db = HexaryTrie(self.db, root_hash=block_header.transaction_root)
         for transaction_idx in itertools.count():
             transaction_key = rlp.encode(transaction_idx)
             if transaction_key in transaction_db:
@@ -208,7 +208,7 @@ class BaseChainDB:
         self.persist_header_to_db(block.header)
 
         # Persist the transactions
-        transaction_db = Trie(self.db, root_hash=BLANK_ROOT_HASH)
+        transaction_db = HexaryTrie(self.db, root_hash=BLANK_ROOT_HASH)
         for i in range(len(block.transactions)):
             index_key = rlp.encode(i, sedes=rlp.sedes.big_endian_int)
             transaction_db[index_key] = rlp.encode(block.transactions[i])
@@ -221,12 +221,12 @@ class BaseChainDB:
         )
 
     def add_transaction(self, block_header, index_key, transaction):
-        transaction_db = Trie(self.db, root_hash=block_header.transaction_root)
+        transaction_db = HexaryTrie(self.db, root_hash=block_header.transaction_root)
         transaction_db[index_key] = rlp.encode(transaction)
         return transaction_db.root_hash
 
     def add_receipt(self, block_header, index_key, receipt):
-        receipt_db = Trie(db=self.db, root_hash=block_header.receipt_root)
+        receipt_db = HexaryTrie(db=self.db, root_hash=block_header.receipt_root)
         receipt_db[index_key] = rlp.encode(receipt)
         return receipt_db.root_hash
 

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -3,7 +3,7 @@ import logging
 import rlp
 
 from trie import (
-    Trie
+    HexaryTrie
 )
 
 from evm.constants import (
@@ -49,7 +49,7 @@ class AccountStateDB:
             self.db = ImmutableDB(db)
         else:
             self.db = db
-        self._trie = HashTrie(Trie(self.db, root_hash))
+        self._trie = HashTrie(HexaryTrie(self.db, root_hash))
 
     #
     # Base API
@@ -68,7 +68,7 @@ class AccountStateDB:
         validate_canonical_address(address, title="Storage Address")
 
         account = self._get_account(address)
-        storage = HashTrie(Trie(self.db, account.storage_root))
+        storage = HashTrie(HexaryTrie(self.db, account.storage_root))
 
         slot_as_key = pad32(int_to_big_endian(slot))
 
@@ -86,7 +86,7 @@ class AccountStateDB:
         validate_uint256(slot, title="Storage Slot")
 
         account = self._get_account(address)
-        storage = HashTrie(Trie(self.db, account.storage_root))
+        storage = HashTrie(HexaryTrie(self.db, account.storage_root))
 
         slot_as_key = pad32(int_to_big_endian(slot))
 

--- a/evm/p2p/lightchain.py
+++ b/evm/p2p/lightchain.py
@@ -20,7 +20,7 @@ from eth_utils import (
     decode_hex,
     encode_hex,
 )
-from trie import Trie
+from trie import HexaryTrie
 
 from evm.chains import Chain
 from evm.constants import GENESIS_BLOCK_NUMBER
@@ -446,7 +446,7 @@ class LightChain(Chain):
         key = keccak(address)
         proof = await self._get_proof(block_hash, account_key=b'', key=key)
         block = await self.get_block_by_hash(block_hash)
-        rlp_account = Trie.get_from_proof(block.header.state_root, key, proof)
+        rlp_account = HexaryTrie.get_from_proof(block.header.state_root, key, proof)
         return rlp.decode(rlp_account, sedes=Account)
 
     async def _get_proof(self, block_hash: bytes, account_key: bytes, key: bytes,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "py-ecc==1.4.2",
         "rlp==0.4.7",
         "eth-keys==0.1.0b3",
-        "trie>=0.3.2",
+        "trie>=1.0.1,<2.0.0",
     ],
     extra_require={
         'leveldb': [


### PR DESCRIPTION
### What was wrong?

Change to use `HexaryTrie` instead of deprecated `Trie` from the py-trie library.

### How was it fixed?

Changed to use `HexaryTrie`.

#### Cute Animal Picture


![582947738-english-springer-spaniel-spotted-puppy-brown](https://user-images.githubusercontent.com/824194/34574033-82a6652c-f133-11e7-9c4f-029f41107045.jpg)
