### PR TITLE
Fix hard fork block numbers for Ropsten chain

### DIFF
--- a/evm/__init__.py
+++ b/evm/__init__.py
@@ -14,6 +14,7 @@ from evm.chains import (  # noqa: F401
     Chain,
     MainnetChain,
     MainnetTesterChain,
+    RopstenChain,
 )
 
 #

--- a/evm/chains/__init__.py
+++ b/evm/chains/__init__.py
@@ -6,6 +6,9 @@ from .chain import (  # noqa: F401
 from .mainnet import (  # noqa: F401
     MainnetChain,
 )
+from .ropsten import (  # noqa: F401
+    RopstenChain,
+)
 from .tester import (  # noqa: F401
     MainnetTesterChain,
 )

--- a/evm/chains/mainnet/__init__.py
+++ b/evm/chains/mainnet/__init__.py
@@ -1,12 +1,12 @@
 from eth_utils import decode_hex
 
-from evm import constants
 from .constants import (
     BYZANTIUM_MAINNET_BLOCK,
     TANGERINE_WHISTLE_MAINNET_BLOCK,
     HOMESTEAD_MAINNET_BLOCK,
     SPURIOUS_DRAGON_MAINNET_BLOCK,
 )
+from evm import constants
 
 from evm.chains.chain import Chain
 from evm.rlp.headers import BlockHeader

--- a/evm/chains/mainnet/constants.py
+++ b/evm/chains/mainnet/constants.py
@@ -1,6 +1,3 @@
-ZERO_HASH32 = 32 * b'\x00'
-
-
 #
 # Byzantium Block
 #
@@ -29,22 +26,3 @@ HOMESTEAD_MAINNET_BLOCK = 1150000
 # Spurious Dragon Block
 #
 SPURIOUS_DRAGON_MAINNET_BLOCK = 2675000
-
-
-#
-# Genesis Data
-#
-GENESIS_NONCE = b'\x00\x00\x00\x00\x00\x00\x00B'  # 0x42 encoded as big-endian-integer
-
-
-#
-# Sha3 Keccak
-#
-BLANK_ROOT_HASH = b'V\xe8\x1f\x17\x1b\xccU\xa6\xff\x83E\xe6\x92\xc0\xf8n\x5bH\xe0\x1b\x99l\xad\xc0\x01b/\xb5\xe3c\xb4!'  # noqa: E501
-
-
-#
-# Block and Header
-#
-# keccak(rlp.encode([]))
-EMPTY_UNCLE_HASH = b'\x1d\xccM\xe8\xde\xc7]z\xab\x85\xb5g\xb6\xcc\xd4\x1a\xd3\x12E\x1b\x94\x8at\x13\xf0\xa1B\xfd@\xd4\x93G'  # noqa: E501

--- a/evm/chains/mainnet/constants.py
+++ b/evm/chains/mainnet/constants.py
@@ -2,31 +2,31 @@ ZERO_HASH32 = 32 * b'\x00'
 
 
 #
-# ByzantiumVM
+# Byzantium Block
 #
 BYZANTIUM_MAINNET_BLOCK = 4370000
 
 
 #
-# DAO Block Number
+# DAO Block
 #
-DAO_FORK_BLOCK_NUMBER = 1920000
+DAO_FORK_MAINNET_BLOCK = 1920000
 
 
 #
-# Tangerine Whistle Mainnet Block
+# Tangerine Whistle Block
 #
 TANGERINE_WHISTLE_MAINNET_BLOCK = 2463000
 
 
 #
-# Homestead Mainnet Block
+# Homestead Block
 #
 HOMESTEAD_MAINNET_BLOCK = 1150000
 
 
 #
-# Spurious Dragon Mainnet Block
+# Spurious Dragon Block
 #
 SPURIOUS_DRAGON_MAINNET_BLOCK = 2675000
 

--- a/evm/chains/ropsten/__init__.py
+++ b/evm/chains/ropsten/__init__.py
@@ -3,6 +3,7 @@ from eth_utils import decode_hex
 from .constants import (
     BYZANTIUM_ROPSTEN_BLOCK,
     SPURIOUS_DRAGON_ROPSTEN_BLOCK,
+    TANGERINE_WHISTLE_ROPSTEN_BLOCK,
 )
 from evm import constants
 
@@ -10,15 +11,14 @@ from evm.chains.chain import Chain
 from evm.rlp.headers import BlockHeader
 from evm.vm.forks import (
     ByzantiumVM,
-    FrontierVM,
     SpuriousDragonVM,
+    TangerineWhistleVM,
 )
 
 
 ROPSTEN_VM_CONFIGURATION = (
-    # Note: Homestead and Tangerine Whistle are excluded here since VMs disallow duplicate block
-    # numbers and they are all zero for Ropsten.
-    (0, FrontierVM),
+    # Note: Frontier and Homestead are excluded since this chain starts at Tangerine Whistle.
+    (TANGERINE_WHISTLE_ROPSTEN_BLOCK, TangerineWhistleVM),
     (SPURIOUS_DRAGON_ROPSTEN_BLOCK, SpuriousDragonVM),
     (BYZANTIUM_ROPSTEN_BLOCK, ByzantiumVM),
 )

--- a/evm/chains/ropsten/__init__.py
+++ b/evm/chains/ropsten/__init__.py
@@ -1,9 +1,27 @@
 from eth_utils import decode_hex
 
 from evm import constants
+from .constants import (
+    BYZANTIUM_ROPSTEN_BLOCK,
+    SPURIOUS_DRAGON_ROPSTEN_BLOCK,
+)
+
 from evm.chains.chain import Chain
-from evm.chains.mainnet import MAINNET_VM_CONFIGURATION
 from evm.rlp.headers import BlockHeader
+from evm.vm.forks import (
+    ByzantiumVM,
+    FrontierVM,
+    SpuriousDragonVM,
+)
+
+
+ROPSTEN_VM_CONFIGURATION = (
+    # Note: Homestead and Tangerine Whistle are excluded here since VMs disallow duplicate block
+    # numbers and they are all zero for Ropsten.
+    (0, FrontierVM),
+    (SPURIOUS_DRAGON_ROPSTEN_BLOCK, SpuriousDragonVM),
+    (BYZANTIUM_ROPSTEN_BLOCK, ByzantiumVM),
+)
 
 
 ROPSTEN_NETWORK_ID = 3
@@ -11,7 +29,7 @@ ROPSTEN_NETWORK_ID = 3
 
 RopstenChain = Chain.configure(
     'RopstenChain',
-    vm_configuration=MAINNET_VM_CONFIGURATION,
+    vm_configuration=ROPSTEN_VM_CONFIGURATION,
     network_id=ROPSTEN_NETWORK_ID,
 )
 

--- a/evm/chains/ropsten/__init__.py
+++ b/evm/chains/ropsten/__init__.py
@@ -1,10 +1,10 @@
 from eth_utils import decode_hex
 
-from evm import constants
 from .constants import (
     BYZANTIUM_ROPSTEN_BLOCK,
     SPURIOUS_DRAGON_ROPSTEN_BLOCK,
 )
+from evm import constants
 
 from evm.chains.chain import Chain
 from evm.rlp.headers import BlockHeader

--- a/evm/chains/ropsten/constants.py
+++ b/evm/chains/ropsten/constants.py
@@ -1,4 +1,28 @@
 #
-# ByzantiumVM
+# Byzantium Block
 #
 BYZANTIUM_ROPSTEN_BLOCK = 1700000
+
+
+#
+# DAO Block
+#
+DAO_FORK_ROPSTEN_BLOCK = 0
+
+
+#
+# Tangerine Whistle Block
+#
+TANGERINE_WHISTLE_ROPSTEN_BLOCK = 0
+
+
+#
+# Homestead Block
+#
+HOMESTEAD_ROPSTEN_BLOCK = 0
+
+
+#
+# Spurious Dragon Block
+#
+SPURIOUS_DRAGON_ROPSTEN_BLOCK = 10

--- a/evm/vm/forks/homestead/__init__.py
+++ b/evm/vm/forks/homestead/__init__.py
@@ -1,5 +1,5 @@
 from evm.chains.mainnet.constants import (
-    DAO_FORK_BLOCK_NUMBER
+    DAO_FORK_MAINNET_BLOCK
 )
 from evm.vm.forks.frontier import FrontierVM
 
@@ -15,7 +15,7 @@ from .vm_state import HomesteadVMState
 
 class MetaHomesteadVM(FrontierVM):
     support_dao_fork = True
-    dao_fork_block_number = DAO_FORK_BLOCK_NUMBER
+    dao_fork_block_number = DAO_FORK_MAINNET_BLOCK
 
 
 HomesteadVM = MetaHomesteadVM.configure(


### PR DESCRIPTION
These block numbers come from
https://github.com/ethereum/cpp-ethereum/blob/develop/libethashseal/genesis/ropsten.cpp.

Update comments and standardize constant names across both Ropsten and
Mainnet chains.

Closes https://github.com/ethereum/py-evm/issues/301.

### What was wrong?

Ropsten chain was using Mainnet chain fork block numbers.

### How was it fixed?

By pulling in the correct Ropsten chain block numbers from cpp-ethereum.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://globalmedicalco.com/photos/globalmedicalco/6/27236.jpg)
