### PR TITLE
Piper/trinity hex encoding decoding utils

### DIFF
--- a/tests/trinity/hexadecimal-utils/test_encode_and_decode.py
+++ b/tests/trinity/hexadecimal-utils/test_encode_and_decode.py
@@ -1,0 +1,62 @@
+from __future__ import unicode_literals
+
+import pytest
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+from evm.utils.hexadecimal import (
+    encode_hex,
+    decode_hex,
+)
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        (b'', '0x'),
+        (b'\x00', '0x00'),
+        (b'\x01', '0x01'),
+    ),
+)
+def test_basic_hexadecimal_encoding(value, expected):
+    actual = encode_hex(value)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        ('0x', b''),
+        ('0x00', b'\x00'),
+        ('0x01', b'\x01'),
+    ),
+)
+def test_basic_hexadecimal_decoding(value, expected):
+    actual = decode_hex(value)
+    assert actual == expected
+
+
+@given(value=st.binary(min_size=0, max_size=256))
+def test_round_trip_with_bytestring_start(value):
+    intermediate_value = encode_hex(value)
+    round_trip_value = decode_hex(intermediate_value)
+    assert round_trip_value == value
+
+
+HEX_ALPHABET = '1234567890abcdef'
+
+
+def _coerce_to_even_hex(raw_hex):
+    return '0x' + raw_hex[:2 * (len(raw_hex) // 2)]
+
+
+@given(
+    value=st.text(alphabet=HEX_ALPHABET, min_size=0, max_size=256).map(_coerce_to_even_hex)
+)
+def test_round_trip_with_hex_string_start(value):
+    intermediate_value = decode_hex(value)
+    round_trip_value = encode_hex(intermediate_value)
+    assert round_trip_value == value

--- a/trinity/utils/hexadecimal.py
+++ b/trinity/utils/hexadecimal.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+
+import codecs
+
+
+def encode_hex(value):
+    return '0x' + codecs.decode(codecs.encode(value, 'hex'), 'utf8')
+
+
+def decode_hex(value):
+    _, _, hex_part = value.rpartition('x')
+    return codecs.decode(hex_part, 'hex')


### PR DESCRIPTION
Replaces https://github.com/ethereum/py-evm/pull/317

### What was wrong?

Trinity needs it's own hexadecimal encoding/decoding utils

### How was it fixed?

Copy/paste from the py-evm ones.  This is a stand alone to help make https://github.com/ethereum/py-evm/pull/310 smaller.

#### Cute Animal Picture

![cute-tiny-animals05](https://user-images.githubusercontent.com/824194/35462850-10c464a2-02ab-11e8-8177-7083c04988f8.jpg)
