### PR TITLE
Remove `get_nonce_key` in tests

### DIFF
--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -15,7 +15,6 @@ from evm.utils.numeric import (
     big_endian_to_int,
 )
 from evm.utils.state_access_restriction import (
-    get_nonce_key,
     get_balance_key,
     get_storage_key,
 )
@@ -172,8 +171,6 @@ def test_get_witness_nodes(populated_chaindb_and_root_hash):
     )
 
     prefixes = [
-        get_nonce_key(A_ADDRESS),
-        get_nonce_key(B_ADDRESS),
         get_balance_key(A_ADDRESS),
         get_balance_key(B_ADDRESS),
         get_storage_key(A_ADDRESS, big_endian_to_int(b"key1")),


### PR DESCRIPTION
### What was wrong?
CI fails because the `get_nonce_key` doesn't exist anymore.

### How was it fixed?
Simply removed `get_nonce_key` from `tests/database/test_chaindb.py`.

#### Cute Animal Picture

![koala-animals-mammals-australian-85678](https://user-images.githubusercontent.com/9263930/35777977-0d10cf46-09f2-11e8-90fa-c43cb31deda9.jpeg)
