### PR TITLE
Add PAYGAS opcode

### DIFF
--- a/evm/exceptions.py
+++ b/evm/exceptions.py
@@ -166,7 +166,7 @@ class GasPriceAlreadySet(Exception):
     pass
 
 
-class NotTopLevelCall(VMError):
+class NotTopLevelCall(Exception):
     """
     Error raised if it's not executing in the top level call(i.e, msg.depth == 0)
     """

--- a/evm/exceptions.py
+++ b/evm/exceptions.py
@@ -164,3 +164,10 @@ class GasPriceAlreadySet(Exception):
     Error raised if trying to reset the already set gas price.
     """
     pass
+
+
+class NotTopLevelCall(VMError):
+    """
+    Error raised if it's not executing in the top level call(i.e, msg.depth == 0)
+    """
+    pass

--- a/evm/exceptions.py
+++ b/evm/exceptions.py
@@ -157,3 +157,10 @@ class UnannouncedStateAccess(VMError):
     been specified in the transaction's read or write list, respectively.
     """
     pass
+
+
+class GasPriceAlreadySet(Exception):
+    """
+    Error raised if trying to reset the already set gas price.
+    """
+    pass

--- a/evm/logic/call.py
+++ b/evm/logic/call.py
@@ -96,6 +96,7 @@ class BaseCall(Opcode):
                 'to': to,
                 'data': call_data,
                 'code': code,
+                'transaction_gas_limit': computation.msg.transaction_gas_limit,
                 'code_address': code_address,
                 'should_transfer_value': should_transfer_value,
                 'is_static': is_static,

--- a/evm/logic/call.py
+++ b/evm/logic/call.py
@@ -96,7 +96,6 @@ class BaseCall(Opcode):
                 'to': to,
                 'data': call_data,
                 'code': code,
-                'transaction_gas_limit': computation.msg.transaction_gas_limit,
                 'code_address': code_address,
                 'should_transfer_value': should_transfer_value,
                 'is_static': is_static,
@@ -343,3 +342,101 @@ class CallSharding(CallByzantium):
         transfer_gas_fee = constants.GAS_CALLVALUE if value else 0
         create_gas_fee = constants.GAS_NEWACCOUNT if not account_is_empty else 0
         return transfer_gas_fee + create_gas_fee
+
+    def __call__(self, computation):
+        computation.gas_meter.consume_gas(
+            self.gas_cost,
+            reason=self.mnemonic,
+        )
+
+        (
+            gas,
+            value,
+            to,
+            sender,
+            code_address,
+            memory_input_start_position,
+            memory_input_size,
+            memory_output_start_position,
+            memory_output_size,
+            should_transfer_value,
+            is_static,
+        ) = self.get_call_params(computation)
+
+        computation.extend_memory(memory_input_start_position, memory_input_size)
+        computation.extend_memory(memory_output_start_position, memory_output_size)
+
+        call_data = computation.memory.read(memory_input_start_position, memory_input_size)
+
+        #
+        # Message gas allocation and fees
+        #
+        child_msg_gas, child_msg_gas_fee = self.compute_msg_gas(computation, gas, to, value)
+        computation.gas_meter.consume_gas(child_msg_gas_fee, reason=self.mnemonic)
+
+        # Pre-call checks
+        with computation.state_db(read_only=True) as state_db:
+            sender_balance = state_db.get_balance(computation.msg.storage_address)
+
+        insufficient_funds = should_transfer_value and sender_balance < value
+        stack_too_deep = computation.msg.depth + 1 > constants.STACK_DEPTH_LIMIT
+
+        if insufficient_funds or stack_too_deep:
+            computation.return_data = b''
+            if insufficient_funds:
+                err_message = "Insufficient Funds: have: {0} | need: {1}".format(
+                    sender_balance,
+                    value,
+                )
+            elif stack_too_deep:
+                err_message = "Stack Limit Reached"
+            else:
+                raise Exception("Invariant: Unreachable code path")
+
+            self.logger.debug(
+                "%s failure: %s",
+                self.mnemonic,
+                err_message,
+            )
+            computation.gas_meter.return_gas(child_msg_gas)
+            computation.stack.push(0)
+        else:
+            with computation.state_db(read_only=True) as state_db:
+                if code_address:
+                    code = state_db.get_code(code_address)
+                else:
+                    code = state_db.get_code(to)
+
+            child_msg_kwargs = {
+                'gas': child_msg_gas,
+                'value': value,
+                'to': to,
+                'data': call_data,
+                'code': code,
+                'transaction_gas_limit': computation.msg.transaction_gas_limit,
+                'code_address': code_address,
+                'should_transfer_value': should_transfer_value,
+                'is_static': is_static,
+            }
+            if sender is not None:
+                child_msg_kwargs['sender'] = sender
+
+            child_msg = computation.prepare_child_message(**child_msg_kwargs)
+
+            child_computation = computation.apply_child_computation(child_msg)
+
+            if child_computation.is_error:
+                computation.stack.push(0)
+            else:
+                computation.stack.push(1)
+
+            if not child_computation.should_erase_return_data:
+                actual_output_size = min(memory_output_size, len(child_computation.output))
+                computation.memory.write(
+                    memory_output_start_position,
+                    actual_output_size,
+                    child_computation.output[:actual_output_size],
+                )
+
+            if not child_computation.should_burn_gas:
+                computation.gas_meter.return_gas(child_computation.gas_meter.gas_remaining)

--- a/evm/logic/system.py
+++ b/evm/logic/system.py
@@ -5,6 +5,7 @@ from evm.exceptions import (
     Revert,
     WriteProtection,
     GasPriceAlreadySet,
+    InsufficientFunds,
 )
 
 from evm.opcode import (
@@ -229,6 +230,7 @@ class Create2(CreateEIP150):
             value=value,
             data=b'',
             code=call_data,
+            transaction_gas_limit=computation.msg.transaction_gas_limit,
             is_create=True,
         )
 

--- a/evm/logic/system.py
+++ b/evm/logic/system.py
@@ -250,7 +250,7 @@ def paygas(computation):
     # (2) not been set already during this transaction execution
     if computation.msg.depth == 0:
         try:
-            computation.set_PAYGAS_gas_price(gas_price)
+            computation.set_PAYGAS_gasprice(gas_price)
         except GasPriceAlreadySet:
             computation.stack.push(0)
         else:

--- a/evm/logic/system.py
+++ b/evm/logic/system.py
@@ -4,8 +4,9 @@ from evm.exceptions import (
     Halt,
     Revert,
     WriteProtection,
-    GasPriceAlreadySet,
     InsufficientFunds,
+    GasPriceAlreadySet,
+    NotTopLevelCall
 )
 
 from evm.opcode import (
@@ -248,30 +249,27 @@ def paygas(computation):
 
     # Only valid if (1) triggered in a top level call and
     # (2) not been set already during this transaction execution
-    if computation.msg.depth == 0:
-        try:
-            computation.set_PAYGAS_gasprice(gas_price)
-        except GasPriceAlreadySet:
-            computation.stack.push(0)
-        else:
-            with computation.state_db(read_only=False) as state_db:
-                tx_initiator = computation.msg.to
-                tx_initiator_balance = state_db.get_balance(tx_initiator)
-
-                PAYGAS_gasprice = computation.get_PAYGAS_gas_price()
-                if PAYGAS_gasprice is None:
-                    PAYGAS_gasprice = 0
-                fee_to_be_charged = PAYGAS_gasprice * computation.msg.transaction_gas_limit
-
-                if tx_initiator_balance < fee_to_be_charged:
-                    raise InsufficientFunds(
-                        "Insufficient funds: {0} < {1}".format(
-                            tx_initiator_balance,
-                            fee_to_be_charged
-                        )
-                    )
-
-                state_db.delta_balance(tx_initiator, -1 * fee_to_be_charged)
-            computation.stack.push(1)
-    else:
+    try:
+        computation.set_PAYGAS_gasprice(gas_price)
+    except (GasPriceAlreadySet, NotTopLevelCall):
         computation.stack.push(0)
+    else:
+        with computation.state_db(read_only=False) as state_db:
+            tx_initiator = computation.msg.to
+            tx_initiator_balance = state_db.get_balance(tx_initiator)
+
+            PAYGAS_gasprice = computation.get_PAYGAS_gas_price()
+            if PAYGAS_gasprice is None:
+                PAYGAS_gasprice = 0
+            fee_to_be_charged = PAYGAS_gasprice * computation.msg.transaction_gas_limit
+
+            if tx_initiator_balance < fee_to_be_charged:
+                raise InsufficientFunds(
+                    "Insufficient funds: {0} < {1}".format(
+                        tx_initiator_balance,
+                        fee_to_be_charged
+                    )
+                )
+
+            state_db.delta_balance(tx_initiator, -1 * fee_to_be_charged)
+        computation.stack.push(1)

--- a/evm/vm/forks/sharding/blocks.py
+++ b/evm/vm/forks/sharding/blocks.py
@@ -19,3 +19,14 @@ class ShardingBlock(HomesteadBlock):
         ('transactions', CountableList(transaction_class)),
         ('uncles', CountableList(BlockHeader))
     ]
+
+    transaction_fee_sum = None
+
+    def __init__(self, header, transactions=None, uncles=None):
+        self.transaction_fee_sum = 0
+
+        super(ShardingBlock, self).__init__(
+            header=header,
+            transactions=transactions,
+            uncles=uncles,
+        )

--- a/evm/vm/forks/sharding/computation.py
+++ b/evm/vm/forks/sharding/computation.py
@@ -56,6 +56,20 @@ class ShardingComputation(SpuriousDragonComputation):
                 "PAYGAS is already triggered once with gas price: {}".format(self._paygas_gasprice)
             )
 
+    def compute_transaction_fee_and_refund(self):
+        gas_price = self.get_PAYGAS_gas_price()
+        if gas_price is None:
+            gas_price = 0
+
+        transaction_gas = self.msg.transaction_gas_limit
+        gas_remaining = self.get_gas_remaining()
+        gas_refunded = self.get_gas_refund()
+        gas_used = transaction_gas - gas_remaining
+        gas_refund = min(gas_refunded, gas_used // 2)
+        gas_refund_amount = (gas_refund + gas_remaining) * gas_price
+        tx_fee = (transaction_gas - gas_remaining - gas_refund) * gas_price
+        return tx_fee, gas_refund_amount
+
     def apply_message(self):
         snapshot = self.vm_state.snapshot()
 

--- a/evm/vm/forks/sharding/computation.py
+++ b/evm/vm/forks/sharding/computation.py
@@ -6,6 +6,7 @@ from evm.exceptions import (
     InsufficientFunds,
     StackDepthLimit,
     GasPriceAlreadySet,
+    NotTopLevelCall,
 )
 from evm.vm.message import (
     ShardingMessage,
@@ -39,6 +40,8 @@ class ShardingComputation(SpuriousDragonComputation):
 
     def set_PAYGAS_gasprice(self, gas_price):
         validate_uint256(gas_price, title="PAYGAY.gas_price")
+        if self.msg.depth != 0:
+            raise NotTopLevelCall("This should only happen in a top level call context.")
         
         if self._paygas_gasprice is None:
             self._paygas_gasprice = gas_price

--- a/evm/vm/forks/sharding/computation.py
+++ b/evm/vm/forks/sharding/computation.py
@@ -17,6 +17,9 @@ from evm.utils.hexadecimal import (
 from evm.utils.keccak import (
     keccak,
 )
+from evm.validation import (
+    validate_uint256,
+)
 
 from ..spurious_dragon.computation import (
     SpuriousDragonComputation,
@@ -42,7 +45,7 @@ class ShardingComputation(SpuriousDragonComputation):
         validate_uint256(gas_price, title="PAYGAY.gas_price")
         if self.msg.depth != 0:
             raise NotTopLevelCall("This should only happen in a top level call context.")
-        
+
         if self._paygas_gasprice is None:
             self._paygas_gasprice = gas_price
         else:

--- a/evm/vm/forks/sharding/computation.py
+++ b/evm/vm/forks/sharding/computation.py
@@ -117,7 +117,7 @@ class ShardingComputation(SpuriousDragonComputation):
                 self.vm_state.commit(snapshot)
             return computation
 
-    def prepare_child_message(self, gas, to, value, data, code, **kwargs):
+    def prepare_child_message(self, gas, to, value, data, code, transaction_gas_limit, **kwargs):
         kwargs.setdefault('sender', self.msg.storage_address)
 
         child_message = ShardingMessage(
@@ -129,6 +129,7 @@ class ShardingComputation(SpuriousDragonComputation):
             value=value,
             data=data,
             code=code,
+            transaction_gas_limit=transaction_gas_limit,
             depth=self.msg.depth + 1,
             access_list=self.msg.access_list,
             **kwargs

--- a/evm/vm/forks/sharding/computation.py
+++ b/evm/vm/forks/sharding/computation.py
@@ -44,7 +44,10 @@ class ShardingComputation(SpuriousDragonComputation):
     def set_PAYGAS_gasprice(self, gas_price):
         validate_uint256(gas_price, title="PAYGAY.gas_price")
         if self.msg.depth != 0:
-            raise NotTopLevelCall("This should only happen in a top level call context.")
+            raise NotTopLevelCall(
+                "The `set_PAYGAS_gasprice` API is only valid when"
+                "called from the top level computation"
+            )
 
         if self._paygas_gasprice is None:
             self._paygas_gasprice = gas_price

--- a/evm/vm/forks/sharding/computation.py
+++ b/evm/vm/forks/sharding/computation.py
@@ -5,6 +5,7 @@ from evm.exceptions import (
     OutOfGas,
     InsufficientFunds,
     StackDepthLimit,
+    GasPriceAlreadySet,
 )
 from evm.vm.message import (
     ShardingMessage,
@@ -28,8 +29,23 @@ from .opcodes import SHARDING_OPCODES
 
 
 class ShardingComputation(SpuriousDragonComputation):
+    _paygas_gasprice = None
+
     # Override
     opcodes = SHARDING_OPCODES
+
+    def get_PAYGAS_gas_price(self):
+        return self._paygas_gasprice
+
+    def set_PAYGAS_gasprice(self, gas_price):
+        validate_uint256(gas_price, title="PAYGAY.gas_price")
+        
+        if self._paygas_gasprice is None:
+            self._paygas_gasprice = gas_price
+        else:
+            raise GasPriceAlreadySet(
+                "PAYGAS is already triggered once with gas price: {}".format(self._paygas_gasprice)
+            )
 
     def apply_message(self):
         snapshot = self.vm_state.snapshot()

--- a/evm/vm/forks/sharding/opcodes.py
+++ b/evm/vm/forks/sharding/opcodes.py
@@ -35,7 +35,7 @@ NEW_OPCODES = {
     opcode_values.PAYGAS: as_opcode(
         logic_fn=system.paygas,
         mnemonic=mnemonics.PAYGAS,
-        gas_cost=0,
+        gas_cost=constants.GAS_VERYLOW,
     ),
 }
 

--- a/evm/vm/forks/sharding/vm_state.py
+++ b/evm/vm/forks/sharding/vm_state.py
@@ -91,6 +91,7 @@ class ShardingVMState(ByzantiumVMState):
             value=0,
             data=data,
             code=code,
+            transaction_gas_limit=transaction.gas,
             is_create=is_create,
             access_list=transaction.prefix_list,
         )

--- a/evm/vm/message.py
+++ b/evm/vm/message.py
@@ -144,6 +144,7 @@ class Message(object):
 class ShardingMessage(Message):
 
     is_create = False
+    transaction_gas_limit = None
 
     def __init__(self,
                  gas,
@@ -154,6 +155,7 @@ class ShardingMessage(Message):
                  value,
                  data,
                  code,
+                 transaction_gas_limit,
                  origin=None,
                  access_list=None,
                  depth=0,
@@ -176,6 +178,9 @@ class ShardingMessage(Message):
             should_transfer_value=should_transfer_value,
             is_static=is_static,
         )
+
+        validate_uint256(transaction_gas_limit, title="Message.transaction_gas_limit")
+        self.transaction_gas_limit = transaction_gas_limit
 
         validate_is_boolean(is_create, title="Message.is_create")
         self.is_create = is_create

--- a/tests/auxiliary/user-account/test_contract.py
+++ b/tests/auxiliary/user-account/test_contract.py
@@ -14,9 +14,6 @@ from evm.constants import (
     ZERO_HASH32,
     ENTRY_POINT,
 )
-from evm.exceptions import (
-    UnannouncedStateAccess,
-)
 from evm.vm.message import (
     ShardingMessage,
 )

--- a/tests/auxiliary/user-account/test_contract.py
+++ b/tests/auxiliary/user-account/test_contract.py
@@ -307,6 +307,7 @@ def test_call_checks_signature(vm, v, r, s):
         "sender": ENTRY_POINT,
         "value": 0,
         "code": ACCOUNT_CODE,
+        "transaction_gas_limit": transaction.gas,
         "is_create": False,
         "access_list": transaction.prefix_list,
     }

--- a/tests/auxiliary/user-account/test_contract.py
+++ b/tests/auxiliary/user-account/test_contract.py
@@ -140,8 +140,6 @@ DEFAULT_V = SIGNED_DEFAULT_TRANSACTION.v
 DEFAULT_R = SIGNED_DEFAULT_TRANSACTION.r
 DEFAULT_S = SIGNED_DEFAULT_TRANSACTION.s
 
-XFAIL_REASON = "gas payment to dynamic coinbase and missing PAYGAS implementation"
-
 
 @pytest.fixture
 def vm():
@@ -173,7 +171,6 @@ def get_nonce(vm):
     return big_endian_to_int(computation.output)
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)  # noqa: F811
 def test_get_nonce(vm):
     computation, _ = vm.apply_transaction(ShardingTransaction(**merge(DEFAULT_BASE_TX_PARAMS, {
         "data": int_to_big_endian(NONCE_GETTER_ID),
@@ -188,7 +185,6 @@ def test_get_nonce(vm):
     assert computation.output == pad32(b"\x01")
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=NotImplementedError)
 def test_call_increments_nonce(vm):
     computation, _ = vm.apply_transaction(SIGNED_DEFAULT_TRANSACTION)
     assert computation.is_success
@@ -202,7 +198,6 @@ def test_call_increments_nonce(vm):
     assert get_nonce(vm) == 2
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=NotImplementedError)
 def test_call_checks_nonce(vm):
     computation, _ = vm.apply_transaction(SIGNED_DEFAULT_TRANSACTION)
     assert computation.is_success
@@ -217,7 +212,6 @@ def test_call_checks_nonce(vm):
     assert computation.is_error
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 @pytest.mark.parametrize("min_block,max_block,valid", [
     (min_block, max_block, True) for min_block, max_block in [
         (0, UINT_256_MAX),
@@ -250,7 +244,6 @@ def test_call_checks_block_range(vm, min_block, max_block, valid):
         assert computation.is_error
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 def test_call_transfers_value(vm):
     vm_state = vm.state
     with vm_state.state_db() as state_db:
@@ -277,7 +270,6 @@ def test_call_transfers_value(vm):
     assert balance_destination_after == balance_destination_before + 10
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=NotImplementedError)
 @pytest.mark.parametrize("v,r,s", [
     (0, 0, 0),
 
@@ -323,7 +315,6 @@ def test_call_checks_signature(vm, v, r, s):
     assert computation.is_success
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 def test_call_uses_remaining_gas(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -340,7 +331,6 @@ def test_call_uses_remaining_gas(vm):
     assert logged_gas > 900 * 1000  # some gas will have been consumed earlier
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 @pytest.mark.parametrize("data,hash", [
     (data, keccak(data)) for data in [
         b"",
@@ -368,7 +358,6 @@ def test_call_uses_data(vm, data, hash):
     assert logged_hash == hash
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 def test_no_call_if_not_enough_gas(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -382,7 +371,6 @@ def test_no_call_if_not_enough_gas(vm):
     assert computation.gas_meter.gas_remaining > 0
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 def test_call_passes_return_code(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -403,7 +391,6 @@ def test_call_passes_return_code(vm):
     assert big_endian_to_int(computation.output) == 0  # failure
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 def test_call_does_not_revert_nonce(vm):
     nonce_before = get_nonce(vm)
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {

--- a/tests/auxiliary/user-account/test_contract.py
+++ b/tests/auxiliary/user-account/test_contract.py
@@ -359,7 +359,7 @@ def test_no_call_if_not_enough_gas(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
         "destination": NOOP_CONTRACT_ADDRESS,
-        "gas": 55000,
+        "gas": 80000,
         "access_list": DEFAULT_TX_PARAMS["access_list"] + [[NOOP_CONTRACT_ADDRESS]],
     })).as_signed_transaction(PRIVATE_KEY)
     computation, _ = vm.apply_transaction(transaction)

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -25,6 +25,8 @@ from tests.core.vm.contract_fixture import (
     simple_transfer_contract_address,
     CREATE2_contract_bytecode,
     CREATE2_contract_address,
+    PAYGAS_contract_bytecode,
+    PAYGAS_contract_address,
 )
 
 
@@ -101,6 +103,11 @@ SHARD_CHAIN_CONTRACTS_FIXTURES = [
         "deployed_address": CREATE2_contract_address,
         "initial_balance": 100000000,
     },
+    {
+        "contract_code": PAYGAS_contract_bytecode,
+        "deployed_address": PAYGAS_contract_address,
+        "initial_balance": 100000000,
+    },
 ]
 
 
@@ -155,6 +162,12 @@ def shard_chain_without_block_validation():
         },
         SHARD_CHAIN_CONTRACTS_FIXTURES[1]["deployed_address"]: {
             'balance': SHARD_CHAIN_CONTRACTS_FIXTURES[1]["initial_balance"],
+            'nonce': 0,
+            'code': b'',
+            'storage': {},
+        },
+        SHARD_CHAIN_CONTRACTS_FIXTURES[2]["deployed_address"]: {
+            'balance': SHARD_CHAIN_CONTRACTS_FIXTURES[2]["initial_balance"],
             'nonce': 0,
             'code': b'',
             'storage': {},

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -33,7 +33,14 @@ def new_sharding_transaction(
     [destination, value, msg_data, vrs].
     """
     assert len(data_vrs) in (0, 65)
-    tx_data = pad32(data_destination) + pad32(bytes([data_value])) + pad32(data_msgdata) + pad32(data_vrs[:32]) + pad32(data_vrs[32:64]) + bytes(data_vrs[64:])  # noqa: E501
+    tx_data = (
+        pad32(data_destination) +
+        pad32(bytes([data_value])) +
+        pad32(data_msgdata) +
+        pad32(data_vrs[:32]) +
+        pad32(data_vrs[32:64]) +
+        bytes(data_vrs[64:])
+    )
     if access_list is None:
         access_list = [[tx_initiator]]
         if data_destination:

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -32,7 +32,8 @@ def new_sharding_transaction(
 
     [destination, value, msg_data, vrs].
     """
-    tx_data = pad32(data_destination) + pad32(bytes([data_value])) + pad32(data_msgdata) + pad32(data_vrs)  # noqa: E501
+    assert len(data_vrs) in (0, 65)
+    tx_data = pad32(data_destination) + pad32(bytes([data_value])) + pad32(data_msgdata) + pad32(data_vrs[:32]) + pad32(data_vrs[32:64]) + bytes(data_vrs[64:])  # noqa: E501
     if access_list is None:
         access_list = [[tx_initiator]]
         if data_destination:

--- a/tests/core/vm/contract_fixture.py
+++ b/tests/core/vm/contract_fixture.py
@@ -2,6 +2,7 @@ from eth_utils import decode_hex
 
 from evm.utils.address import generate_CREATE2_contract_address
 
+# Simple Transfer Contract
 # contract code to be deployed
 simple_transfer_contract_lll_code = ['seq',
                                         ['return',  # noqa: E127
@@ -29,6 +30,7 @@ simple_transfer_contract_address = generate_CREATE2_contract_address(
 simple_contract_factory_bytecode = b'\x61\xbe\xef\x60\x20\x52\x60\x02\x60\x3e\xf3'
 
 
+# CREATE2 Contract
 # This contract will deploy a new contract and increment it's only storage variable 'nonce'
 # every time it's invoked.
 # Contract address: generate_CREATE2_contract_address(nonce, simple_contract_factory_bytecode)
@@ -54,4 +56,30 @@ CREATE2_contract_bytecode = '0x610039566000546020526a61beef6020526002603ef360405
 CREATE2_contract_address = generate_CREATE2_contract_address(
     b'',
     decode_hex(CREATE2_contract_bytecode)
+)
+
+
+# PAYGAS Contract
+PAYGAS_contract_lll_code = ['seq',
+                                ['return',  # noqa: E127
+                                    0,
+                                    ['lll',
+                                        ['seq',
+                                            ['paygas', ['calldataload', 64]],
+                                            # Transfer value
+                                            ['mstore', 128, 1461501637330902918203684832716283019655932542976],  # noqa: E501
+                                            ['uclamplt', ['calldataload', 0], ['mload', 128]],  # noqa: E501
+                                            ['assert', ['call', 0, ['calldataload', 0], ['calldataload', 32], 0, 0, 0, 0]],  # noqa: E501
+                                            'stop'],
+                                    0]]]  # noqa: E128
+
+
+# compiled byte code
+PAYGAS_contract_bytecode = '0x61004f56604035f55074010000000000000000000000000000000000000000608052600035608051811061002e57600080fd5b5060006000600060006020356000356000f161004957600080fd5b005b61000461004f0361000460003961000461004f036000f3'  # noqa: E501
+
+
+# address where this contract will be deployed
+PAYGAS_contract_address = generate_CREATE2_contract_address(
+    b'',
+    decode_hex(PAYGAS_contract_bytecode)
 )

--- a/tests/core/vm/test_PAYGAS_tx_fee.py
+++ b/tests/core/vm/test_PAYGAS_tx_fee.py
@@ -1,0 +1,49 @@
+from eth_utils import (
+    decode_hex,
+)
+
+from tests.core.fixtures import (  # noqa: F401
+    shard_chain_without_block_validation,
+)
+from tests.core.helpers import (
+    new_sharding_transaction,
+)
+from tests.core.vm.contract_fixture import (
+    PAYGAS_contract_bytecode,
+    PAYGAS_contract_address,
+)
+
+
+def test_trigger_PAYGAS(shard_chain_without_block_validation):  # noqa: F811
+    chain = shard_chain_without_block_validation
+    deploy_tx = new_sharding_transaction(
+        tx_initiator=PAYGAS_contract_address,
+        data_destination=b'',
+        data_value=0,
+        data_msgdata=b'',
+        data_vrs=b'',
+        code=PAYGAS_contract_bytecode,
+    )
+
+    vm = chain.get_vm()
+    computation, _ = vm.apply_transaction(deploy_tx)
+    assert not computation.is_error
+    gas_used = vm.block.header.gas_used
+    assert gas_used > deploy_tx.intrinsic_gas
+    last_gas_used = gas_used
+
+    # Trigger the contract
+    recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
+    amount = 100
+    tx_initiator = PAYGAS_contract_address
+    gas_price = bytes([33])
+    vrs = 64 * b'\xAA' + b'\x01'
+    trigger_tx = new_sharding_transaction(tx_initiator, recipient, amount, gas_price, vrs, b'')
+
+    computation, _ = vm.apply_transaction(trigger_tx)
+    assert not computation.is_error
+    gas_used = vm.block.header.gas_used - last_gas_used
+    assert gas_used > trigger_tx.intrinsic_gas
+    last_gas_used = vm.block.header.gas_used
+    with vm.state.state_db(read_only=True) as state_db:
+        assert state_db.get_balance(recipient) == amount

--- a/tests/core/vm/test_shard_vm.py
+++ b/tests/core/vm/test_shard_vm.py
@@ -1,5 +1,3 @@
-import pytest
-
 from eth_utils import (
     int_to_big_endian,
     decode_hex,
@@ -8,7 +6,6 @@ from eth_utils import (
 from evm.exceptions import (
     IncorrectContractCreationAddress,
     ContractCreationCollision,
-    UnannouncedStateAccess,
 )
 from evm.utils.address import generate_CREATE2_contract_address
 from evm.utils.padding import pad32
@@ -28,11 +25,7 @@ from tests.core.vm.contract_fixture import (
 )
 
 
-XFAIL_REASON = "gas payment to dynamic coinbase"
-
-
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)  # noqa: F811
-def test_sharding_apply_transaction(shard_chain_without_block_validation):
+def test_sharding_apply_transaction(shard_chain_without_block_validation):  # noqa: F811
     chain = shard_chain_without_block_validation
     # First test: simple ether transfer contract
     first_deploy_tx = new_sharding_transaction(
@@ -110,8 +103,7 @@ def test_sharding_apply_transaction(shard_chain_without_block_validation):
         assert state_db.get_storage(CREATE2_contract_address, 0) == 1
 
 
-@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)  # noqa: F811
-def test_CREATE2_deploy_contract_edge_cases(shard_chain_without_block_validation):
+def test_CREATE2_deploy_contract_edge_cases(shard_chain_without_block_validation):  # noqa: F811
     # First case: computed contract address not the same as provided in `transaction.to`
     chain = shard_chain_without_block_validation
     code = b"0xf3"


### PR DESCRIPTION
### What was wrong?
Implementation of #234 


### How was it fixed?
#### Add `PAYGAS` opcode
* Carry additional informations such as `transaction_gas_limit`, `paygas_gasprice ` and `paygas_total_fee` in `ShardingMessage` object
    * `transaction_gas_limit` is the same as `transaction.gas`
    * `paygas_gasprice ` is set by `PAYGAS` opcode and only under two conditions:
        1. in a top level call(i.e., `computation.msg.depth == 0`)
        2. the value has not been set before during this transaction
    * If the two conditions are not met, current action is to do nothing.
    * `paygas_total_fee` is equal to `transaction_gas_limit * paygas_gasprice`
* Once triggered, deduct `paygas_total_fee` from transaction initiator(`transaction.to`)'s balance
* Refund fee is calculated base on `paygas_gasprice` instead of `transaction.gas_price`
* Opcode value is currently set as ~~`0x5c`~~ `0xf5`, placed in ~~Stack, Memory, Storage and Flow Operations~~ Systems section. I preferred to put it in Environment Information section but it's full already.

- [x] 1. Remove coinbase from `execute_transaction` and ~transfer the fee directly to `PAYGAS_TEMPORARY_ACCOUNT` of which the account data is enforced to be permanently stored in database hence it's witness data is not required.~ store the tx fee amount due in `block.tx_fee_sum` and transfer all fees to coinbase in `finalize_block` function
- ~2. Add a function that generates a transaction to transfer fees collected from all transactions of this block to coinbase.~
- 3. Abstract `gas_price` away, removing it from transaction format.(Moved to another PR)
- 4. Add tests.(More to be added in another PR)

#### Cute Animal Picture

![](http://www.strangetravel.com/images/content/136379.jpg)