### PR TITLE
Fix CI errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "eth-keys==0.1.0b3",
         "trie>=0.3.1",
         "trie>=1.0.1,<2.0.0",
-        "eth-tester>=0.1.0b11",
+        "eth-tester==0.1.0b12",
         "web3>=4.0.0b5",
     ],
     extra_require={

--- a/tests/sharding/test_vmc_handler.py
+++ b/tests/sharding/test_vmc_handler.py
@@ -9,11 +9,8 @@ import pytest
 
 import rlp
 
-from web3.exceptions import (
-    BadFunctionCallOutput,
-)
-
 from eth_tester.exceptions import (
+    TransactionFailed,
     ValidationError,
 )
 
@@ -395,8 +392,8 @@ def test_vmc_contract_calls(vmc):  # noqa: F811
     header1 = get_testing_colhdr(vmc, shard_id, genesis_colhdr_hash, 1)
     header1_hash = keccak(header1)
     # if a header is added before its parent header is added, `add_header` should fail
-    # BadFunctionCallOutput raised when assertions fail
-    with pytest.raises(BadFunctionCallOutput):
+    # TransactionFailed raised when assertions fail
+    with pytest.raises(TransactionFailed):
         header_parent_not_added = get_testing_colhdr(
             vmc,
             shard_id,
@@ -412,7 +409,7 @@ def test_vmc_contract_calls(vmc):  # noqa: F811
     vmc.add_header(header1)
     mine(vmc, SHUFFLING_CYCLE_LENGTH)
     # if a header is added before, the second trial should fail
-    with pytest.raises(BadFunctionCallOutput):
+    with pytest.raises(TransactionFailed):
         vmc.call(vmc.mk_contract_tx_detail(
             sender_address=primary_addr,
             gas=default_gas,


### PR DESCRIPTION
### What was wrong?
* In the latest `eth-tester`, there is some usage of the latest syntax in py-evm master branch, which is not yet merged(rebased) to py-evm sharding branch. This cause CI errors in sharding branch.
<img width="881" alt="2018-01-23 2 27 40" src="https://user-images.githubusercontent.com/8223657/35262147-5b6aa408-004e-11e8-9870-f3857dc790b7.png">

* Moreover, since `TransactionFailed` is added in `eth-tester` recently and is not caught by `web3.py`, which causes tests to fail.

### How was it fixed?
* Specify the version of `eth-tester` to `0.1.0b12`
* Modify the test code to catch `eth_tester.exceptions.TransactionFailed`, instead of `web3.exceptions.BadFunctionCallOutput`


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent-tpe1-1.xx.fbcdn.net/v/t1.0-9/26167517_848854815308921_5161406054675104007_n.jpg?oh=2274cfca5e517dbdd1aaaa4b5879df0d&oe=5AE6C7C1)
