### PR TITLE
Avoid usage of account_exists

### DIFF
--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -26,8 +26,7 @@ from evm.db.journal import (
     JournalDB,
 )
 from evm.db.state import (
-    AccountStateDB,
-    NestedTrieBackend,
+    MainAccountStateDB,
 )
 from evm.rlp.headers import (
     BlockHeader,
@@ -59,9 +58,9 @@ class TransactionKey(rlp.Serializable):
 
 class BaseChainDB:
 
-    def __init__(self, db, state_backend_class=NestedTrieBackend):
+    def __init__(self, db, account_state_class=MainAccountStateDB):
         self.db = JournalDB(db)
-        self.state_backend_class = state_backend_class
+        self.account_state_class = account_state_class
 
     def exists(self, key):
         return self.db.exists(key)
@@ -376,10 +375,11 @@ class BaseChainDB:
         self.db.clear()
 
     def get_state_db(self, state_root, read_only, access_list=None):
-        return AccountStateDB(
-            db=self.db,
-            root_hash=state_root,
-            read_only=read_only,
-            access_list=access_list,
-            backend_class=self.state_backend_class,
-        )
+        kwargs = {
+            "db": self.db,
+            "root_hash": state_root,
+            "read_only": read_only,
+        }
+        if access_list is not None:
+            kwargs["access_list"] = access_list
+        return self.account_state_class(**kwargs)

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -375,11 +375,12 @@ class BaseChainDB:
         self.db.clear()
 
     def get_state_db(self, state_root, read_only, access_list=None):
-        kwargs = {
-            "db": self.db,
-            "root_hash": state_root,
-            "read_only": read_only,
-        }
+        extra_kwargs = {}
         if access_list is not None:
-            kwargs["access_list"] = access_list
-        return self.account_state_class(**kwargs)
+            extra_kwargs["access_list"] = access_list
+        return self.account_state_class(
+            db=self.db,
+            root_hash=state_root,
+            read_only=read_only,
+            **extra_kwargs
+        )

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -40,10 +40,10 @@ from evm.utils.padding import (
     pad32,
 )
 from evm.utils.state_access_restriction import (
-    code_key,
-    balance_key,
-    nonce_key,
-    storage_key,
+    get_code_key,
+    get_balance_key,
+    get_nonce_key,
+    get_storage_key,
 )
 
 from .hash_trie import HashTrie
@@ -319,7 +319,7 @@ class ShardingAccountStateDB(BaseAccountStateDB):
         validate_canonical_address(address, title="Storage Address")
         validate_uint256(slot, title="Storage Slot")
 
-        key = storage_key(address, slot)
+        key = get_storage_key(address, slot)
         self._check_accessibility(key)
 
         if key in self._trie:
@@ -332,7 +332,7 @@ class ShardingAccountStateDB(BaseAccountStateDB):
         validate_uint256(slot, title="Storage Slot")
         validate_canonical_address(address, title="Storage Address")
 
-        key = storage_key(address, slot)
+        key = get_storage_key(address, slot)
         self._check_accessibility(key)
 
         if value:
@@ -346,7 +346,7 @@ class ShardingAccountStateDB(BaseAccountStateDB):
     def get_balance(self, address):
         validate_canonical_address(address, title="Storage Address")
 
-        key = balance_key(address)
+        key = get_balance_key(address)
         self._check_accessibility(key)
 
         if key in self._trie:
@@ -358,7 +358,7 @@ class ShardingAccountStateDB(BaseAccountStateDB):
         validate_canonical_address(address, title="Storage Address")
         validate_uint256(balance, title="Account Balance")
 
-        key = balance_key(address)
+        key = get_balance_key(address)
         self._check_accessibility(key)
 
         self._trie[key] = int_to_big_endian(balance)
@@ -369,7 +369,7 @@ class ShardingAccountStateDB(BaseAccountStateDB):
     def get_nonce(self, address):
         validate_canonical_address(address, title="Storage Address")
 
-        key = nonce_key(address)
+        key = get_nonce_key(address)
         self._check_accessibility(key)
 
         if key in self._trie:
@@ -381,7 +381,7 @@ class ShardingAccountStateDB(BaseAccountStateDB):
         validate_canonical_address(address, title="Storage Address")
         validate_uint256(nonce, title="Nonce")
 
-        key = nonce_key(address)
+        key = get_nonce_key(address)
         self._check_accessibility(key)
 
         self._trie[key] = int_to_big_endian(nonce)
@@ -392,7 +392,7 @@ class ShardingAccountStateDB(BaseAccountStateDB):
     def get_code(self, address):
         validate_canonical_address(address, title="Storage Address")
 
-        key = code_key(address)
+        key = get_code_key(address)
         self._check_accessibility(key)
 
         if key in self._trie:
@@ -408,7 +408,7 @@ class ShardingAccountStateDB(BaseAccountStateDB):
         validate_canonical_address(address, title="Storage Address")
         validate_is_bytes(code, title="Code")
 
-        key = code_key(address)
+        key = get_code_key(address)
         self._check_accessibility(key)
 
         self._trie[key] = code
@@ -416,7 +416,7 @@ class ShardingAccountStateDB(BaseAccountStateDB):
     def delete_code(self, address):
         validate_canonical_address(address, title="Storage Address")
 
-        key = code_key(address)
+        key = get_code_key(address)
         self._check_accessibility(key)
 
         del self._trie[key]

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -49,7 +49,79 @@ from evm.utils.state_access_restriction import (
 from .hash_trie import HashTrie
 
 
-class MainAccountStateDB:
+class BaseAccountStateDB:
+
+    def decommission(self):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    @property
+    def root_hash(self):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    @root_hash.setter
+    def root_hash(self, value):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    #
+    # Storage
+    #
+    def get_storage(self, address, slot):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    def set_storage(self, address, slot, value):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    #
+    # Balance
+    #
+    def get_balance(self, address):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    def set_balance(self, address, balance):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    def delta_balance(self, address, delta):
+        self.set_balance(address, self.get_balance(address) + delta)
+
+    #
+    # Nonce
+    #
+    def set_nonce(self, address, nonce):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    def get_nonce(self, address):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    def increment_nonce(self, address):
+        current_nonce = self.get_nonce(address)
+        self.set_nonce(address, current_nonce + 1)
+
+    #
+    # Code
+    #
+    def set_code(self, address, code):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    def get_code(self, address):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    def get_code_hash(self, address):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    def delete_code(self, address):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    #
+    # Account Methods
+    #
+    def account_has_code_or_nonce(self, address):
+        return self.get_nonce(address) != 0 or self.get_code_hash(address) != EMPTY_SHA3
+
+    def account_is_empty(self, address):
+        return not self.account_has_code_or_nonce(address) and self.get_balance(address) == 0
+
+
+class MainAccountStateDB(BaseAccountStateDB):
 
     def __init__(self, db, root_hash=BLANK_ROOT_HASH, read_only=False):
         if read_only:
@@ -131,9 +203,6 @@ class MainAccountStateDB:
         account.balance = balance
         self._set_account(address, account)
 
-    def delta_balance(self, address, delta):
-        self.set_balance(address, self.get_balance(address) + delta)
-
     #
     # Nonce
     #
@@ -151,10 +220,6 @@ class MainAccountStateDB:
 
         account = self._get_account(address)
         return account.nonce
-
-    def increment_nonce(self, address):
-        current_nonce = self.get_nonce(address)
-        self.set_nonce(address, current_nonce + 1)
 
     #
     # Code
@@ -203,17 +268,11 @@ class MainAccountStateDB:
 
         return bool(self._trie[address])
 
-    def account_has_code_or_nonce(self, address):
-        return self.get_nonce(address) != 0 or self.get_code_hash(address) != EMPTY_SHA3
-
     def touch_account(self, address):
         validate_canonical_address(address, title="Storage Address")
 
         account = self._get_account(address)
         self._set_account(address, account)
-
-    def account_is_empty(self, address):
-        return not self.account_has_code_or_nonce(address) and self.get_balance(address) == 0
 
     #
     # Internal
@@ -231,7 +290,7 @@ class MainAccountStateDB:
         self._trie[address] = rlp.encode(account, sedes=Account)
 
 
-class ShardingAccountStateDB:
+class ShardingAccountStateDB(BaseAccountStateDB):
 
     def __init__(self, db, root_hash=BLANK_ROOT_HASH, read_only=False, access_list=None):
         if read_only:
@@ -304,9 +363,6 @@ class ShardingAccountStateDB:
 
         self._trie[key] = int_to_big_endian(balance)
 
-    def delta_balance(self, address, delta):
-        self.set_balance(address, self.get_balance(address) + delta)
-
     #
     # Nonce
     #
@@ -330,10 +386,6 @@ class ShardingAccountStateDB:
 
         self._trie[key] = int_to_big_endian(nonce)
 
-    def increment_nonce(self, address):
-        current_nonce = self.get_nonce(address)
-        self.set_nonce(address, current_nonce + 1)
-
     #
     # Code
     #
@@ -347,6 +399,10 @@ class ShardingAccountStateDB:
             return self._trie[key]
         else:
             return b''
+
+    def get_code_hash(self, address):
+        code = self.get_code(address)
+        return keccak(code)
 
     def set_code(self, address, code):
         validate_canonical_address(address, title="Storage Address")
@@ -364,15 +420,6 @@ class ShardingAccountStateDB:
         self._check_accessibility(key)
 
         del self._trie[key]
-
-    #
-    # Account Methods
-    #
-    def account_has_code_or_nonce(self, address):
-        return self.get_nonce(address) != 0 or self.get_code(address) != b''
-
-    def account_is_empty(self, address):
-        return not self.account_has_code_or_nonce(address) and self.get_balance(address) == 0
 
     #
     # Internal

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -303,7 +303,8 @@ class FlatTrieBackend:
         return self.get_code(address) != b'' or self.get_nonce(address) != 0
 
     def touch_account(self, address):
-        if not self.account_exists(address):
+        do_not_touch = self.account_has_code_or_nonce(address) or self.get_balance(address) != 0
+        if not do_not_touch:
             self.set_nonce(address, 0)
             self.set_balance(address, 0)
             self.set_code(address, b'')

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -1,5 +1,3 @@
-import logging
-
 import rlp
 
 from trie import (
@@ -9,10 +7,6 @@ from trie import (
 from evm.constants import (
     BLANK_ROOT_HASH,
     EMPTY_SHA3,
-    BALANCE_TRIE_PREFIX,
-    CODE_TRIE_PREFIX,
-    NONCE_TRIE_PREFIX,
-    STORAGE_TRIE_PREFIX,
 )
 from evm.exceptions import (
     UnannouncedStateAccess,
@@ -45,18 +39,24 @@ from evm.utils.numeric import (
 from evm.utils.padding import (
     pad32,
 )
+from evm.utils.state_access_restriction import (
+    code_key,
+    balance_key,
+    nonce_key,
+    storage_key,
+)
 
 from .hash_trie import HashTrie
 
 
-class NestedTrieBackend:
-    def __init__(self, db, root_hash=BLANK_ROOT_HASH, access_list=None):
-        self.db = db
+class MainAccountStateDB:
+
+    def __init__(self, db, root_hash=BLANK_ROOT_HASH, read_only=False):
+        if read_only:
+            self.db = ImmutableDB(db)
+        else:
+            self.db = TrackedDB(db)
         self._trie = HashTrie(HexaryTrie(self.db, root_hash))
-        if access_list is not None:
-            raise NotImplementedError(
-                "State access restriction not implemented for two layer trie"
-            )
 
     def decommission(self):
         self.db = None
@@ -70,7 +70,29 @@ class NestedTrieBackend:
     def root_hash(self, value):
         self._trie.root_hash = value
 
+    #
+    # Storage
+    #
+    def get_storage(self, address, slot):
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(slot, title="Storage Slot")
+
+        account = self._get_account(address)
+        storage = HashTrie(HexaryTrie(self.db, account.storage_root))
+
+        slot_as_key = pad32(int_to_big_endian(slot))
+
+        if slot_as_key in storage:
+            encoded_value = storage[slot_as_key]
+            return rlp.decode(encoded_value, sedes=rlp.sedes.big_endian_int)
+        else:
+            return 0
+
     def set_storage(self, address, slot, value):
+        validate_uint256(value, title="Storage Value")
+        validate_uint256(slot, title="Storage Slot")
+        validate_canonical_address(address, title="Storage Address")
+
         account = self._get_account(address)
         storage = HashTrie(HexaryTrie(self.db, account.storage_root))
 
@@ -85,44 +107,62 @@ class NestedTrieBackend:
         account.storage_root = storage.root_hash
         self._set_account(address, account)
 
-    def get_storage(self, address, slot):
-        account = self._get_account(address)
-        storage = HashTrie(HexaryTrie(self.db, account.storage_root))
-
-        slot_as_key = pad32(int_to_big_endian(slot))
-
-        if slot_as_key in storage:
-            encoded_value = storage[slot_as_key]
-            return rlp.decode(encoded_value, sedes=rlp.sedes.big_endian_int)
-        else:
-            return 0
-
     def delete_storage(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
         account = self._get_account(address)
         account.storage_root = BLANK_ROOT_HASH
         self._set_account(address, account)
 
-    def set_balance(self, address, balance):
-        account = self._get_account(address)
-        account.balance = balance
-
-        self._set_account(address, account)
-
+    #
+    # Balance
+    #
     def get_balance(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
         account = self._get_account(address)
         return account.balance
 
+    def set_balance(self, address, balance):
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(balance, title="Account Balance")
+
+        account = self._get_account(address)
+        account.balance = balance
+        self._set_account(address, account)
+
+    def delta_balance(self, address, delta):
+        self.set_balance(address, self.get_balance(address) + delta)
+
+    #
+    # Nonce
+    #
     def set_nonce(self, address, nonce):
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(nonce, title="Nonce")
+
         account = self._get_account(address)
         account.nonce = nonce
 
         self._set_account(address, account)
 
     def get_nonce(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
         account = self._get_account(address)
         return account.nonce
 
+    def increment_nonce(self, address):
+        current_nonce = self.get_nonce(address)
+        self.set_nonce(address, current_nonce + 1)
+
+    #
+    # Code
+    #
     def set_code(self, address, code):
+        validate_canonical_address(address, title="Storage Address")
+        validate_is_bytes(code, title="Code")
+
         account = self._get_account(address)
 
         account.code_hash = keccak(code)
@@ -130,16 +170,22 @@ class NestedTrieBackend:
         self._set_account(address, account)
 
     def get_code(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
         try:
             return self.db[self.get_code_hash(address)]
         except KeyError:
             return b''
 
     def get_code_hash(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
         account = self._get_account(address)
         return account.code_hash
 
     def delete_code(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
         account = self._get_account(address)
         account.code_hash = EMPTY_SHA3
         self._set_account(address, account)
@@ -148,17 +194,26 @@ class NestedTrieBackend:
     # Account Methods
     #
     def delete_account(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
         del self._trie[address]
 
     def account_exists(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
         return bool(self._trie[address])
 
     def account_has_code_or_nonce(self, address):
         return self.get_nonce(address) != 0 or self.get_code_hash(address) != EMPTY_SHA3
 
     def touch_account(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
         account = self._get_account(address)
         self._set_account(address, account)
+
+    def account_is_empty(self, address):
+        return not self.account_has_code_or_nonce(address) and self.get_balance(address) == 0
 
     #
     # Internal
@@ -176,9 +231,14 @@ class NestedTrieBackend:
         self._trie[address] = rlp.encode(account, sedes=Account)
 
 
-class FlatTrieBackend:
-    def __init__(self, db, root_hash=BLANK_ROOT_HASH, access_list=None):
-        self._trie = HexaryTrie(db, root_hash)
+class ShardingAccountStateDB:
+
+    def __init__(self, db, root_hash=BLANK_ROOT_HASH, read_only=False, access_list=None):
+        if read_only:
+            self.db = ImmutableDB(db)
+        else:
+            self.db = TrackedDB(db)
+        self._trie = HexaryTrie(self.db, root_hash)
         self.is_access_restricted = access_list is not None
         self.access_list = access_list
 
@@ -193,33 +253,27 @@ class FlatTrieBackend:
     def root_hash(self, value):
         self._trie.root_hash = value
 
-    @staticmethod
-    def storage_key(address, slot):
-        return keccak(address) + STORAGE_TRIE_PREFIX + pad32(int_to_big_endian(slot))
+    #
+    # Storage
+    #
+    def get_storage(self, address, slot):
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(slot, title="Storage Slot")
 
-    @staticmethod
-    def full_storage_key(address):
-        return keccak(address) + STORAGE_TRIE_PREFIX
+        key = storage_key(address, slot)
+        self._check_accessibility(key)
 
-    @staticmethod
-    def balance_key(address):
-        return keccak(address) + BALANCE_TRIE_PREFIX
-
-    @staticmethod
-    def nonce_key(address):
-        return keccak(address) + NONCE_TRIE_PREFIX
-
-    @staticmethod
-    def code_key(address):
-        return keccak(address) + CODE_TRIE_PREFIX
-
-    def _check_accessibility(self, key):
-        if self.is_access_restricted:
-            if not is_accessible(key, self.access_list):
-                raise UnannouncedStateAccess("Attempted state access outside of access set")
+        if key in self._trie:
+            return big_endian_to_int(self._trie[key])
+        else:
+            return 0
 
     def set_storage(self, address, slot, value):
-        key = self.storage_key(address, slot)
+        validate_uint256(value, title="Storage Value")
+        validate_uint256(slot, title="Storage Slot")
+        validate_canonical_address(address, title="Storage Address")
+
+        key = storage_key(address, slot)
         self._check_accessibility(key)
 
         if value:
@@ -227,8 +281,13 @@ class FlatTrieBackend:
         else:
             del self._trie[key]
 
-    def get_storage(self, address, slot):
-        key = self.storage_key(address, slot)
+    #
+    # Balance
+    #
+    def get_balance(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
+        key = balance_key(address)
         self._check_accessibility(key)
 
         if key in self._trie:
@@ -236,17 +295,25 @@ class FlatTrieBackend:
         else:
             return 0
 
-    def delete_storage(self, address):
-        raise NotImplementedError("Full storage deletion not supported in flat trie state")
-
     def set_balance(self, address, balance):
-        key = self.balance_key(address)
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(balance, title="Account Balance")
+
+        key = balance_key(address)
         self._check_accessibility(key)
 
         self._trie[key] = int_to_big_endian(balance)
 
-    def get_balance(self, address):
-        key = self.balance_key(address)
+    def delta_balance(self, address, delta):
+        self.set_balance(address, self.get_balance(address) + delta)
+
+    #
+    # Nonce
+    #
+    def get_nonce(self, address):
+        validate_canonical_address(address, title="Storage Address")
+
+        key = nonce_key(address)
         self._check_accessibility(key)
 
         if key in self._trie:
@@ -255,28 +322,25 @@ class FlatTrieBackend:
             return 0
 
     def set_nonce(self, address, nonce):
-        key = self.nonce_key(address)
+        validate_canonical_address(address, title="Storage Address")
+        validate_uint256(nonce, title="Nonce")
+
+        key = nonce_key(address)
         self._check_accessibility(key)
 
         self._trie[key] = int_to_big_endian(nonce)
 
-    def get_nonce(self, address):
-        key = self.nonce_key(address)
-        self._check_accessibility(key)
+    def increment_nonce(self, address):
+        current_nonce = self.get_nonce(address)
+        self.set_nonce(address, current_nonce + 1)
 
-        if key in self._trie:
-            return big_endian_to_int(self._trie[key])
-        else:
-            return 0
-
-    def set_code(self, address, code):
-        key = self.code_key(address)
-        self._check_accessibility(key)
-
-        self._trie[key] = code
-
+    #
+    # Code
+    #
     def get_code(self, address):
-        key = self.code_key(address)
+        validate_canonical_address(address, title="Storage Address")
+
+        key = code_key(address)
         self._check_accessibility(key)
 
         if key in self._trie:
@@ -284,8 +348,19 @@ class FlatTrieBackend:
         else:
             return b''
 
+    def set_code(self, address, code):
+        validate_canonical_address(address, title="Storage Address")
+        validate_is_bytes(code, title="Code")
+
+        key = code_key(address)
+        self._check_accessibility(key)
+
+        self._trie[key] = code
+
     def delete_code(self, address):
-        key = self.code_key(address)
+        validate_canonical_address(address, title="Storage Address")
+
+        key = code_key(address)
         self._check_accessibility(key)
 
         del self._trie[key]
@@ -293,132 +368,16 @@ class FlatTrieBackend:
     #
     # Account Methods
     #
-    def delete_account(self, address):
-        raise NotImplementedError("Account deletion not supported in flat trie state")
-
-    def account_exists(self, address):
-        raise NotImplementedError("Account existence check not supported in flat trie")
-
     def account_has_code_or_nonce(self, address):
-        return self.get_code(address) != b'' or self.get_nonce(address) != 0
-
-    def touch_account(self, address):
-        do_not_touch = self.account_has_code_or_nonce(address) or self.get_balance(address) != 0
-        if not do_not_touch:
-            self.set_nonce(address, 0)
-            self.set_balance(address, 0)
-            self.set_code(address, b'')
-
-
-class AccountStateDB:
-    """
-    High level API around account storage.
-    """
-    db = None
-    _trie = None
-
-    logger = logging.getLogger('evm.state.State')
-
-    def __init__(
-        self,
-        db,
-        root_hash=BLANK_ROOT_HASH,
-        read_only=False,
-        access_list=None,
-        backend_class=NestedTrieBackend
-    ):
-        if read_only:
-            self.db = ImmutableDB(db)
-        else:
-            self.db = TrackedDB(db)
-        self.backend = backend_class(self.db, root_hash, access_list)
-
-    def decommission(self):
-        self.backend.decommission()
-        self.db = None
-
-    #
-    # Base API
-    #
-    @property
-    def root_hash(self):
-        return self.backend.root_hash
-
-    @root_hash.setter
-    def root_hash(self, value):
-        self.backend.root_hash = value
-
-    def set_storage(self, address, slot, value):
-        validate_uint256(value, title="Storage Value")
-        validate_uint256(slot, title="Storage Slot")
-        validate_canonical_address(address, title="Storage Address")
-        self.backend.set_storage(address, slot, value)
-
-    def get_storage(self, address, slot):
-        validate_canonical_address(address, title="Storage Address")
-        validate_uint256(slot, title="Storage Slot")
-        return self.backend.get_storage(address, slot)
-
-    def delete_storage(self, address):
-        validate_canonical_address(address, title="Storage Address")
-        self.backend.delete_storage(address)
-
-    def set_balance(self, address, balance):
-        validate_canonical_address(address, title="Storage Address")
-        validate_uint256(balance, title="Account Balance")
-        self.backend.set_balance(address, balance)
-
-    def delta_balance(self, address, delta):
-        self.set_balance(address, self.get_balance(address) + delta)
-
-    def get_balance(self, address):
-        validate_canonical_address(address, title="Storage Address")
-        return self.backend.get_balance(address)
-
-    def set_nonce(self, address, nonce):
-        validate_canonical_address(address, title="Storage Address")
-        validate_uint256(nonce, title="Nonce")
-        self.backend.set_nonce(address, nonce)
-
-    def get_nonce(self, address):
-        validate_canonical_address(address, title="Storage Address")
-        return self.backend.get_nonce(address)
-
-    def set_code(self, address, code):
-        validate_canonical_address(address, title="Storage Address")
-        validate_is_bytes(code, title="Code")
-        self.backend.set_code(address, code)
-
-    def get_code(self, address):
-        validate_canonical_address(address, title="Storage Address")
-        return self.backend.get_code(address)
-
-    def delete_code(self, address):
-        validate_canonical_address(address, title="Storage Address")
-        self.backend.delete_code(address)
-
-    #
-    # Account Methods
-    #
-    def delete_account(self, address):
-        validate_canonical_address(address, title="Storage Address")
-        self.backend.delete_account(address)
-
-    def account_exists(self, address):
-        validate_canonical_address(address, title="Storage Address")
-        return self.backend.account_exists(address)
-
-    def account_has_code_or_nonce(self, address):
-        validate_canonical_address(address, title="Storage Address")
-        return self.backend.account_has_code_or_nonce(address)
+        return self.get_nonce(address) != 0 or self.get_code(address) != b''
 
     def account_is_empty(self, address):
         return not self.account_has_code_or_nonce(address) and self.get_balance(address) == 0
 
-    def touch_account(self, address):
-        validate_canonical_address(address, title="Storage Address")
-        self.backend.touch_account(address)
-
-    def increment_nonce(self, address):
-        current_nonce = self.get_nonce(address)
-        self.set_nonce(address, current_nonce + 1)
+    #
+    # Internal
+    #
+    def _check_accessibility(self, key):
+        if self.is_access_restricted:
+            if not is_accessible(key, self.access_list):
+                raise UnannouncedStateAccess("Attempted state access outside of access set")

--- a/evm/logic/call.py
+++ b/evm/logic/call.py
@@ -348,3 +348,13 @@ class CallByzantium(CallEIP161):
         if computation.msg.is_static and value != 0:
             raise WriteProtection("Cannot modify state while inside of a STATICCALL context")
         return call_params
+
+
+class CallSharding(CallByzantium):
+    def compute_msg_extra_gas(self, computation, gas, to, value):
+        with computation.state_db(read_only=True) as state_db:
+            account_is_empty = state_db.account_is_empty(to)
+
+        transfer_gas_fee = constants.GAS_CALLVALUE if value else 0
+        create_gas_fee = constants.GAS_NEWACCOUNT if not account_is_empty else 0
+        return transfer_gas_fee + create_gas_fee

--- a/evm/p2p/test_state.py
+++ b/evm/p2p/test_state.py
@@ -3,12 +3,12 @@ import logging
 import random
 
 from evm.db.backends.memory import MemoryDB
-from evm.db.state import AccountStateDB
+from evm.db.state import MainAccountStateDB
 from evm.p2p.state import StateSync
 
 
 def make_random_state(n):
-    state_db = AccountStateDB(MemoryDB())
+    state_db = MainAccountStateDB(MemoryDB())
     contents = {}
     for i in range(n):
         addr = os.urandom(20)
@@ -36,7 +36,7 @@ def test_state_sync():
             results.append([request.node_key, state_db.db[request.node_key]])
         scheduler.process(results)
         requests = scheduler.next_batch(10)
-    dest_state = AccountStateDB(dest_db, state_db.root_hash)
+    dest_state = MainAccountStateDB(dest_db, state_db.root_hash)
     for addr, account_data in contents.items():
         balance, nonce, storage, code = account_data
         assert dest_state.get_balance(addr) == balance

--- a/evm/utils/state_access_restriction.py
+++ b/evm/utils/state_access_restriction.py
@@ -9,8 +9,15 @@ from evm.constants import (
     STORAGE_TRIE_PREFIX,
 )
 
+
 from evm.utils.keccak import (
     keccak,
+)
+from evm.utils.padding import (
+    pad32,
+)
+from evm.utils.numeric import (
+    int_to_big_endian,
 )
 
 
@@ -60,8 +67,28 @@ def to_prefix_list_form(access_list):
     """
     for obj in access_list:
         address, *storage_prefixes = obj
-        yield keccak(address) + NONCE_TRIE_PREFIX
-        yield keccak(address) + BALANCE_TRIE_PREFIX
-        yield keccak(address) + CODE_TRIE_PREFIX
+        yield nonce_key(address)
+        yield balance_key(address)
+        yield code_key(address)
         for prefix in remove_redundant_prefixes(storage_prefixes):
             yield keccak(address) + STORAGE_TRIE_PREFIX + prefix
+
+
+def storage_key(address, slot):
+    return keccak(address) + STORAGE_TRIE_PREFIX + pad32(int_to_big_endian(slot))
+
+
+def full_storage_key(address):
+    return keccak(address) + STORAGE_TRIE_PREFIX
+
+
+def balance_key(address):
+    return keccak(address) + BALANCE_TRIE_PREFIX
+
+
+def nonce_key(address):
+    return keccak(address) + NONCE_TRIE_PREFIX
+
+
+def code_key(address):
+    return keccak(address) + CODE_TRIE_PREFIX

--- a/evm/utils/state_access_restriction.py
+++ b/evm/utils/state_access_restriction.py
@@ -67,28 +67,28 @@ def to_prefix_list_form(access_list):
     """
     for obj in access_list:
         address, *storage_prefixes = obj
-        yield nonce_key(address)
-        yield balance_key(address)
-        yield code_key(address)
+        yield get_nonce_key(address)
+        yield get_balance_key(address)
+        yield get_code_key(address)
         for prefix in remove_redundant_prefixes(storage_prefixes):
             yield keccak(address) + STORAGE_TRIE_PREFIX + prefix
 
 
-def storage_key(address, slot):
+def get_storage_key(address, slot):
     return keccak(address) + STORAGE_TRIE_PREFIX + pad32(int_to_big_endian(slot))
 
 
-def full_storage_key(address):
+def get_full_storage_key(address):
     return keccak(address) + STORAGE_TRIE_PREFIX
 
 
-def balance_key(address):
+def get_balance_key(address):
     return keccak(address) + BALANCE_TRIE_PREFIX
 
 
-def nonce_key(address):
+def get_nonce_key(address):
     return keccak(address) + NONCE_TRIE_PREFIX
 
 
-def code_key(address):
+def get_code_key(address):
     return keccak(address) + CODE_TRIE_PREFIX

--- a/evm/vm/forks/sharding/opcodes.py
+++ b/evm/vm/forks/sharding/opcodes.py
@@ -5,11 +5,15 @@ from cytoolz import (
 )
 
 from evm import constants
+from evm.vm.forks.tangerine_whistle.constants import (
+    GAS_CALL_EIP150,
+)
 from evm import opcode_values
 from evm import mnemonics
 
 from evm.opcode import as_opcode
 from evm.logic import (
+    call,
     context,
     system,
 )
@@ -35,8 +39,21 @@ NEW_OPCODES = {
     ),
 }
 
+REMOVED_OPCODES = [
+    opcode_values.CREATE,
+]
+
+REPLACED_OPCODES = {
+    opcode_values.CALL: call.CallSharding.configure(
+        name='opcode:CALL',
+        mnemonic=mnemonics.CALL,
+        gas_cost=GAS_CALL_EIP150,
+    )(),
+}
+
 
 SHARDING_OPCODES = merge(
-    dissoc(copy.deepcopy(BYZANTIUM_OPCODES), opcode_values.CREATE),
-    NEW_OPCODES
+    dissoc(copy.deepcopy(BYZANTIUM_OPCODES), *REMOVED_OPCODES),
+    NEW_OPCODES,
+    REPLACED_OPCODES,
 )

--- a/evm/vm/forks/sharding/opcodes.py
+++ b/evm/vm/forks/sharding/opcodes.py
@@ -41,6 +41,7 @@ NEW_OPCODES = {
 
 REMOVED_OPCODES = [
     opcode_values.CREATE,
+    opcode_values.SELFDESTRUCT,
 ]
 
 REPLACED_OPCODES = {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 python_paths= .
+xfail_strict=True

--- a/tests/auxiliary/user-account/test_contract.py
+++ b/tests/auxiliary/user-account/test_contract.py
@@ -35,7 +35,7 @@ from evm.db.chain import (
     BaseChainDB,
 )
 from evm.db.state import (
-    NestedTrieBackend,
+    ShardingAccountStateDB,
 )
 
 from eth_utils import (
@@ -137,7 +137,7 @@ def vm():
         timestamp=1422494849,
         parent_hash=ZERO_HASH32,
     )
-    chaindb = BaseChainDB(get_db_backend(), state_backend_class=NestedTrieBackend)
+    chaindb = BaseChainDB(get_db_backend(), account_state_class=ShardingAccountStateDB)
     vm = ShardingVM(header=header, chaindb=chaindb)
     vm_state = vm.state
     with vm_state.state_db() as statedb:

--- a/tests/auxiliary/user-account/test_contract.py
+++ b/tests/auxiliary/user-account/test_contract.py
@@ -157,6 +157,7 @@ def get_nonce(vm):
     return big_endian_to_int(computation.output)
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 def test_get_nonce(vm):
     computation, _ = vm.apply_transaction(ShardingTransaction(**merge(DEFAULT_BASE_TX_PARAMS, {
         "data": int_to_big_endian(NONCE_GETTER_ID),
@@ -171,6 +172,7 @@ def test_get_nonce(vm):
     assert computation.output == pad32(b"\x01")
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 def test_call_increments_nonce(vm):
     computation, _ = vm.apply_transaction(SIGNED_DEFAULT_TRANSACTION)
     assert computation.is_success
@@ -184,6 +186,7 @@ def test_call_increments_nonce(vm):
     assert get_nonce(vm) == 2
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 def test_call_checks_nonce(vm):
     computation, _ = vm.apply_transaction(SIGNED_DEFAULT_TRANSACTION)
     assert computation.is_success
@@ -198,6 +201,7 @@ def test_call_checks_nonce(vm):
     assert computation.is_error
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 @pytest.mark.parametrize("min_block,max_block,valid", [
     (min_block, max_block, True) for min_block, max_block in [
         (0, UINT_256_MAX),
@@ -230,6 +234,7 @@ def test_call_checks_block_range(vm, min_block, max_block, valid):
         assert computation.is_error
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 def test_call_transfers_value(vm):
     vm_state = vm.state
     with vm_state.state_db() as state_db:
@@ -256,6 +261,7 @@ def test_call_transfers_value(vm):
     assert balance_destination_after == balance_destination_before + 10
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 @pytest.mark.parametrize("v,r,s", [
     (0, 0, 0),
 
@@ -299,6 +305,7 @@ def test_call_checks_signature(vm, v, r, s):
     assert computation.is_success
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 def test_call_uses_remaining_gas(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -314,6 +321,7 @@ def test_call_uses_remaining_gas(vm):
     assert logged_gas > 900 * 1000  # some gas will have been consumed earlier
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 @pytest.mark.parametrize("data,hash", [
     (data, keccak(data)) for data in [
         b"",
@@ -340,6 +348,7 @@ def test_call_uses_data(vm, data, hash):
     assert logged_hash == hash
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 def test_no_call_if_not_enough_gas(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -352,6 +361,7 @@ def test_no_call_if_not_enough_gas(vm):
     assert computation.gas_meter.gas_remaining > 0
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 def test_call_passes_return_code(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -370,6 +380,7 @@ def test_call_passes_return_code(vm):
     assert big_endian_to_int(computation.output) == 0  # failure
 
 
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
 def test_call_does_not_revert_nonce(vm):
     nonce_before = get_nonce(vm)
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {

--- a/tests/auxiliary/user-account/test_contract.py
+++ b/tests/auxiliary/user-account/test_contract.py
@@ -157,7 +157,7 @@ def get_nonce(vm):
     return big_endian_to_int(computation.output)
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 def test_get_nonce(vm):
     computation, _ = vm.apply_transaction(ShardingTransaction(**merge(DEFAULT_BASE_TX_PARAMS, {
         "data": int_to_big_endian(NONCE_GETTER_ID),
@@ -172,7 +172,7 @@ def test_get_nonce(vm):
     assert computation.output == pad32(b"\x01")
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 def test_call_increments_nonce(vm):
     computation, _ = vm.apply_transaction(SIGNED_DEFAULT_TRANSACTION)
     assert computation.is_success
@@ -186,7 +186,7 @@ def test_call_increments_nonce(vm):
     assert get_nonce(vm) == 2
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 def test_call_checks_nonce(vm):
     computation, _ = vm.apply_transaction(SIGNED_DEFAULT_TRANSACTION)
     assert computation.is_success
@@ -201,7 +201,7 @@ def test_call_checks_nonce(vm):
     assert computation.is_error
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 @pytest.mark.parametrize("min_block,max_block,valid", [
     (min_block, max_block, True) for min_block, max_block in [
         (0, UINT_256_MAX),
@@ -234,7 +234,7 @@ def test_call_checks_block_range(vm, min_block, max_block, valid):
         assert computation.is_error
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 def test_call_transfers_value(vm):
     vm_state = vm.state
     with vm_state.state_db() as state_db:
@@ -261,7 +261,7 @@ def test_call_transfers_value(vm):
     assert balance_destination_after == balance_destination_before + 10
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 @pytest.mark.parametrize("v,r,s", [
     (0, 0, 0),
 
@@ -305,7 +305,7 @@ def test_call_checks_signature(vm, v, r, s):
     assert computation.is_success
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 def test_call_uses_remaining_gas(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -321,7 +321,7 @@ def test_call_uses_remaining_gas(vm):
     assert logged_gas > 900 * 1000  # some gas will have been consumed earlier
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 @pytest.mark.parametrize("data,hash", [
     (data, keccak(data)) for data in [
         b"",
@@ -348,7 +348,7 @@ def test_call_uses_data(vm, data, hash):
     assert logged_hash == hash
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 def test_no_call_if_not_enough_gas(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -361,7 +361,7 @@ def test_no_call_if_not_enough_gas(vm):
     assert computation.gas_meter.gas_remaining > 0
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 def test_call_passes_return_code(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -380,7 +380,7 @@ def test_call_passes_return_code(vm):
     assert big_endian_to_int(computation.output) == 0  # failure
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", strict=True)
+@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
 def test_call_does_not_revert_nonce(vm):
     nonce_before = get_nonce(vm)
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -11,7 +11,9 @@ from evm import Chain
 from evm import constants
 from evm.db import get_db_backend
 from evm.db.chain import BaseChainDB
-from evm.db.state import FlatTrieBackend
+from evm.db.state import (
+    ShardingAccountStateDB
+)
 from evm.vm.forks.frontier import FrontierVM
 from evm.vm.forks.sharding import ShardingVM
 
@@ -101,7 +103,7 @@ SHARD_CHAIN_CONTRACTS_FIXTURES = [
 
 @pytest.fixture
 def shard_chain():
-    shard_chaindb = BaseChainDB(get_db_backend(), state_backend_class=FlatTrieBackend)
+    shard_chaindb = BaseChainDB(get_db_backend(), account_state_class=ShardingAccountStateDB)
     return chain(shard_chaindb)
 
 
@@ -118,7 +120,7 @@ def shard_chain_without_block_validation():
     """
     # TODO: Once the helper function which generates access list for a transaction is implemented,
     # replace NestedTrieBackend in `get_db_backend` with FlatTrieBackend.
-    shard_chaindb = BaseChainDB(get_db_backend())
+    shard_chaindb = BaseChainDB(get_db_backend(), account_state_class=ShardingAccountStateDB)
     overrides = {
         'import_block': import_block_without_validation,
         'validate_block': lambda self, block: None,

--- a/tests/core/vm/test_sharding_vm.py
+++ b/tests/core/vm/test_sharding_vm.py
@@ -1,3 +1,5 @@
+import pytest
+
 from eth_utils import (
     int_to_big_endian,
     decode_hex,
@@ -24,6 +26,7 @@ from tests.core.vm.contract_fixture import (
 )
 
 
+@pytest.mark.xfail(reason="#281", strict=True)
 def test_sharding_apply_transaction(shard_chain_without_block_validation):  # noqa: F811
     chain = shard_chain_without_block_validation
     # First test: simple ether transfer contract
@@ -90,6 +93,7 @@ def test_sharding_apply_transaction(shard_chain_without_block_validation):  # no
         assert state_db.get_storage(CREATE2_contract_address, 0) == 1
 
 
+@pytest.mark.xfail(reason="#281", strict=True)
 def test_CREATE2_deploy_contract_edge_cases(shard_chain_without_block_validation):  # noqa: F811
     # First case: computed contract address not the same as provided in `transaction.to`
     chain = shard_chain_without_block_validation

--- a/tests/core/vm/test_sharding_vm.py
+++ b/tests/core/vm/test_sharding_vm.py
@@ -26,8 +26,8 @@ from tests.core.vm.contract_fixture import (
 )
 
 
-@pytest.mark.xfail(reason="#281", strict=True)
-def test_sharding_apply_transaction(shard_chain_without_block_validation):  # noqa: F811
+@pytest.mark.xfail(reason="#281", strict=True)  # noqa: F811
+def test_sharding_apply_transaction(shard_chain_without_block_validation):
     chain = shard_chain_without_block_validation
     # First test: simple ether transfer contract
     first_deploy_tx = new_sharding_transaction(
@@ -93,8 +93,8 @@ def test_sharding_apply_transaction(shard_chain_without_block_validation):  # no
         assert state_db.get_storage(CREATE2_contract_address, 0) == 1
 
 
-@pytest.mark.xfail(reason="#281", strict=True)
-def test_CREATE2_deploy_contract_edge_cases(shard_chain_without_block_validation):  # noqa: F811
+@pytest.mark.xfail(reason="#281", strict=True)  # noqa: F811
+def test_CREATE2_deploy_contract_edge_cases(shard_chain_without_block_validation):
     # First case: computed contract address not the same as provided in `transaction.to`
     chain = shard_chain_without_block_validation
     first_failed_deploy_tx = new_sharding_transaction(

--- a/tests/core/vm/test_sharding_vm.py
+++ b/tests/core/vm/test_sharding_vm.py
@@ -26,7 +26,7 @@ from tests.core.vm.contract_fixture import (
 )
 
 
-@pytest.mark.xfail(reason="#281", strict=True)  # noqa: F811
+@pytest.mark.xfail(reason="#281", raises=AttributeError)  # noqa: F811
 def test_sharding_apply_transaction(shard_chain_without_block_validation):
     chain = shard_chain_without_block_validation
     # First test: simple ether transfer contract
@@ -93,7 +93,7 @@ def test_sharding_apply_transaction(shard_chain_without_block_validation):
         assert state_db.get_storage(CREATE2_contract_address, 0) == 1
 
 
-@pytest.mark.xfail(reason="#281", strict=True)  # noqa: F811
+@pytest.mark.xfail(reason="#281", raises=AttributeError)  # noqa: F811
 def test_CREATE2_deploy_contract_edge_cases(shard_chain_without_block_validation):
     # First case: computed contract address not the same as provided in `transaction.to`
     chain = shard_chain_without_block_validation

--- a/tests/database/test_account_state_db.py
+++ b/tests/database/test_account_state_db.py
@@ -20,10 +20,10 @@ from evm.utils.keccak import (
     keccak,
 )
 from evm.utils.state_access_restriction import (
-    balance_key,
-    code_key,
-    nonce_key,
-    storage_key,
+    get_balance_key,
+    get_code_key,
+    get_nonce_key,
+    get_storage_key,
 )
 
 
@@ -189,10 +189,10 @@ def test_access_restriction():
         return ShardingAccountStateDB(db, original_root_hash, access_list=access_list)
 
     # access lists to use
-    CODE_ACCESS_LIST = [code_key(ADDRESS)]
-    BALANCE_ACCESS_LIST = [balance_key(ADDRESS)]
-    NONCE_ACCESS_LIST = [nonce_key(ADDRESS)]
-    STORAGE_ACCESS_LIST = [storage_key(ADDRESS, 123)]
+    CODE_ACCESS_LIST = [get_code_key(ADDRESS)]
+    BALANCE_ACCESS_LIST = [get_balance_key(ADDRESS)]
+    NONCE_ACCESS_LIST = [get_nonce_key(ADDRESS)]
+    STORAGE_ACCESS_LIST = [get_storage_key(ADDRESS, 123)]
 
     # test with access list
     state = make_state(NONCE_ACCESS_LIST)

--- a/tests/database/test_account_state_db.py
+++ b/tests/database/test_account_state_db.py
@@ -184,7 +184,7 @@ def test_access_restriction():
     original_root_hash = state.root_hash
 
     def make_state(access_list):
-        kv_store = copy.deepcopy(original_db.kv_store)
+        kv_store = copy.deepcopy(original_db.wrapped_db.kv_store)
         db = MemoryDB(kv_store)
         return ShardingAccountStateDB(db, original_root_hash, access_list=access_list)
 

--- a/tests/database/test_account_state_db.py
+++ b/tests/database/test_account_state_db.py
@@ -13,6 +13,12 @@ from evm.db.state import (
     ShardingAccountStateDB,
 )
 
+from evm.constants import (
+    EMPTY_SHA3,
+)
+from evm.utils.keccak import (
+    keccak,
+)
 from evm.utils.state_access_restriction import (
     balance_key,
     code_key,
@@ -84,10 +90,12 @@ def test_nonce(state):
 ])
 def test_code(state):
     assert state.get_code(ADDRESS) == b''
+    assert state.get_code_hash(ADDRESS) == EMPTY_SHA3
 
     state.set_code(ADDRESS, b'code')
     assert state.get_code(ADDRESS) == b'code'
     assert state.get_code(OTHER_ADDRESS) == b''
+    assert state.get_code_hash(ADDRESS) == keccak(b'code')
 
     with pytest.raises(ValidationError):
         state.get_code(INVALID_ADDRESS)


### PR DESCRIPTION
### What was wrong?

#281

### How was it fixed?

- [x] SELFDESTRUCT was removed
- [x] the implementation of CALL was updated to not check for account existence, but emptiness instead (only used for gas calculation)
- [x] `touch_account` was reimplemented to check for "zero-ness" instead of existence before touching.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://imgur.com/Qi6axOo)
