### PR TITLE
Initial support for trinity REPL

### DIFF
--- a/tests/trinity/cli/test_trinity_repl.py
+++ b/tests/trinity/cli/test_trinity_repl.py
@@ -1,0 +1,29 @@
+import pytest
+
+from trinity.cli import console
+
+
+@pytest.fixture
+def chain():
+    # Attach a dummy run method to chain fixture as console method needs it.
+    from tests.core.fixtures import chain
+
+    async def run():
+        pass
+    # Setup
+    chain.run = run
+    yield chain
+    # Teardown
+    del chain.run
+
+
+def test_console(chain):
+    # Test running the console, actually start it.
+    with pytest.raises(OSError, match='^reading .* stdin .* captured$'):
+        console(chain)
+
+
+def test_python_console(chain):
+    # Test running the default python REPL, actually start it.
+    with pytest.raises(OSError, match='^reading .* stdin .* captured$'):
+        console(chain, use_ipython=False)

--- a/trinity/cli.py
+++ b/trinity/cli.py
@@ -1,0 +1,110 @@
+import asyncio
+import atexit
+import logging
+import traceback
+import threading
+
+
+LOGFILE = '/tmp/trinity-shell.log'
+LOGLEVEL = logging.INFO
+
+loop = asyncio.get_event_loop()
+
+
+def wait_for_result(coroutine):
+    future = asyncio.run_coroutine_threadsafe(coroutine, loop)
+    return future.result()
+
+
+def setup_namespace(chain):
+    """Setup the variables to be used in shell instance."""
+
+    namespace = dict(
+        chain=chain,
+        wait_for_result=wait_for_result
+    )
+    return namespace
+
+
+def ipython_shell(namespace=None, banner=None, debug=False):
+    """Try to run IPython shell."""
+    try:
+        import IPython
+    except ImportError:
+        if debug:
+            traceback.print_exc()
+        print("IPython not available. Running default shell...")
+        return
+    # First try newer(IPython >=1.0) top `IPython` level import
+    if hasattr(IPython, 'terminal'):
+        from IPython.terminal.embed import InteractiveShellEmbed
+        kwargs = dict(user_ns=namespace)
+    else:
+        from IPython.frontend.terminal.embed import InteractiveShellEmbed
+        kwargs = dict(user_ns=namespace)
+    if banner:
+        kwargs = dict(banner1=banner)
+    return InteractiveShellEmbed(**kwargs)
+
+
+def python_shell(namespace=None, banner=None, debug=False):
+    """Start a vanilla Python REPL shell."""
+    import code
+    from functools import partial
+    try:
+        import readline, rlcompleter    # NOQA
+    except ImportError:
+        if debug:
+            traceback.print_exc()
+    else:
+        readline.parse_and_bind('tab: complete')
+    # Add global, local and custom namespaces to current shell
+    default_ns = globals().copy()
+    default_ns.update(locals())
+    if namespace:
+        default_ns.update(namespace)
+    # Configure kwargs to pass banner
+    kwargs = dict()
+    if banner:
+        kwargs = dict(banner=banner)
+    shell = code.InteractiveConsole(default_ns)
+    return partial(shell.interact, **kwargs)
+
+
+def console(chain, use_ipython=True, namespace=None, banner=None, debug=False):
+    """
+    Method that starts the chain, setups the trinity CLI and register the
+    cleanup function.
+    """
+    # update the namespace with the required variables
+    namespace = {} if namespace is None else namespace
+    namespace.update(setup_namespace(chain))
+
+    if use_ipython:
+        shell = ipython_shell(namespace, banner, debug)
+
+    print("Logging to", LOGFILE)
+    log_level = logging.DEBUG if debug else LOGLEVEL
+    logging.basicConfig(level=log_level, filename=LOGFILE)
+
+    # Start the thread
+    t = threading.Thread(target=loop.run_until_complete, args=(chain.run(),),
+                         daemon=True)
+    t.start()
+
+    # If can't import or start the IPython shell, use the default shell
+    if not use_ipython or shell is None:
+        shell = python_shell(namespace, banner, debug)
+    shell()
+
+    def cleanup():
+        # Instruct chain.run() to exit, which will cause the event loop to stop.
+        chain._should_stop.set()
+        # Block until the event loop has stopped.
+        t.join()
+        # The above was needed because the event loop stops when chain.run() returns and then
+        # chain.stop() would never finish if we just ran it with run_coroutine_threadsafe().
+        loop.run_until_complete(chain.stop())
+        loop.close()
+
+    atexit.register(cleanup)

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -88,6 +88,17 @@ parser.add_argument(
     )
 )
 
+# Add console sub-command to trinity CLI.
+subparser = parser.add_subparsers(dest='subcommand')
+console_parser = subparser.add_parser('console', help='start the trinity REPL')
+console_parser.add_argument(
+    '--vanilla-shell',
+    action='store_true',
+    default=False,
+    help='start a native Python shell'
+)
+console_parser.set_defaults(func=console)
+
 
 def chain_obj(chain_config, sync_mode):
     if not is_chain_initialized(chain_config):
@@ -126,12 +137,12 @@ def main():
     chain_config = ChainConfig.from_parser_args(chain_identifier, args)
 
     # if console command, run the trinity CLI
-    if args.console:
+    if args.subcommand == 'console':
         use_ipython = not args.vanilla_shell
         debug = args.log_level.upper() == 'DEBUG'
 
         chain = chain_obj(chain_config, sync_mode)
-        console(chain, use_ipython=use_ipython, debug=debug)
+        args.func(chain, use_ipython=use_ipython, debug=debug)
         sys.exit(0)
 
     logger, log_queue, listener = setup_trinity_logging(args.log_level.upper())

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -109,7 +109,7 @@ def chain_obj(chain_config, sync_mode):
     else:
         chain_class = get_chain_protocol_class(chain_config, sync_mode=sync_mode)
 
-    chaindb = get_chain_db(chain_config.data_dir)
+    chaindb = get_chain_db(chain_config.database_dir)
     try:
         chaindb.get_canonical_head()
     except CanonicalHeadNotFound:


### PR DESCRIPTION
### What was wrong?
Implements #302. Ports the initial work done in #298 

### How was it fixed?
Added support for Python REPL to trinity CLI. Running `trinity console` starts either an IPython, if it is installed, or a Python REPL. The shell comes loaded with chain variable that can be used while it's syncing. Running `trinity --log-level info console --vanilla-shell` sets the log level as `INFO` and run the default Python shell even if IPythin is installed on the system.

Chain syncing continues in the background while the shell is running in the foreground. Starting the REPL starts the chain syncing in a thread instead of a process. This is unlike trinity CLI which starts syncing in a separate process.

The reason for using multithreaded syncing instead of multiprocess is when we use a Python REPL we need to share the same `chain` object across sync process and the REPL so that user can interact with the `chain`. The `Chain` object contains coroutines which run in an event loop which is owned by the process that runs it. So a complex object like chain can't be shared across processes through `PIPE/QUEUE` or a [BaseManager](https://docs.python.org/2/library/multiprocessing.html#multiprocessing.managers.BaseManager). 

This might change after things clear out around #304.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/a6/80/81/a68081a619d012a7a1c4ca9ff1849a7e.jpg)
