### PR TITLE
Added support for IPython shell and improved default shell, updated docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,6 +5,12 @@ Contributing to py-evm
 
     pip install -e . -r requirements-dev.txt
 
+.. note::
+
+  This step doesn't install the "leveldb" package by default. Leveldb is
+  required if you are running Py-EVM *lightchain_shell*. To install
+  leveldb run `pip install "leveldb>=0.194"`.
+
 Running the tests
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -25,11 +25,11 @@ and let you use the python interpreter to interact with it:
 
 .. code:: sh
 
-  $ python -i -m evm.lightchain_shell -db /tmp/testnet.db
+  $ python -m evm.lightchain_shell -db /tmp/testnet.db
 
 
-That will immediately give you a python shell, with a chain variable that you
-can use even before it has finished syncing:
+That will immediately give you a IPython, if it is installed, or a Python REPL_,
+with a chain variable that you can use even before it has finished syncing:
 
 .. code:: sh
 
@@ -102,3 +102,7 @@ a few of them are supported. To start the JSON-RPC server, simply run:
 
 That will start a server listening on port 8080, with a LightChain syncing block headers on the
 Ropsten network. You can then use curl as described on the wikipage above to interact with it.
+
+
+
+.. _REPL: https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop

--- a/evm/lightchain_shell.py
+++ b/evm/lightchain_shell.py
@@ -29,7 +29,8 @@ LOGLEVEL = logging.INFO
 parser = argparse.ArgumentParser()
 parser.add_argument('-db', type=str, required=True)
 parser.add_argument('-debug', action='store_true')
-parser.add_argument('-default_shell', action='store_true', default=False)
+# pass -vanilla_shell at command line to run a Python REPL
+parser.add_argument('-vanilla_shell', action='store_true', default=False)
 args = parser.parse_args()
 
 print("Logging to", LOGFILE)
@@ -77,59 +78,42 @@ def cleanup():
 
 atexit.register(cleanup)
 
-# This is to start IPython or Python REPL.
-
-def ipython_shell_1(namespace=None, banner=None, debug=False):
-    """IPyhton v1.0 specific import"""
-    try:
-        from IPython.frontend.terminal.embed import InteractiveShellEmbed
-    except ImportError:
-        if debug:
-            traceback.print_exc()
-        return None
-    kwargs = dict(user_ns=namespace)
-    if banner:
-        kwargs = dict(banner1=banner)
-    return InteractiveShellEmbed.instance(**kwargs)
-
-
-def ipython_shell(namespace=None, banner=None, debug=False):
-    """IPython version > 1.0"""
-    try:
-        from IPython.terminal.embed import InteractiveShellEmbed
-    except ImportError:
-        if debug:
-            traceback.print_exc()
-        return None
-    kwargs = dict(local_ns=namespace)
-    if banner:
-        kwargs = dict(banner1=banner)
-    return InteractiveShellEmbed.instance(**kwargs)
+# This is to start Py-EVM shell.
 
 
 def start_ipython_shell(namespace=None, banner=None, debug=False):
-    """Trt to run IPython shell."""
-    for shell_method in [ipython_shell, ipython_shell_1]:
-        shell = shell_method(namespace, banner, debug)
-        if shell is not None:
-            shell()
-            break
-    else:
-        print('IPython not installed.')
+    """Try to run IPython shell."""
+    try:
+        import IPython
+    except ImportError:
+        if debug:
+            traceback.print_exc()
+        print("IPython not available. Running default shell...")
         return False
+    # First try newer(IPython >=1.0) top `IPython` level import
+    if hasattr(IPython, 'terminal'):
+        from IPython.terminal.embed import InteractiveShellEmbed
+        kwargs = dict(local_ns=namespace)
+    else:
+        from IPython.frontend.terminal.embed import InteractiveShellEmbed
+        kwargs = dict(user_ns=namespace)
+    if banner:
+        kwargs = dict(banner1=banner)
+    shell = InteractiveShellEmbed(**kwargs)
+    shell()
 
 
 def start_python_shell(namespace=None, banner=None, debug=False):
-    """Start a normal Python rlp shell."""
+    """Start a vanilla Python REPL shell."""
     import code
     try:
-        import readline, rlcompleter
+        import readline, rlcompleter    # NOQA
     except ImportError:
         if debug:
             traceback.print_exc()
     else:
         readline.parse_and_bind('tab: complete')
-    # Add global, local and custome namespaces to current shell
+    # Add global, local and custom namespaces to current shell
     default_ns = globals().copy()
     default_ns.update(locals())
     if namespace:
@@ -146,11 +130,10 @@ def start_shell(use_ipython=True, namespace=None, banner=None, debug=False):
     ip_shell_status = None
     if use_ipython:
         ip_shell_status = start_ipython_shell(namespace, banner, debug)
-    # If can't import/start the ipython shell use the default shell
+    # If can't import or start the IPython shell use the default shell
     if not use_ipython or ip_shell_status is False:
         start_python_shell(namespace, banner, debug)
 
 
-banner = ''
-use_ipython = not args.default_shell
-start_shell(use_ipython=use_ipython, banner=banner, debug=args.debug)
+use_ipython = not args.vanilla_shell
+start_shell(use_ipython=use_ipython, debug=args.debug)

--- a/evm/lightchain_shell.py
+++ b/evm/lightchain_shell.py
@@ -9,6 +9,7 @@ import asyncio
 import atexit
 import logging
 import threading
+import traceback
 
 from evm.db.chain import BaseChainDB
 from evm.exceptions import CanonicalHeadNotFound
@@ -28,6 +29,7 @@ LOGLEVEL = logging.INFO
 parser = argparse.ArgumentParser()
 parser.add_argument('-db', type=str, required=True)
 parser.add_argument('-debug', action='store_true')
+parser.add_argument('-default_shell', action='store_true', default=False)
 args = parser.parse_args()
 
 print("Logging to", LOGFILE)
@@ -74,3 +76,81 @@ def cleanup():
 
 
 atexit.register(cleanup)
+
+# This is to start IPython or Python REPL.
+
+def ipython_shell_1(namespace=None, banner=None, debug=False):
+    """IPyhton v1.0 specific import"""
+    try:
+        from IPython.frontend.terminal.embed import InteractiveShellEmbed
+    except ImportError:
+        if debug:
+            traceback.print_exc()
+        return None
+    kwargs = dict(user_ns=namespace)
+    if banner:
+        kwargs = dict(banner1=banner)
+    return InteractiveShellEmbed.instance(**kwargs)
+
+
+def ipython_shell(namespace=None, banner=None, debug=False):
+    """IPython version > 1.0"""
+    try:
+        from IPython.terminal.embed import InteractiveShellEmbed
+    except ImportError:
+        if debug:
+            traceback.print_exc()
+        return None
+    kwargs = dict(local_ns=namespace)
+    if banner:
+        kwargs = dict(banner1=banner)
+    return InteractiveShellEmbed.instance(**kwargs)
+
+
+def start_ipython_shell(namespace=None, banner=None, debug=False):
+    """Trt to run IPython shell."""
+    for shell_method in [ipython_shell, ipython_shell_1]:
+        shell = shell_method(namespace, banner, debug)
+        if shell is not None:
+            shell()
+            break
+    else:
+        print('IPython not installed.')
+        return False
+
+
+def start_python_shell(namespace=None, banner=None, debug=False):
+    """Start a normal Python rlp shell."""
+    import code
+    try:
+        import readline, rlcompleter
+    except ImportError:
+        if debug:
+            traceback.print_exc()
+    else:
+        readline.parse_and_bind('tab: complete')
+    # Add global, local and custome namespaces to current shell
+    default_ns = globals().copy()
+    default_ns.update(locals())
+    if namespace:
+        default_ns.update(namespace)
+    # Configure kwargs to pass banner and exit message
+    kwargs = dict()
+    if banner:
+        kwargs = dict(banner=banner)
+    shell = code.InteractiveConsole(default_ns)
+    shell.interact(**kwargs)
+
+
+def start_shell(use_ipython=True, namespace=None, banner=None, debug=False):
+    ip_shell_status = None
+    if use_ipython:
+        ip_shell_status = start_ipython_shell(namespace, banner, debug)
+    # If can't import/start the ipython shell use the default shell
+    if not use_ipython or ip_shell_status is False:
+        start_python_shell(namespace, banner, debug)
+
+
+banner = ''
+use_ipython = not args.default_shell
+start_shell(use_ipython=use_ipython, banner=banner, debug=args.debug)


### PR DESCRIPTION
### What was wrong?

Implementation of https://github.com/ethereum/py-evm/issues/297

### How was it fixed?

Added support for IPython shell in the lightchain_shell.py module.

- Run `IPython.terminal.embed.InteractiveShellEmbed` if IPython <= v1.0.
- Run `IPython.frontend.terminal.embed.InteractiveShellEmbed` if IPython > v1.0.
- If IPython is installed run the default Python shell.

By default, IPython is run if it is available. To run the default Python shell pass `-default_shell` as an argument on command line. Ex:

`python -m evm.lightchain_shell -db /tmp/testnet.db -default_shell`

Also updated the docs for changes and leveldb requirement with lighchain_shell as note.

#### Cute Animal Picture

![choco](https://pbs.twimg.com/media/DUPaj2nVwAAPlzJ.jpg)
