### PR TITLE
Fix transaction execution

### DIFF
--- a/evm/computation.py
+++ b/evm/computation.py
@@ -35,7 +35,6 @@ from evm.vm.memory import (
 )
 from evm.vm.message import (
     Message,
-    ShardingMessage,
 )
 from evm.vm.stack import (
     Stack,
@@ -144,31 +143,6 @@ class BaseComputation(object):
             **kwargs
         )
         return child_message
-
-    def prepare_child_sharding_message(self,
-                                       gas,
-                                       to,
-                                       value,
-                                       data,
-                                       code,
-                                       is_create,
-                                       **kwargs):
-        kwargs.setdefault('sender', self.msg.storage_address)
-
-        child_sharding_message = ShardingMessage(
-            gas=gas,
-            gas_price=self.msg.gas_price,
-            origin=self.msg.origin,
-            sig_hash=self.msg.sig_hash,
-            to=to,
-            value=value,
-            data=data,
-            code=code,
-            depth=self.msg.depth + 1,
-            is_create=is_create,
-            **kwargs
-        )
-        return child_sharding_message
 
     #
     # Memory Management

--- a/evm/logic/call.py
+++ b/evm/logic/call.py
@@ -58,11 +58,7 @@ class BaseCall(Opcode):
         computation.gas_meter.consume_gas(child_msg_gas_fee, reason=self.mnemonic)
 
         # Pre-call checks
-        _state_db = computation.vm_state.state_db(
-            read_only=True,
-            access_list=computation.msg.access_list,
-        )
-        with _state_db as state_db:
+        with computation.state_db(read_only=True) as state_db:
             sender_balance = state_db.get_balance(computation.msg.storage_address)
 
         insufficient_funds = should_transfer_value and sender_balance < value
@@ -88,11 +84,7 @@ class BaseCall(Opcode):
             computation.gas_meter.return_gas(child_msg_gas)
             computation.stack.push(0)
         else:
-            _state_db = computation.vm_state.state_db(
-                read_only=True,
-                access_list=computation.msg.access_list,
-            )
-            with _state_db as state_db:
+            with computation.state_db(read_only=True) as state_db:
                 if code_address:
                     code = state_db.get_code(code_address)
                 else:
@@ -134,11 +126,7 @@ class BaseCall(Opcode):
 
 class Call(BaseCall):
     def compute_msg_extra_gas(self, computation, gas, to, value):
-        _state_db = computation.vm_state.state_db(
-            read_only=True,
-            access_list=computation.msg.access_list,
-        )
-        with _state_db as state_db:
+        with computation.state_db(read_only=True) as state_db:
             account_exists = state_db.account_exists(to)
 
         transfer_gas_fee = constants.GAS_CALLVALUE if value else 0
@@ -296,11 +284,7 @@ def compute_eip150_msg_gas(computation, gas, extra_gas, value, mnemonic, callsti
 #
 class CallEIP161(CallEIP150):
     def compute_msg_extra_gas(self, computation, gas, to, value):
-        _state_db = computation.vm_state.state_db(
-            read_only=True,
-            access_list=computation.msg.access_list,
-        )
-        with _state_db as state_db:
+        with computation.state_db(read_only=True) as state_db:
             account_is_dead = (
                 not state_db.account_exists(to) or
                 state_db.account_is_empty(to)

--- a/evm/logic/context.py
+++ b/evm/logic/context.py
@@ -16,11 +16,7 @@ from evm.utils.padding import (
 
 def balance(computation):
     addr = force_bytes_to_address(computation.stack.pop(type_hint=constants.BYTES))
-    _state_db = computation.vm_state.state_db(
-        read_only=True,
-        access_list=computation.msg.access_list,
-    )
-    with _state_db as state_db:
+    with computation.state_db(read_only=True) as state_db:
         balance = state_db.get_balance(addr)
     computation.stack.push(balance)
 
@@ -115,11 +111,7 @@ def gasprice(computation):
 
 def extcodesize(computation):
     account = force_bytes_to_address(computation.stack.pop(type_hint=constants.BYTES))
-    _state_db = computation.vm_state.state_db(
-        read_only=True,
-        access_list=computation.msg.access_list,
-    )
-    with _state_db as state_db:
+    with computation.state_db(read_only=True) as state_db:
         code_size = len(state_db.get_code(account))
 
     computation.stack.push(code_size)
@@ -143,11 +135,7 @@ def extcodecopy(computation):
         reason='EXTCODECOPY: word gas cost',
     )
 
-    _state_db = computation.vm_state.state_db(
-        read_only=True,
-        access_list=computation.msg.access_list,
-    )
-    with _state_db as state_db:
+    with computation.state_db(read_only=True) as state_db:
         code = state_db.get_code(account)
 
     code_bytes = code[code_start_position:code_start_position + size]

--- a/evm/logic/storage.py
+++ b/evm/logic/storage.py
@@ -8,11 +8,7 @@ from evm.utils.hexadecimal import (
 def sstore(computation):
     slot, value = computation.stack.pop(num_items=2, type_hint=constants.UINT256)
 
-    _state_db = computation.vm_state.state_db(
-        read_only=True,
-        access_list=computation.msg.access_list,
-    )
-    with _state_db as state_db:
+    with computation.state_db(read_only=True) as state_db:
         current_value = state_db.get_storage(
             address=computation.msg.storage_address,
             slot=slot,
@@ -47,10 +43,7 @@ def sstore(computation):
     if gas_refund:
         computation.gas_meter.refund_gas(gas_refund)
 
-    _state_db = computation.vm_state.state_db(
-        access_list=computation.msg.access_list,
-    )
-    with _state_db as state_db:
+    with computation.state_db() as state_db:
         state_db.set_storage(
             address=computation.msg.storage_address,
             slot=slot,
@@ -61,11 +54,7 @@ def sstore(computation):
 def sload(computation):
     slot = computation.stack.pop(type_hint=constants.UINT256)
 
-    _state_db = computation.vm_state.state_db(
-        read_only=True,
-        access_list=computation.msg.access_list,
-    )
-    with _state_db as state_db:
+    with computation.state_db(read_only=True) as state_db:
         value = state_db.get_storage(
             address=computation.msg.storage_address,
             slot=slot,

--- a/evm/logic/system.py
+++ b/evm/logic/system.py
@@ -49,11 +49,7 @@ def selfdestruct(computation):
 
 def selfdestruct_eip150(computation):
     beneficiary = force_bytes_to_address(computation.stack.pop(type_hint=constants.BYTES))
-    _state_db = computation.vm_state.state_db(
-        read_only=True,
-        access_list=computation.msg.access_list,
-    )
-    with _state_db as state_db:
+    with computation.state_db(read_only=True) as state_db:
         if not state_db.account_exists(beneficiary):
             computation.gas_meter.consume_gas(
                 constants.GAS_SELFDESTRUCT_NEWACCOUNT,
@@ -64,11 +60,7 @@ def selfdestruct_eip150(computation):
 
 def selfdestruct_eip161(computation):
     beneficiary = force_bytes_to_address(computation.stack.pop(type_hint=constants.BYTES))
-    _state_db = computation.vm_state.state_db(
-        read_only=True,
-        access_list=computation.msg.access_list,
-    )
-    with _state_db as state_db:
+    with computation.state_db(read_only=True) as state_db:
         is_dead = (
             not state_db.account_exists(beneficiary) or
             state_db.account_is_empty(beneficiary)
@@ -82,10 +74,7 @@ def selfdestruct_eip161(computation):
 
 
 def _selfdestruct(computation, beneficiary):
-    _state_db = computation.vm_state.state_db(
-        access_list=computation.msg.access_list,
-    )
-    with _state_db as state_db:
+    with computation.state_db() as state_db:
         local_balance = state_db.get_balance(computation.msg.storage_address)
         beneficiary_balance = state_db.get_balance(beneficiary)
 
@@ -122,11 +111,7 @@ class Create(Opcode):
 
         computation.extend_memory(start_position, size)
 
-        _state_db = computation.vm_state.state_db(
-            read_only=True,
-            access_list=computation.msg.access_list,
-        )
-        with _state_db as state_db:
+        with computation.state_db(read_only=True) as state_db:
             insufficient_funds = state_db.get_balance(computation.msg.storage_address) < value
         stack_too_deep = computation.msg.depth + 1 > constants.STACK_DEPTH_LIMIT
 
@@ -141,10 +126,7 @@ class Create(Opcode):
         )
         computation.gas_meter.consume_gas(create_msg_gas, reason="CREATE")
 
-        _state_db = computation.vm_state.state_db(
-            access_list=computation.msg.access_list,
-        )
-        with _state_db as state_db:
+        with computation.state_db() as state_db:
             creation_nonce = state_db.get_nonce(computation.msg.storage_address)
             state_db.increment_nonce(computation.msg.storage_address)
 

--- a/evm/logic/system.py
+++ b/evm/logic/system.py
@@ -222,7 +222,7 @@ class Create2(CreateEIP150):
             computation.stack.push(0)
             return
 
-        child_msg = computation.prepare_child_sharding_message(
+        child_msg = computation.prepare_child_message(
             gas=create_msg_gas,
             to=contract_address,
             value=value,

--- a/evm/rlp/transactions.py
+++ b/evm/rlp/transactions.py
@@ -15,6 +15,9 @@ from evm.rlp.sedes import (
 from evm.utils.keccak import (
     keccak,
 )
+from evm.utils.state_access_restriction import (
+    to_prefix_list_form,
+)
 
 
 class BaseTransaction(rlp.Serializable):
@@ -160,6 +163,10 @@ class BaseShardingTransaction(rlp.Serializable):
         ('access_list', access_list_sedes),
         ('code', binary),
     ]
+
+    def __init__(self, chain_id, shard_id, to, data, gas, gas_price, access_list, code):
+        super().__init__(chain_id, shard_id, to, data, gas, gas_price, access_list, code)
+        self.prefix_list = to_prefix_list_form(self.access_list)
 
     @property
     def hash(self):

--- a/evm/rlp/transactions.py
+++ b/evm/rlp/transactions.py
@@ -164,8 +164,8 @@ class BaseShardingTransaction(rlp.Serializable):
         ('code', binary),
     ]
 
-    def __init__(self, chain_id, shard_id, to, data, gas, gas_price, access_list, code):
-        super().__init__(chain_id, shard_id, to, data, gas, gas_price, access_list, code)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.prefix_list = to_prefix_list_form(self.access_list)
 
     @property

--- a/evm/vm/forks/sharding/computation.py
+++ b/evm/vm/forks/sharding/computation.py
@@ -6,6 +6,9 @@ from evm.exceptions import (
     InsufficientFunds,
     StackDepthLimit,
 )
+from evm.vm.message import (
+    ShardingMessage,
+)
 from evm.utils.hexadecimal import (
     encode_hex,
 )
@@ -113,3 +116,21 @@ class ShardingComputation(SpuriousDragonComputation):
             else:
                 self.vm_state.commit(snapshot)
             return computation
+
+    def prepare_child_message(self, gas, to, value, data, code, **kwargs):
+        kwargs.setdefault('sender', self.msg.storage_address)
+
+        child_message = ShardingMessage(
+            gas=gas,
+            gas_price=self.msg.gas_price,
+            origin=self.msg.origin,
+            sig_hash=self.msg.sig_hash,
+            to=to,
+            value=value,
+            data=data,
+            code=code,
+            depth=self.msg.depth + 1,
+            access_list=self.msg.access_list,
+            **kwargs
+        )
+        return child_message

--- a/evm/vm/forks/sharding/computation.py
+++ b/evm/vm/forks/sharding/computation.py
@@ -53,9 +53,6 @@ class ShardingComputation(SpuriousDragonComputation):
                 encode_hex(self.msg.storage_address),
             )
 
-        with self.vm_state.state_db() as state_db:
-            state_db.touch_account(self.msg.storage_address)
-
         computation = self.apply_computation(
             self.vm_state,
             self.msg,

--- a/evm/vm/forks/sharding/computation.py
+++ b/evm/vm/forks/sharding/computation.py
@@ -35,7 +35,7 @@ class ShardingComputation(SpuriousDragonComputation):
             raise StackDepthLimit("Stack depth limit reached")
 
         if self.msg.should_transfer_value and self.msg.value:
-            with self.vm_state.state_db() as state_db:
+            with self.state_db() as state_db:
                 sender_balance = state_db.get_balance(self.msg.sender)
 
                 if sender_balance < self.msg.value:
@@ -110,7 +110,7 @@ class ShardingComputation(SpuriousDragonComputation):
                             encode_hex(keccak(contract_code))
                         )
 
-                    with self.vm_state.state_db() as state_db:
+                    with self.state_db() as state_db:
                         state_db.set_code(self.msg.storage_address, contract_code)
                     self.vm_state.commit(snapshot)
             else:

--- a/evm/vm/forks/sharding/vm_state.py
+++ b/evm/vm/forks/sharding/vm_state.py
@@ -92,6 +92,7 @@ class ShardingVMState(ByzantiumVMState):
             data=data,
             code=code,
             is_create=is_create,
+            access_list=transaction.prefix_list,
         )
 
         #

--- a/evm/vm/message.py
+++ b/evm/vm/message.py
@@ -186,26 +186,3 @@ class ShardingMessage(Message):
         if access_list is not None:
             validate_access_list(access_list)
         self.access_list = access_list
-
-    def prepare_child_message(self,
-                              gas,
-                              to,
-                              value,
-                              data,
-                              code,
-                              **kwargs):
-        kwargs.setdefault('sender', self.msg.storage_address)
-
-        child_message = ShardingMessage(
-            gas=gas,
-            gas_price=self.msg.gas_price,
-            origin=self.msg.origin,
-            sig_hash=self.msg.sig_hash,
-            to=to,
-            value=value,
-            data=data,
-            code=code,
-            depth=self.msg.depth + 1,
-            **kwargs
-        )
-        return child_message

--- a/tests/auxiliary/user-account/test_contract.py
+++ b/tests/auxiliary/user-account/test_contract.py
@@ -14,6 +14,9 @@ from evm.constants import (
     ZERO_HASH32,
     ENTRY_POINT,
 )
+from evm.exceptions import (
+    UnannouncedStateAccess,
+)
 from evm.vm.message import (
     ShardingMessage,
 )
@@ -137,6 +140,8 @@ DEFAULT_V = SIGNED_DEFAULT_TRANSACTION.v
 DEFAULT_R = SIGNED_DEFAULT_TRANSACTION.r
 DEFAULT_S = SIGNED_DEFAULT_TRANSACTION.s
 
+XFAIL_REASON = "gas payment to dynamic coinbase and missing PAYGAS implementation"
+
 
 @pytest.fixture
 def vm():
@@ -168,7 +173,7 @@ def get_nonce(vm):
     return big_endian_to_int(computation.output)
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)  # noqa: F811
 def test_get_nonce(vm):
     computation, _ = vm.apply_transaction(ShardingTransaction(**merge(DEFAULT_BASE_TX_PARAMS, {
         "data": int_to_big_endian(NONCE_GETTER_ID),
@@ -183,7 +188,7 @@ def test_get_nonce(vm):
     assert computation.output == pad32(b"\x01")
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=NotImplementedError)
 def test_call_increments_nonce(vm):
     computation, _ = vm.apply_transaction(SIGNED_DEFAULT_TRANSACTION)
     assert computation.is_success
@@ -197,7 +202,7 @@ def test_call_increments_nonce(vm):
     assert get_nonce(vm) == 2
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=NotImplementedError)
 def test_call_checks_nonce(vm):
     computation, _ = vm.apply_transaction(SIGNED_DEFAULT_TRANSACTION)
     assert computation.is_success
@@ -212,7 +217,7 @@ def test_call_checks_nonce(vm):
     assert computation.is_error
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 @pytest.mark.parametrize("min_block,max_block,valid", [
     (min_block, max_block, True) for min_block, max_block in [
         (0, UINT_256_MAX),
@@ -245,7 +250,7 @@ def test_call_checks_block_range(vm, min_block, max_block, valid):
         assert computation.is_error
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 def test_call_transfers_value(vm):
     vm_state = vm.state
     with vm_state.state_db() as state_db:
@@ -272,7 +277,7 @@ def test_call_transfers_value(vm):
     assert balance_destination_after == balance_destination_before + 10
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=NotImplementedError)
 @pytest.mark.parametrize("v,r,s", [
     (0, 0, 0),
 
@@ -317,7 +322,7 @@ def test_call_checks_signature(vm, v, r, s):
     assert computation.is_success
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 def test_call_uses_remaining_gas(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -334,7 +339,7 @@ def test_call_uses_remaining_gas(vm):
     assert logged_gas > 900 * 1000  # some gas will have been consumed earlier
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 @pytest.mark.parametrize("data,hash", [
     (data, keccak(data)) for data in [
         b"",
@@ -362,7 +367,7 @@ def test_call_uses_data(vm, data, hash):
     assert logged_hash == hash
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 def test_no_call_if_not_enough_gas(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -376,7 +381,7 @@ def test_no_call_if_not_enough_gas(vm):
     assert computation.gas_meter.gas_remaining > 0
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 def test_call_passes_return_code(vm):
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {
         "nonce": get_nonce(vm),
@@ -397,7 +402,7 @@ def test_call_passes_return_code(vm):
     assert big_endian_to_int(computation.output) == 0  # failure
 
 
-@pytest.mark.xfail(reason="obsolete gas payment mechanism, #234, and #281", raises=AttributeError)
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)
 def test_call_does_not_revert_nonce(vm):
     nonce_before = get_nonce(vm)
     transaction = UnsignedUserAccountTransaction(**merge(DEFAULT_TX_PARAMS, {

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -25,13 +25,18 @@ def new_sharding_transaction(
         data_vrs,
         code,
         gas=1000000,
-        gas_price=10):
+        gas_price=10,
+        access_list=None):
     """
     Create and return a sharding transaction. Data will be encoded in the following order
 
     [destination, value, msg_data, vrs].
     """
     tx_data = pad32(data_destination) + pad32(bytes([data_value])) + pad32(data_msgdata) + pad32(data_vrs)  # noqa: E501
+    if access_list is None:
+        access_list = [[tx_initiator]]
+        if data_destination:
+            access_list.append([data_destination])
     return ShardingTransaction(
         chain_id=1,
         shard_id=1,
@@ -39,6 +44,6 @@ def new_sharding_transaction(
         data=tx_data,
         gas=gas,
         gas_price=gas_price,
-        access_list=[],
+        access_list=access_list,
         code=decode_hex(code),
     )

--- a/tests/core/vm/test_shard_vm.py
+++ b/tests/core/vm/test_shard_vm.py
@@ -8,6 +8,7 @@ from eth_utils import (
 from evm.exceptions import (
     IncorrectContractCreationAddress,
     ContractCreationCollision,
+    UnannouncedStateAccess,
 )
 from evm.utils.address import generate_CREATE2_contract_address
 from evm.utils.padding import pad32
@@ -27,7 +28,10 @@ from tests.core.vm.contract_fixture import (
 )
 
 
-@pytest.mark.xfail(reason="#281", raises=AttributeError)  # noqa: F811
+XFAIL_REASON = "gas payment to dynamic coinbase"
+
+
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)  # noqa: F811
 def test_sharding_apply_transaction(shard_chain_without_block_validation):
     chain = shard_chain_without_block_validation
     # First test: simple ether transfer contract
@@ -106,7 +110,7 @@ def test_sharding_apply_transaction(shard_chain_without_block_validation):
         assert state_db.get_storage(CREATE2_contract_address, 0) == 1
 
 
-@pytest.mark.xfail(reason="#281", raises=AttributeError)  # noqa: F811
+@pytest.mark.xfail(reason=XFAIL_REASON, raises=UnannouncedStateAccess)  # noqa: F811
 def test_CREATE2_deploy_contract_edge_cases(shard_chain_without_block_validation):
     # First case: computed contract address not the same as provided in `transaction.to`
     chain = shard_chain_without_block_validation


### PR DESCRIPTION
Replaces #276 (I suck at rebasing and thought rewriting this would be faster -- probably mistakenly, but well...).

1) transaction access list is converted to prefix list at initialization (that's the format used in the rest of the code)
2) state accessibility is checked during transaction execution (both during pre- and post-processing and for all opcodes), using `computation.state_db` when available.
3) access lists are passed down from transaction to message and from message to child message (see also #262)
4) `test_sharding_vm` and user account contract tests have been updated to provide transactions with correct access lists

When fixing 3) I noticed the use of `prepare_child_message` was not consistent: `BaseComputation` has methods `prepare_child_message` and `prepare_child_sharding_message`. `ShardingMessage` has an additional `prepare_child_message`.

What I did was removing all `prepare_child_sharding_message`s and implementing `ShardingComputation.prepare_child_message`. So now only the computation objects have a `prepare_child_message`, and the sharding specific functionality (passing on access list and sighash) is implemented in `ShardingComputation`. I don't see anything wrong with this, just mentioning it explicitly because it's probably the only noteworthy difference to #276.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pixabay.com/get/ed33b90d2afc1c22d9584518a33219c8b66ae3d018b7184992f0c07b/hedgehog-468228_1920.jpg)
