### PR TITLE
Adjust create account fee in Sharding

### DIFF
--- a/evm/logic/call.py
+++ b/evm/logic/call.py
@@ -340,5 +340,5 @@ class CallSharding(CallByzantium):
             account_is_empty = state_db.account_is_empty(to)
 
         transfer_gas_fee = constants.GAS_CALLVALUE if value else 0
-        create_gas_fee = constants.GAS_NEWACCOUNT if not account_is_empty else 0
+        create_gas_fee = constants.GAS_NEWACCOUNT if account_is_empty else 0
         return transfer_gas_fee + create_gas_fee


### PR DESCRIPTION
### What was wrong?
Since
1. `FlatTrieBackend`
2. `Binary Trie`

is adopted in Sharding, `touch_account` doesn't seem to be needed because account's `code_hash`, `balance` and `nonce` now belongs to different trie entries. Also, initializing these attributes to `b''` has no effect in a `Binary Trie`.

### How was it fixed?
- [x] ~remove `touch_account` called in `ShardingComputation.apply_message`~ solved in #313 
- [x] fix gas fee charged for creating a new account(to be discussed, see below)

However since we no longer create a new account like we used to, we should not charge `create_gas_fee` but instead (1)separately charge for setting `code_hash`, `nonce` and `balance` if not been set before. Or (2)we still charge it but multiply it by x(say 3 since there will be 3 trie entries for one account, but I'm not sure that's all the reason it's charged `25000` gas for creating a new account).

At first thought there doesn't seem to be an easy and clean way to charge separately so I personally would prefer (2).


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://cdn.odishatv.in/wp-content/uploads/2016/06/fish-699x430.jpg)
