### PR TITLE
Minor naming and import fix

### DIFF
--- a/evm/rlp/transactions.py
+++ b/evm/rlp/transactions.py
@@ -45,11 +45,11 @@ class BaseTransaction(rlp.Serializable):
         return self.get_sender()
 
     @property
-    def intrensic_gas(self):
+    def intrinsic_gas(self):
         """
-        Convenience property for the return value of `get_intrensic_gas`
+        Convenience property for the return value of `get_intrinsic_gas`
         """
-        return self.get_intrensic_gas()
+        return self.get_intrinsic_gas()
 
     # +-------------------------------------------------------------+
     # | API that must be implemented by all Transaction subclasses. |
@@ -63,7 +63,7 @@ class BaseTransaction(rlp.Serializable):
         Hook called during instantiation to ensure that all transaction
         parameters pass validation rules.
         """
-        if self.intrensic_gas > self.gas:
+        if self.intrinsic_gas > self.gas:
             raise ValidationError("Insufficient gas")
         self.check_signature_validity()
 
@@ -95,7 +95,7 @@ class BaseTransaction(rlp.Serializable):
     #
     # Base gas costs
     #
-    def get_intrensic_gas(self):
+    def get_intrinsic_gas(self):
         """
         Compute the baseline gas cost for this transaction.  This is the amount
         of gas needed to send this transaction (but that is not actually used

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 
 from evm import VM
-from evm import constants
 
 from evm.exceptions import (
     ContractCreationCollision,
@@ -27,6 +26,10 @@ from evm.utils.keccak import (
     keccak,
 )
 
+from .constants import (
+    CREATE_CONTRACT_ADDRESS,
+    REFUND_SELFDESTRUCT,
+)
 from .opcodes import FRONTIER_OPCODES
 from .blocks import FrontierBlock
 from .computation import FrontierComputation
@@ -66,7 +69,7 @@ def _execute_frontier_transaction(vm, transaction):
         # Setup VM Message
         message_gas = transaction.gas - transaction.intrinsic_gas
 
-        if transaction.to == constants.CREATE_CONTRACT_ADDRESS:
+        if transaction.to == CREATE_CONTRACT_ADDRESS:
             contract_address = generate_contract_address(
                 transaction.sender,
                 state_db.get_nonce(transaction.sender) - 1,
@@ -136,7 +139,7 @@ def _execute_frontier_transaction(vm, transaction):
     # Self Destruct Refunds
     num_deletions = len(computation.get_accounts_for_deletion())
     if num_deletions:
-        computation.gas_meter.refund_gas(constants.REFUND_SELFDESTRUCT * num_deletions)
+        computation.gas_meter.refund_gas(REFUND_SELFDESTRUCT * num_deletions)
 
     # Gas Refunds
     gas_remaining = computation.get_gas_remaining()

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -64,7 +64,7 @@ def _execute_frontier_transaction(vm, transaction):
         state_db.increment_nonce(transaction.sender)
 
         # Setup VM Message
-        message_gas = transaction.gas - transaction.intrensic_gas
+        message_gas = transaction.gas - transaction.intrinsic_gas
 
         if transaction.to == constants.CREATE_CONTRACT_ADDRESS:
             contract_address = generate_contract_address(

--- a/evm/vm/forks/frontier/transactions.py
+++ b/evm/vm/forks/frontier/transactions.py
@@ -59,8 +59,8 @@ class FrontierTransaction(BaseTransaction):
     def get_sender(self):
         return extract_transaction_sender(self)
 
-    def get_intrensic_gas(self):
-        return _get_frontier_intrensic_gas(self.data)
+    def get_intrinsic_gas(self):
+        return _get_frontier_intrinsic_gas(self.data)
 
     def get_message_for_signing(self):
         return rlp.encode(FrontierUnsignedTransaction(
@@ -104,7 +104,7 @@ class FrontierUnsignedTransaction(BaseUnsignedTransaction):
         )
 
 
-def _get_frontier_intrensic_gas(transaction_data):
+def _get_frontier_intrinsic_gas(transaction_data):
     num_zero_bytes = transaction_data.count(b'\x00')
     num_non_zero_bytes = len(transaction_data) - num_zero_bytes
     return (

--- a/evm/vm/forks/homestead/transactions.py
+++ b/evm/vm/forks/homestead/transactions.py
@@ -26,8 +26,8 @@ class HomesteadTransaction(FrontierTransaction):
         super(HomesteadTransaction, self).validate()
         validate_lt_secpk1n2(self.s, title="Transaction.s")
 
-    def get_intrensic_gas(self):
-        return _get_homestead_intrensic_gas(self)
+    def get_intrinsic_gas(self):
+        return _get_homestead_intrinsic_gas(self)
 
     def get_message_for_signing(self):
         return rlp.encode(HomesteadUnsignedTransaction(
@@ -60,7 +60,7 @@ class HomesteadUnsignedTransaction(FrontierUnsignedTransaction):
         )
 
 
-def _get_homestead_intrensic_gas(transaction):
+def _get_homestead_intrinsic_gas(transaction):
     num_zero_bytes = transaction.data.count(b'\x00')
     num_non_zero_bytes = len(transaction.data) - num_zero_bytes
     if transaction.to == CREATE_CONTRACT_ADDRESS:


### PR DESCRIPTION
### How was it fixed?
Rename `intrensic` to `intrinsic`
Change `constants` module import to local module import

#### Cute Animal Picture

![](https://i.pinimg.com/564x/c7/ca/8e/c7ca8eb5fac55fbc990d79aaf8f3330a--baby-polar-bears-teddy-bears.jpg)