### PR TITLE
p2p: PeerPool now has subscribers that get notified of new peers

### DIFF
--- a/evm/p2p/integration_test_helpers.py
+++ b/evm/p2p/integration_test_helpers.py
@@ -1,0 +1,18 @@
+from eth_utils import decode_hex
+from eth_keys import keys
+from evm.p2p import kademlia
+from evm.p2p.peer import PeerPool
+
+
+class LocalGethPeerPool(PeerPool):
+    min_peers = 1
+
+    async def get_nodes_to_connect(self):
+        nodekey = keys.PrivateKey(decode_hex(
+            "45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"))
+        remoteid = nodekey.public_key.to_hex()
+        return [
+            kademlia.Node(
+                keys.PublicKey(decode_hex(remoteid)),
+                kademlia.Address('127.0.0.1', 30303, 30303))
+        ]

--- a/evm/p2p/protocol.py
+++ b/evm/p2p/protocol.py
@@ -112,6 +112,9 @@ class Protocol:
     def send(self, header: bytes, body: bytes) -> None:
         self.peer.send(header, body)
 
+    def __repr__(self):
+        return "(%s, %d)" % (self.name.decode('ascii'), self.version)
+
 
 def _pad_to_16_byte_boundary(data):
     """Pad the given data with NULL_BYTE up to the next 16-byte boundary."""

--- a/evm/p2p/test_auth.py
+++ b/evm/p2p/test_auth.py
@@ -139,14 +139,11 @@ async def test_handshake():
 
     # The handshake msgs sent by each peer (above) are going to be fed directly into their remote's
     # reader, and thus the read_msg() calls will return immediately.
-    responder_hello = await responder_peer.read_msg()
-    initiator_hello = await initiator_peer.read_msg()
+    responder_hello, _ = await responder_peer.read_msg()
+    initiator_hello, _ = await initiator_peer.read_msg()
 
-    cmd = responder_peer.get_protocol_command_for(responder_hello)
-    assert isinstance(cmd, Hello)
-
-    cmd = initiator_peer.get_protocol_command_for(initiator_hello)
-    assert isinstance(cmd, Hello)
+    assert isinstance(responder_hello, Hello)
+    assert isinstance(initiator_hello, Hello)
 
 
 def test_handshake_eip8():

--- a/evm/p2p/test_peer.py
+++ b/evm/p2p/test_peer.py
@@ -115,6 +115,9 @@ async def get_directly_linked_peers(
     assert peer1.sub_proto.version == peer2.sub_proto.version
     assert peer1.sub_proto.cmd_id_offset == peer2.sub_proto.cmd_id_offset
 
+    # Perform the handshake for the enabled sub-protocol.
+    await asyncio.gather(peer1.do_sub_proto_handshake(), peer2.do_sub_proto_handshake())
+
     asyncio.ensure_future(peer1.run())
     asyncio.ensure_future(peer2.run())
 
@@ -125,8 +128,6 @@ async def get_directly_linked_peers(
         event_loop.run_until_complete(afinalizer())
     request.addfinalizer(finalizer)
 
-    # Perform the handshake for the enabled sub-protocol.
-    await asyncio.gather(peer1.do_sub_proto_handshake(), peer2.do_sub_proto_handshake())
     return peer1, peer2
 
 
@@ -148,14 +149,11 @@ async def test_les_handshake():
 
     # Perform the base protocol (P2P) handshake.
     await asyncio.gather(peer1.do_p2p_handshake(), peer2.do_p2p_handshake())
-    asyncio.ensure_future(peer1.run())
-    asyncio.ensure_future(peer2.run())
     # Perform the handshake for the enabled sub-protocol (LES).
     await asyncio.gather(peer1.do_sub_proto_handshake(), peer2.do_sub_proto_handshake())
 
     assert isinstance(peer1.sub_proto, LESProtocol)
     assert isinstance(peer2.sub_proto, LESProtocol)
-    await asyncio.gather(peer1.stop(), peer2.stop())
 
 
 def test_sub_protocol_selection():


### PR DESCRIPTION
Instead of taking a single callback to be called when a new peer is
added, PeerPool now can have multiple subscribers that will be notified
when new peers are added.

Also LightChain is no longer responsible for creating/running a PeerPool
itself

This way we can share a single PeerPool among multiple p2p services.