### PR TITLE
Look up transaction by hash

### DIFF
--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -94,6 +94,9 @@ class Chain(object):
         """
         return self.get_vm().block
 
+    def get_transaction(self, transaction_hash):
+        return self.get_vm().get_transaction_by_hash(transaction_hash)
+
     def create_transaction(self, *args, **kwargs):
         """
         Passthrough helper to the current VM class.

--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -99,7 +99,9 @@ class Chain(object):
         try:
             (block_num, index) = self.chaindb.get_transaction_index(transaction_hash)
             vm = self.get_vm_class_for_block_number(block_num)
-            return vm.get_transaction_by_index(block_num, index)
+            transaction = vm.get_transaction_by_index(block_num, index)
+            if transaction.hash != transaction_hash:
+                raise TransactionNotFound("Mismatched transaction, bailing...")
         except TransactionNotFound:
             # transaction has not been mined into the canonical chain
             try:

--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -115,6 +115,9 @@ class Chain(object):
                 index,
             ))
 
+    def add_pending_transaction(self, transaction):
+        return self.chaindb.add_pending_transaction(transaction)
+
     def get_pending_transaction(self, transaction_hash):
         return self.get_vm().get_pending_transaction(transaction_hash)
 

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -96,15 +96,15 @@ class BaseChainDB:
 
         new_canonical_headers = tuple(reversed(self._find_new_ancestors(header)))
 
-        # TODO move hash-> block id lookup to pending, to indicate that transaction is not in canonical chain
+        # remove transaction lookups for blocks that are no longer canonical
         for h in new_canonical_headers:
             try:
                 old_hash = self.lookup_block_hash(h.block_number)
             except KeyError:
-                # no old block, keep looking
-                continue
+                # no old block, and no more possible
+                break
             else:
-                old_header = self.get_block_header_by_hash(header.hash)
+                old_header = self.get_block_header_by_hash(old_hash)
                 for transaction_hash in self.get_block_transaction_hashes(old_header):
                     self._remove_transaction_from_canonical_chain(transaction_hash)
                     # TODO re-add txn to internal pending pool (only if local sender)

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -334,9 +334,11 @@ class BaseChainDB:
         )
 
         # because transaction is now in canonical chain, can now remove from pending txn lookups
-        self.db.delete(make_transaction_hash_to_data_lookup_key(transaction_hash))
+        lookup_key = make_transaction_hash_to_data_lookup_key(transaction_hash)
+        if self.db.exists(lookup_key):
+            self.db.delete(lookup_key)
 
-    def _add_transaction_hash_to_data_lookup(self, transaction):
+    def add_pending_transaction(self, transaction):
         self.db.set(
             make_transaction_hash_to_data_lookup_key(transaction.hash),
             rlp.encode(transaction),
@@ -345,7 +347,6 @@ class BaseChainDB:
     def add_transaction(self, block_header, index_key, transaction):
         transaction_db = HexaryTrie(self.db, root_hash=block_header.transaction_root)
         transaction_db[index_key] = rlp.encode(transaction)
-        self._add_transaction_hash_to_data_lookup(transaction)
         return transaction_db.root_hash
 
     def add_receipt(self, block_header, index_key, receipt):

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -100,8 +100,8 @@ class BaseChainDB:
             else:
                 old_header = self.get_block_header_by_hash(header.hash)
                 for transaction_hash in self.get_block_transaction_hashes(old_header):
-                    # TODO remove from txn block lookup
-                    # TODO re-add txn to sent pool (only if local sender)
+                    self._remove_transaction_from_canonical_chain(transaction_hash)
+                    # TODO re-add txn to internal pending pool (only if local sender)
                     pass
 
         for h in new_canonical_headers:
@@ -302,6 +302,9 @@ class BaseChainDB:
             block.header.uncles_hash,
             rlp.encode(block.uncles, sedes=rlp.sedes.CountableList(type(block.header))),
         )
+
+    def _remove_transaction_from_canonical_chain(self, transaction_hash):
+        self.db.delete(make_transaction_hash_to_block_lookup_key(transaction_hash))
 
     def _add_transaction_to_canonical_chain(self, transaction, block_header, transaction_index):
         '''

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -204,7 +204,7 @@ class BaseChainDB:
         for encoded_transaction in self._get_block_transaction_data(block_header):
             yield rlp.decode(encoded_transaction, sedes=transaction_class)
 
-    def get_transaction_by_key(self, block_number, transaction_index, transaction_class):
+    def get_transaction_by_index(self, block_number, transaction_index, transaction_class):
         try:
             block_header = self.get_canonical_block_header_by_number(block_number)
         except KeyError:
@@ -225,7 +225,7 @@ class BaseChainDB:
             raise TransactionNotFound(
                 "Transaction with hash {} not found".format(encode_hex(transaction_hash)))
 
-    def get_transaction_key(self, transaction_hash, transaction_class):
+    def get_transaction_index(self, transaction_hash):
         try:
             encoded_key = self.db.get(make_transaction_hash_to_block_lookup_key(transaction_hash))
         except KeyError:

--- a/evm/exceptions.py
+++ b/evm/exceptions.py
@@ -19,6 +19,13 @@ class BlockNotFound(PyEVMError):
     pass
 
 
+class TransactionNotFound(PyEVMError):
+    """
+    The transaction with the given hash or block index dos not exist.
+    """
+    pass
+
+
 class ParentNotFound(PyEVMError):
     """
     The parent of a given block does not exist.

--- a/evm/utils/db.py
+++ b/evm/utils/db.py
@@ -7,6 +7,10 @@ def make_block_hash_to_score_lookup_key(block_hash):
     return b'block-hash-to-score:%s' % block_hash
 
 
+def make_transaction_hash_to_data_lookup_key(transaction_hash):
+    return b'transaction-hash-to-data:%s' % transaction_hash
+
+
 def get_parent_header(block_header, db):
     """
     Returns the header for the parent block.

--- a/evm/utils/db.py
+++ b/evm/utils/db.py
@@ -8,6 +8,9 @@ def make_block_hash_to_score_lookup_key(block_hash):
 
 
 def make_transaction_hash_to_data_lookup_key(transaction_hash):
+    '''
+    Look up a transaction that is pending, after being issued locally
+    '''
     return b'transaction-hash-to-data:%s' % transaction_hash
 
 

--- a/evm/utils/db.py
+++ b/evm/utils/db.py
@@ -11,6 +11,10 @@ def make_transaction_hash_to_data_lookup_key(transaction_hash):
     return b'transaction-hash-to-data:%s' % transaction_hash
 
 
+def make_transaction_hash_to_block_lookup_key(transaction_hash):
+    return b'transaction-hash-to-block:%s' % transaction_hash
+
+
 def get_parent_header(block_header, db):
     """
     Returns the header for the parent block.

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -350,7 +350,7 @@ class VM(object):
         '''
         Return a transaction that has been mined in block_num at index
         '''
-        return self.chaindb.get_transaction_by_key(block_num, index, self.get_transaction_class())
+        return self.chaindb.get_transaction_by_index(block_num, index, self.get_transaction_class())
 
     def create_transaction(self, *args, **kwargs):
         """

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -343,9 +343,14 @@ class VM(object):
         """
         return self.get_block_class().get_transaction_class()
 
-    def get_transaction_by_hash(self, transaction_hash):
-        # TODO How do I know which transaction class to use if I don't know what block it is in, yet
-        return self.chaindb.get_transaction_by_hash(transaction_hash, self.get_transaction_class())
+    def get_pending_transaction(self, transaction_hash):
+        return self.chaindb.get_pending_transaction(transaction_hash, self.get_transaction_class())
+
+    def get_transaction_by_index(self, block_num, index):
+        '''
+        Return a transaction that has been mined in block_num at index
+        '''
+        return self.chaindb.get_transaction_by_key(block_num, index, self.get_transaction_class())
 
     def create_transaction(self, *args, **kwargs):
         """

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -337,20 +337,16 @@ class VM(object):
     #
     # Transactions
     #
-    def get_transaction_class(self):
+
+    @classmethod
+    def get_transaction_class(cls):
         """
         Return the class that this VM uses for transactions.
         """
-        return self.get_block_class().get_transaction_class()
+        return cls.get_block_class().get_transaction_class()
 
     def get_pending_transaction(self, transaction_hash):
         return self.chaindb.get_pending_transaction(transaction_hash, self.get_transaction_class())
-
-    def get_transaction_by_index(self, block_num, index):
-        '''
-        Return a transaction that has been mined in block_num at index
-        '''
-        return self.chaindb.get_transaction_by_index(block_num, index, self.get_transaction_class())
 
     def create_transaction(self, *args, **kwargs):
         """

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -343,6 +343,10 @@ class VM(object):
         """
         return self.get_block_class().get_transaction_class()
 
+    def get_transaction_by_hash(self, transaction_hash):
+        # TODO How do I know which transaction class to use if I don't know what block it is in, yet
+        return self.chaindb.get_transaction_by_hash(transaction_hash, self.get_transaction_class())
+
     def create_transaction(self, *args, **kwargs):
         """
         Proxy for instantiating a transaction for this VM.

--- a/tests/core/chain-object/conftest.py
+++ b/tests/core/chain-object/conftest.py
@@ -1,0 +1,4 @@
+from tests.core.fixtures import (  # noqa: F401
+    chain as valid_chain,
+    chain_without_block_validation as chain,
+)

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -19,6 +19,16 @@ from tests.core.fixtures import (  # noqa: F401
 from tests.core.helpers import new_transaction
 
 
+@pytest.fixture()
+def tx(chain_without_block_validation):  # noqa: F811
+    chain = chain_without_block_validation  # noqa: F811
+    recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
+    amount = 100
+    vm = chain.get_vm()
+    from_ = chain.funded_address
+    return new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
+
+
 def test_import_block_validation(chain):  # noqa: F811
     block = rlp.decode(valid_block_rlp, sedes=FrontierBlock)
     imported_block = chain.import_block(block)
@@ -34,21 +44,31 @@ def test_import_block_validation(chain):  # noqa: F811
             chain.funded_address_initial_balance - tx.value - tx_gas)
 
 
-def test_import_block(chain_without_block_validation):  # noqa: F811
+def test_import_block(chain_without_block_validation, tx):  # noqa: F811
     chain = chain_without_block_validation  # noqa: F811
-    recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
-    amount = 100
     vm = chain.get_vm()
-    from_ = chain.funded_address
-    tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
     computation, _ = vm.apply_transaction(tx)
     assert not computation.is_error
-    assert chain.get_pending_transaction(tx.hash) == tx
+
+    # add pending so that we can confirm it gets removed when imported to a block
+    chain.add_pending_transaction(tx)
+
     block = chain.import_block(vm.block)
     assert block.transactions == [tx]
     assert chain.get_block_by_hash(block.hash) == block
     assert chain.get_canonical_block_by_number(block.number) == block
     assert chain.get_canonical_transaction(tx.hash) == tx
+
+    with pytest.raises(TransactionNotFound):
+        # after mining, the transaction shouldn't be in the pending set anymore
+        chain.get_pending_transaction(tx.hash)
+
+
+def test_get_pending_transaction(chain_without_block_validation, tx):  # noqa: F811
+    chain = chain_without_block_validation  # noqa: F811
+    vm = chain.get_vm()
+    chain.add_pending_transaction(tx)
+    assert chain.get_pending_transaction(tx.hash) == tx
 
 
 def test_empty_transaction_lookups(chain_without_block_validation):

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -11,17 +11,12 @@ from evm.exceptions import (
 )
 from evm.vm.forks.frontier.blocks import FrontierBlock
 
-from tests.core.fixtures import (  # noqa: F401
-    chain,
-    chain_without_block_validation,
-    valid_block_rlp,
-)
+from tests.core.fixtures import valid_block_rlp
 from tests.core.helpers import new_transaction
 
 
 @pytest.fixture()
-def tx(chain_without_block_validation):  # noqa: F811
-    chain = chain_without_block_validation  # noqa: F811
+def tx(chain):
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
     vm = chain.get_vm()
@@ -29,23 +24,22 @@ def tx(chain_without_block_validation):  # noqa: F811
     return new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
 
 
-def test_import_block_validation(chain):  # noqa: F811
+def test_import_block_validation(valid_chain):
     block = rlp.decode(valid_block_rlp, sedes=FrontierBlock)
-    imported_block = chain.import_block(block)
+    imported_block = valid_chain.import_block(block)
     assert len(imported_block.transactions) == 1
     tx = imported_block.transactions[0]
     assert tx.value == 10
-    vm = chain.get_vm()
+    vm = valid_chain.get_vm()
     with vm.state.state_db(read_only=True) as state_db:
         assert state_db.get_balance(
             decode_hex("095e7baea6a6c7c4c2dfeb977efac326af552d87")) == tx.value
         tx_gas = tx.gas_price * constants.GAS_TX
-        assert state_db.get_balance(chain.funded_address) == (
-            chain.funded_address_initial_balance - tx.value - tx_gas)
+        assert state_db.get_balance(valid_chain.funded_address) == (
+            valid_chain.funded_address_initial_balance - tx.value - tx_gas)
 
 
-def test_import_block(chain_without_block_validation, tx):  # noqa: F811
-    chain = chain_without_block_validation  # noqa: F811
+def test_import_block(chain, tx):
     vm = chain.get_vm()
     computation, _ = vm.apply_transaction(tx)
     assert not computation.is_error
@@ -64,15 +58,12 @@ def test_import_block(chain_without_block_validation, tx):  # noqa: F811
         chain.get_pending_transaction(tx.hash)
 
 
-def test_get_pending_transaction(chain_without_block_validation, tx):  # noqa: F811
-    chain = chain_without_block_validation  # noqa: F811
-    vm = chain.get_vm()
+def test_get_pending_transaction(chain, tx):
     chain.add_pending_transaction(tx)
     assert chain.get_pending_transaction(tx.hash) == tx
 
 
-def test_empty_transaction_lookups(chain_without_block_validation):
-    chain = chain_without_block_validation
+def test_empty_transaction_lookups(chain):
 
     with pytest.raises(TransactionNotFound):
         chain.get_canonical_transaction(b'\0' * 32)
@@ -81,19 +72,19 @@ def test_empty_transaction_lookups(chain_without_block_validation):
         chain.get_pending_transaction(b'\0' * 32)
 
 
-def test_canonical_chain(chain):  # noqa: F811
-    genesis_header = chain.chaindb.get_canonical_block_header_by_number(
+def test_canonical_chain(valid_chain):
+    genesis_header = valid_chain.chaindb.get_canonical_block_header_by_number(
         constants.GENESIS_BLOCK_NUMBER)
 
     # Our chain fixture is created with only the genesis header, so initially that's the head of
     # the canonical chain.
-    assert chain.get_canonical_head() == genesis_header
+    assert valid_chain.get_canonical_head() == genesis_header
 
     block = rlp.decode(valid_block_rlp, sedes=FrontierBlock)
-    chain.chaindb.persist_header_to_db(block.header)
+    valid_chain.chaindb.persist_header_to_db(block.header)
 
-    assert chain.get_canonical_head() == block.header
-    canonical_block_1 = chain.chaindb.get_canonical_block_header_by_number(
+    assert valid_chain.get_canonical_head() == block.header
+    canonical_block_1 = valid_chain.chaindb.get_canonical_block_header_by_number(
         constants.GENESIS_BLOCK_NUMBER + 1)
     assert canonical_block_1 == block.header
 

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -31,6 +31,7 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     block = vm.block
     assert block.transactions[tx_idx] == tx
     assert block.header.gas_used == constants.GAS_TX
+    assert vm.get_transaction_by_hash(tx.hash) == tx
 
     assert len(access_logs.reads) > 0
     assert len(access_logs.writes) > 0

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -32,6 +32,7 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     assert block.transactions[tx_idx] == tx
     assert block.header.gas_used == constants.GAS_TX
     assert vm.get_pending_transaction(tx.hash) == tx
+    assert chain.get_transaction(tx.hash) == tx
 
     assert len(access_logs.reads) > 0
     assert len(access_logs.writes) > 0

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -31,7 +31,6 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     block = vm.block
     assert block.transactions[tx_idx] == tx
     assert block.header.gas_used == constants.GAS_TX
-    assert vm.get_pending_transaction(tx.hash) == tx
 
     assert len(access_logs.reads) > 0
     assert len(access_logs.writes) > 0

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -32,7 +32,6 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     assert block.transactions[tx_idx] == tx
     assert block.header.gas_used == constants.GAS_TX
     assert vm.get_pending_transaction(tx.hash) == tx
-    assert chain.get_transaction(tx.hash) == tx
 
     assert len(access_logs.reads) > 0
     assert len(access_logs.writes) > 0

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -31,7 +31,7 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     block = vm.block
     assert block.transactions[tx_idx] == tx
     assert block.header.gas_used == constants.GAS_TX
-    assert vm.get_transaction_by_hash(tx.hash) == tx
+    assert vm.get_pending_transaction(tx.hash) == tx
 
     assert len(access_logs.reads) > 0
     assert len(access_logs.writes) > 0


### PR DESCRIPTION
### What was wrong?

Need to be able to look up transactions by hash

### How was it fixed?

Split transaction lookups in two for now (in three to four later)

1. **Done:** Transactions in the canonical chain
2. **Done:** Pending transactions issued locally
3. **Punt:** pending transactions received by peers for txpool
4. **Punt:** transactions in blocks that fall off the canonical chain (This is really just a special case of 2 or 3 above. I think most of the work to do is figuring out whether a transaction is from pool 2 or 3 when it falls off the canonical chain.)

Chain API changes:

- `chain.get_canonical_transaction(txn_hash)` -- find a transaction in the canonical chain
- `chain.get_pending_transaction(txn_hash)` -- find a pending transaction (only works for locally issued transactions, for now)
- `chain.add_pending_transaction(txn_hash)` -- add transaction to the pending lookup set (this indicates the transaction was issued locally)

Rejected alternative implementations, and rationale:

- For all transactions, store a hash => body lookup (stores all transaction bodies twice -- once in transaction Trie, and once in key/val lookup, too expensive on disk)
- Store transaction hash in transaction trie, and use single transaction hash=>body lookup (cannot validate `transaction_root` easily anymore)

I was originally going to do the RPC interface in this PR, but it has grown big enough without those changes.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/AGZ3AY9XAiI/hqdefault.jpg)