### PR TITLE
Backport evm.utils.env and related tests from sharding branch

### DIFF
--- a/evm/utils/env.py
+++ b/evm/utils/env.py
@@ -1,0 +1,218 @@
+"""
+This module is copied from https://github.com/simpleenergy/env-excavator, which is helpful for
+extracting environment variables.
+"""
+
+import os
+
+
+# No set literals because we support Python 2.6.
+TRUE_VALUES = set((
+    True,
+    'True',
+    'true',
+))
+
+
+class empty(object):
+    """
+    We use this sentinel object, instead of None, as None is a plausible value
+    for a default in real Python code.
+    """
+    pass
+
+
+def get_env_value(name, required=False, default=empty):
+    """
+    Core function for extracting the environment variable.
+
+    Enforces mutual exclusivity between `required` and `default` keywords.
+
+    The `empty` sentinal value is used as the default `default` value to allow
+    other function to handle default/empty logic in the appropriate way.
+    """
+    if required and default is not empty:
+        raise ValueError("Using `default` with `required=True` is invalid")
+    elif required:
+        try:
+            value = os.environ[name]
+        except KeyError:
+            raise KeyError(
+                "Must set environment variable {0}".format(name)
+            )
+    else:
+        value = os.environ.get(name, default)
+    return value
+
+
+def env_int(name, required=False, default=empty):
+    """Pulls an environment variable out of the environment and casts it to an
+    integer. If the name is not present in the environment and no default is
+    specified then a ``ValueError`` will be raised. Similarly, if the
+    environment value is not castable to an integer, a ``ValueError`` will be
+    raised.
+
+    :param name: The name of the environment variable be pulled
+    :type name: str
+
+    :param required: Whether the environment variable is required. If ``True``
+    and the variable is not present, a ``KeyError`` is raised.
+    :type required: bool
+
+    :param default: The value to return if the environment variable is not
+    present. (Providing a default alongside setting ``required=True`` will raise
+    a ``ValueError``)
+    :type default: bool
+    """
+    value = get_env_value(name, required=required, default=default)
+    if value is empty:
+        raise ValueError(
+            "`env_int` requires either a default value to be specified, or for "
+            "the variable to be present in the environment"
+        )
+    return int(value)
+
+
+def env_float(name, required=False, default=empty):
+    """Pulls an environment variable out of the environment and casts it to an
+    float. If the name is not present in the environment and no default is
+    specified then a ``ValueError`` will be raised. Similarly, if the
+    environment value is not castable to an float, a ``ValueError`` will be
+    raised.
+
+    :param name: The name of the environment variable be pulled
+    :type name: str
+
+    :param required: Whether the environment variable is required. If ``True``
+    and the variable is not present, a ``KeyError`` is raised.
+    :type required: bool
+
+    :param default: The value to return if the environment variable is not
+    present. (Providing a default alongside setting ``required=True`` will raise
+    a ``ValueError``)
+    :type default: bool
+    """
+    value = get_env_value(name, required=required, default=default)
+    if value is empty:
+        raise ValueError(
+            "`env_float` requires either a default value to be specified, or for "
+            "the variable to be present in the environment"
+        )
+    return float(value)
+
+
+def env_bool(name, truthy_values=TRUE_VALUES, required=False, default=empty):
+    """Pulls an environment variable out of the environment returning it as a
+    boolean. The strings ``'True'`` and ``'true'`` are the default *truthy*
+    values. If not present in the environment and no default is specified,
+    ``None`` is returned.
+
+    :param name: The name of the environment variable be pulled
+    :type name: str
+
+    :param truthy_values: An iterable of values that should be considered
+    truthy.
+    :type truthy_values: iterable
+
+    :param required: Whether the environment variable is required. If ``True``
+    and the variable is not present, a ``KeyError`` is raised.
+    :type required: bool
+
+    :param default: The value to return if the environment variable is not
+    present. (Providing a default alongside setting ``required=True`` will raise
+    a ``ValueError``)
+    :type default: bool
+    """
+    value = get_env_value(name, required=required, default=default)
+    if value is empty:
+        return None
+    return value in TRUE_VALUES
+
+
+def env_string(name, required=False, default=empty):
+    """Pulls an environment variable out of the environment returning it as a
+    string. If not present in the environment and no default is specified, an
+    empty string is returned.
+
+    :param name: The name of the environment variable be pulled
+    :type name: str
+
+    :param required: Whether the environment variable is required. If ``True``
+    and the variable is not present, a ``KeyError`` is raised.
+    :type required: bool
+
+    :param default: The value to return if the environment variable is not
+    present. (Providing a default alongside setting ``required=True`` will raise
+    a ``ValueError``)
+    :type default: bool
+    """
+    value = get_env_value(name, default=default, required=required)
+    if value is empty:
+        value = ''
+    return value
+
+
+def env_list(name, separator=',', required=False, default=empty):
+    """Pulls an environment variable out of the environment, splitting it on a
+    separator, and returning it as a list. Extra whitespace on the list values
+    is stripped. List values that evaluate as falsy are removed. If not present
+    and no default specified, an empty list is returned.
+
+    :param name: The name of the environment variable be pulled
+    :type name: str
+
+    :param separator: The separator that the string should be split on.
+    :type separator: str
+
+    :param required: Whether the environment variable is required. If ``True``
+    and the variable is not present, a ``KeyError`` is raised.
+    :type required: bool
+
+    :param default: The value to return if the environment variable is not
+    present. (Providing a default alongside setting ``required=True`` will raise
+    a ``ValueError``)
+    :type default: bool
+    """
+    value = get_env_value(name, required=required, default=default)
+    if value is empty:
+        return []
+    # wrapped in list to force evaluation in python 3
+    return list(filter(bool, [v.strip() for v in value.split(separator)]))
+
+
+def get(name, required=False, default=empty, type=None):
+    """Generic getter for environment variables. Handles defaults,
+    required-ness, and what type to expect.
+
+    :param name: The name of the environment variable be pulled
+    :type name: str
+
+    :param required: Whether the environment variable is required. If ``True``
+    and the variable is not present, a ``KeyError`` is raised.
+    :type required: bool
+
+    :param default: The value to return if the environment variable is not
+    present. (Providing a default alongside setting ``required=True`` will raise
+    a ``ValueError``)
+    :type default: bool
+
+    :param type: The type of variable expected.
+    :param type: str or type
+    """
+    fn = {
+        'int': env_int,
+        int: env_int,
+
+        # 'float': env_float,
+        # float: env_float,
+
+        'bool': env_bool,
+        bool: env_bool,
+
+        'string': env_string,
+        str: env_string,
+
+        'list': env_list,
+        list: env_list,
+    }.get(type, env_string)
+    return fn(name, default=default, required=required)

--- a/tests/core/env-utils/test_env_bool.py
+++ b/tests/core/env-utils/test_env_bool.py
@@ -1,0 +1,79 @@
+import os
+import pytest
+
+from evm.utils.env import (
+    env_bool,
+)
+
+
+@pytest.mark.parametrize(
+    'env_value,expected',
+    (
+        ('True', True),
+        ('true', True),
+        ('not-a-known-value', False),
+        ('False', False),
+    )
+)
+def test_env_bool_not_required_with_no_default(monkeypatch, env_value, expected):
+    """
+    Test that when the environment variable is present that it is parsed to a boolean.
+    """
+    monkeypatch.setenv('TEST_BOOLEAN_ENV_VARIABLE', env_value)
+
+    actual = env_bool('TEST_BOOLEAN_ENV_VARIABLE')
+    assert actual is expected
+
+
+def test_env_bool_not_required_and_not_set():
+    """
+    Test that when the env variable is not set and not required it returns
+    `None`.
+    """
+    # sanity check
+    assert 'TEST_BOOLEAN_ENV_VARIABLE' not in os.environ
+
+    actual = env_bool('TEST_BOOLEAN_ENV_VARIABLE')
+    assert actual is None
+
+
+def test_env_bool_when_missing_and_required_is_error():
+    """
+    Test that when the env variable is not set and is required, it raises an
+    error.
+    """
+    # sanity check
+    assert 'TEST_BOOLEAN_ENV_VARIABLE' not in os.environ
+
+    with pytest.raises(KeyError):
+        env_bool('TEST_BOOLEAN_ENV_VARIABLE', required=True)
+
+
+@pytest.mark.parametrize(
+    'default,expected',
+    (
+        (True, True),
+        ('true', True),
+        ('True', True),
+        ('1', False),  # not sure if this is the correct behavior...
+        (False, False),
+        ('0', False),
+    )
+)
+def test_env_bool_when_missing_and_default_provided(default, expected):
+    """
+    Test that when the env variable is not set and a default is provided, the
+    default is used.
+    """
+    assert 'TEST_BOOLEAN_ENV_VARIABLE' not in os.environ
+
+    actual = env_bool('TEST_BOOLEAN_ENV_VARIABLE', default=default)
+    assert actual is expected
+
+
+def test_that_required_and_default_are_mutually_exclusive():
+    """
+    Test that when `required` and `default` are both set, raises a ValueError.
+    """
+    with pytest.raises(ValueError):
+        env_bool('TEST_BOOLEAN_ENV_VARIABLE', required=True, default=True)

--- a/tests/core/env-utils/test_env_float.py
+++ b/tests/core/env-utils/test_env_float.py
@@ -1,0 +1,48 @@
+import os
+import pytest
+
+from evm.utils.env import (
+    env_float,
+)
+
+
+@pytest.mark.parametrize(
+    'env_value,expected',
+    (
+        ('1.01', 1.01),
+        ('123.0', 123.0),
+        ('-123.99', -123.99),
+    )
+)
+def test_env_float_not_required_with_no_default(monkeypatch, env_value, expected):
+    """
+    Test that when the environment variable is present that it is parsed to a float.
+    """
+    monkeypatch.setenv('TEST_FLOAT_ENV_VARIABLE', env_value)
+
+    actual = env_float('TEST_FLOAT_ENV_VARIABLE')
+    assert actual == expected
+
+
+def test_env_float_not_required_and_not_set():
+    """
+    Test that when the env variable is not set and not required it raises a
+    ValueError
+    """
+    # sanity check
+    assert 'TEST_FLOAT_ENV_VARIABLE' not in os.environ
+
+    with pytest.raises(ValueError):
+        env_float('TEST_FLOAT_ENV_VARIABLE')
+
+
+def test_env_float_when_missing_and_required_is_error():
+    """
+    Test that when the env variable is not set and is required, it raises an
+    error.
+    """
+    # sanity check
+    assert 'TEST_FLOAT_ENV_VARIABLE' not in os.environ
+
+    with pytest.raises(KeyError):
+        env_float('TEST_FLOAT_ENV_VARIABLE', required=True)

--- a/tests/core/env-utils/test_env_int.py
+++ b/tests/core/env-utils/test_env_int.py
@@ -1,0 +1,76 @@
+import os
+import pytest
+
+from evm.utils.env import (
+    env_int,
+)
+
+
+@pytest.mark.parametrize(
+    'env_value,expected',
+    (
+        ('1', 1),
+        ('123', 123),
+        ('-123', -123),
+    )
+)
+def test_env_int_not_required_with_no_default(monkeypatch, env_value, expected):
+    """
+    Test that when the environment variable is present that it is parsed to a int.
+    """
+    monkeypatch.setenv('TEST_INT_ENV_VARIABLE', env_value)
+
+    actual = env_int('TEST_INT_ENV_VARIABLE')
+    assert actual == expected
+
+
+def test_env_int_not_required_and_not_set():
+    """
+    Test that when the env variable is not set and not required it raises a
+    ValueError
+    """
+    # sanity check
+    assert 'TEST_INT_ENV_VARIABLE' not in os.environ
+
+    with pytest.raises(ValueError):
+        env_int('TEST_INT_ENV_VARIABLE')
+
+
+def test_env_int_when_missing_and_required_is_error():
+    """
+    Test that when the env variable is not set and is required, it raises an
+    error.
+    """
+    # sanity check
+    assert 'TEST_INT_ENV_VARIABLE' not in os.environ
+
+    with pytest.raises(KeyError):
+        env_int('TEST_INT_ENV_VARIABLE', required=True)
+
+
+@pytest.mark.parametrize(
+    'default,expected',
+    (
+        (1, 1),
+        ('1', 1),
+        ('-1', -1),
+        (-1, -1),
+    )
+)
+def test_env_int_when_missing_and_default_provided(default, expected):
+    """
+    Test that when the env variable is not set and a default is provided, the
+    default is used.
+    """
+    assert 'TEST_INT_ENV_VARIABLE' not in os.environ
+
+    actual = env_int('TEST_INT_ENV_VARIABLE', default=default)
+    assert actual == expected
+
+
+def test_that_required_and_default_are_mutually_exclusive():
+    """
+    Test that when `required` and `default` are both set, raises a ValueError.
+    """
+    with pytest.raises(ValueError):
+        env_int('TEST_INT_ENV_VARIABLE', required=True, default=1)

--- a/tests/core/env-utils/test_env_list.py
+++ b/tests/core/env-utils/test_env_list.py
@@ -1,0 +1,74 @@
+import os
+import pytest
+
+from evm.utils.env import (
+    env_list,
+)
+
+
+def test_env_list_with_stock_usage(monkeypatch):
+    """
+    Test that when the environment variable is present that is is split on
+    commas (by default) and returned as a list.
+    """
+    monkeypatch.setenv('TEST_LIST_ENV_VARIABLE', 'a,b,c')
+
+    actual = env_list('TEST_LIST_ENV_VARIABLE')
+    assert actual == ['a', 'b', 'c']
+
+
+def test_env_list_removes_whitespace(monkeypatch):
+    """
+    Test that extra whitespace is removed from list values.
+    """
+    monkeypatch.setenv('TEST_LIST_ENV_VARIABLE', 'a, b, c')
+
+    actual = env_list('TEST_LIST_ENV_VARIABLE')
+    assert actual == ['a', 'b', 'c']
+
+
+def test_env_list_with_custom_separator(monkeypatch):
+    """
+    Test that when the environment variable is missing and a default is
+    provided, the default is retured.
+    """
+    monkeypatch.setenv('TEST_LIST_ENV_VARIABLE', 'a:b:c')
+
+    actual = env_list('TEST_LIST_ENV_VARIABLE', separator=':')
+    assert actual == ['a', 'b', 'c']
+
+
+def test_env_list_with_empty_list(monkeypatch):
+    """
+    Test that when the environment variable is missing and a default is
+    provided, the default is used.
+    """
+    monkeypatch.setenv('TEST_LIST_ENV_VARIABLE', '')
+
+    actual = env_list('TEST_LIST_ENV_VARIABLE')
+    assert actual == []
+
+
+def test_env_list_with_default_value():
+    """
+    Test that when the environment variable is missing and a default is
+    provided, the default is used.
+    """
+    # sanity check
+    assert 'TEST_LIST_ENV_VARIABLE' not in os.environ
+
+    actual = env_list('TEST_LIST_ENV_VARIABLE', default='a,b,c')
+    assert actual == ['a', 'b', 'c']
+
+
+def test_env_list_with_required_raises_when_not_present():
+    # sanity check
+    assert 'TEST_LIST_ENV_VARIABLE' not in os.environ
+
+    with pytest.raises(KeyError):
+        env_list('TEST_LIST_ENV_VARIABLE', required=True)
+
+
+def test_env_list_with_required_and_default_is_error():
+    with pytest.raises(ValueError):
+        env_list('TEST_LIST_ENV_VARIABLE', required=True, default='a,b,c')

--- a/tests/core/env-utils/test_env_string.py
+++ b/tests/core/env-utils/test_env_string.py
@@ -1,0 +1,44 @@
+import os
+import pytest
+
+from evm.utils.env import (
+    env_string,
+)
+
+
+def test_env_string_with_basic_usage(monkeypatch):
+    """
+    Test that when the environment variable is present that it is returned as a
+    string.
+    """
+    monkeypatch.setenv('TEST_BOOLEAN_ENV_VARIABLE', 'test-value')
+
+    actual = env_string('TEST_BOOLEAN_ENV_VARIABLE')
+    assert actual == 'test-value'
+
+
+def test_env_string_with_default_value(monkeypatch):
+    """
+    Test that when the environment variable is missing and a default is
+    provided, the default is retured.
+    """
+    assert 'TEST_BOOLEAN_ENV_VARIABLE' not in os.environ
+
+    actual = env_string('TEST_BOOLEAN_ENV_VARIABLE', default='test-value')
+    assert actual == 'test-value'
+
+
+def test_env_string_with_required():
+    """
+    Test that when the environment variable is missing and a default is
+    provided, the default is retured.
+    """
+    assert 'TEST_BOOLEAN_ENV_VARIABLE' not in os.environ
+
+    with pytest.raises(KeyError):
+        env_string('TEST_BOOLEAN_ENV_VARIABLE', required=True)
+
+
+def test_env_string_with_required_and_default_is_error():
+    with pytest.raises(ValueError):
+        env_string('TEST_BOOLEAN_ENV_VARIABLE', required=True, default='test-value')

--- a/tests/core/env-utils/test_get.py
+++ b/tests/core/env-utils/test_get.py
@@ -1,0 +1,38 @@
+import pytest
+
+from evm.utils.env import (
+    get,
+)
+
+
+@pytest.mark.parametrize(
+    'type,expected',
+    (
+        ('int', 42),
+        (int, 42),
+
+        ('bool', False),
+        (bool, True),
+
+        ('string', 'ozymandias'),
+        (str, 'hannibal'),
+
+        ('float', 42.0),
+        (float, 42.0),
+    )
+)
+def test_get_mapping(type, expected):
+    actual = get('ENV_VARIABLE', default=expected, type=type)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'type,default,expected',
+    (
+        ('list', '1,2,3', ['1', '2', '3']),
+        (list, '3,2,1', ['3', '2', '1']),
+    )
+)
+def test_get_mapping_for_lists(type, default, expected):
+    actual = get('ENV_VARIABLE', default=default, type=type)
+    assert actual == expected


### PR DESCRIPTION
### What was wrong?

`evm.utils.env` needed to be backported to `master`.

### How was it fixed?

Copied the `evm.utils.env` module and `tests/core/env-tests` directory to `master` from `sharding` branch.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/7f/2a/a2/7f2aa2c54dee9ce171db688d3c3b91b9--deer-pictures-cute-animal-pictures.jpg)
