### PR TITLE
Convert configure to base class

### DIFF
--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -26,13 +26,14 @@ from evm.validation import (
     validate_uint256,
     validate_word,
 )
-
 from evm.rlp.headers import (
     BlockHeader,
 )
-
 from evm.utils.chain import (
     generate_vms_by_range,
+)
+from evm.utils.datatypes import (
+    Configurable,
 )
 from evm.utils.headers import (
     compute_gas_limit_bounds,
@@ -45,7 +46,7 @@ from evm.utils.rlp import (
 )
 
 
-class Chain(object):
+class Chain(Configurable):
     """
     An Chain is a combination of one or more VM classes.  Each VM is associated
     with a range of blocks.  The Chain class acts as a wrapper around these other
@@ -71,20 +72,10 @@ class Chain(object):
     @classmethod
     def configure(cls, name, vm_configuration, **overrides):
         if 'vms_by_range' in overrides:
-            raise ValueError("Cannot override vms_by_range.")
+            raise ValueError("Cannot override vms_by_range")
 
-        for key in overrides:
-            if not hasattr(cls, key):
-                raise TypeError(
-                    "The Chain.configure cannot set attributes that are not "
-                    "already present on the base class.  The attribute `{0}` was "
-                    "not found on the base class `{1}`".format(key, cls)
-                )
-
-        # Organize the Chain classes by their starting blocks.
         overrides['vms_by_range'] = generate_vms_by_range(vm_configuration)
-
-        return type(name, (cls,), overrides)
+        return super().configure(name, **overrides)
 
     #
     # Convenience and Helpers

--- a/evm/computation.py
+++ b/evm/computation.py
@@ -12,6 +12,9 @@ from evm.exceptions import (
 from evm.logic.invalid import (
     InvalidOpcode,
 )
+from evm.utils.datatypes import (
+    Configurable,
+)
 from evm.utils.hexadecimal import (
     encode_hex,
 )
@@ -49,7 +52,7 @@ def memory_gas_cost(size_in_bytes):
     return total_cost
 
 
-class BaseComputation(object):
+class BaseComputation(Configurable):
     """
     The execution computation
     """
@@ -411,22 +414,3 @@ class BaseComputation(object):
             return opcodes[opcode]
         except KeyError:
             return InvalidOpcode(opcode)
-
-    #
-    # classmethod
-    #
-    @classmethod
-    def configure(cls,
-                  name,
-                  **overrides):
-        """
-        Class factory method for simple inline subclassing.
-        """
-        for key in overrides:
-            if not hasattr(cls, key):
-                raise TypeError(
-                    "The Computation.configure cannot set attributes that are not "
-                    "already present on the base class.  The attribute `{0}` was "
-                    "not found on the base class `{1}`".format(key, cls)
-                )
-        return type(name, (cls,), overrides)

--- a/evm/rlp/blocks.py
+++ b/evm/rlp/blocks.py
@@ -1,18 +1,11 @@
 import rlp
 
+from evm.utils.datatypes import (
+    Configurable,
+)
 
-class BaseBlock(rlp.Serializable):
-    @classmethod
-    def configure(cls, **overrides):
-        class_name = cls.__name__
-        for key in overrides:
-            if not hasattr(cls, key):
-                raise TypeError(
-                    "The {0}.configure cannot set attributes that are not "
-                    "already present on the base class.  The attribute `{1}` was "
-                    "not found on the base class `{2}`".format(class_name, key, cls)
-                )
-        return type(class_name, (cls,), overrides)
+
+class BaseBlock(rlp.Serializable, Configurable):
 
     # TODO: Remove this once https://github.com/ethereum/pyrlp/issues/45 is
     # fixed.

--- a/evm/utils/datatypes.py
+++ b/evm/utils/datatypes.py
@@ -1,0 +1,21 @@
+class Configurable(object):
+    """
+    Base class for simple inline subclassing
+    """
+    @classmethod
+    def configure(cls,
+                  name=None,
+                  **overrides):
+
+        if name is None:
+            name = cls.__name__
+
+        for key in overrides:
+            if not hasattr(cls, key):
+                raise TypeError(
+                    "The {0}.configure cannot set attributes that are not "
+                    "already present on the base class. The attribute `{1}` was "
+                    "not found on the base class `{2}`".format(cls.__name__, key, cls)
+                )
+
+        return type(name, (cls,), overrides)

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -21,6 +21,9 @@ from evm.db.chain import BaseChainDB
 from evm.rlp.headers import (
     BlockHeader,
 )
+from evm.utils.datatypes import (
+    Configurable,
+)
 from evm.utils.db import (
     get_parent_header,
     get_block_header_by_hash,
@@ -41,7 +44,7 @@ from .execution_context import (
 )
 
 
-class VM(object):
+class VM(Configurable):
     """
     The VM class represents the Chain rules for a specific protocol definition
     such as the Frontier or Homestead network.  Defining an Chain  defining
@@ -58,22 +61,6 @@ class VM(object):
         self.chaindb = chaindb
         block_class = self.get_block_class()
         self.block = block_class.from_header(header=header, chaindb=self.chaindb)
-
-    @classmethod
-    def configure(cls,
-                  name=None,
-                  **overrides):
-        if name is None:
-            name = cls.__name__
-
-        for key in overrides:
-            if not hasattr(cls, key):
-                raise TypeError(
-                    "The VM.configure cannot set attributes that are not "
-                    "already present on the base class.  The attribute `{0}` was "
-                    "not found on the base class `{1}`".format(key, cls)
-                )
-        return type(name, (cls,), overrides)
 
     #
     # Logging

--- a/evm/vm_state.py
+++ b/evm/vm_state.py
@@ -12,12 +12,15 @@ from evm.constants import (
 from evm.db.tracked import (
     AccessLogs,
 )
+from evm.utils.datatypes import (
+    Configurable,
+)
 from evm.utils.state import (
     make_trie_root_and_nodes,
 )
 
 
-class BaseVMState(object):
+class BaseVMState(Configurable):
     #
     # Set from __init__
     #
@@ -303,22 +306,3 @@ class BaseVMState(object):
     @classmethod
     def get_nephew_reward(cls):
         raise NotImplementedError("Must be implemented by subclasses")
-
-    #
-    # classmethod
-    #
-    @classmethod
-    def configure(cls,
-                  name,
-                  **overrides):
-        """
-        Class factory method for simple inline subclassing.
-        """
-        for key in overrides:
-            if not hasattr(cls, key):
-                raise TypeError(
-                    "The State.configure cannot set attributes that are not "
-                    "already present on the base class.  The attribute `{0}` was "
-                    "not found on the base class `{1}`".format(key, cls)
-                )
-        return type(name, (cls,), overrides)


### PR DESCRIPTION
### What was wrong?
`Configure` classmethod was repeated across different classes. 

### How was it fixed?
Wrote `evm.utils.datatypes.Configurable` base class for classes to inherit from. 
Classes changed. . .
`evm.rlp.blocks.BaseBlock`
`evm.vm.base.VM`
`evm.chains.chain.Chain`
`evm.computation.Computation`
`evm.vm_state.VMState`

#### Cute Animal Picture
![giphy 44](https://user-images.githubusercontent.com/9753150/34971675-4d1dd278-fa39-11e7-8cc3-562e8bbaf570.gif)

closes #245 