### PR TITLE
p2p: Redesign sub-protocol msg processing

### DIFF
--- a/evm/p2p/eth.py
+++ b/evm/p2p/eth.py
@@ -1,5 +1,5 @@
 import logging
-from typing import cast, List, Union
+from typing import List, Union
 
 import rlp
 from rlp import sedes
@@ -52,13 +52,6 @@ class GetBlockHeaders(Command):
         ('reverse', sedes.big_endian_int),
     ]
 
-    def handle(self, data: bytes):
-        decoded = super().handle(data)
-        # TODO: Actually send the requested block headers. For now we reply with an empty list
-        # just so nodes don't disconnect us straight away
-        cast(ETHProtocol, self.proto).send_block_headers([])
-        return decoded
-
 
 class BlockHeaders(Command):
     _cmd_id = 4
@@ -68,13 +61,6 @@ class BlockHeaders(Command):
 class GetBlockBodies(Command):
     _cmd_id = 5
     structure = sedes.CountableList(sedes.binary)
-
-    def handle(self, data: bytes):
-        decoded = super().handle(data)
-        # TODO: Actually send the requested block bodies. For now we reply with an empty list
-        # just so nodes don't disconnect us straight away
-        cast(ETHProtocol, self.proto).send_block_bodies([])
-        return decoded
 
 
 class BlockBody(rlp.Serializable):
@@ -98,7 +84,6 @@ class NewBlock(Command):
         ('total_difficulty', sedes.big_endian_int)]
 
 
-# TODO: Implement handling of incoming GetNodeData msgs.
 class GetNodeData(Command):
     _cmd_id = 13
     structure = sedes.CountableList(sedes.binary)
@@ -109,7 +94,6 @@ class NodeData(Command):
     structure = sedes.CountableList(sedes.binary)
 
 
-# TODO: Implement handling of incoming GetReceipts msgs.
 class GetReceipts(Command):
     _cmd_id = 15
     structure = sedes.CountableList(sedes.binary)

--- a/evm/p2p/exceptions.py
+++ b/evm/p2p/exceptions.py
@@ -10,7 +10,7 @@ class PeerConnectionLost(Exception):
     pass
 
 
-class PeerDisconnected(Exception):
+class HandshakeFailure(Exception):
     pass
 
 
@@ -18,7 +18,7 @@ class UnknownProtocolCommand(Exception):
     pass
 
 
-class UselessPeer(Exception):
+class UnexpectedMessage(Exception):
     pass
 
 
@@ -39,4 +39,8 @@ class TooManyTimeouts(Exception):
 
 
 class StopRequested(Exception):
+    pass
+
+
+class PeerFinished(Exception):
     pass

--- a/evm/p2p/p2p_proto.py
+++ b/evm/p2p/p2p_proto.py
@@ -58,27 +58,13 @@ class Disconnect(Command):
         raw_decoded = super(Disconnect, self).decode(data)
         return assoc(raw_decoded, 'reason_name', self.get_reason_name(raw_decoded['reason']))
 
-    def handle(self, data):
-        decoded = self.decode(data)
-        self.proto.logger.debug(
-            "%s disconnected; reason given: %s", self.proto.peer, decoded['reason_name'])
-        self.proto.peer.close()
-        return decoded
-
 
 class Ping(Command):
     _cmd_id = 2
 
-    def handle(self, data):
-        self.proto.send_pong()
-        return None
-
 
 class Pong(Command):
     _cmd_id = 3
-
-    def handle(self, data):
-        return None
 
 
 class P2PProtocol(Protocol):

--- a/evm/p2p/protocol.py
+++ b/evm/p2p/protocol.py
@@ -34,10 +34,6 @@ class Command:
     def __init__(self, proto: 'Protocol') -> None:
         self.proto = proto
 
-    # XXX: See if it's possible to get rid of this and use just the decode() method
-    def handle(self, data: bytes) -> _DecodedMsgType:
-        return self.decode(data)
-
     def __str__(self):
         return "{} (cmd_id={})".format(self.__class__.__name__, self.cmd_id)
 
@@ -108,7 +104,6 @@ class Protocol:
     _commands = []  # type: List[Type[Command]]
 
     def __init__(self, peer: 'BasePeer', cmd_id_offset: int) -> None:
-        """Initialize this protocol and send its handshake msg."""
         self.peer = peer
         self.cmd_id_offset = cmd_id_offset
         self.commands = [cmd_class(self) for cmd_class in self._commands]

--- a/evm/p2p/test_lightchain_integration.py
+++ b/evm/p2p/test_lightchain_integration.py
@@ -93,7 +93,8 @@ async def test_lightchain_integration(request, event_loop):
     assert encode_hex(keccak(rlp.encode(receipts[0]))) == (
         '0xf709ed2c57efc18a1675e8c740f3294c9e2cb36ba7bb3b89d3ab4c8fef9d8860')
 
-    head_info = list(chain._latest_head_info.values())[0]
+    assert len(chain.peer_pool.peers) == 1
+    head_info = chain.peer_pool.peers[0].head_info
     head = await chain.get_block_by_hash(head_info.block_hash)
     assert head.number == head_info.block_number
 


### PR DESCRIPTION
Now BasePeer only handles P2P msgs (via the handle_p2p_msg()) method, and
places sub-proto messages onto a queue to be consumed by our services (e.g.
LightChain)

Also get rid of the Command.handle() method; last step in order to have
Protocol/Command responsible only for encoding/decoding of data.