### PR TITLE
Two new gas estimators

### DIFF
--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -15,6 +15,9 @@ from evm.constants import (
     BLANK_ROOT_HASH,
     MAX_UNCLE_DEPTH,
 )
+from evm.estimators import (
+    get_gas_estimator,
+)
 from evm.exceptions import (
     BlockNotFound,
     TransactionNotFound,
@@ -56,6 +59,7 @@ class Chain(object):
     header = None
     network_id = None
     vms_by_range = None
+    gas_estimator = None
 
     def __init__(self, chaindb, header=None):
         if not self.vms_by_range:
@@ -67,6 +71,8 @@ class Chain(object):
         self.header = header
         if self.header is None:
             self.header = self.create_header_from_parent(self.get_canonical_head())
+        if self.gas_estimator is None:
+            self.gas_estimator = get_gas_estimator()
 
     @classmethod
     def configure(cls, name, vm_configuration, **overrides):
@@ -267,6 +273,12 @@ class Chain(object):
         vm = self.get_vm()
         computation, _ = vm.apply_transaction(transaction)
         return computation
+
+    def estimate_gas(self, transaction, at_header=None):
+        if at_header is None:
+            at_header = self.get_canonical_head()
+        with self.get_vm(at_header).state_in_temp_block() as state:
+            return self.gas_estimator(state, transaction)
 
     def import_block(self, block, perform_validation=True):
         """

--- a/evm/db/__init__.py
+++ b/evm/db/__init__.py
@@ -8,15 +8,14 @@ from evm.utils.module_loading import (
 DEFAULT_DB_BACKEND = 'evm.db.backends.memory.MemoryDB'
 
 
-def get_db_backend_class(import_path=None):
-    if import_path is None:
-        import_path = os.environ.get(
-            'CHAIN_DB_BACKEND_CLASS',
-            DEFAULT_DB_BACKEND,
-        )
+def get_db_backend_class():
+    import_path = os.environ.get(
+        'CHAIN_DB_BACKEND_CLASS',
+        DEFAULT_DB_BACKEND,
+    )
     return import_string(import_path)
 
 
-def get_db_backend(import_path=None, **init_kwargs):
-    backend_class = get_db_backend_class(import_path)
+def get_db_backend(**init_kwargs):
+    backend_class = get_db_backend_class()
     return backend_class(**init_kwargs)

--- a/evm/estimators/__init__.py
+++ b/evm/estimators/__init__.py
@@ -8,6 +8,6 @@ from evm.utils.module_loading import (
 def get_gas_estimator():
     import_path = os.environ.get(
         'GAS_ESTIMATOR_BACKEND_FUNC',
-        'evm.estimators.gas.binary_search_intrinsic_tolerance',
+        'evm.estimators.gas.binary_gas_search_intrinsic_tolerance',
     )
     return import_string(import_path)

--- a/evm/estimators/__init__.py
+++ b/evm/estimators/__init__.py
@@ -5,10 +5,9 @@ from evm.utils.module_loading import (
 )
 
 
-def get_gas_estimator(import_path=None):
-    if not import_path:
-        import_path = os.environ.get(
-            'GAS_ESTIMATOR_BACKEND_FUNC',
-            'evm.estimators.gas.binary_search_intrinsic_tolerance',
-        )
+def get_gas_estimator():
+    import_path = os.environ.get(
+        'GAS_ESTIMATOR_BACKEND_FUNC',
+        'evm.estimators.gas.binary_search_intrinsic_tolerance',
+    )
     return import_string(import_path)

--- a/evm/estimators/__init__.py
+++ b/evm/estimators/__init__.py
@@ -1,0 +1,14 @@
+import os
+
+from evm.utils.module_loading import (
+    import_string,
+)
+
+
+def get_gas_estimator(import_path=None):
+    if not import_path:
+        import_path = os.environ.get(
+            'GAS_ESTIMATOR_BACKEND_FUNC',
+            'evm.estimators.gas.double_execution_cost',
+        )
+    return import_string(import_path)

--- a/evm/estimators/__init__.py
+++ b/evm/estimators/__init__.py
@@ -9,6 +9,6 @@ def get_gas_estimator(import_path=None):
     if not import_path:
         import_path = os.environ.get(
             'GAS_ESTIMATOR_BACKEND_FUNC',
-            'evm.estimators.gas.double_execution_cost',
+            'evm.estimators.gas.binary_search_intrinsic_tolerance',
         )
     return import_string(import_path)

--- a/evm/estimators/gas.py
+++ b/evm/estimators/gas.py
@@ -3,6 +3,14 @@ from cytoolz import (
 )
 
 
+from evm.exceptions import (
+    OutOfGas,
+)
+from evm.utils.spoof import (
+    SpoofTransaction,
+)
+
+
 @curry
 def execute_plus_buffer(multiplier, state, transaction):
     computation = state.execute_transaction(transaction)
@@ -18,3 +26,60 @@ def execute_plus_buffer(multiplier, state, transaction):
 
 
 double_execution_cost = execute_plus_buffer(2)
+
+
+def _is_enough_gas(state, transaction):
+    snapshot = state.snapshot()
+    computation = state.execute_transaction(transaction)
+    state.revert(snapshot)
+
+    if computation.is_error:
+        return not isinstance(computation._error, OutOfGas)
+    else:
+        return True
+
+
+@curry
+def binary_search(tolerance, state, transaction):
+    """
+    Run the transaction with various gas limits, progressively
+    approaching the minimum needed to succeed without an OutOfGas exception.
+
+    The starting range of possible estimates is: [transaction.intrinsic_gas, state.gas_limit].
+    After the first OutOfGas exception, the range is: (largest_limit_out_of_gas, state.gas_limit].
+    After the first run not out of gas, the range is: (largest_limit_out_of_gas, smallest_success].
+
+    :param int tolerance: When the range of estimates is less than tolerance,
+        return the top of the range.
+    :return int: The smallest confirmed gas to not throw an OutOfGas exception,
+        subject to tolerance. If OutOfGas is thrown at block limit, return block limit.
+    """
+    minimum_transaction = SpoofTransaction(transaction, gas=transaction.intrinsic_gas)
+    if _is_enough_gas(state, minimum_transaction):
+        return transaction.intrinsic_gas
+
+    maximum_transaction = SpoofTransaction(transaction, gas=state.gas_limit)
+    if not _is_enough_gas(state, maximum_transaction):
+        return state.gas_limit
+
+    minimum_viable = state.gas_limit
+    maximum_out_of_gas = transaction.intrinsic_gas
+    while minimum_viable - maximum_out_of_gas > tolerance:
+        midpoint = (minimum_viable + maximum_out_of_gas) // 2
+        test_transaction = SpoofTransaction(transaction, gas=midpoint)
+        if _is_enough_gas(state, test_transaction):
+            minimum_viable = midpoint
+        else:
+            maximum_out_of_gas = midpoint
+
+    return minimum_viable
+
+
+# Estimate in increments of intrinsic gas usage
+binary_search_intrinsic_tolerance = binary_search(21000)
+
+# Estimate in increments of 1000 gas, takes roughly 5 more executions than intrinsic to estimate
+binary_search_1000_tolerance = binary_search(1000)
+
+# Estimate to the exact gas, takes roughly 15 more executions than intrinsic to estimate
+binary_search_exact = binary_search(1)

--- a/evm/estimators/gas.py
+++ b/evm/estimators/gas.py
@@ -2,10 +2,6 @@ from cytoolz import (
     curry,
 )
 
-
-from evm.exceptions import (
-    OutOfGas,
-)
 from evm.utils.spoof import (
     SpoofTransaction,
 )

--- a/evm/estimators/gas.py
+++ b/evm/estimators/gas.py
@@ -40,7 +40,7 @@ def _get_computation_error(state, transaction):
 
 
 @curry
-def binary_search(tolerance, state, transaction):
+def binary_gas_search(state, transaction, tolerance=1):
     """
     Run the transaction with various gas limits, progressively
     approaching the minimum needed to succeed without an OutOfGas exception.
@@ -78,10 +78,10 @@ def binary_search(tolerance, state, transaction):
 
 
 # Estimate in increments of intrinsic gas usage
-binary_search_intrinsic_tolerance = binary_search(21000)
+binary_gas_search_intrinsic_tolerance = binary_gas_search(tolerance=21000)
 
 # Estimate in increments of 1000 gas, takes roughly 5 more executions than intrinsic to estimate
-binary_search_1000_tolerance = binary_search(1000)
+binary_gas_search_1000_tolerance = binary_gas_search(tolerance=1000)
 
 # Estimate to the exact gas, takes roughly 15 more executions than intrinsic to estimate
-binary_search_exact = binary_search(1)
+binary_gas_search_exact = binary_gas_search(tolerance=1)

--- a/evm/estimators/gas.py
+++ b/evm/estimators/gas.py
@@ -1,0 +1,20 @@
+from cytoolz import (
+    curry,
+)
+
+
+@curry
+def execute_plus_buffer(multiplier, state, transaction):
+    computation = state.execute_transaction(transaction)
+
+    if computation.is_error:
+        raise computation._error
+
+    gas_used = transaction.gas_used_by(computation)
+
+    gas_plus_buffer = int(gas_used * multiplier)
+
+    return min(gas_plus_buffer, state.gas_limit)
+
+
+double_execution_cost = execute_plus_buffer(2)

--- a/evm/rlp/transactions.py
+++ b/evm/rlp/transactions.py
@@ -93,7 +93,7 @@ class BaseTransaction(rlp.Serializable):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
-    # Base gas costs
+    # Get gas costs
     #
     def get_intrinsic_gas(self):
         """
@@ -102,6 +102,14 @@ class BaseTransaction(rlp.Serializable):
         for computation).
         """
         raise NotImplementedError("Must be implemented by subclasses")
+
+    def gas_used_by(self, computation):
+        """
+        Return the gas used by the given computation. In Frontier,
+        for example, this is sum of the intrinsic cost and the gas used
+        during computation.
+        """
+        return self.get_intrinsic_gas() + computation.get_gas_used()
 
     #
     # Conversion to and creation of unsigned transactions.

--- a/evm/utils/spoof.py
+++ b/evm/utils/spoof.py
@@ -1,0 +1,18 @@
+class SpoofAttributes:
+    def __init__(self, spoof_target, **overrides):
+        self.spoof_target = spoof_target
+        self.overrides = overrides
+
+    def __getattr__(self, attr):
+        if attr in self.overrides:
+            return self.overrides[attr]
+        else:
+            return getattr(self.spoof_target, attr)
+
+
+class SpoofTransaction(SpoofAttributes):
+    def __init__(self, transaction, **overrides):
+        if 'get_sender' not in overrides:
+            current_sender = transaction.get_sender()
+            overrides['get_sender'] = lambda: current_sender
+        super().__init__(transaction, **overrides)

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -6,7 +6,7 @@ from eth_utils import decode_hex
 from evm import constants
 from evm.chains.mainnet import MAINNET_GENESIS_HEADER
 from evm.chains.ropsten import ROPSTEN_GENESIS_HEADER
-from evm.estimators.gas import binary_search_1000_tolerance
+from evm.estimators.gas import binary_gas_search_1000_tolerance
 from evm.exceptions import (
     TransactionNotFound,
 )
@@ -88,7 +88,7 @@ def test_empty_transaction_lookups(chain):
         (b'\xff' * 32, None, ADDRESS_2, False, 35369),
         (b'\xff' * 320, None, ADDRESS_2, True, 54888),
         # 1000_tolerance binary search
-        (b'\xff' * 32, binary_search_1000_tolerance, ADDRESS_2, True, 23938),
+        (b'\xff' * 32, binary_gas_search_1000_tolerance, ADDRESS_2, True, 23938),
     ),
     ids=[
         'simple default pending',

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -72,6 +72,19 @@ def test_empty_transaction_lookups(chain):
         chain.get_pending_transaction(b'\0' * 32)
 
 
+def test_estimate_gas(chain):
+    vm = chain.get_vm()
+    recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
+    amount = 100
+    from_ = chain.funded_address
+    tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
+    # both estimates on top of *latest* block
+    assert chain.estimate_gas(tx, chain.get_canonical_head()) == 42000
+    assert chain.estimate_gas(tx) == 42000
+    # estimate on *pending* block
+    assert chain.estimate_gas(tx, chain.header) == 42000
+
+
 def test_canonical_chain(valid_chain):
     genesis_header = valid_chain.chaindb.get_canonical_block_header_by_number(
         constants.GENESIS_BLOCK_NUMBER)

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -1,4 +1,4 @@
-def new_transaction(vm, from_, to, amount, private_key, gas_price=10, gas=100000):
+def new_transaction(vm, from_, to, amount, private_key, gas_price=10, gas=100000, data=b''):
     """
     Create and return a transaction sending amount from <from_> to <to>.
 
@@ -7,5 +7,5 @@ def new_transaction(vm, from_, to, amount, private_key, gas_price=10, gas=100000
     with vm.state.state_db(read_only=True) as state_db:
         nonce = state_db.get_nonce(from_)
     tx = vm.create_unsigned_transaction(
-        nonce=nonce, gas_price=gas_price, gas=gas, to=to, value=amount, data=b'')
+        nonce=nonce, gas_price=gas_price, gas=gas, to=to, value=amount, data=data)
     return tx.as_signed_transaction(private_key)

--- a/tests/core/vm/conftest.py
+++ b/tests/core/vm/conftest.py
@@ -1,0 +1,4 @@
+from tests.core.fixtures import (  # noqa: F401
+    chain as valid_chain,
+    chain_without_block_validation as chain,
+)

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -7,12 +7,10 @@ from evm import constants
 from evm.db.backends.memory import MemoryDB
 from evm.db.chain import BaseChainDB
 
-from tests.core.fixtures import chain_without_block_validation  # noqa: F401
 from tests.core.helpers import new_transaction
 
 
-def test_apply_transaction(chain_without_block_validation):  # noqa: F811
-    chain = chain_without_block_validation  # noqa: F811
+def test_apply_transaction(chain):
     vm = chain.get_vm()
     tx_idx = len(vm.block.transactions)
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
@@ -36,16 +34,14 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     assert len(access_logs.writes) > 0
 
 
-def test_mine_block(chain_without_block_validation):  # noqa: F811
-    chain = chain_without_block_validation  # noqa: F811
+def test_mine_block(chain):
     vm = chain.get_vm()
     block = vm.mine_block()
     with vm.state.state_db(read_only=True) as state_db:
         assert state_db.get_balance(block.header.coinbase) == constants.BLOCK_REWARD
 
 
-def test_import_block(chain_without_block_validation):  # noqa: F811
-    chain = chain_without_block_validation  # noqa: F811
+def test_import_block(chain):
     vm = chain.get_vm()
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
@@ -59,8 +55,7 @@ def test_import_block(chain_without_block_validation):  # noqa: F811
     assert block.transactions == [tx]
 
 
-def test_get_cumulative_gas_used(chain_without_block_validation):  # noqa: F811
-    chain = chain_without_block_validation  # noqa: F811
+def test_get_cumulative_gas_used(chain):
     vm = chain.get_vm()
 
     # Empty block.
@@ -89,8 +84,7 @@ def test_get_cumulative_gas_used(chain_without_block_validation):  # noqa: F811
     assert blockgas == constants.GAS_TX
 
 
-def test_create_block(chain_without_block_validation):  # noqa: F811
-    chain = chain_without_block_validation  # noqa: F811
+def test_create_block(chain):
 
     # (1) Empty block.
     # block = vm.mine_block()


### PR DESCRIPTION
### What was wrong?

#264 - Want to easily estimate gas usage of a transaction.

### How was it fixed?

Now fully fixes #264 

- Add two gas estimators to `Chain`.
  - The simplest one just runs the transaction to see how much gas was used, and multiplies the estimate by 2. The estimator cannot return an amount higher than the gas set in the transaction. It might under-guess the gas if there is a long chain of calls (because it doesn't account for the 63/64 gas passed to subcall)
  - The more complicated one does binary search, (roughly) as defined in #264
- Add `gas_used_by(computation)` API to Transaction (for now, just intrinsic cost + gas used)
- Generate the state of a temporary block on top of the current header. This allows us to estimate gas taking into account the pending state, but still have a full block's worth of gas available to test with.
- Some flake8 warning suppression cleanup
- gas_estimator is added to `Chain`. It takes a `VMState` and a `Transaction`. It loads an estimator function from the environment variable `GAS_ESTIMATOR_BACKEND_FUNC`. If none is set, it loads the `binary_search_intrinsic_tolerance` estimator, which runs binary search to find the minimum gas required to within 21k gas.
- Added a `utils.spoof.SpoofTransaction` class which neatly lets you alter some attributes of a signed transaction without changing the sender, using `spoofed = SpoofTransaction(transaction, gas=123456)`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/BGlCdSP2I3A/maxresdefault.jpg)
