### PR TITLE
Implement CancelToken and use it everywhere

### DIFF
--- a/evm/lightchain_shell.py
+++ b/evm/lightchain_shell.py
@@ -77,7 +77,7 @@ def wait_for_result(coroutine):
 
 
 def cleanup():
-    chain._should_stop.set()
+    chain.cancel_token.trigger()
     # Wait until run() finishes.
     t.join()
 

--- a/evm/p2p/cancel_token.py
+++ b/evm/p2p/cancel_token.py
@@ -1,0 +1,97 @@
+import asyncio
+from typing import Any, Awaitable, List  # noqa: F401
+
+from evm.p2p.exceptions import OperationCancelled
+
+
+class CancelToken:
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._chain = []  # type: List['CancelToken']
+        self._triggered = asyncio.Event()
+
+    def chain(self, token: 'CancelToken') -> 'CancelToken':
+        """Return a new CancelToken chaining this and the given token.
+
+        The new CancelToken's triggered will return True if trigger() has been
+        called on either of the chained tokens, but calling trigger() on the new token
+        has no effect on either of the chained tokens.
+        """
+        chain_name = ":".join([self.name, token.name])
+        chain = CancelToken(chain_name)
+        chain._chain.extend([self, token])
+        return chain
+
+    def trigger(self) -> None:
+        self._triggered.set()
+
+    @property
+    def triggered_token(self) -> 'CancelToken':
+        if self._triggered.is_set():
+            return self
+        for token in self._chain:
+            if token.triggered:
+                # Use token.triggered_token here to make the lookup recursive as self._chain may
+                # contain other chains.
+                return token.triggered_token
+        return None
+
+    @property
+    def triggered(self) -> bool:
+        if self._triggered.is_set():
+            return True
+        return any(token.triggered for token in self._chain)
+
+    async def wait(self) -> None:
+        if self.triggered_token is not None:
+            return
+
+        futures = [asyncio.ensure_future(self._triggered.wait())]
+        for token in self._chain:
+            futures.append(asyncio.ensure_future(token.wait()))
+
+        def cancel_pending(f):
+            for future in futures:
+                if not future.done():
+                    future.cancel()
+
+        fut = asyncio.ensure_future(_wait_for_first(futures))
+        fut.add_done_callback(cancel_pending)
+        await fut
+
+    def __str__(self):
+        return self.name
+
+
+async def _wait_for_first(futures):
+    for future in asyncio.as_completed(futures):
+        await future
+        return
+
+
+async def wait_with_token(future: Awaitable,
+                          cancel_token: CancelToken,
+                          timeout: float = None) -> Any:
+    """Wait for future to complete, unless we timeout or the cancel token is triggered.
+
+    Returns the future's result in case it completes.
+
+    Raises TimeoutError if we timeout or OperationCancelled if the cancel token is triggered.
+    """
+    done, pending = await asyncio.wait(
+        [future, cancel_token.wait()],
+        timeout=timeout,
+        return_when=asyncio.FIRST_COMPLETED)
+    for task in pending:
+        task.cancel()
+    if not done:
+        raise TimeoutError()
+    if cancel_token.triggered_token is not None:
+        # We've been asked to cancel so we don't care about our future, but we must
+        # consume its exception or else asyncio will emit warnings.
+        for task in done:
+            task.exception()
+        raise OperationCancelled(
+            "Cancellation requested by {} token".format(cancel_token.triggered_token))
+    return done.pop().result()

--- a/evm/p2p/discovery.py
+++ b/evm/p2p/discovery.py
@@ -70,6 +70,7 @@ CMD_NEIGHBOURS = Command("neighbours", 4, 2)
 CMD_ID_MAP = dict((cmd.id, cmd) for cmd in [CMD_PING, CMD_PONG, CMD_FIND_NODE, CMD_NEIGHBOURS])
 
 
+# TODO: Use a CancelToken here, to cancel pending operations when we stop()
 class DiscoveryProtocol(asyncio.DatagramProtocol):
     """A Kademlia-like protocol to discover RLPx nodes."""
     logger = logging.getLogger("evm.p2p.discovery.DiscoveryProtocol")

--- a/evm/p2p/exceptions.py
+++ b/evm/p2p/exceptions.py
@@ -38,9 +38,9 @@ class TooManyTimeouts(Exception):
     pass
 
 
-class StopRequested(Exception):
+class PeerFinished(Exception):
     pass
 
 
-class PeerFinished(Exception):
+class OperationCancelled(Exception):
     pass

--- a/evm/p2p/test_cancel_token.py
+++ b/evm/p2p/test_cancel_token.py
@@ -1,0 +1,134 @@
+import asyncio
+import functools
+
+import pytest
+
+from evm.p2p.cancel_token import CancelToken, wait_with_token
+from evm.p2p.exceptions import OperationCancelled
+
+
+def test_token_single():
+    token = CancelToken('token')
+    assert not token.triggered
+    token.trigger()
+    assert token.triggered
+    assert token.triggered_token == token
+
+
+def test_token_chain_trigger_chain():
+    token = CancelToken('token')
+    token2 = CancelToken('token2')
+    token3 = CancelToken('token3')
+    chain = token.chain(token2).chain(token3)
+    assert not chain.triggered
+    chain.trigger()
+    assert chain.triggered
+    assert chain.triggered_token == chain
+    assert not token.triggered
+    assert not token2.triggered
+    assert not token3.triggered
+
+
+def test_token_chain_trigger_first():
+    token = CancelToken('token')
+    token2 = CancelToken('token2')
+    token3 = CancelToken('token3')
+    chain = token.chain(token2).chain(token3)
+    assert not chain.triggered
+    token.trigger()
+    assert chain.triggered
+    assert chain.triggered_token == token
+
+
+def test_token_chain_trigger_middle():
+    token = CancelToken('token')
+    token2 = CancelToken('token2')
+    token3 = CancelToken('token3')
+    chain = token.chain(token2).chain(token3)
+    assert not chain.triggered
+    token2.trigger()
+    assert chain.triggered
+    assert chain.triggered_token == token2
+
+
+def test_token_chain_trigger_last():
+    token = CancelToken('token')
+    token2 = CancelToken('token2')
+    token3 = CancelToken('token3')
+    chain = token.chain(token2).chain(token3)
+    assert not chain.triggered
+    token3.trigger()
+    assert chain.triggered
+    assert chain.triggered_token == token3
+
+
+@pytest.mark.asyncio
+async def test_wait_cancel_pending_tasks_on_completion(event_loop):
+    token = CancelToken('token')
+    token2 = CancelToken('token2')
+    chain = token.chain(token2)
+    token2.trigger()
+    await chain.wait()
+    await assert_only_current_task_not_done()
+
+
+@pytest.mark.asyncio
+async def test_wait_cancel_pending_tasks_on_cancellation(event_loop):
+    """Test that cancelling a pending CancelToken.wait() coroutine doesn't leave .wait()
+    coroutines for any chained tokens behind.
+    """
+    token = CancelToken('token').chain(CancelToken('token2')).chain(CancelToken('token3'))
+    token_wait_coroutine = token.wait()
+    done, pending = await asyncio.wait([token_wait_coroutine], timeout=0.1)
+    assert len(done) == 0
+    assert len(pending) == 1
+    pending_task = pending.pop()
+    assert pending_task._coro == token_wait_coroutine
+    pending_task.cancel()
+    await assert_only_current_task_not_done()
+
+
+@pytest.mark.asyncio
+async def test_wait_with_token(event_loop):
+    fut = asyncio.Future()
+    event_loop.call_soon(functools.partial(fut.set_result, 'result'))
+    result = await wait_with_token(fut, CancelToken('token'), timeout=1)
+    assert result == 'result'
+    await assert_only_current_task_not_done()
+
+
+@pytest.mark.asyncio
+async def test_wait_with_token_future_exception(event_loop):
+    fut = asyncio.Future()
+    event_loop.call_soon(functools.partial(fut.set_exception, Exception()))
+    with pytest.raises(Exception):
+        await wait_with_token(fut, CancelToken('token'), timeout=1)
+    await assert_only_current_task_not_done()
+
+
+@pytest.mark.asyncio
+async def test_wait_with_token_timeout():
+    with pytest.raises(TimeoutError):
+        await wait_with_token(asyncio.sleep(0.02), CancelToken('token'), timeout=0.01)
+    await assert_only_current_task_not_done()
+
+
+@pytest.mark.asyncio
+async def test_wait_with_token_operation_cancelled(event_loop):
+    token = CancelToken('token')
+    token.trigger()
+    with pytest.raises(OperationCancelled):
+        await wait_with_token(asyncio.sleep(0.02), token)
+    await assert_only_current_task_not_done()
+
+
+async def assert_only_current_task_not_done():
+    # This sleep() is necessary because Task.cancel() doesn't immediately cancels the task:
+    # https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancel
+    await asyncio.sleep(0.01)
+    for task in asyncio.Task.all_tasks():
+        if task == asyncio.Task.current_task():
+            # This is the task for this very test, so it will be running
+            assert not task.done()
+        else:
+            assert task.done()

--- a/trinity/cli.py
+++ b/trinity/cli.py
@@ -99,7 +99,7 @@ def console(chain, use_ipython=True, namespace=None, banner=None, debug=False):
 
     def cleanup():
         # Instruct chain.run() to exit, which will cause the event loop to stop.
-        chain._should_stop.set()
+        chain.cancel_token.trigger()
         # Block until the event loop has stopped.
         t.join()
         # The above was needed because the event loop stops when chain.run() returns and then

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -242,7 +242,7 @@ def run_networking_process(chain_config, sync_mode):
 
     def cleanup():
         # This is to instruct chain.run() to exit, which will cause the event loop to stop.
-        chain._should_stop.set()
+        chain.cancel_token.trigger()
 
         loop.close()
 


### PR DESCRIPTION
    CancelTokens should be passed to any async operation, and whenever
    they are trigger()ed they cause those operations to be cancelled. It was
    inspired by http://goo.gl/MUFMKU and right now is used mainly to ensure
    we cancel pending operations when terminating services
