### PR TITLE
Configurable trie_class

### DIFF
--- a/evm/vm/forks/frontier/vm_state.py
+++ b/evm/vm/forks/frontier/vm_state.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
 
+from trie import (
+    HexaryTrie,
+)
+
 from evm import constants
 from evm.constants import (
     BLOCK_REWARD,
@@ -205,6 +209,7 @@ def _make_frontier_receipt(vm_state, transaction, computation):
 class FrontierVMState(BaseVMState):
     block_class = FrontierBlock
     computation_class = FrontierComputation
+    trie_class = HexaryTrie
 
     def execute_transaction(self, transaction):
         computation = _execute_frontier_transaction(self, transaction)

--- a/evm/vm_state.py
+++ b/evm/vm_state.py
@@ -30,6 +30,7 @@ class BaseVMState(Configurable):
 
     block_class = None
     computation_class = None
+    trie_class = None
     access_logs = None
 
     def __init__(self, chaindb, execution_context, state_root, receipts=[]):
@@ -233,7 +234,7 @@ class BaseVMState(Configurable):
         block.transactions.append(transaction)
 
         # Get trie roots and changed key-values.
-        tx_root_hash, tx_kv_nodes = make_trie_root_and_nodes(block.transactions)
+        tx_root_hash, tx_kv_nodes = make_trie_root_and_nodes(block.transactions, self.trie_class)
         receipt_root_hash, receipt_kv_nodes = make_trie_root_and_nodes(self.receipts)
 
         trie_data = merge(tx_kv_nodes, receipt_kv_nodes)


### PR DESCRIPTION
### What was wrong?
part 1 of #331: make configurable `trie_class` in `master` branch.

### How was it fixed?
1.  Made `trie_class` to be configurable in `BaseChainDB.__init__`.
2. To generate `trie_data`, added `trie_class` in `VMState` and set `trie_class = HexaryTrie` in `FrontierVMState`.

#### Cute Animal Picture

![baby fox](https://media.giphy.com/media/bGl8yMNLsU7ao/giphy.gif)
