### PR TITLE
p2p: Redesign sub-protocol matching and msg processing

### DIFF
--- a/evm/p2p/constants.py
+++ b/evm/p2p/constants.py
@@ -41,16 +41,6 @@ HANDSHAKE_TIMEOUT = 5
 # Timeout used when waiting for a reply from a remote node.
 REPLY_TIMEOUT = 3
 
-# Max number of items we can ask for in LES requests. These are the values used in geth and if we
-# ask for more than this the peers will disconnect from us.
-MAX_HEADERS_FETCH = 192
-MAX_BODIES_FETCH = 32
-MAX_RECEIPTS_FETCH = 128
-MAX_CODE_FETCH = 64
-MAX_PROOFS_FETCH = 64
-MAX_HEADER_PROOFS_FETCH = 64
-MAX_STATE_FETCH = 384
-
 # Types of LES Announce messages
 LES_ANNOUNCE_SIMPLE = 1
 LES_ANNOUNCE_SIGNED = 2

--- a/evm/p2p/exceptions.py
+++ b/evm/p2p/exceptions.py
@@ -1,11 +1,3 @@
-from typing import TYPE_CHECKING
-
-# Workaround for import cycles caused by type annotations:
-# http://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
-if TYPE_CHECKING:
-    from evm.p2p.p2p_proto import DisconnectReason  # noqa: F401
-
-
 class AuthenticationError(Exception):
     pass
 
@@ -48,12 +40,3 @@ class TooManyTimeouts(Exception):
 
 class StopRequested(Exception):
     pass
-
-
-class HandshakeFailure(Exception):
-
-    def __init__(self, reason: 'DisconnectReason') -> None:
-        self.reason = reason
-
-    def __str__(self):
-        return self.reason.name

--- a/evm/p2p/lightchain.py
+++ b/evm/p2p/lightchain.py
@@ -42,9 +42,8 @@ from evm.p2p.exceptions import (
 )
 from evm.p2p import les
 from evm.p2p import protocol
-from evm.p2p.peer import (  # noqa: F401
+from evm.p2p.peer import (
     BasePeer,
-    handshake,
     LESPeer,
     PeerPool,
 )

--- a/evm/p2p/lightchain.py
+++ b/evm/p2p/lightchain.py
@@ -256,7 +256,7 @@ class LightChain(Chain):
             self.logger.debug("Fetching header %s from %s", encode_hex(block_hash), peer)
             request_id = gen_request_id()
             max_headers = 1
-            peer.les_proto.send_get_block_headers(block_hash, max_headers, request_id)
+            peer.sub_proto.send_get_block_headers(block_hash, max_headers, request_id)
             reply = await peer.wait_for_reply(request_id)
             if len(reply['headers']) == 0:
                 raise BlockNotFound("Peer {} has no block with hash {}".format(peer, block_hash))
@@ -264,7 +264,7 @@ class LightChain(Chain):
 
         self.logger.debug("Fetching block %s from %s", encode_hex(block_hash), peer)
         request_id = gen_request_id()
-        peer.les_proto.send_get_block_bodies([block_hash], request_id)
+        peer.sub_proto.send_get_block_bodies([block_hash], request_id)
         reply = await peer.wait_for_reply(request_id)
         if len(reply['bodies']) == 0:
             raise BlockNotFound("Peer {} has no block with hash {}".format(peer, block_hash))
@@ -285,7 +285,7 @@ class LightChain(Chain):
         peer = await self.get_best_peer()
         self.logger.debug("Fetching %s receipts from %s", encode_hex(block_hash), peer)
         request_id = gen_request_id()
-        peer.les_proto.send_get_receipts(block_hash, request_id)
+        peer.sub_proto.send_get_receipts(block_hash, request_id)
         reply = await peer.wait_for_reply(request_id)
         if len(reply['receipts']) == 0:
             raise BlockNotFound("No block with hash {} found".format(block_hash))
@@ -303,7 +303,7 @@ class LightChain(Chain):
                          from_level: int = 0) -> List[bytes]:
         peer = await self.get_best_peer()
         request_id = gen_request_id()
-        peer.les_proto.send_get_proof(block_hash, account_key, key, from_level, request_id)
+        peer.sub_proto.send_get_proof(block_hash, account_key, key, from_level, request_id)
         reply = await peer.wait_for_reply(request_id)
         return reply['proof']
 
@@ -311,7 +311,7 @@ class LightChain(Chain):
     async def get_contract_code(self, block_hash: bytes, key: bytes) -> bytes:
         peer = await self.get_best_peer()
         request_id = gen_request_id()
-        peer.les_proto.send_get_contract_code(block_hash, key, request_id)
+        peer.sub_proto.send_get_contract_code(block_hash, key, request_id)
         reply = await peer.wait_for_reply(request_id)
         if len(reply['codes']) == 0:
             return b''

--- a/evm/p2p/state.py
+++ b/evm/p2p/state.py
@@ -94,7 +94,7 @@ class StateDownloader:
         now = time.time()
         for node_key in node_keys:
             self._pending_nodes[node_key] = now
-        peer.eth_proto.send_get_node_data(node_keys)
+        peer.sub_proto.send_get_node_data(node_keys)
 
     async def retry_timedout(self):
         timed_out = []

--- a/evm/p2p/state.py
+++ b/evm/p2p/state.py
@@ -26,7 +26,7 @@ from evm.utils.keccak import keccak
 from evm.p2p import eth
 from evm.p2p import protocol
 from evm.p2p.peer import BasePeer, ETHPeer, PeerPool
-from .constants import MAX_STATE_FETCH
+from evm.p2p.eth import MAX_STATE_FETCH
 
 
 class StateDownloader:
@@ -36,6 +36,7 @@ class StateDownloader:
     _report_interval = 10  # Number of seconds between progress reports.
     # TODO: Experiment with different timeout/max_pending values to find the combination that
     # yields the best results.
+    # FIXME: Should use the # of peers times MAX_STATE_FETCH here
     _max_pending = 5 * MAX_STATE_FETCH
     _reply_timeout = 10  # seconds
     # For simplicity/readability we use 0 here to force a report on the first iteration of the

--- a/evm/p2p/test_auth.py
+++ b/evm/p2p/test_auth.py
@@ -2,9 +2,6 @@ import asyncio
 
 import pytest
 
-import rlp
-from rlp import sedes
-
 from eth_utils import (
     decode_hex,
 )
@@ -14,6 +11,7 @@ from eth_keys import keys
 from evm.p2p import ecies
 from evm.p2p import kademlia
 from evm.p2p.p2p_proto import Hello
+from evm.p2p.protocol import Protocol
 from evm.p2p.auth import (
     HandshakeInitiator,
     HandshakeResponder,
@@ -144,13 +142,11 @@ async def test_handshake():
     responder_hello = await responder_peer.read_msg()
     initiator_hello = await initiator_peer.read_msg()
 
-    cmd_id = rlp.decode(responder_hello[:1], sedes=sedes.big_endian_int)
-    proto = responder_peer.get_protocol_for(cmd_id)
-    assert cmd_id == proto.cmd_by_class[Hello].cmd_id
+    cmd = responder_peer.get_protocol_command_for(responder_hello)
+    assert isinstance(cmd, Hello)
 
-    cmd_id = rlp.decode(initiator_hello[:1], sedes=sedes.big_endian_int)
-    proto = initiator_peer.get_protocol_for(cmd_id)
-    assert cmd_id == proto.cmd_by_class[Hello].cmd_id
+    cmd = initiator_peer.get_protocol_command_for(initiator_hello)
+    assert isinstance(cmd, Hello)
 
 
 def test_handshake_eip8():
@@ -248,4 +244,5 @@ def test_eip8_hello():
         "f87137916b6e6574682f76302e39312f706c616e39cdc5836574683dc6846d6f726b1682270fb840"
         "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569"
         "bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877c883666f6f836261720304")
-    Hello(id_offset=0).decode_payload(payload)
+    dummy_proto = Protocol(peer=None, cmd_id_offset=0)
+    Hello(dummy_proto).decode_payload(payload)

--- a/evm/p2p/test_lightchain.py
+++ b/evm/p2p/test_lightchain.py
@@ -134,7 +134,7 @@ class LESProtocolServer(LESProtocol):
             'reorg_depth': reorg_depth,
             'params': [],
         }
-        header, body = Announce(self.cmd_id_offset).encode(data)
+        header, body = Announce(self).encode(data)
         self.send(header, body)
 
     def send_block_headers(self, headers, buffer_value, request_id):
@@ -143,7 +143,7 @@ class LESProtocolServer(LESProtocol):
             'headers': headers,
             'buffer_value': buffer_value,
         }
-        header, body = BlockHeaders(self.cmd_id_offset).encode(data)
+        header, body = BlockHeaders(self).encode(data)
         self.send(header, body)
 
 
@@ -176,7 +176,7 @@ class LESPeerServer(LESPeer):
             header.hash, header.block_number, total_difficulty, reorg_depth)
 
     def process_msg(self, msg):
-        cmd, decoded = super(LESPeerServer, self).process_msg(msg)
+        cmd, decoded = super().process_msg(msg)
         if isinstance(cmd, GetBlockHeaders):
             self.handle_get_block_headers(decoded)
         return cmd, decoded

--- a/evm/p2p/test_lightchain.py
+++ b/evm/p2p/test_lightchain.py
@@ -172,7 +172,7 @@ class LESPeerServer(LESPeer):
             self._head_number = head_number
         header = self.chaindb.get_canonical_block_header_by_number(self.head_number)
         total_difficulty = self.chaindb.get_score(header.hash)
-        self.les_proto.send_announce(
+        self.sub_proto.send_announce(
             header.hash, header.block_number, total_difficulty, reorg_depth)
 
     def process_msg(self, msg):
@@ -198,7 +198,7 @@ class LESPeerServer(LESPeer):
             self.chaindb.get_canonical_block_header_by_number(i)
             for i in block_numbers
         )
-        self.les_proto.send_block_headers(headers, buffer_value=0, request_id=msg['request_id'])
+        self.sub_proto.send_block_headers(headers, buffer_value=0, request_id=msg['request_id'])
 
 
 async def get_client_and_server_peer_pair(

--- a/evm/p2p/test_peer.py
+++ b/evm/p2p/test_peer.py
@@ -3,9 +3,6 @@ import os
 
 import pytest
 
-import rlp
-from rlp import sedes
-
 from evm.chains.mainnet import MAINNET_GENESIS_HEADER
 from evm.db.backends.memory import MemoryDB
 from evm.db.chain import BaseChainDB
@@ -17,19 +14,18 @@ from evm.p2p import kademlia
 from evm.p2p.les import (
     LESProtocol,
     LESProtocolV2,
-    StatusV2,
 )
 from evm.p2p.peer import LESPeer
 from evm.p2p.protocol import Protocol
 from evm.p2p.p2p_proto import P2PProtocol
 
 
-async def get_directly_linked_peers(
+async def _get_directly_linked_peers_without_handshake(
         peer1_class=LESPeer, peer1_chaindb=None, peer1_received_msg_callback=None,
         peer2_class=LESPeer, peer2_chaindb=None, peer2_received_msg_callback=None):
-    """Create two LESPeers with their readers/writers connected directly.
+    """See get_directly_linked_peers().
 
-    The first peer's reader will write directly to the second's writer, and vice-versa.
+    Neither the P2P handshake nor the sub-protocol handshake will be performed here.
     """
     if peer1_chaindb is None:
         peer1_chaindb = get_fresh_mainnet_chaindb()
@@ -99,20 +95,23 @@ async def get_directly_linked_peers(
 
     await handshake_finished.wait()
 
+    return peer1, peer2
+
+
+async def get_directly_linked_peers(
+        peer1_class=LESPeer, peer1_chaindb=None, peer1_received_msg_callback=None,
+        peer2_class=LESPeer, peer2_chaindb=None, peer2_received_msg_callback=None):
+    """Create two peers with their readers/writers connected directly.
+
+    The first peer's reader will write directly to the second's writer, and vice-versa.
+    """
+    peer1, peer2 = await _get_directly_linked_peers_without_handshake(
+        peer1_class, peer1_chaindb, peer1_received_msg_callback,
+        peer2_class, peer2_chaindb, peer2_received_msg_callback)
     # Perform the base protocol (P2P) handshake.
-    peer1.base_protocol.send_handshake()
-    peer2.base_protocol.send_handshake()
-    msg1 = await peer1.read_msg()
-    peer1.process_msg(msg1)
-    msg2 = await peer2.read_msg()
-    peer2.process_msg(msg2)
-
-    # Now send the handshake msg for each enabled sub-protocol.
-    for proto in peer1.enabled_sub_protocols:
-        proto.send_handshake(peer1._local_chain_info)
-    for proto in peer2.enabled_sub_protocols:
-        proto.send_handshake(peer2._local_chain_info)
-
+    await asyncio.gather(peer1.do_p2p_handshake(), peer2.do_p2p_handshake())
+    # Perform the handshake for the enabled sub-protocol.
+    await asyncio.gather(peer1.do_sub_proto_handshake(), peer2.do_sub_proto_handshake())
     return peer1, peer2
 
 
@@ -135,13 +134,15 @@ def get_fresh_mainnet_chaindb():
 
 @pytest.mark.asyncio
 async def test_les_handshake():
-    peer1, peer2 = await get_directly_linked_peers()
-    # The peers above have already performed the sub-protocol agreement, and sent the handshake
-    # msg for each enabled sub protocol -- in this case that's the Status msg of the LES/2 protocol.
-    msg = await peer1.read_msg()
-    cmd_id = rlp.decode(msg[:1], sedes=sedes.big_endian_int)
-    proto = peer1.get_protocol_for(cmd_id)
-    assert cmd_id == proto.cmd_by_class[StatusV2].cmd_id
+    peer1, peer2 = await _get_directly_linked_peers_without_handshake()
+
+    # Perform the base protocol (P2P) handshake.
+    await asyncio.gather(peer1.do_p2p_handshake(), peer2.do_p2p_handshake())
+    # Perform the handshake for the enabled sub-protocol (LES).
+    await asyncio.gather(peer1.do_sub_proto_handshake(), peer2.do_sub_proto_handshake())
+
+    assert isinstance(peer1.les_proto, LESProtocol)
+    assert isinstance(peer2.les_proto, LESProtocol)
 
 
 def test_sub_protocol_matching():
@@ -167,17 +168,11 @@ def test_sub_protocol_matching():
 class LESProtocolV3(LESProtocol):
     version = 3
 
-    def send_handshake(self):
-        pass
-
 
 class ETHProtocol63(Protocol):
     name = b'eth'
     version = 63
     cmd_length = 15
-
-    def send_handshake(self):
-        pass
 
 
 class ProtoMatchingPeer(LESPeer):


### PR DESCRIPTION
P2P message processing was scattered across methods from multiple classes (Protocol,
Peer, LightChain).

Also, the sub-protocol matching was designed to allow a connection to a single remote
node to use various different protocols, but that's not useful now and may never be.


Started consolidating msg processing on Peer methods. Now Protocol/Command methods
only deal with encoding/decoding of messages

Changed sub-protocol matching to pick just one sub-protocol

Better to review both commits separately, I believe