### PR TITLE
Add automatic chain initialization of chain directories to trinity.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     ],
     extra_require={
         'trinity': [
-            "leveldb>=0.194",
+            "leveldb>=0.194,<1.0",
+            "coincurve>=7.0.0,<8.0.0",
         ]
     },
     setup_requires=['setuptools-markdown'],

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "trie>=1.0.1,<2.0.0",
     ],
     extra_require={
-        'leveldb': [
+        'trinity': [
             "leveldb>=0.194",
         ]
     },

--- a/tests/trinity/chain-management/test_is_chain_initialized.py
+++ b/tests/trinity/chain-management/test_is_chain_initialized.py
@@ -76,9 +76,11 @@ def test_fully_initialized_chain_datadir(chain_config,
                                          nodekey):
     # Database Initialization
     chaindb = get_chain_db(chain_config.data_dir)
-    RopstenLightChain.from_genesis_header(chaindb, ROPSTEN_GENESIS_HEADER)
+    chain = RopstenLightChain.from_genesis_header(chaindb, ROPSTEN_GENESIS_HEADER)
 
     # we need to delete the chaindb in order to release the leveldb LOCK.
+    del chain
+    del chaindb.db
     del chaindb
 
     assert is_chain_initialized(chain_config)

--- a/tests/trinity/chain-management/test_is_chain_initialized.py
+++ b/tests/trinity/chain-management/test_is_chain_initialized.py
@@ -75,7 +75,7 @@ def test_fully_initialized_chain_datadir(chain_config,
                                          database_dir,
                                          nodekey):
     # Database Initialization
-    chaindb = get_chain_db(chain_config.data_dir)
+    chaindb = get_chain_db(chain_config.database_dir)
     chain = RopstenLightChain.from_genesis_header(chaindb, ROPSTEN_GENESIS_HEADER)
 
     # we need to delete the chaindb in order to release the leveldb LOCK.

--- a/tests/trinity/chain-management/test_is_chain_initialized.py
+++ b/tests/trinity/chain-management/test_is_chain_initialized.py
@@ -1,11 +1,84 @@
 import pytest
 
-from trinity.chain import (
+import os
+
+from evm.chains.ropsten import ROPSTEN_GENESIS_HEADER
+
+from trinity.chains import (
     is_chain_initialized,
 )
-
-
-@pytest.mark.parametrize(
+from trinity.chains.ropsten import (
+    RopstenLightChain,
 )
-def data_dir():
-    assert False # TODO
+from trinity.utils.chains import (
+    ChainConfig,
+)
+from trinity.utils.db import (
+    get_chain_db,
+)
+
+
+@pytest.fixture
+def chain_config():
+    return ChainConfig('test_chain')
+
+
+@pytest.fixture
+def data_dir(chain_config):
+    os.makedirs(chain_config.data_dir, exist_ok=True)
+    assert os.path.exists(chain_config.data_dir)
+    return chain_config.data_dir
+
+
+@pytest.fixture
+def database_dir(chain_config, data_dir):
+    os.makedirs(chain_config.database_dir, exist_ok=True)
+    assert os.path.exists(chain_config.database_dir)
+    return chain_config.database_dir
+
+
+@pytest.fixture
+def nodekey(chain_config, data_dir):
+    with open(chain_config.nodekey_path, 'wb') as nodekey_file:
+        nodekey_file.write(b'\x01' * 32)
+    return chain_config.nodekey_path
+
+
+def test_not_initialized_without_data_dir(chain_config):
+    assert not os.path.exists(chain_config.data_dir)
+    assert not is_chain_initialized(chain_config)
+
+
+def test_not_initialized_without_database_dir(chain_config, data_dir):
+    assert not os.path.exists(chain_config.database_dir)
+    assert not is_chain_initialized(chain_config)
+
+
+def test_not_initialized_without_nodekey_file(chain_config, data_dir, database_dir):
+    assert not os.path.exists(chain_config.nodekey_path)
+    assert not is_chain_initialized(chain_config)
+
+
+def test_not_initialized_without_initialized_chaindb(chain_config,
+                                                     data_dir,
+                                                     database_dir,
+                                                     nodekey):
+    assert os.path.exists(chain_config.data_dir)
+    assert os.path.exists(chain_config.database_dir)
+    assert chain_config.nodekey is not None
+
+    assert not is_chain_initialized(chain_config)
+
+
+def test_fully_initialized_chain_datadir(chain_config,
+                                         data_dir,
+                                         database_dir,
+                                         nodekey):
+    # Database Initialization
+    chaindb = get_chain_db(chain_config.data_dir)
+    RopstenLightChain.from_genesis_header(chaindb, ROPSTEN_GENESIS_HEADER)
+
+    # we need to delete the chaindb in order to release the leveldb LOCK.
+    del chaindb
+
+    assert is_chain_initialized(chain_config)

--- a/tests/trinity/chain-management/test_is_chain_initialized.py
+++ b/tests/trinity/chain-management/test_is_chain_initialized.py
@@ -1,0 +1,11 @@
+import pytest
+
+from trinity.chain import (
+    is_chain_initialized,
+)
+
+
+@pytest.mark.parametrize(
+)
+def data_dir():
+    assert False # TODO

--- a/tests/trinity/chains-utils/test_chain_config_object.py
+++ b/tests/trinity/chains-utils/test_chain_config_object.py
@@ -1,0 +1,73 @@
+import pytest
+
+from eth_keys import keys
+
+from trinity.utils.chains import (
+    get_base_dir,
+    get_data_dir,
+    get_nodekey_path,
+    ChainConfig,
+)
+from trinity.utils.hexadecimal import (
+    decode_hex,
+)
+from trinity.utils.filesystem import (
+    is_same_path,
+)
+
+
+def test_chain_config_computed_properties():
+    chain_config = ChainConfig('muffin')
+
+    assert chain_config.base_dir == get_base_dir('muffin')
+    assert chain_config.data_dir == get_data_dir('muffin')
+    assert chain_config.nodekey_path == get_nodekey_path('muffin')
+
+
+def test_chain_config_explicit_properties():
+    chain_config = ChainConfig(
+        'muffin',
+        base_dir='./base-dir',
+        data_dir='./data-dir',
+        nodekey_path='./nodekey'
+    )
+
+    assert is_same_path(chain_config.base_dir, './base-dir')
+    assert is_same_path(chain_config.data_dir, './data-dir')
+    assert is_same_path(chain_config.nodekey_path, './nodekey')
+
+
+NODEKEY = '0xd18445cc77139cd8e09110e99c9384f0601bd2dfa5b230cda917df7e56b69949'
+
+
+@pytest.fixture
+def nodekey_bytes():
+    _nodekey_bytes = decode_hex(NODEKEY)
+    return _nodekey_bytes
+
+
+@pytest.fixture
+def nodekey_path(tmpdir, nodekey_bytes):
+    nodekey_file = tmpdir.mkdir('temp-nodekey-dir').join('nodekey')
+    nodekey_file.write_binary(nodekey_bytes)
+
+    return str(nodekey_file)
+
+
+def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
+    chain_config = ChainConfig(
+        'muffin',
+        nodekey_path=nodekey_path,
+    )
+
+    assert chain_config.nodekey.to_bytes() == nodekey_bytes
+
+
+@pytest.mark.parametrize('as_bytes', (True, False))
+def test_chain_config_explictely_provided_nodekey(nodekey_bytes, as_bytes):
+    chain_config = ChainConfig(
+        'muffin',
+        nodekey=nodekey_bytes if as_bytes else keys.PrivateKey(nodekey_bytes),
+    )
+
+    assert chain_config.nodekey.to_bytes() == nodekey_bytes

--- a/tests/trinity/chains-utils/test_chain_config_object.py
+++ b/tests/trinity/chains-utils/test_chain_config_object.py
@@ -3,8 +3,8 @@ import pytest
 from eth_keys import keys
 
 from trinity.utils.chains import (
-    get_base_dir,
-    get_data_dir,
+    get_default_data_dir,
+    get_database_dir,
     get_nodekey_path,
     ChainConfig,
 )
@@ -19,20 +19,18 @@ from trinity.utils.filesystem import (
 def test_chain_config_computed_properties():
     chain_config = ChainConfig('muffin')
 
-    assert chain_config.base_dir == get_base_dir('muffin')
-    assert chain_config.data_dir == get_data_dir('muffin')
+    assert chain_config.data_dir == get_default_data_dir('muffin')
+    assert chain_config.database_dir == get_database_dir('muffin')
     assert chain_config.nodekey_path == get_nodekey_path('muffin')
 
 
 def test_chain_config_explicit_properties():
     chain_config = ChainConfig(
         'muffin',
-        base_dir='./base-dir',
         data_dir='./data-dir',
         nodekey_path='./nodekey'
     )
 
-    assert is_same_path(chain_config.base_dir, './base-dir')
     assert is_same_path(chain_config.data_dir, './data-dir')
     assert is_same_path(chain_config.nodekey_path, './nodekey')
 

--- a/tests/trinity/conftest.py
+++ b/tests/trinity/conftest.py
@@ -1,11 +1,22 @@
 import pytest
 
+from trinity.utils.xdg import (
+    XDG_DATA_HOME,
+    get_xdg_trinity_root,
+)
+from trinity.utils.filesystem import (
+    is_under_path,
+)
+
 
 @pytest.fixture(autouse=True)
-def xdg_trinity_home(monkeypatch, tmpdir):
+def xdg_trinity_root(monkeypatch, tmpdir):
     """
     Ensure proper test isolation as well as protecting the real directories.
     """
-    dir_path = tmpdir.mkdir('xdg_trinity_home')
-    monkeypatch.setenv('XDG_TRINITY_HOME', str(dir_path))
+    dir_path = tmpdir.mkdir('xdg_trinity_root')
+    monkeypatch.setenv('XDG_TRINITY_ROOT', str(dir_path))
+
+    assert not is_under_path(XDG_DATA_HOME, get_xdg_trinity_root())
+
     return str(dir_path)

--- a/tests/trinity/conftest.py
+++ b/tests/trinity/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def xdg_trinity_home(monkeypatch, tmpdir):
+    """
+    Ensure proper test isolation as well as protecting the real directories.
+    """
+    dir_path = tmpdir.mkdir('xdg_trinity_home')
+    monkeypatch.setenv('XDG_TRINITY_HOME', str(dir_path))
+    return str(dir_path)

--- a/tox.ini
+++ b/tox.ini
@@ -42,11 +42,10 @@ commands=
 deps = -r{toxinidir}/requirements-dev.txt
     coincurve
     database: leveldb
+    trinity: leveldb
 basepython =
     py35: python3.5
     py36: python3.6
-extras =
-    trinity: trinity
 
 [testenv:flake8]
 basepython=python

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,8 @@ deps = -r{toxinidir}/requirements-dev.txt
 basepython =
     py35: python3.5
     py36: python3.6
+extras =
+    trinity: trinity
 
 [testenv:flake8]
 basepython=python

--- a/trinity/README.md
+++ b/trinity/README.md
@@ -4,7 +4,6 @@
 ## Environment Configuration
 
 - `TRINITY_MP_CONTEXT` - The context that new processes will be spawned from the python `multiprocessing` library.
-- `TRINITY_HOME` - Base directory where trinity stores data
-- `TRINITY_BASE_DIR` - The base directory where data will be store for the currently running chain.
-- `TRINITY_DATA_DIR` - The directory where the chain data will be stored for the currently running chain.
+- `TRINITY_ROOT` - Base directory where trinity stores data
+- `TRINITY_DATA_DIR` - The root directory where the chain data will be stored for the currently running chain.
 - `TRINITY_NODEKEY` - The path to a file where the devp2p private key is stored.

--- a/trinity/README.md
+++ b/trinity/README.md
@@ -5,6 +5,6 @@
 
 - `TRINITY_MP_CONTEXT` - The context that new processes will be spawned from the python `multiprocessing` library.
 - `TRINITY_HOME` - Base directory where trinity stores data
-- `TRINITY_CHAIN_DIR` - The base directory where data will be store for the currently running chain.
+- `TRINITY_BASE_DIR` - The base directory where data will be store for the currently running chain.
 - `TRINITY_DATA_DIR` - The directory where the chain data will be stored for the currently running chain.
 - `TRINITY_NODEKEY` - The path to a file where the devp2p private key is stored.

--- a/trinity/README.md
+++ b/trinity/README.md
@@ -4,6 +4,6 @@
 ## Environment Configuration
 
 - `TRINITY_MP_CONTEXT` - The context that new processes will be spawned from the python `multiprocessing` library.
-- `TRINITY_ROOT` - Base directory where trinity stores data
+- `XDG_TRINITY_ROOT` - Base directory where trinity stores data
 - `TRINITY_DATA_DIR` - The root directory where the chain data will be stored for the currently running chain.
 - `TRINITY_NODEKEY` - The path to a file where the devp2p private key is stored.

--- a/trinity/__version__.py
+++ b/trinity/__version__.py
@@ -1,0 +1,5 @@
+import pkg_resources
+
+
+# TODO: update to trinity package when it gets split out.
+__version__ = pkg_resources.get_distribution("py-evm").version

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -34,14 +34,14 @@ def is_chain_initialized(chain_config):
 
     if chain_config.nodekey_path is None:
         # has an explicitely defined nodekey
-        return True
+        pass
     elif not os.path.exists(chain_config.nodekey_path):
         return False
 
     if chain_config.nodekey is None:
         return False
 
-    chaindb = get_chain_db(chain_config.data_dir)
+    chaindb = get_chain_db(chain_config.database_dir)
     try:
         chaindb.get_canonical_head()
     except CanonicalHeadNotFound:
@@ -77,7 +77,7 @@ def initialize_chain(chain_config, sync_mode):
     chain_class = get_chain_protocol_class(chain_config, sync_mode)
 
     # Database Initialization
-    chaindb = get_chain_db(chain_config.data_dir)
+    chaindb = get_chain_db(chain_config.database_dir)
     try:
         chaindb.get_canonical_head()
     except CanonicalHeadNotFound:

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -1,0 +1,128 @@
+import os
+
+from eth_utils import (
+    to_dict,
+)
+
+from evm.chains.ropsten import ROPSTEN_GENESIS_HEADER
+from evm.p2p import ecies
+from evm.exceptions import CanonicalHeadNotFound
+
+from trinity.constants import (
+    ROPSTEN,
+)
+from trinity.utils.db import (
+    get_chain_db,
+)
+from trinity.utils.filesystem import (
+    ensure_path_exists,
+)
+from trinity.utils.xdg import (
+    is_under_xdg_trinity_home,
+)
+
+from .ropsten import (
+    RopstenLightChain,
+)
+
+
+def is_chain_initialized(chain_config):
+    """
+    - base dir exists
+    - chain data-dir exists
+    - nodekey exists and is non-empty
+    - canonical chain head in db
+    """
+    if not os.path.exists(chain_config.base_dir):
+        return False
+
+    if not os.path.exists(chain_config.data_dir):
+        return False
+
+    if chain_config.nodekey_path is None:
+        # has an explicitely defined nodekey
+        return True
+    elif not os.path.exists(chain_config.nodekey_path):
+        return False
+
+    if chain_config.nodekey is None:
+        return False
+
+    chaindb = get_chain_db(chain_config.data_dir)
+    try:
+        chaindb.get_canonical_head()
+    except CanonicalHeadNotFound:
+        # empty chain database
+        return False
+
+    return True
+
+
+# TODO: this function shouldn't care about the sync_mode.  We should have some
+# sort of `BaseChain` class that we can retrieve which knows how to do the
+# header initialization.
+def initialize_chain(chain_config, sync_mode):
+    if is_under_xdg_trinity_home(chain_config.base_dir):
+        ensure_path_exists(chain_config.base_dir)
+    elif not os.path.exists(chain_config.base_dir):
+        # we don't lazily create the base dir for non-default base directories.
+        raise ValueError(
+            "The base chain directory provided does not exist: `{0}`".format(
+                chain_config.base_dir,
+            )
+        )
+
+    # Chain data-dir
+    ensure_path_exists(chain_config.data_dir)
+
+    # Nodekey
+    if chain_config.nodekey is None:
+        nodekey = ecies.generate_privkey()
+        with open(chain_config.nodekey_path, 'wb') as nodekey_file:
+            nodekey_file.write(nodekey.to_bytes())
+
+    chain_class = get_chain_protocol_class(chain_config, sync_mode)
+
+    # Database Initialization
+    chaindb = get_chain_db(chain_config.data_dir)
+    try:
+        chaindb.get_canonical_head()
+    except CanonicalHeadNotFound:
+        if chain_config.chain_identifier == ROPSTEN:
+            # We're starting with a fresh DB.
+            # TODO: log that we initialized the chain
+            chain_class.from_genesis_header(chaindb, ROPSTEN_GENESIS_HEADER)
+        else:
+            # TODO: add genesis data to ChainConfig and if it's present, use it
+            # here to initialize the chain.
+            raise NotImplementedError("Not implemented for other chains yet")
+
+    return chain_class
+
+
+def get_chain_protocol_class(chain_config, sync_mode):
+    if sync_mode != 'light':
+        raise NotImplementedError("Currently, `sync_mode` must be set to 'light'")
+
+    if chain_config.chain_identifier != 'ropsten':
+        raise NotImplementedError("Ropsten is the only chain currently supported.")
+
+    return RopstenLightChain.configure(
+        privkey=chain_config.nodekey,
+    )
+
+
+@to_dict
+def construct_chain_config_params(args):
+    if args.base_dir is not None:
+        yield 'base_dir', args.base_dir
+
+    if args.data_dir is not None:
+        yield 'data_dir', args.data_dir
+
+    if args.nodekey_path and args.nodekey:
+        raise ValueError("Cannot provide both nodekey_path and nodekey")
+    elif args.nodekey_path is not None:
+        yield 'nodekey_path', args.nodekey_path
+    elif args.nodekey is not None:
+        yield 'nodekey', args.nodekey

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -10,9 +10,6 @@ from trinity.constants import (
 from trinity.utils.db import (
     get_chain_db,
 )
-from trinity.utils.filesystem import (
-    ensure_path_exists,
-)
 from trinity.utils.xdg import (
     is_under_xdg_trinity_root,
 )
@@ -59,7 +56,7 @@ def is_chain_initialized(chain_config):
 # header initialization.
 def initialize_chain(chain_config, sync_mode):
     if is_under_xdg_trinity_root(chain_config.data_dir):
-        ensure_path_exists(chain_config.data_dir)
+        os.makedirs(chain_config.data_dir, exist_ok=True)
     elif not os.path.exists(chain_config.data_dir):
         # we don't lazily create the base dir for non-default base directories.
         raise ValueError(
@@ -69,7 +66,7 @@ def initialize_chain(chain_config, sync_mode):
         )
 
     # Chain data-dir
-    ensure_path_exists(chain_config.database_dir)
+    os.makedirs(chain_config.database_dir, exist_ok=True)
 
     # Nodekey
     if chain_config.nodekey is None:

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -1,9 +1,5 @@
 import os
 
-from eth_utils import (
-    to_dict,
-)
-
 from evm.chains.ropsten import ROPSTEN_GENESIS_HEADER
 from evm.p2p import ecies
 from evm.exceptions import CanonicalHeadNotFound
@@ -18,7 +14,7 @@ from trinity.utils.filesystem import (
     ensure_path_exists,
 )
 from trinity.utils.xdg import (
-    is_under_xdg_trinity_home,
+    is_under_xdg_trinity_root,
 )
 
 from .ropsten import (
@@ -33,10 +29,10 @@ def is_chain_initialized(chain_config):
     - nodekey exists and is non-empty
     - canonical chain head in db
     """
-    if not os.path.exists(chain_config.base_dir):
+    if not os.path.exists(chain_config.data_dir):
         return False
 
-    if not os.path.exists(chain_config.data_dir):
+    if not os.path.exists(chain_config.database_dir):
         return False
 
     if chain_config.nodekey_path is None:
@@ -62,18 +58,18 @@ def is_chain_initialized(chain_config):
 # sort of `BaseChain` class that we can retrieve which knows how to do the
 # header initialization.
 def initialize_chain(chain_config, sync_mode):
-    if is_under_xdg_trinity_home(chain_config.base_dir):
-        ensure_path_exists(chain_config.base_dir)
-    elif not os.path.exists(chain_config.base_dir):
+    if is_under_xdg_trinity_root(chain_config.data_dir):
+        ensure_path_exists(chain_config.data_dir)
+    elif not os.path.exists(chain_config.data_dir):
         # we don't lazily create the base dir for non-default base directories.
         raise ValueError(
             "The base chain directory provided does not exist: `{0}`".format(
-                chain_config.base_dir,
+                chain_config.data_dir,
             )
         )
 
     # Chain data-dir
-    ensure_path_exists(chain_config.data_dir)
+    ensure_path_exists(chain_config.database_dir)
 
     # Nodekey
     if chain_config.nodekey is None:
@@ -101,6 +97,9 @@ def initialize_chain(chain_config, sync_mode):
 
 
 def get_chain_protocol_class(chain_config, sync_mode):
+    """
+    Retrieve the protocol class for the given chain and sync mode.
+    """
     if sync_mode != 'light':
         raise NotImplementedError("Currently, `sync_mode` must be set to 'light'")
 
@@ -110,19 +109,3 @@ def get_chain_protocol_class(chain_config, sync_mode):
     return RopstenLightChain.configure(
         privkey=chain_config.nodekey,
     )
-
-
-@to_dict
-def construct_chain_config_params(args):
-    if args.base_dir is not None:
-        yield 'base_dir', args.base_dir
-
-    if args.data_dir is not None:
-        yield 'data_dir', args.data_dir
-
-    if args.nodekey_path and args.nodekey:
-        raise ValueError("Cannot provide both nodekey_path and nodekey")
-    elif args.nodekey_path is not None:
-        yield 'nodekey_path', args.nodekey_path
-    elif args.nodekey is not None:
-        yield 'nodekey', args.nodekey

--- a/trinity/chains/ropsten.py
+++ b/trinity/chains/ropsten.py
@@ -1,0 +1,10 @@
+from evm.p2p.lightchain import LightChain
+from evm.chains.mainnet import MAINNET_VM_CONFIGURATION
+from evm.chains.ropsten import ROPSTEN_NETWORK_ID
+
+
+RopstenLightChain = LightChain.configure(
+    name='RopstenLightChain',
+    vm_configuration=MAINNET_VM_CONFIGURATION,  # TODO: use real ropsten configuration
+    network_id=ROPSTEN_NETWORK_ID,
+)

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -1,1 +1,3 @@
 ROPSTEN = 'ropsten'
+
+SYNC_LIGHT = 'light'

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -1,7 +1,6 @@
 import argparse
 import asyncio
 import atexit
-import os
 
 from evm.exceptions import CanonicalHeadNotFound
 
@@ -10,7 +9,6 @@ from trinity.chains import (
     is_chain_initialized,
     initialize_chain,
     get_chain_protocol_class,
-    construct_chain_config_params,
 )
 from trinity.constants import (
     ROPSTEN,
@@ -63,16 +61,29 @@ parser.add_argument(
     action='store_true',
 )
 parser.add_argument(
-    '--base-dir',
+    '--trinity-root-dir',
+    help=(
+        "The filesystem path to the base directory that trinity will store it's "
+        "information.  Default: $XDG_DATA_HOME/.local/share/trinity"
+    ),
 )
 parser.add_argument(
     '--data-dir',
+    help=(
+        "The directory where chain data is stored"
+    ),
 )
 parser.add_argument(
     '--nodekey',
+    help=(
+        "Hexadecimal encoded private key to use for the nodekey"
+    )
 )
 parser.add_argument(
     '--nodekey-path',
+    help=(
+        "The filesystem path to the file which contains the nodekey"
+    )
 )
 
 
@@ -85,10 +96,6 @@ def main():
     # the local logger.
     listener.start()
 
-<<<<<<< HEAD
-    db_path = get_data_dir(ROPSTEN)
-    os.makedirs(db_path, exist_ok=True)
-=======
     if args.ropsten:
         chain_identifier = ROPSTEN
     else:
@@ -101,9 +108,7 @@ def main():
         # TODO: actually use args.sync_mode (--sync-mode)
         sync_mode = SYNC_LIGHT
 
-    chain_config_params = construct_chain_config_params(args)
-    chain_config = ChainConfig(chain_identifier, **chain_config_params)
->>>>>>> Chain initialization and CLI args for chain params.
+    chain_config = ChainConfig.from_parser_args(chain_identifier, args)
 
     # For now we just run the light sync against ropsten by default.
     process = ctx.Process(

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -3,29 +3,31 @@ import asyncio
 import atexit
 import os
 
-from evm.db.chain import BaseChainDB
 from evm.exceptions import CanonicalHeadNotFound
-from evm.chains.ropsten import (
-    ROPSTEN_GENESIS_HEADER,
-    ROPSTEN_NETWORK_ID,
-)
-from evm.chains.mainnet import MAINNET_VM_CONFIGURATION
-from evm.p2p import ecies
-from evm.p2p.lightchain import LightChain
-from evm.db.backends.level import LevelDB
 
+from trinity.__version__ import __version__
+from trinity.chains import (
+    is_chain_initialized,
+    initialize_chain,
+    get_chain_protocol_class,
+    construct_chain_config_params,
+)
 from trinity.constants import (
     ROPSTEN,
+    SYNC_LIGHT,
+)
+from trinity.utils.chains import (
+    ChainConfig,
+)
+from trinity.utils.db import (
+    get_chain_db,
 )
 from trinity.utils.logging import (
     setup_trinity_logging,
-    setup_queue_logging,
+    with_queued_logging,
 )
 from trinity.utils.mp import (
     ctx,
-)
-from trinity.utils.xdg import (
-    get_data_dir,
 )
 
 
@@ -37,19 +39,40 @@ LOG_LEVEL_CHOICES = (
 
 
 parser = argparse.ArgumentParser(description='Trinity')
+
+# enable `trinity --version`
+parser.add_argument('--version', action='version', version=__version__)
+
+# set global logging level
 parser.add_argument(
     '-l',
     '--log-level',
     choices=LOG_LEVEL_CHOICES,
     default=DEFAULT_LOG_LEVEL,
+    help="Sets the logging level",
 )
 
-
-DemoLightChain = LightChain.configure(
-    name='Demo LightChain',
-    privkey=ecies.generate_privkey(),  # TODO: get from stored key.
-    vm_configuration=MAINNET_VM_CONFIGURATION,
-    network_id=ROPSTEN_NETWORK_ID,
+# options for running chains
+parser.add_argument(
+    '--ropsten',
+    action='store_true',
+    help="Ropsten network: pre configured proof-of-work test network",
+)
+parser.add_argument(
+    '--light',  # TODO: consider --sync-mode like geth.
+    action='store_true',
+)
+parser.add_argument(
+    '--base-dir',
+)
+parser.add_argument(
+    '--data-dir',
+)
+parser.add_argument(
+    '--nodekey',
+)
+parser.add_argument(
+    '--nodekey-path',
 )
 
 
@@ -62,13 +85,31 @@ def main():
     # the local logger.
     listener.start()
 
+<<<<<<< HEAD
     db_path = get_data_dir(ROPSTEN)
     os.makedirs(db_path, exist_ok=True)
+=======
+    if args.ropsten:
+        chain_identifier = ROPSTEN
+    else:
+        # TODO: mainnet
+        chain_identifier = ROPSTEN
+
+    if args.light:
+        sync_mode = SYNC_LIGHT
+    else:
+        # TODO: actually use args.sync_mode (--sync-mode)
+        sync_mode = SYNC_LIGHT
+
+    chain_config_params = construct_chain_config_params(args)
+    chain_config = ChainConfig(chain_identifier, **chain_config_params)
+>>>>>>> Chain initialization and CLI args for chain params.
 
     # For now we just run the light sync against ropsten by default.
     process = ctx.Process(
-        target=ropsten_light_node_sync,
-        args=(log_queue, db_path),
+        target=run_chain,
+        args=(chain_config, sync_mode),
+        kwargs={'log_queue': log_queue}
     )
 
     try:
@@ -79,21 +120,26 @@ def main():
         process.terminate()
 
 
-def ropsten_light_node_sync(log_queue, db_path):
-    """
-    Runs an LES node against the Ropsten network.
-    """
-    setup_queue_logging(log_queue)
+@with_queued_logging
+def run_chain(chain_config, sync_mode):
+    if not is_chain_initialized(chain_config):
+        # TODO: this will only work as is for chains with known genesis
+        # parameters.  Need to flesh out how genesis parameters for custom
+        # chains are defined and passed around.
+        chain_class = initialize_chain(chain_config, sync_mode=sync_mode)
+    else:
+        chain_class = get_chain_protocol_class(chain_config, sync_mode=sync_mode)
 
-    chaindb = BaseChainDB(LevelDB(db_path))
+    # TODO: this should probably be something that is passed in to allow
+    # specifying the db_path via the CLI as well as the db class.
+    chaindb = get_chain_db(chain_config.data_dir)
     try:
         chaindb.get_canonical_head()
     except CanonicalHeadNotFound:
-        # We're starting with a fresh DB.
-        chain = DemoLightChain.from_genesis_header(chaindb, ROPSTEN_GENESIS_HEADER)
-    else:
-        # We're reusing an existing db.
-        chain = DemoLightChain(chaindb)
+        # TODO: figure out amore appropriate error to raise here.
+        raise ValueError('Chain not intiialized')
+
+    chain = chain_class(chaindb)
 
     loop = asyncio.get_event_loop()
 

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -135,8 +135,6 @@ def run_chain(chain_config, sync_mode):
     else:
         chain_class = get_chain_protocol_class(chain_config, sync_mode=sync_mode)
 
-    # TODO: this should probably be something that is passed in to allow
-    # specifying the db_path via the CLI as well as the db class.
     chaindb = get_chain_db(chain_config.data_dir)
     try:
         chaindb.get_canonical_head()

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -1,0 +1,151 @@
+import os
+
+from eth_keys import keys
+from eth_keys.datatypes import PrivateKey
+
+from .xdg import (
+    get_xdg_trinity_home,
+)
+
+
+def get_base_dir(chain_identifier):
+    """
+    Returns the base directory path where data for a given chain will be stored.
+    """
+    return os.environ.get(
+        'TRINITY_BASE_DIR',
+        os.path.join(get_xdg_trinity_home(), chain_identifier),
+    )
+
+
+DATA_DIR_NAME = 'chain'
+
+
+def get_data_dir(chain_identifier, base_dir=None):
+    """
+    Returns the directory path where chain data will be stored.
+    """
+    if base_dir is None:
+        base_dir = get_base_dir(chain_identifier)
+    return os.environ.get(
+        'TRINITY_DATA_DIR',
+        os.path.join(base_dir, DATA_DIR_NAME),
+    )
+
+
+NODEKEY_FILENAME = 'nodekey'
+
+
+def get_nodekey_path(chain_identifier, base_dir=None):
+    """
+    Returns the path to the private key used for devp2p connections.
+    """
+    if base_dir is None:
+        base_dir = get_base_dir(chain_identifier)
+    return os.environ.get(
+        'TRINITY_NODEKEY',
+        os.path.join(base_dir, NODEKEY_FILENAME),
+    )
+
+
+def load_nodekey(nodekey_path):
+    with open(nodekey_path, 'rb') as nodekey_file:
+        nodekey_raw = nodekey_file.read()
+    nodekey = keys.PrivateKey(nodekey_raw)
+    return nodekey
+
+
+class ChainConfig:
+    chain_identifier = None
+
+    _base_dir = None
+    _data_dir = None
+    _nodekey_path = None
+    _nodekey = None
+
+    def __init__(self,
+                 chain_identifier,
+                 base_dir=None,
+                 data_dir=None,
+                 nodekey_path=None,
+                 nodekey=None):
+        # validation
+        if nodekey is not None and nodekey_path is not None:
+            raise ValueError("It is invalid to provide both a `nodekey` and a `nodekey_path`")
+
+        # set values
+        self.chain_identifier = chain_identifier
+
+        if base_dir is not None:
+            self.base_dir = base_dir
+
+        if data_dir is not None:
+            self.data_dir = data_dir
+
+        if nodekey_path is not None:
+            self.nodekey_path = nodekey_path
+        elif nodekey is not None:
+            self.nodekey = nodekey
+
+    @property
+    def base_dir(self):
+        if self._base_dir is None:
+            return get_base_dir(self.chain_identifier)
+        else:
+            return self._base_dir
+
+    @base_dir.setter
+    def base_dir(self, value):
+        self._base_dir = os.path.abspath(value)
+
+    @property
+    def data_dir(self):
+        if self._data_dir is None:
+            return get_data_dir(self.chain_identifier, self.base_dir)
+        else:
+            return self._data_dir
+
+    @data_dir.setter
+    def data_dir(self, value):
+        self._data_dir = os.path.abspath(value)
+
+    @property
+    def nodekey_path(self):
+        if self._nodekey_path is None:
+            if self._nodekey is not None:
+                return None
+            else:
+                return get_nodekey_path(self.chain_identifier, self.base_dir)
+        else:
+            return self._nodekey_path
+
+    @nodekey_path.setter
+    def nodekey_path(self, value):
+        self._nodekey_path = os.path.abspath(value)
+
+    @property
+    def nodekey(self):
+        if self._nodekey is None:
+            try:
+                return load_nodekey(self.nodekey_path)
+            except FileNotFoundError:
+                # no file at the nodekey_path so we have a null nodekey
+                return None
+        else:
+            if isinstance(self._nodekey, bytes):
+                return keys.PrivateKey(self._nodekey)
+            elif isinstance(self._nodekey, PrivateKey):
+                return self._nodekey
+            return self._nodekey
+
+    @nodekey.setter
+    def nodekey(self, value):
+        if isinstance(value, bytes):
+            self._nodekey = keys.PrivateKey(value)
+        elif isinstance(value, PrivateKey):
+            self._nodekey = value
+        else:
+            raise TypeError(
+                "Nodekey must either be a raw byte-string or an eth_keys "
+                "`PrivateKey` instance"
+            )

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -1,50 +1,54 @@
 import os
 
+from eth_utils import (
+    to_dict,
+)
+
 from eth_keys import keys
 from eth_keys.datatypes import PrivateKey
 
+from .hexadecimal import (
+    decode_hex,
+)
 from .xdg import (
-    get_xdg_trinity_home,
+    get_xdg_trinity_root,
 )
 
 
-def get_base_dir(chain_identifier):
+def get_default_data_dir(chain_identifier):
     """
     Returns the base directory path where data for a given chain will be stored.
     """
     return os.environ.get(
-        'TRINITY_BASE_DIR',
-        os.path.join(get_xdg_trinity_home(), chain_identifier),
+        'TRINITY_DATA_DIR',
+        os.path.join(get_xdg_trinity_root(), chain_identifier),
     )
 
 
-DATA_DIR_NAME = 'chain'
+DATABASE_DIR_NAME = 'chain'
 
 
-def get_data_dir(chain_identifier, base_dir=None):
+def get_database_dir(chain_identifier, data_dir=None):
     """
     Returns the directory path where chain data will be stored.
     """
-    if base_dir is None:
-        base_dir = get_base_dir(chain_identifier)
-    return os.environ.get(
-        'TRINITY_DATA_DIR',
-        os.path.join(base_dir, DATA_DIR_NAME),
-    )
+    if data_dir is None:
+        data_dir = get_default_data_dir(chain_identifier)
+    return os.path.join(data_dir, DATABASE_DIR_NAME)
 
 
 NODEKEY_FILENAME = 'nodekey'
 
 
-def get_nodekey_path(chain_identifier, base_dir=None):
+def get_nodekey_path(chain_identifier, data_dir=None):
     """
     Returns the path to the private key used for devp2p connections.
     """
-    if base_dir is None:
-        base_dir = get_base_dir(chain_identifier)
+    if data_dir is None:
+        data_dir = get_default_data_dir(chain_identifier)
     return os.environ.get(
         'TRINITY_NODEKEY',
-        os.path.join(base_dir, NODEKEY_FILENAME),
+        os.path.join(data_dir, NODEKEY_FILENAME),
     )
 
 
@@ -58,14 +62,12 @@ def load_nodekey(nodekey_path):
 class ChainConfig:
     chain_identifier = None
 
-    _base_dir = None
     _data_dir = None
     _nodekey_path = None
     _nodekey = None
 
     def __init__(self,
                  chain_identifier,
-                 base_dir=None,
                  data_dir=None,
                  nodekey_path=None,
                  nodekey=None):
@@ -76,9 +78,6 @@ class ChainConfig:
         # set values
         self.chain_identifier = chain_identifier
 
-        if base_dir is not None:
-            self.base_dir = base_dir
-
         if data_dir is not None:
             self.data_dir = data_dir
 
@@ -88,20 +87,9 @@ class ChainConfig:
             self.nodekey = nodekey
 
     @property
-    def base_dir(self):
-        if self._base_dir is None:
-            return get_base_dir(self.chain_identifier)
-        else:
-            return self._base_dir
-
-    @base_dir.setter
-    def base_dir(self, value):
-        self._base_dir = os.path.abspath(value)
-
-    @property
     def data_dir(self):
         if self._data_dir is None:
-            return get_data_dir(self.chain_identifier, self.base_dir)
+            return get_default_data_dir(self.chain_identifier)
         else:
             return self._data_dir
 
@@ -110,12 +98,16 @@ class ChainConfig:
         self._data_dir = os.path.abspath(value)
 
     @property
+    def database_dir(self):
+        return get_database_dir(self.chain_identifier, self.data_dir)
+
+    @property
     def nodekey_path(self):
         if self._nodekey_path is None:
             if self._nodekey is not None:
                 return None
             else:
-                return get_nodekey_path(self.chain_identifier, self.base_dir)
+                return get_nodekey_path(self.chain_identifier, self.data_dir)
         else:
             return self._nodekey_path
 
@@ -149,3 +141,24 @@ class ChainConfig:
                 "Nodekey must either be a raw byte-string or an eth_keys "
                 "`PrivateKey` instance"
             )
+
+    @classmethod
+    def from_parser_args(cls, chain_identifier, parser_args):
+        constructor_kwargs = construct_chain_config_params(parser_args)
+        return cls(chain_identifier, **constructor_kwargs)
+
+
+@to_dict
+def construct_chain_config_params(args):
+    """
+    Hel
+    """
+    if args.data_dir is not None:
+        yield 'data_dir', args.data_dir
+
+    if args.nodekey_path and args.nodekey:
+        raise ValueError("Cannot provide both nodekey_path and nodekey")
+    elif args.nodekey_path is not None:
+        yield 'nodekey_path', args.nodekey_path
+    elif args.nodekey is not None:
+        yield 'nodekey', decode_hex(args.nodekey)

--- a/trinity/utils/db.py
+++ b/trinity/utils/db.py
@@ -1,0 +1,19 @@
+import os
+
+from evm.db import get_db_backend
+from evm.db.chain import BaseChainDB
+
+
+def get_chain_db_backend_class_path():
+    return os.environ.get(
+        'TRINITY_DB_BACKEND',
+        'evm.db.backends.level.LevelDB',
+    )
+
+
+def get_chain_db(data_dir, db_backend_class=None):
+    if db_backend_class is None:
+        db_backend_class = get_chain_db_backend_class_path()
+
+    db = get_db_backend(db_backend_class, db_path=data_dir)
+    return BaseChainDB(db)

--- a/trinity/utils/xdg.py
+++ b/trinity/utils/xdg.py
@@ -1,5 +1,9 @@
 import os
 
+from .filesystem import (
+    is_under_path,
+)
+
 
 XDG_CACHE_HOME = os.environ.get(
     'XDG_CACHE_HOME',
@@ -17,7 +21,7 @@ XDG_DATA_HOME = os.environ.get(
 )
 
 
-def get_trinity_home():
+def get_xdg_trinity_home():
     """
     Returns the base directory under which trinity will store all data.
     """
@@ -27,37 +31,8 @@ def get_trinity_home():
     )
 
 
-def get_chain_dir(chain_identifier):
-    """
-    Returns the base directory path where data for a given chain will be stored.
-    """
-    return os.environ.get(
-        'TRINITY_CHAIN_DIR',
-        os.path.join(get_trinity_home(), chain_identifier),
-    )
-
-
-DATA_DIR_NAME = 'chain'
-
-
-def get_data_dir(chain_identifier):
-    """
-    Returns the directory path where chain data will be stored.
-    """
-    return os.environ.get(
-        'TRINITY_DATA_DIR',
-        os.path.join(get_chain_dir(chain_identifier), DATA_DIR_NAME),
-    )
-
-
-NODEKEY_FILENAME = 'nodekey'
-
-
-def get_nodekey_path(chain_identifier):
-    """
-    Returns the path to the private key used for devp2p connections.
-    """
-    return os.environ.get(
-        'TRINITY_NODEKEY',
-        os.path.join(get_chain_dir(chain_identifier), NODEKEY_FILENAME),
+def is_under_xdg_trinity_home(path):
+    return is_under_path(
+        get_xdg_trinity_home(),
+        path,
     )

--- a/trinity/utils/xdg.py
+++ b/trinity/utils/xdg.py
@@ -26,7 +26,7 @@ def get_xdg_trinity_root():
     Returns the base directory under which trinity will store all data.
     """
     return os.environ.get(
-        'TRINITY_ROOT',
+        'XDG_TRINITY_ROOT',
         os.path.join(XDG_DATA_HOME, 'trinity'),
     )
 

--- a/trinity/utils/xdg.py
+++ b/trinity/utils/xdg.py
@@ -21,18 +21,18 @@ XDG_DATA_HOME = os.environ.get(
 )
 
 
-def get_xdg_trinity_home():
+def get_xdg_trinity_root():
     """
     Returns the base directory under which trinity will store all data.
     """
     return os.environ.get(
-        'TRINITY_HOME',
+        'TRINITY_ROOT',
         os.path.join(XDG_DATA_HOME, 'trinity'),
     )
 
 
-def is_under_xdg_trinity_home(path):
+def is_under_xdg_trinity_root(path):
     return is_under_path(
-        get_xdg_trinity_home(),
+        get_xdg_trinity_root(),
         path,
     )


### PR DESCRIPTION
### What was wrong?

There are a small number of things that need to be in place in order to run a chain.

- chain directory structure created
- chaindb initialized wtih genesis data
- nodekey

### How was it fixed?

Added detection for whether these things are initialized and code to do intelligent initialization.  Note that this is just a start, as it won't handle cases where it's a custom chain with custom genesis data, etc.

This PR currently special cases a number of things that will need to be polished out (such as only supporting the ropsten chain and light sync mode.

#### Cute Animal Picture

![cute-tiny-animals-6](https://user-images.githubusercontent.com/824194/35416369-243f3734-01e6-11e8-898b-c6badd6f516d.jpg)

