### PR TITLE
Bugfix: should move `validate_transaction` from `VM` to `VMState`

### DIFF
--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -355,12 +355,6 @@ class VM(object):
         """
         return self.get_transaction_class().create_unsigned_transaction(*args, **kwargs)
 
-    def validate_transaction(self, transaction):
-        """
-        Perform chain-aware validation checks on the transaction.
-        """
-        raise NotImplementedError("Must be implemented by subclasses")
-
     #
     # Blocks
     #

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -8,7 +8,6 @@ from evm.constants import (
 
 from .blocks import FrontierBlock
 from .vm_state import FrontierVMState
-from .validation import validate_frontier_transaction
 from .headers import (
     create_frontier_header_from_parent,
     compute_frontier_difficulty,
@@ -42,8 +41,6 @@ FrontierVM = VM.configure(
     get_block_reward=staticmethod(_frontier_get_block_reward),
     get_uncle_reward=staticmethod(_frontier_get_uncle_reward),
     get_nephew_reward=_frontier_get_nephew_reward,
-    # validation
-    validate_transaction=validate_frontier_transaction,
     # mode
     _is_stateless=True,
 )

--- a/evm/vm/forks/frontier/vm_state.py
+++ b/evm/vm/forks/frontier/vm_state.py
@@ -54,7 +54,7 @@ def _execute_frontier_transaction(vm_state, transaction):
     # Validate the transaction
     transaction.validate()
 
-    validate_frontier_transaction(vm_state, transaction)
+    vm_state.validate_transaction(transaction)
 
     gas_fee = transaction.gas * transaction.gas_price
     with vm_state.state_db() as state_db:
@@ -314,3 +314,6 @@ class FrontierVMState(BaseVMState):
             raise ValidationError(
                 "Uncle's gas usage ({0}) is above the limit ({1})".format(
                     uncle.gas_used, uncle.gas_limit))
+
+    def validate_transaction(self, transaction):
+        validate_frontier_transaction(self, transaction)

--- a/evm/vm/forks/homestead/__init__.py
+++ b/evm/vm/forks/homestead/__init__.py
@@ -4,7 +4,6 @@ from evm.chains.mainnet.constants import (
 from evm.vm.forks.frontier import FrontierVM
 
 from .blocks import HomesteadBlock
-from .validation import validate_homestead_transaction
 from .headers import (
     create_homestead_header_from_parent,
     compute_homestead_difficulty,
@@ -24,7 +23,6 @@ HomesteadVM = MetaHomesteadVM.configure(
     _block_class=HomesteadBlock,
     _state_class=HomesteadVMState,
     # method overrides
-    validate_transaction=validate_homestead_transaction,
     create_header_from_parent=staticmethod(create_homestead_header_from_parent),
     compute_difficulty=staticmethod(compute_homestead_difficulty),
     configure_header=configure_homestead_header,

--- a/evm/vm/forks/homestead/vm_state.py
+++ b/evm/vm/forks/homestead/vm_state.py
@@ -1,7 +1,11 @@
 from evm.vm.forks.frontier.vm_state import FrontierVMState
 
 from .computation import HomesteadComputation
+from .validation import validate_homestead_transaction
 
 
 class HomesteadVMState(FrontierVMState):
     computation_class = HomesteadComputation
+
+    def validate_transaction(self, transaction):
+        validate_homestead_transaction(self, transaction)

--- a/evm/vm_state.py
+++ b/evm/vm_state.py
@@ -285,6 +285,12 @@ class BaseVMState(object):
         """
         raise NotImplementedError("Must be implemented by subclasses")
 
+    def validate_transaction(self, transaction):
+        """
+        Perform chain-aware validation checks on the transaction.
+        """
+        raise NotImplementedError("Must be implemented by subclasses")
+
     #
     # classmethod
     #


### PR DESCRIPTION
### What was wrong?
I deeply apologize for that in the previous refactoring, the `validate_transaction` should be moved from `VM` to `VMState`. The current codebase misses calling `validate_homestead_transaction`.

### How was it fixed?
Implement `VMState.validate_transaction` by moving the logics from `VM.validate_transaction` to `VMState.validate_transaction`.

#### Cute Animal Picture

![pug](https://user-images.githubusercontent.com/9263930/34984037-793ca9a4-faea-11e7-9f94-d06d9d26159c.jpg)
