### PR TITLE
Make vm_configuration optional to allow multi-step configuration

### DIFF
--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -76,11 +76,12 @@ class Chain(Configurable):
             self.gas_estimator = get_gas_estimator()
 
     @classmethod
-    def configure(cls, name, vm_configuration, **overrides):
+    def configure(cls, name=None, vm_configuration=None, **overrides):
         if 'vms_by_range' in overrides:
             raise ValueError("Cannot override vms_by_range")
 
-        overrides['vms_by_range'] = generate_vms_by_range(vm_configuration)
+        if vm_configuration is not None:
+            overrides['vms_by_range'] = generate_vms_by_range(vm_configuration)
         return super().configure(name, **overrides)
 
     #


### PR DESCRIPTION
### What was wrong?

In the `trinity` branch, I'm finding that I need to be able to do mult-step configuration for the chain classes.  The way that the `configure` method is written, it requires the `vm_configuration` be passed in each time (even if it's already been configured)

### How was it fixed?

* Modified `Chain.configure` to have `vm_configuration` be optional.

This should be fine since the `Chain.__init__` does perform a validation check that `self.vms_by_range` is configured.

#### Cute Animal Picture

![udqgaqu-710x533](https://user-images.githubusercontent.com/824194/35416753-8b8e0798-01e7-11e8-9e71-f8b8097a6346.jpg)

