### PR TITLE
Batch committing to db with BatchDB

### DIFF
--- a/evm/db/batch.py
+++ b/evm/db/batch.py
@@ -1,0 +1,41 @@
+from evm.db.journal import (
+    JournalDB,
+)
+
+
+class BatchDB(JournalDB):
+    """
+    BatchDB builds on top of evm.db.journal.JournalDB and adds batch capability.
+    All operations performed within a context manager is saved to a temporary database.
+    This is committed to the final database if execution of everything within
+    the context manager is successful. Otherwise results are rolledback to the initial state
+    before execution.
+    """
+    def __init__(self, db):
+        JournalDB.__init__(self, db)
+        self.db_class = db
+        self.db = db()
+        self.tmp_db = db()
+
+    def commit(self):
+        # Commit the values in temp_db to our db
+        # And reset the tmp_db
+        self.db = self.db_class(self.tmp_db)
+        self.tmp_db = self.db_class()
+        self.wrapped_db = self.db_class(self.db)
+
+    def rollback(self, exception):
+        # Clear tmp_db and raise exception
+        self.tmp_db = self.db_class()
+        self.wrapped_db = self.db_class(self.db)
+        raise exception
+
+    def __enter__(self):
+        self.wrapped_db = self.db_class(self.tmp_db)
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        if exception_type:
+            self.rollback(exception_type)
+        else:
+            self.commit()

--- a/tests/database/test_batch_db.py
+++ b/tests/database/test_batch_db.py
@@ -7,12 +7,6 @@ from evm.db.batch import (
 )
 
 
-def test_set_and_get_permanence():
-    with BatchDB(MemoryDB) as batch_db:
-        batch_db.set(b'1', b'test')
-    assert batch_db.get(b'1') == b'test'
-
-
 def test_rollback_internal_error():
     with pytest.raises(KeyError):
         with BatchDB(MemoryDB) as batch_db:

--- a/tests/database/test_batch_db.py
+++ b/tests/database/test_batch_db.py
@@ -1,0 +1,127 @@
+import pytest
+from evm.db.backends.memory import (
+    MemoryDB,
+)
+from evm.db.batch import (
+    BatchDB,
+)
+
+
+def test_set_and_get_permanence():
+    with BatchDB(MemoryDB) as batch_db:
+        batch_db.set(b'1', b'test')
+    assert batch_db.get(b'1') == b'test'
+
+
+def test_rollback_internal_error():
+    with pytest.raises(KeyError):
+        with BatchDB(MemoryDB) as batch_db:
+            batch_db.set(b'1', b'test')
+            batch_db.get(b'does-not-exist')
+    assert batch_db.exists(b'1') is False
+
+
+def test_rollback_external_error():
+    with pytest.raises(AssertionError):
+        with BatchDB(MemoryDB) as batch_db:
+            batch_db.set(b'1', b'test')
+            assert False
+    assert batch_db.exists(b'1') is False
+
+
+def test_set_and_get():
+    with BatchDB(MemoryDB) as batch_db:
+        batch_db.set(b'1', b'test')
+        assert batch_db.get(b'1') == b'test'
+    assert batch_db.get(b'1') == b'test'
+
+
+def test_get_non_existent_value():
+    with pytest.raises(KeyError):
+        with BatchDB(MemoryDB) as batch_db:
+            batch_db.get(b'does-not-exist')
+    with pytest.raises(KeyError):
+        batch_db.get(b'does-not-exist')
+
+
+def test_delete_non_existent_value():
+    with pytest.raises(KeyError):
+        with BatchDB(MemoryDB) as batch_db:
+            batch_db.delete(b'does-not-exist')
+    with pytest.raises(KeyError):
+        batch_db.delete(b'does-not-exist')
+
+
+def test_snapshot_and_revert_with_set():
+    with BatchDB(MemoryDB) as batch_db:
+        batch_db.set(b'1', b'test-a')
+
+        assert batch_db.get(b'1') == b'test-a'
+
+        snapshot = batch_db.snapshot()
+
+        batch_db.set(b'1', b'test-b')
+
+        assert batch_db.get(b'1') == b'test-b'
+
+        batch_db.revert(snapshot)
+
+        assert batch_db.get(b'1') == b'test-a'
+    assert batch_db.get(b'1') == b'test-a'
+
+
+def test_snapshot_and_revert_with_delete():
+    with BatchDB(MemoryDB) as batch_db:
+        batch_db.set(b'1', b'test-a')
+
+        assert batch_db.exists(b'1') is True
+        assert batch_db.get(b'1') == b'test-a'
+
+        snapshot = batch_db.snapshot()
+
+        batch_db.delete(b'1')
+
+        assert batch_db.exists(b'1') is False
+
+        batch_db.revert(snapshot)
+
+        assert batch_db.exists(b'1') is True
+        assert batch_db.get(b'1') == b'test-a'
+    assert batch_db.exists(b'1') is True
+    assert batch_db.get(b'1') == b'test-a'
+
+
+def test_revert_clears_reverted_journal_entries():
+    with BatchDB(MemoryDB) as batch_db:
+        batch_db.set(b'1', b'test-a')
+
+        assert batch_db.get(b'1') == b'test-a'
+
+        snapshot_a = batch_db.snapshot()
+
+        batch_db.set(b'1', b'test-b')
+        batch_db.delete(b'1')
+        batch_db.set(b'1', b'test-c')
+
+        assert batch_db.get(b'1') == b'test-c'
+
+        snapshot_b = batch_db.snapshot()
+
+        batch_db.set(b'1', b'test-d')
+        batch_db.delete(b'1')
+        batch_db.set(b'1', b'test-e')
+
+        assert batch_db.get(b'1') == b'test-e'
+
+        batch_db.revert(snapshot_b)
+
+        assert batch_db.get(b'1') == b'test-c'
+
+        batch_db.delete(b'1')
+
+        assert batch_db.exists(b'1') is False
+
+        batch_db.revert(snapshot_a)
+
+        assert batch_db.get(b'1') == b'test-a'
+    assert batch_db.get(b'1') == b'test-a'


### PR DESCRIPTION
### What was wrong?
In reference to #160. Needed a way to commit to the database in a batch, rolling back all changes on error.


### How was it fixed?
 I don't quite understand everything that `evm.db.journal.Journal` and `evm.db.journal.JournalDB` are doing so I did my best to make sure that `evm.db.batch.BatchDB` can do everything `JournalDB` can do along with the added batch committing functionality.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.northpole.com/blog/wp-content/uploads/2014/12/hamster-elf.jpg)
