### PR TITLE
Add Collation and CollationHeader classes

### DIFF
--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -5,11 +5,16 @@ import rlp
 from trie import (
     HexaryTrie,
 )
+from trie.branches import (
+    get_witness_for_key_prefix,
+)
 
 from eth_utils import (
     keccak,
     to_list,
     to_tuple,
+    to_set,
+    flatten_return,
 )
 
 from evm.constants import (
@@ -249,6 +254,13 @@ class BaseChainDB:
 
         transaction_key = rlp.decode(encoded_key, sedes=TransactionKey)
         return (transaction_key.block_number, transaction_key.index)
+
+    @to_set
+    @flatten_return
+    def get_witness_nodes(self, collation_header, prefixes):
+        root_hash = collation_header.state_root
+        for prefix in prefixes:
+            yield get_witness_for_key_prefix(self.db, root_hash, prefix)
 
     def add_block_number_to_hash_lookup(self, header):
         block_number_to_hash_key = make_block_number_to_hash_lookup_key(

--- a/evm/rlp/collations.py
+++ b/evm/rlp/collations.py
@@ -1,0 +1,57 @@
+import rlp
+
+
+class BaseCollation(rlp.Serializable):
+    @classmethod
+    def configure(cls, **overrides):
+        class_name = cls.__name__
+        for key in overrides:
+            if not hasattr(cls, key):
+                raise TypeError(
+                    "The {0}.configure cannot set attributes that are not "
+                    "already present on the base class.  The attribute `{1}` was "
+                    "not found on the base class `{2}`".format(class_name, key, cls)
+                )
+        return type(class_name, (cls,), overrides)
+
+    # TODO: Remove this once https://github.com/ethereum/pyrlp/issues/45 is
+    # fixed.
+    @classmethod
+    def get_sedes(cls):
+        return rlp.sedes.List(sedes for _, sedes in cls.fields)
+
+    transaction_class = None
+
+    @classmethod
+    def get_transaction_class(cls):
+        if cls.transaction_class is None:
+            raise AttributeError("Collation subclasses must declare a transaction_class")
+        return cls.transaction_class
+
+    @classmethod
+    def from_header(cls, header, chaindb):
+        """
+        Returns the collation denoted by the given collation header.
+        """
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    @property
+    def hash(self):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    @property
+    def shard_id(self):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    @property
+    def expected_period_number(self):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    def __repr__(self):
+        return '<{class_name}(#{b})>'.format(
+            class_name=self.__class__.__name__,
+            b=str(self),
+        )
+
+    def __str__(self):
+        return "Collation #{b.expected_period_number} (shard #{b.header.shard_id})".format(b=self)

--- a/evm/rlp/collations.py
+++ b/evm/rlp/collations.py
@@ -1,18 +1,11 @@
 import rlp
 
+from evm.utils.datatypes import (
+    Configurable,
+)
 
-class BaseCollation(rlp.Serializable):
-    @classmethod
-    def configure(cls, **overrides):
-        class_name = cls.__name__
-        for key in overrides:
-            if not hasattr(cls, key):
-                raise TypeError(
-                    "The {0}.configure cannot set attributes that are not "
-                    "already present on the base class.  The attribute `{1}` was "
-                    "not found on the base class `{2}`".format(class_name, key, cls)
-                )
-        return type(class_name, (cls,), overrides)
+
+class BaseCollation(rlp.Serializable, Configurable):
 
     # TODO: Remove this once https://github.com/ethereum/pyrlp/issues/45 is
     # fixed.

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -193,7 +193,7 @@ class CollationHeader(rlp.Serializable):
     def from_parent(cls,
                     parent,
                     period_start_prevhash,
-                    expected_period_number=None,
+                    expected_period_number,
                     coinbase=ZERO_ADDRESS,
                     sig=b""):
         """
@@ -202,7 +202,7 @@ class CollationHeader(rlp.Serializable):
         """
         header_kwargs = {
             "shard_id": parent.shard_id,
-            "expected_period_number": expected_period_number or parent.expected_period_number + 1,
+            "expected_period_number": expected_period_number,
             "period_start_prevhash": period_start_prevhash,
             "parent_hash": parent.hash,
             "state_root": parent.state_root,

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -141,3 +141,76 @@ class BlockHeader(rlp.Serializable):
             for field_name
             in tuple(zip(*self.fields))[0]
         })
+
+
+class CollationHeader(rlp.Serializable):
+    fields = [
+        ("shard_id", big_endian_int),
+        ("expected_period_number", big_endian_int),
+        ("period_start_prevhash", hash32),
+        ("parent_hash", hash32),
+        ("coinbase", address),
+        ("transaction_root", hash32),
+        ("state_root", hash32),
+        ("receipt_root", hash32),
+        ("sig", binary)
+    ]
+
+    def __init__(self,
+                 shard_id,
+                 expected_period_number,
+                 period_start_prevhash,
+                 parent_hash,
+                 transaction_root=BLANK_ROOT_HASH,
+                 coinbase=ZERO_ADDRESS,
+                 state_root=BLANK_ROOT_HASH,
+                 receipt_root=BLANK_ROOT_HASH,
+                 sig=b""):
+        super(CollationHeader, self).__init__(
+            shard_id=shard_id,
+            expected_period_number=expected_period_number,
+            period_start_prevhash=period_start_prevhash,
+            parent_hash=parent_hash,
+            transaction_root=transaction_root,
+            coinbase=coinbase,
+            state_root=state_root,
+            receipt_root=receipt_root,
+            sig=sig
+        )
+
+    def __repr__(self):
+        return "<CollationHeader #{0} {1} (shard #{2})>".format(
+            self.expected_period_number,
+            encode_hex(self.hash)[2:10],
+            self.shard_id,
+        )
+
+    @property
+    def hash(self):
+        return keccak(rlp.encode(self))
+
+    @property
+    def hex_hash(self):
+        return encode_hex(self.hash)
+
+    @classmethod
+    def from_parent(cls,
+                    parent,
+                    period_start_prevhash,
+                    expected_period_number=None,
+                    coinbase=ZERO_ADDRESS,
+                    sig=b""):
+        """
+        Initialize a new collation header with the `parent` header as the collation's
+        parent hash.
+        """
+        header_kwargs = {
+            "shard_id": parent.shard_id,
+            "expected_period_number": expected_period_number or parent.expected_period_number + 1,
+            "period_start_prevhash": period_start_prevhash,
+            "parent_hash": parent.hash,
+            "state_root": parent.state_root,
+            "sig": sig
+        }
+        header = cls(**header_kwargs)
+        return header

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -189,10 +189,6 @@ class CollationHeader(rlp.Serializable):
     def hash(self):
         return keccak(rlp.encode(self))
 
-    @property
-    def hex_hash(self):
-        return encode_hex(self.hash)
-
     @classmethod
     def from_parent(cls,
                     parent,

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -153,6 +153,7 @@ class CollationHeader(rlp.Serializable):
         ("coinbase", address),
         ("state_root", hash32),
         ("receipt_root", hash32),
+        ("number", big_endian_int),
         ("sig", binary)
     ]
 
@@ -161,6 +162,7 @@ class CollationHeader(rlp.Serializable):
                  expected_period_number,
                  period_start_prevhash,
                  parent_hash,
+                 number,
                  transaction_root=BLANK_ROOT_HASH,
                  coinbase=ZERO_ADDRESS,
                  state_root=BLANK_ROOT_HASH,
@@ -175,6 +177,7 @@ class CollationHeader(rlp.Serializable):
             coinbase=coinbase,
             state_root=state_root,
             receipt_root=receipt_root,
+            number=number,
             sig=sig
         )
 
@@ -206,6 +209,7 @@ class CollationHeader(rlp.Serializable):
             "period_start_prevhash": period_start_prevhash,
             "parent_hash": parent.hash,
             "state_root": parent.state_root,
+            "number": parent.number + 1,
             "sig": sig
         }
         header = cls(**header_kwargs)

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -149,8 +149,8 @@ class CollationHeader(rlp.Serializable):
         ("expected_period_number", big_endian_int),
         ("period_start_prevhash", hash32),
         ("parent_hash", hash32),
-        ("coinbase", address),
         ("transaction_root", hash32),
+        ("coinbase", address),
         ("state_root", hash32),
         ("receipt_root", hash32),
         ("sig", binary)

--- a/evm/vm/forks/sharding/collations.py
+++ b/evm/vm/forks/sharding/collations.py
@@ -1,0 +1,76 @@
+from rlp.sedes import (
+    CountableList,
+    binary,
+)
+
+from evm.rlp.headers import CollationHeader
+from evm.rlp.collations import BaseCollation
+from evm.rlp.receipts import Receipt
+
+from evm.vm.forks.sharding.transactions import ShardingTransaction
+
+
+class Collation(BaseCollation):
+    transaction_class = ShardingTransaction
+    fields = [
+        ('header', CollationHeader),
+        ('transactions', CountableList(transaction_class)),
+        ('witness_nodes', CountableList(binary))
+    ]
+
+    def __init__(self, header, transactions=None, witness_nodes=None):
+        if transactions is None:
+            transactions = []
+        if witness_nodes is None:
+            witness_nodes = []
+
+        super(Collation, self).__init__(
+            header=header,
+            transactions=transactions,
+            witness_nodes=witness_nodes,
+        )
+
+    #
+    # Helpers
+    #
+    @property
+    def shard_id(self):
+        return self.header.shard_id
+
+    @property
+    def expected_period_number(self):
+        return self.header.expected_period_number
+
+    @property
+    def hash(self):
+        return self.header.hash
+
+    #
+    # Transaction class for this block class
+    #
+    @classmethod
+    def get_transaction_class(cls):
+        return cls.transaction_class
+
+    #
+    # Receipts API
+    #
+    def get_receipts(self, chaindb):
+        return chaindb.get_receipts(self.header, Receipt)
+
+    #
+    # Header API
+    #
+    @classmethod
+    def from_header(cls, header, chaindb):
+        """
+        Returns the collation denoted by the given collation header.
+        """
+        transactions = chaindb.get_block_transactions(header, cls.get_transaction_class())
+        witness_nodes = chaindb.get_witness_nodes(header, transactions)
+
+        return cls(
+            header=header,
+            transactions=transactions,
+            witness_nodes=witness_nodes,
+        )

--- a/evm/vm/forks/sharding/collations.py
+++ b/evm/vm/forks/sharding/collations.py
@@ -1,3 +1,5 @@
+import itertools
+
 from rlp.sedes import (
     CountableList,
     binary,
@@ -67,7 +69,10 @@ class Collation(BaseCollation):
         Returns the collation denoted by the given collation header.
         """
         transactions = chaindb.get_block_transactions(header, cls.get_transaction_class())
-        witness_nodes = chaindb.get_witness_nodes(header, transactions)
+        prefixes_nested = [transaction.prefix_list for transaction in transactions]
+        prefixes = itertools.chain.from_iterable(prefixes_nested)
+        witness_node_set = chaindb.get_witness_nodes(header, prefixes)
+        witness_nodes = sorted(list(witness_node_set))
 
         return cls(
             header=header,

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -158,6 +158,7 @@ def test_get_witness_nodes(populated_chaindb_and_root_hash):
         expected_period_number=0,
         period_start_prevhash=ZERO_HASH32,
         parent_hash=ZERO_HASH32,
+        number=0,
         state_root=root_hash
     )
 

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -14,6 +14,11 @@ from evm.utils.fixture_tests import (
 from evm.utils.numeric import (
     big_endian_to_int,
 )
+from evm.utils.state_access_restriction import (
+    get_nonce_key,
+    get_balance_key,
+    get_storage_key,
+)
 from evm.constants import (
     BLANK_ROOT_HASH,
     ZERO_HASH32,
@@ -26,8 +31,8 @@ from evm.db.chain import (
     BaseChainDB,
 )
 from evm.db.state import (
-    FlatTrieBackend,
-    NestedTrieBackend,
+    MainAccountStateDB,
+    ShardingAccountStateDB,
 )
 from evm.exceptions import (
     BlockNotFound,
@@ -59,9 +64,9 @@ A_ADDRESS = b"\xaa" * 20
 B_ADDRESS = b"\xbb" * 20
 
 
-@pytest.fixture(params=[NestedTrieBackend, FlatTrieBackend])
+@pytest.fixture(params=[MainAccountStateDB, ShardingAccountStateDB])
 def chaindb(request):
-    return BaseChainDB(get_db_backend(), state_backend_class=request.param)
+    return BaseChainDB(get_db_backend(), account_state_class=request.param)
 
 
 @pytest.fixture
@@ -167,15 +172,15 @@ def test_get_witness_nodes(populated_chaindb_and_root_hash):
     )
 
     prefixes = [
-        FlatTrieBackend.nonce_key(A_ADDRESS),
-        FlatTrieBackend.nonce_key(B_ADDRESS),
-        FlatTrieBackend.balance_key(A_ADDRESS),
-        FlatTrieBackend.balance_key(B_ADDRESS),
-        FlatTrieBackend.storage_key(A_ADDRESS, big_endian_to_int(b"key1")),
-        FlatTrieBackend.storage_key(B_ADDRESS, big_endian_to_int(b"key1")),
-        FlatTrieBackend.storage_key(B_ADDRESS, big_endian_to_int(b"key2")),
-        FlatTrieBackend.storage_key(B_ADDRESS, big_endian_to_int(b"key")),
-        FlatTrieBackend.storage_key(B_ADDRESS, big_endian_to_int(b"")),
+        get_nonce_key(A_ADDRESS),
+        get_nonce_key(B_ADDRESS),
+        get_balance_key(A_ADDRESS),
+        get_balance_key(B_ADDRESS),
+        get_storage_key(A_ADDRESS, big_endian_to_int(b"key1")),
+        get_storage_key(B_ADDRESS, big_endian_to_int(b"key1")),
+        get_storage_key(B_ADDRESS, big_endian_to_int(b"key2")),
+        get_storage_key(B_ADDRESS, big_endian_to_int(b"key")),
+        get_storage_key(B_ADDRESS, big_endian_to_int(b"")),
     ]
 
     witness_nodes = chaindb.get_witness_nodes(header, prefixes)

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -6,6 +6,7 @@ from hypothesis import (
 )
 
 import rlp
+import trie
 
 from evm.utils.fixture_tests import (
     assert_rlp_equal,
@@ -150,7 +151,10 @@ def test_lookup_block_hash(chaindb, block):
     assert block_hash == block.hash
 
 
-@pytest.mark.xfail(reason="#289 (switch to binary trie not complete yet)", strict=True)
+@pytest.mark.xfail(
+    reason="#289 (switch to binary trie not complete yet)",
+    raises=trie.exceptions.InvalidNode
+)
 def test_get_witness_nodes(populated_chaindb_and_root_hash):
     chaindb, root_hash = populated_chaindb_and_root_hash
     header = CollationHeader(

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -150,6 +150,7 @@ def test_lookup_block_hash(chaindb, block):
     assert block_hash == block.hash
 
 
+@pytest.mark.xfail(reason="#289 (switch to binary trie not complete yet)", strict=True)
 def test_get_witness_nodes(populated_chaindb_and_root_hash):
     chaindb, root_hash = populated_chaindb_and_root_hash
     header = CollationHeader(


### PR DESCRIPTION
This pull request adds a Collation and CollationHeader classes. I used the Block and BlockHeader classes in the current master as a model, so they are very slim. Only functionality added is the ability to get witnesses from `BaseChainDB` (using `py-trie`s `get_witness_for_key_prefix`) which is needed for `Collation.from_header`. I wrote a test for this, which unfortunately fails. I believe the reason for this is that `get_witness_for_key_prefix` has been written for `BinaryTrie` instead of `HexaryTrie` (which is still in use), but would appreciate feedback by @NIC619 on that matter. If this is confirmed I'd mark it as `xfail`ing (as switching to `BinaryTrie` should be done in another PR).

@hwwhww Is there anything missing?

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/35109528-f535be32-fc76-11e7-8622-af93a4553b6d.jpeg)