### PR TITLE
Configurable trie_class in master branch - part2

### DIFF
--- a/evm/chains/chain.py
+++ b/evm/chains/chain.py
@@ -8,11 +8,16 @@ from cytoolz import (
 from eth_utils import (
     to_tuple,
 )
+from trie import (
+    HexaryTrie,
+)
+
 from evm.consensus.pow import (
     check_pow,
 )
 from evm.constants import (
     BLANK_ROOT_HASH,
+    EMPTY_SHA3,
     MAX_UNCLE_DEPTH,
 )
 from evm.estimators import (
@@ -217,7 +222,11 @@ class Chain(Configurable):
         """
         Initialize the Chain from a genesis state.
         """
-        state_db = chaindb.get_state_db(BLANK_ROOT_HASH, read_only=False)
+        if chaindb.trie_class is HexaryTrie:
+            root_hash = BLANK_ROOT_HASH
+        else:
+            root_hash = EMPTY_SHA3
+        state_db = chaindb.get_state_db(root_hash, read_only=False)
 
         if genesis_state is None:
             genesis_state = {}

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -14,6 +14,7 @@ from eth_utils import (
 
 from evm.constants import (
     BLANK_ROOT_HASH,
+    EMPTY_SHA3,
     GENESIS_PARENT_HASH,
 )
 from evm.exceptions import (
@@ -301,7 +302,12 @@ class BaseChainDB:
         new_canonical_headers = self.persist_header_to_db(block.header)
 
         # Persist the transaction bodies
-        transaction_db = self.trie_class(self.db, root_hash=BLANK_ROOT_HASH)
+        if self.trie_class is HexaryTrie:
+            root_hash = BLANK_ROOT_HASH
+        else:
+            root_hash = EMPTY_SHA3
+
+        transaction_db = self.trie_class(self.db, root_hash=root_hash)
         for i, transaction in enumerate(block.transactions):
             index_key = rlp.encode(i, sedes=rlp.sedes.big_endian_int)
             transaction_db[index_key] = rlp.encode(transaction)

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -114,8 +114,7 @@ class BlockHeader(rlp.Serializable):
                     nonce=None,
                     extra_data=None,
                     transaction_root=None,
-                    receipt_root=None,
-                    state_root=None):
+                    receipt_root=None):
         """
         Initialize a new block header with the `parent` header as the block's
         parent hash.
@@ -137,8 +136,6 @@ class BlockHeader(rlp.Serializable):
             header_kwargs['transaction_root'] = transaction_root
         if receipt_root is not None:
             header_kwargs['receipt_root'] = receipt_root
-        if state_root is not None:
-            header_kwargs['state_root'] = state_root
 
         header = cls(**header_kwargs)
         return header

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -112,7 +112,9 @@ class BlockHeader(rlp.Serializable):
                     timestamp,
                     coinbase=ZERO_ADDRESS,
                     nonce=None,
-                    extra_data=None):
+                    extra_data=None,
+                    transaction_root=None,
+                    receipt_root=None):
         """
         Initialize a new block header with the `parent` header as the block's
         parent hash.
@@ -130,6 +132,10 @@ class BlockHeader(rlp.Serializable):
             header_kwargs['nonce'] = nonce
         if extra_data is not None:
             header_kwargs['extra_data'] = extra_data
+        if transaction_root is not None:
+            header_kwargs['transaction_root'] = transaction_root
+        if receipt_root is not None:
+            header_kwargs['receipt_root'] = receipt_root
 
         header = cls(**header_kwargs)
         return header

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -114,7 +114,8 @@ class BlockHeader(rlp.Serializable):
                     nonce=None,
                     extra_data=None,
                     transaction_root=None,
-                    receipt_root=None):
+                    receipt_root=None,
+                    state_root=None):
         """
         Initialize a new block header with the `parent` header as the block's
         parent hash.
@@ -136,6 +137,8 @@ class BlockHeader(rlp.Serializable):
             header_kwargs['transaction_root'] = transaction_root
         if receipt_root is not None:
             header_kwargs['receipt_root'] = receipt_root
+        if state_root is not None:
+            header_kwargs['state_root'] = state_root
 
         header = cls(**header_kwargs)
         return header


### PR DESCRIPTION
### What was wrong?
Another patch for switching transaction and receipt tries (#331) , and also prepare for switching State trie (#289).

### How was it fixed?
The empty `HexaryTrie` root is `BLANK_ROOT_HASH` and empty `BinaryTrie` root is `EMPTY_SHA3`, so it requires setting the default root by `chaindb.trie_class`.

#### Cute Animal Picture

![dog](https://media.giphy.com/media/OI8TsOa9KFAPu/giphy.gif)
