### PR TITLE
Revert get_db_backend to take an import path

### DIFF
--- a/evm/db/__init__.py
+++ b/evm/db/__init__.py
@@ -8,14 +8,15 @@ from evm.utils.module_loading import (
 DEFAULT_DB_BACKEND = 'evm.db.backends.memory.MemoryDB'
 
 
-def get_db_backend_class():
-    import_path = os.environ.get(
-        'CHAIN_DB_BACKEND_CLASS',
-        DEFAULT_DB_BACKEND,
-    )
+def get_db_backend_class(import_path=None):
+    if import_path is None:
+        import_path = os.environ.get(
+            'CHAIN_DB_BACKEND_CLASS',
+            DEFAULT_DB_BACKEND,
+        )
     return import_string(import_path)
 
 
-def get_db_backend(**init_kwargs):
-    backend_class = get_db_backend_class()
+def get_db_backend(import_path=None, **init_kwargs):
+    backend_class = get_db_backend_class(import_path)
     return backend_class(**init_kwargs)


### PR DESCRIPTION
extracted from https://github.com/ethereum/py-evm/pull/310

### What was wrong?

The API for the `get_db_backend` was recently change in proper accordance with YAGNI.  However, I gonna need it.

### How was it fixed?

Reverted the change to allow passing in an import path.

#### Cute Animal Picture

![tiny-baby-animals-12jpg](https://user-images.githubusercontent.com/824194/35462895-4a93d2a8-02ab-11e8-98cf-1d5f51a887ba.jpg)

