### PR TITLE
Set gas cost of SIGHASH

### DIFF
--- a/evm/vm/forks/sharding/opcodes.py
+++ b/evm/vm/forks/sharding/opcodes.py
@@ -21,7 +21,7 @@ NEW_OPCODES = {
     opcode_values.SIGHASH: as_opcode(
         logic_fn=context.sighash,
         mnemonic=mnemonics.SIGHASH,
-        gas_cost=0,
+        gas_cost=constants.GAS_BASE,
     ),
     opcode_values.CREATE2: system.Create2.configure(
         name='opcode:CREATE2',


### PR DESCRIPTION
### What was wrong?

Gas cost of the new SIGHASH opcode was set to 0.

### How was it fixed?

Gas cost was set to GAS_BASE (2). This seems reasonable to me as similar environmental constants have the same cost (TIMESTAMP, CALLER,  GASPRICE, ...)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.publicdomainpictures.net/download-picture.php?id=65667&check=882229b5e0663df7c5c74e5591f77b7b)
