### PR TITLE
Switch all tries to BinaryTrie

### DIFF
--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -1,7 +1,8 @@
 import rlp
 
 from trie import (
-    HexaryTrie
+    BinaryTrie,
+    HexaryTrie,
 )
 
 from evm.constants import (
@@ -297,12 +298,12 @@ class MainAccountStateDB(BaseAccountStateDB):
 
 class ShardingAccountStateDB(BaseAccountStateDB):
 
-    def __init__(self, db, root_hash=BLANK_ROOT_HASH, read_only=False, access_list=None):
+    def __init__(self, db, root_hash=EMPTY_SHA3, read_only=False, access_list=None):
         if read_only:
             self.db = ImmutableDB(db)
         else:
             self.db = TrackedDB(db)
-        self._trie = HexaryTrie(self.db, root_hash)
+        self._trie = BinaryTrie(self.db, root_hash)
         self.is_access_restricted = access_list is not None
         self.access_list = access_list
 

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -13,6 +13,7 @@ from evm.constants import (
     EMPTY_UNCLE_HASH,
     GENESIS_NONCE,
     BLANK_ROOT_HASH,
+    EMPTY_SHA3,
 )
 
 from evm.utils.hexadecimal import (
@@ -169,10 +170,10 @@ class CollationHeader(rlp.Serializable):
                  period_start_prevhash,
                  parent_hash,
                  number,
-                 transaction_root=BLANK_ROOT_HASH,
+                 transaction_root=EMPTY_SHA3,
                  coinbase=ZERO_ADDRESS,
-                 state_root=BLANK_ROOT_HASH,
-                 receipt_root=BLANK_ROOT_HASH,
+                 state_root=EMPTY_SHA3,
+                 receipt_root=EMPTY_SHA3,
                  sig=b""):
         super(CollationHeader, self).__init__(
             shard_id=shard_id,

--- a/evm/utils/db.py
+++ b/evm/utils/db.py
@@ -1,3 +1,14 @@
+from trie import (
+    BinaryTrie,
+    HexaryTrie,
+)
+
+from evm.constants import (
+    BLANK_ROOT_HASH,
+    EMPTY_SHA3,
+)
+
+
 def make_block_number_to_hash_lookup_key(block_number):
     number_to_hash_key = b'block-number-to-hash:%d' % block_number
     return number_to_hash_key
@@ -30,3 +41,18 @@ def get_block_header_by_hash(block_hash, db):
     Returns the header for the parent block.
     """
     return db.get_block_header_by_hash(block_hash)
+
+
+def get_empty_root_hash(db):
+    # TODO: Backport and refactor evm.chains.base.BaseChain and
+    # evm.db.chain.BaseChainDB in master branch
+    root_hash = None
+    if db.trie_class is HexaryTrie:
+        root_hash = BLANK_ROOT_HASH
+    elif db.trie_class is BinaryTrie:
+        root_hash = EMPTY_SHA3
+    else:
+        raise ValueError(
+            "db.trie_class has not been set."
+        )
+    return root_hash

--- a/evm/utils/db.py
+++ b/evm/utils/db.py
@@ -51,8 +51,12 @@ def get_empty_root_hash(db):
         root_hash = BLANK_ROOT_HASH
     elif db.trie_class is BinaryTrie:
         root_hash = EMPTY_SHA3
+    elif db.trie_class is None:
+        raise AttributeError(
+            "BaseChainDB must declare a trie_class."
+        )
     else:
-        raise ValueError(
-            "db.trie_class has not been set."
+        raise NotImplementedError(
+            "db.trie_class {} is not supported.".format(db.trie_class)
         )
     return root_hash

--- a/evm/vm/forks/sharding/__init__.py
+++ b/evm/vm/forks/sharding/__init__.py
@@ -2,14 +2,15 @@ from evm.vm.shard_vm import (
     ShardVM,
 )
 from evm.vm.forks.byzantium import (
-    create_byzantium_header_from_parent,
     configure_byzantium_header,
     compute_byzantium_difficulty,
 )
 
 from .blocks import ShardingBlock
+from .headers import (
+    create_sharding_header_from_parent,
+)
 from .vm_state import ShardingVMState
-
 
 ShardingVM = ShardVM.configure(
     name='ShardingVM',
@@ -17,7 +18,7 @@ ShardingVM = ShardVM.configure(
     _block_class=ShardingBlock,
     _state_class=ShardingVMState,
     # TODO: Replace them after we apply Collation structure
-    create_header_from_parent=staticmethod(create_byzantium_header_from_parent),
+    create_header_from_parent=staticmethod(create_sharding_header_from_parent),
     compute_difficulty=staticmethod(compute_byzantium_difficulty),
     configure_header=configure_byzantium_header,
 )

--- a/evm/vm/forks/sharding/headers.py
+++ b/evm/vm/forks/sharding/headers.py
@@ -7,8 +7,6 @@ from evm.vm.forks.byzantium.headers import (
 
 
 def create_sharding_header_from_parent(parent_header, **header_params):
-    if 'transaction_root' not in header_params:
-        header_params['transaction_root'] = EMPTY_SHA3
-    if 'receipt_root' not in header_params:
-        header_params['receipt_root'] = EMPTY_SHA3
+    header_params.setdefault('transaction_root', EMPTY_SHA3)
+    header_params.setdefault('receipt_root', EMPTY_SHA3)
     return create_byzantium_header_from_parent(parent_header, **header_params)

--- a/evm/vm/forks/sharding/headers.py
+++ b/evm/vm/forks/sharding/headers.py
@@ -1,0 +1,14 @@
+from evm.constants import (
+    EMPTY_SHA3,
+)
+from evm.vm.forks.byzantium.headers import (
+    create_byzantium_header_from_parent,
+)
+
+
+def create_sharding_header_from_parent(parent_header, **header_params):
+    if 'transaction_root' not in header_params:
+        header_params['transaction_root'] = EMPTY_SHA3
+    if 'receipt_root' not in header_params:
+        header_params['receipt_root'] = EMPTY_SHA3
+    return create_byzantium_header_from_parent(parent_header, **header_params)

--- a/evm/vm/forks/sharding/vm_state.py
+++ b/evm/vm/forks/sharding/vm_state.py
@@ -3,6 +3,10 @@ from cytoolz import (
     merge,
 )
 
+from trie import (
+    BinaryTrie,
+)
+
 from evm.constants import (
     ENTRY_POINT,
 )
@@ -40,6 +44,7 @@ from .validation import validate_sharding_transaction
 class ShardingVMState(ByzantiumVMState):
     block_class = ShardingBlock
     computation_class = ShardingComputation
+    trie_class = BinaryTrie
 
     def execute_transaction(self, transaction):
         # state_db ontext manager that restricts access as specified in the transacion
@@ -216,7 +221,10 @@ class ShardingVMState(ByzantiumVMState):
 
         # Get trie roots and changed key-values.
         tx_root_hash, tx_kv_nodes = make_trie_root_and_nodes(block.transactions)
-        receipt_root_hash, receipt_kv_nodes = make_trie_root_and_nodes(self.receipts)
+        receipt_root_hash, receipt_kv_nodes = make_trie_root_and_nodes(
+            self.receipts,
+            trie_class=BinaryTrie,
+        )
 
         trie_data = merge(tx_kv_nodes, receipt_kv_nodes)
 

--- a/tests/auxiliary/user-account/test_contract.py
+++ b/tests/auxiliary/user-account/test_contract.py
@@ -1,6 +1,9 @@
 import pytest
 
 from eth_keys import keys
+from trie import (
+    BinaryTrie,
+)
 
 from cytoolz import (
     merge,
@@ -13,6 +16,7 @@ from evm.constants import (
     SECPK1_N,
     ZERO_HASH32,
     ENTRY_POINT,
+    EMPTY_SHA3,
 )
 from evm.vm.message import (
     ShardingMessage,
@@ -147,8 +151,14 @@ def vm():
         gas_limit=3141592,
         timestamp=1422494849,
         parent_hash=ZERO_HASH32,
+        transaction_root=EMPTY_SHA3,
+        receipt_root=EMPTY_SHA3,
     )
-    chaindb = BaseChainDB(get_db_backend(), account_state_class=ShardingAccountStateDB)
+    chaindb = BaseChainDB(
+        get_db_backend(),
+        account_state_class=ShardingAccountStateDB,
+        trie_class=BinaryTrie,
+    )
     vm = ShardingVM(header=header, chaindb=chaindb)
     vm_state = vm.state
     with vm_state.state_db() as statedb:

--- a/tests/auxiliary/user-account/test_contract.py
+++ b/tests/auxiliary/user-account/test_contract.py
@@ -153,6 +153,7 @@ def vm():
         parent_hash=ZERO_HASH32,
         transaction_root=EMPTY_SHA3,
         receipt_root=EMPTY_SHA3,
+        state_root=EMPTY_SHA3,
     )
     chaindb = BaseChainDB(
         get_db_backend(),

--- a/tests/core/chain-object/conftest.py
+++ b/tests/core/chain-object/conftest.py
@@ -1,4 +1,9 @@
 from tests.core.fixtures import (  # noqa: F401
+    # Constant
+    funded_address,
+    funded_address_private_key,
+    funded_address_initial_balance,
+    # Chain
     chain as valid_chain,
     chain_without_block_validation as chain,
 )

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -23,12 +23,12 @@ ADDRESS_2 = b'\0' * 19 + b'\x02'
 
 
 @pytest.fixture()
-def tx(chain):
+def tx(chain, funded_address, funded_address_private_key):
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
     vm = chain.get_vm()
-    from_ = chain.funded_address
-    return new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
+    from_ = funded_address
+    return new_transaction(vm, from_, recipient, amount, funded_address_private_key)
 
 
 def test_apply_transaction(chain, tx):
@@ -43,7 +43,7 @@ def test_apply_transaction(chain, tx):
         assert state_db.get_balance(tx.to) == tx.value
 
 
-def test_import_block_validation(valid_chain):
+def test_import_block_validation(valid_chain, funded_address, funded_address_initial_balance):
     block = rlp.decode(valid_block_rlp, sedes=FrontierBlock)
     imported_block = valid_chain.import_block(block)
     assert len(imported_block.transactions) == 1
@@ -54,8 +54,8 @@ def test_import_block_validation(valid_chain):
         assert state_db.get_balance(
             decode_hex("095e7baea6a6c7c4c2dfeb977efac326af552d87")) == tx.value
         tx_gas = tx.gas_price * constants.GAS_TX
-        assert state_db.get_balance(valid_chain.funded_address) == (
-            valid_chain.funded_address_initial_balance - tx.value - tx_gas)
+        assert state_db.get_balance(funded_address) == (
+            funded_address_initial_balance - tx.value - tx_gas)
 
 
 def test_import_block(chain, tx):
@@ -116,7 +116,15 @@ def test_empty_transaction_lookups(chain):
         'sha3 precompile 32 bytes 1000_tolerance binary pending',
     ],
 )
-def test_estimate_gas(chain, data, gas_estimator, to, on_pending, expected):
+def test_estimate_gas(
+        chain,
+        data,
+        gas_estimator,
+        to,
+        on_pending,
+        expected,
+        funded_address,
+        funded_address_private_key):
     if gas_estimator:
         chain.gas_estimator = gas_estimator
     vm = chain.get_vm()
@@ -125,8 +133,8 @@ def test_estimate_gas(chain, data, gas_estimator, to, on_pending, expected):
     else:
         recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
-    from_ = chain.funded_address
-    tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key, data=data)
+    from_ = funded_address
+    tx = new_transaction(vm, from_, recipient, amount, funded_address_private_key, data=data)
     if on_pending:
         # estimate on *pending* block
         assert chain.estimate_gas(tx, chain.header) == expected

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -4,8 +4,10 @@ from eth_utils import (
     decode_hex,
     to_canonical_address,
 )
-
 from eth_keys import KeyAPI
+from trie import (
+    BinaryTrie,
+)
 
 from evm import Chain
 from evm import constants
@@ -113,8 +115,51 @@ SHARD_CHAIN_CONTRACTS_FIXTURES = [
 
 @pytest.fixture
 def shard_chain():
-    shard_chaindb = BaseChainDB(get_db_backend(), account_state_class=ShardingAccountStateDB)
-    return chain(shard_chaindb)
+    shard_chaindb = BaseChainDB(
+        get_db_backend(),
+        account_state_class=ShardingAccountStateDB,
+        trie_class=BinaryTrie,
+    )
+
+    genesis_params = {
+        "bloom": 0,
+        "coinbase": to_canonical_address("8888f1f195afa192cfee860698584c030f4c9db1"),
+        "difficulty": 131072,
+        "extra_data": b"B",
+        "gas_limit": 3141592,
+        "gas_used": 0,
+        "mix_hash": decode_hex(
+            "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
+        "nonce": decode_hex("0102030405060708"),
+        "block_number": 0,
+        "parent_hash": decode_hex(
+            "0000000000000000000000000000000000000000000000000000000000000000"),
+        "transaction_root": constants.EMPTY_SHA3,
+        "receipt_root": constants.EMPTY_SHA3,
+        "timestamp": 1422494849,
+        "uncles_hash": decode_hex(
+            "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
+    }
+    funded_addr = to_canonical_address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b")
+    initial_balance = 10000000000
+    genesis_state = {
+        funded_addr: {
+            "balance": initial_balance,
+            "nonce": 0,
+            "code": b"",
+            "storage": {}
+        }
+    }
+    klass = Shard.configure(
+        name='TestChain',
+        vm_configuration=(
+            (constants.GENESIS_BLOCK_NUMBER, ShardingVM),
+        ))
+    shard = klass.from_genesis(shard_chaindb, genesis_params, genesis_state)
+    shard.funded_address = funded_addr
+    shard.funded_address_initial_balance = initial_balance
+
+    return shard
 
 
 @pytest.fixture
@@ -130,7 +175,11 @@ def shard_chain_without_block_validation():
     """
     # TODO: Once the helper function which generates access list for a transaction is implemented,
     # replace NestedTrieBackend in `get_db_backend` with FlatTrieBackend.
-    shard_chaindb = BaseChainDB(get_db_backend(), account_state_class=ShardingAccountStateDB)
+    shard_chaindb = BaseChainDB(
+        get_db_backend(),
+        account_state_class=ShardingAccountStateDB,
+        trie_class=BinaryTrie,
+    )
     overrides = {
         'import_block': import_block_without_validation,
         'validate_block': lambda self, block: None,
@@ -152,6 +201,8 @@ def shard_chain_without_block_validation():
         'mix_hash': constants.GENESIS_MIX_HASH,
         'extra_data': constants.GENESIS_EXTRA_DATA,
         'timestamp': 1501851927,
+        'transaction_root': constants.EMPTY_SHA3,
+        'receipt_root': constants.EMPTY_SHA3,
     }
     genesis_state = {
         SHARD_CHAIN_CONTRACTS_FIXTURES[0]["deployed_address"]: {
@@ -171,8 +222,8 @@ def shard_chain_without_block_validation():
             'storage': {},
         }
     }
-    chain = klass.from_genesis(shard_chaindb, genesis_params, genesis_state)
-    return chain
+    shard = klass.from_genesis(shard_chaindb, genesis_params, genesis_state)
+    return shard
 
 
 # This block is a child of the genesis defined in the chain fixture above and contains a single tx

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -33,6 +33,23 @@ from tests.core.vm.contract_fixture import (
 
 
 @pytest.fixture
+def funded_address_private_key():
+    return KeyAPI().PrivateKey(
+        decode_hex('0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8')
+    )
+
+
+@pytest.fixture
+def funded_address(funded_address_private_key):  # noqa: F811
+    return funded_address_private_key.public_key.to_canonical_address()
+
+
+@pytest.fixture
+def funded_address_initial_balance():
+    return 10000000000
+
+
+@pytest.fixture
 def chaindb():
     return BaseChainDB(get_db_backend())
 
@@ -47,7 +64,7 @@ def shard_chaindb():
 
 
 @pytest.fixture
-def chain(chaindb):
+def chain(chaindb, funded_address, funded_address_initial_balance):  # noqa: F811
     """
     Return a Chain object containing just the genesis block.
 
@@ -65,28 +82,18 @@ def chain(chaindb):
         "extra_data": b"B",
         "gas_limit": 3141592,
         "gas_used": 0,
-        "mix_hash": decode_hex(
-            "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
+        "mix_hash": decode_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
         "nonce": decode_hex("0102030405060708"),
         "block_number": 0,
-        "parent_hash": decode_hex(
-            "0000000000000000000000000000000000000000000000000000000000000000"),
-        "receipt_root": decode_hex(
-            "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
-        # TODO: uncomment when there's a dedicated shard chain object with separate fixture
-        # "state_root": decode_hex(
-        #     "cafd881ab193703b83816c49ff6c2bf6ba6f464a1be560c42106128c8dbc35e7"),
+        "parent_hash": decode_hex("0000000000000000000000000000000000000000000000000000000000000000"),  # noqa: E501
+        "receipt_root": decode_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),  # noqa: E501
         "timestamp": 1422494849,
-        "transaction_root": decode_hex(
-            "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
-        "uncles_hash": decode_hex(
-            "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
+        "transaction_root": decode_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),  # noqa: E501
+        "uncles_hash": decode_hex("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")  # noqa: E501
     }
-    funded_addr = to_canonical_address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b")
-    initial_balance = 10000000000
     genesis_state = {
-        funded_addr: {
-            "balance": initial_balance,
+        funded_address: {
+            "balance": funded_address_initial_balance,
             "nonce": 0,
             "code": b"",
             "storage": {}
@@ -98,8 +105,6 @@ def chain(chaindb):
             (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
         ))
     chain = klass.from_genesis(chaindb, genesis_params, genesis_state)
-    chain.funded_address = funded_addr
-    chain.funded_address_initial_balance = initial_balance
     return chain
 
 
@@ -123,8 +128,7 @@ SHARD_CHAIN_CONTRACTS_FIXTURES = [
 
 
 @pytest.fixture
-def shard_chain(shard_chaindb):
-    shard_chaindb = shard_chaindb
+def shard_chain(shard_chaindb, funded_address, funded_address_initial_balance):  # noqa: F811
     genesis_params = {
         "bloom": 0,
         "coinbase": to_canonical_address("8888f1f195afa192cfee860698584c030f4c9db1"),
@@ -132,23 +136,18 @@ def shard_chain(shard_chaindb):
         "extra_data": b"B",
         "gas_limit": 3141592,
         "gas_used": 0,
-        "mix_hash": decode_hex(
-            "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
+        "mix_hash": decode_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),  # noqa: E501
         "nonce": decode_hex("0102030405060708"),
         "block_number": 0,
-        "parent_hash": decode_hex(
-            "0000000000000000000000000000000000000000000000000000000000000000"),
+        "parent_hash": decode_hex("0000000000000000000000000000000000000000000000000000000000000000"),  # noqa: E501
         "transaction_root": constants.EMPTY_SHA3,
         "receipt_root": constants.EMPTY_SHA3,
         "timestamp": 1422494849,
-        "uncles_hash": decode_hex(
-            "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")
+        "uncles_hash": decode_hex("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")  # noqa: E501
     }
-    funded_addr = to_canonical_address("a94f5374fce5edbc8e2a8697c15331677e6ebf0b")
-    initial_balance = 10000000000
     genesis_state = {
-        funded_addr: {
-            "balance": initial_balance,
+        funded_address: {
+            "balance": funded_address_initial_balance,
             "nonce": 0,
             "code": b"",
             "storage": {}
@@ -160,14 +159,12 @@ def shard_chain(shard_chaindb):
             (constants.GENESIS_BLOCK_NUMBER, ShardingVM),
         ))
     shard = klass.from_genesis(shard_chaindb, genesis_params, genesis_state)
-    shard.funded_address = funded_addr
-    shard.funded_address_initial_balance = initial_balance
 
     return shard
 
 
 @pytest.fixture
-def shard_chain_without_block_validation(shard_chaindb):
+def shard_chain_without_block_validation(shard_chaindb):  # noqa: F811
     shard_chaindb = shard_chaindb
     """
     Return a Chain object containing just the genesis block.
@@ -231,12 +228,15 @@ valid_block_rlp = decode_hex(
     "0xf90260f901f9a07285abd5b24742f184ad676e31f6054663b3529bc35ea2fcad8a3e0f642a46f7a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347948888f1f195afa192cfee860698584c030f4c9db1a0964e6c9995e7e3757e934391b4f16b50c20409ee4eb9abd4c4617cb805449b9aa053d5b71a8fbb9590de82d69dfa4ac31923b0c8afce0d30d0d8d1e931f25030dca0bc37d79753ad738a6dac4921e57392f145d8887476de3f783dfa7edae9283e52b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008302000001832fefd8825208845754132380a0194605bacef646779359318c7b5899559a5bf4074bbe2cfb7e1b83b1504182dd88e0205813b22e5a9cf861f85f800a82c35094095e7baea6a6c7c4c2dfeb977efac326af552d870a801ba0f3266921c93d600c43f6fa4724b7abae079b35b9e95df592f95f9f3445e94c88a012f977552ebdb7a492cf35f3106df16ccb4576ebad4113056ee1f52cbe4978c1c0")  # noqa: E501
 
 
-def import_block_without_validation(chain, block):
+def import_block_without_validation(chain, block):  # noqa: F811
     return Chain.import_block(chain, block, perform_validation=False)
 
 
 @pytest.fixture
-def chain_without_block_validation():
+def chain_without_block_validation(
+        chaindb,
+        funded_address,
+        funded_address_initial_balance):  # noqa: F811
     """
     Return a Chain object containing just the genesis block.
 
@@ -257,11 +257,6 @@ def chain_without_block_validation():
         ),
         **overrides,
     )
-    private_key = KeyAPI().PrivateKey(
-        decode_hex('0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8')
-    )
-    funded_addr = private_key.public_key.to_canonical_address()
-    initial_balance = 100000000
     genesis_params = {
         'block_number': constants.GENESIS_BLOCK_NUMBER,
         'difficulty': constants.GENESIS_DIFFICULTY,
@@ -272,19 +267,14 @@ def chain_without_block_validation():
         'mix_hash': constants.GENESIS_MIX_HASH,
         'extra_data': constants.GENESIS_EXTRA_DATA,
         'timestamp': 1501851927,
-        'state_root': decode_hex(
-            '0x9d354f9b5ba851a35eced279ef377111387197581429cfcc7f744ef89a30b5d4')
     }
     genesis_state = {
-        funded_addr: {
-            'balance': initial_balance,
+        funded_address: {
+            'balance': funded_address_initial_balance,
             'nonce': 0,
             'code': b'',
             'storage': {},
         }
     }
-    chain = klass.from_genesis(BaseChainDB(get_db_backend()), genesis_params, genesis_state)
-    chain.funded_address = funded_addr
-    chain.funded_address_initial_balance = initial_balance
-    chain.funded_address_private_key = private_key
+    chain = klass.from_genesis(chaindb, genesis_params, genesis_state)
     return chain

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -38,6 +38,15 @@ def chaindb():
 
 
 @pytest.fixture
+def shard_chaindb():
+    return BaseChainDB(
+        get_db_backend(),
+        account_state_class=ShardingAccountStateDB,
+        trie_class=BinaryTrie,
+    )
+
+
+@pytest.fixture
 def chain(chaindb):
     """
     Return a Chain object containing just the genesis block.
@@ -114,13 +123,7 @@ SHARD_CHAIN_CONTRACTS_FIXTURES = [
 
 
 @pytest.fixture
-def shard_chain():
-    shard_chaindb = BaseChainDB(
-        get_db_backend(),
-        account_state_class=ShardingAccountStateDB,
-        trie_class=BinaryTrie,
-    )
-
+def shard_chain(shard_chaindb):
     genesis_params = {
         "bloom": 0,
         "coinbase": to_canonical_address("8888f1f195afa192cfee860698584c030f4c9db1"),
@@ -163,7 +166,7 @@ def shard_chain():
 
 
 @pytest.fixture
-def shard_chain_without_block_validation():
+def shard_chain_without_block_validation(shard_chaindb):
     """
     Return a Chain object containing just the genesis block.
 
@@ -173,13 +176,6 @@ def shard_chain_without_block_validation():
 
     contract will be deployed at.
     """
-    # TODO: Once the helper function which generates access list for a transaction is implemented,
-    # replace NestedTrieBackend in `get_db_backend` with FlatTrieBackend.
-    shard_chaindb = BaseChainDB(
-        get_db_backend(),
-        account_state_class=ShardingAccountStateDB,
-        trie_class=BinaryTrie,
-    )
     overrides = {
         'import_block': import_block_without_validation,
         'validate_block': lambda self, block: None,

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -124,6 +124,7 @@ SHARD_CHAIN_CONTRACTS_FIXTURES = [
 
 @pytest.fixture
 def shard_chain(shard_chaindb):
+    shard_chaindb = shard_chaindb
     genesis_params = {
         "bloom": 0,
         "coinbase": to_canonical_address("8888f1f195afa192cfee860698584c030f4c9db1"),
@@ -167,6 +168,7 @@ def shard_chain(shard_chaindb):
 
 @pytest.fixture
 def shard_chain_without_block_validation(shard_chaindb):
+    shard_chaindb = shard_chaindb
     """
     Return a Chain object containing just the genesis block.
 

--- a/tests/core/vm/conftest.py
+++ b/tests/core/vm/conftest.py
@@ -1,8 +1,15 @@
 from tests.core.fixtures import (  # noqa: F401
+    # Constant
+    funded_address,
+    funded_address_private_key,
+    funded_address_initial_balance,
+    # Chain
+    chaindb,
     chain as valid_chain,
     chain_without_block_validation as chain,
-
+    # Shard
     shard_chaindb,
     shard_chain as valid_shard_chain,
     shard_chain_without_block_validation as unvalidated_shard_chain,
+
 )

--- a/tests/core/vm/conftest.py
+++ b/tests/core/vm/conftest.py
@@ -1,4 +1,8 @@
 from tests.core.fixtures import (  # noqa: F401
     chain as valid_chain,
     chain_without_block_validation as chain,
+
+    shard_chaindb,
+    shard_chain as valid_shard_chain,
+    shard_chain_without_block_validation as unvalidated_shard_chain,
 )

--- a/tests/core/vm/test_PAYGAS_tx_fee.py
+++ b/tests/core/vm/test_PAYGAS_tx_fee.py
@@ -2,9 +2,6 @@ from eth_utils import (
     decode_hex,
 )
 
-from tests.core.fixtures import (  # noqa: F401
-    shard_chain_without_block_validation,
-)
 from tests.core.helpers import (
     new_sharding_transaction,
 )
@@ -14,8 +11,8 @@ from tests.core.vm.contract_fixture import (
 )
 
 
-def test_trigger_PAYGAS(shard_chain_without_block_validation):  # noqa: F811
-    chain = shard_chain_without_block_validation
+def test_trigger_PAYGAS(unvalidated_shard_chain):  # noqa: F811
+    chain = unvalidated_shard_chain
     deploy_tx = new_sharding_transaction(
         tx_initiator=PAYGAS_contract_address,
         data_destination=b'',

--- a/tests/core/vm/test_shard_vm.py
+++ b/tests/core/vm/test_shard_vm.py
@@ -10,9 +10,6 @@ from evm.exceptions import (
 from evm.utils.address import generate_CREATE2_contract_address
 from evm.utils.padding import pad32
 
-from tests.core.fixtures import (  # noqa: F401
-    shard_chain_without_block_validation,
-)
 from tests.core.helpers import (
     new_sharding_transaction,
 )
@@ -25,8 +22,8 @@ from tests.core.vm.contract_fixture import (
 )
 
 
-def test_sharding_apply_transaction(shard_chain_without_block_validation):  # noqa: F811
-    chain = shard_chain_without_block_validation
+def test_sharding_apply_transaction(unvalidated_shard_chain):  # noqa: F811
+    chain = unvalidated_shard_chain
     # First test: simple ether transfer contract
     first_deploy_tx = new_sharding_transaction(
         tx_initiator=simple_transfer_contract_address,
@@ -103,9 +100,9 @@ def test_sharding_apply_transaction(shard_chain_without_block_validation):  # no
         assert state_db.get_storage(CREATE2_contract_address, 0) == 1
 
 
-def test_CREATE2_deploy_contract_edge_cases(shard_chain_without_block_validation):  # noqa: F811
+def test_CREATE2_deploy_contract_edge_cases(unvalidated_shard_chain):  # noqa: F811
     # First case: computed contract address not the same as provided in `transaction.to`
-    chain = shard_chain_without_block_validation
+    chain = unvalidated_shard_chain
     code = b"0xf3"
     computed_address = generate_CREATE2_contract_address(b"", decode_hex(code))
     first_failed_deploy_tx = new_sharding_transaction(

--- a/tests/core/vm/test_state_access_restrictions.py
+++ b/tests/core/vm/test_state_access_restrictions.py
@@ -9,10 +9,9 @@ from evm.utils.state_access_restriction import (
     to_prefix_list_form,
 )
 
-from tests.core.fixtures import shard_chain  # noqa: F401
 
-
-def test_balance_restriction(shard_chain):  # noqa: F811
+def test_balance_restriction(valid_shard_chain):  # noqa: F811
+    shard_chain = valid_shard_chain
     vm = shard_chain.get_vm()
     address = shard_chain.funded_address
     access_list = to_prefix_list_form([[address]])
@@ -31,7 +30,8 @@ def test_balance_restriction(shard_chain):  # noqa: F811
                 getattr(state_db, method)(*args)
 
 
-def test_code_restriction(shard_chain):  # noqa: F811
+def test_code_restriction(valid_shard_chain):  # noqa: F811
+    shard_chain = valid_shard_chain
     vm = shard_chain.get_vm()
     address = shard_chain.funded_address
     access_list = to_prefix_list_form([[address]])
@@ -50,7 +50,8 @@ def test_code_restriction(shard_chain):  # noqa: F811
                 getattr(state_db, method)(*args)
 
 
-def test_storage_restriction(shard_chain):  # noqa: F811
+def test_storage_restriction(valid_shard_chain):  # noqa: F811
+    shard_chain = valid_shard_chain
     vm = shard_chain.get_vm()
     address = shard_chain.funded_address
     other_address = b'\xaa' * 20

--- a/tests/core/vm/test_state_access_restrictions.py
+++ b/tests/core/vm/test_state_access_restrictions.py
@@ -10,10 +10,10 @@ from evm.utils.state_access_restriction import (
 )
 
 
-def test_balance_restriction(valid_shard_chain):  # noqa: F811
+def test_balance_restriction(valid_shard_chain, funded_address):  # noqa: F811
     shard_chain = valid_shard_chain
     vm = shard_chain.get_vm()
-    address = shard_chain.funded_address
+    address = funded_address
     access_list = to_prefix_list_form([[address]])
 
     method_and_args = (
@@ -30,10 +30,10 @@ def test_balance_restriction(valid_shard_chain):  # noqa: F811
                 getattr(state_db, method)(*args)
 
 
-def test_code_restriction(valid_shard_chain):  # noqa: F811
+def test_code_restriction(valid_shard_chain, funded_address):  # noqa: F811
     shard_chain = valid_shard_chain
     vm = shard_chain.get_vm()
-    address = shard_chain.funded_address
+    address = funded_address
     access_list = to_prefix_list_form([[address]])
 
     method_and_args = (
@@ -50,10 +50,10 @@ def test_code_restriction(valid_shard_chain):  # noqa: F811
                 getattr(state_db, method)(*args)
 
 
-def test_storage_restriction(valid_shard_chain):  # noqa: F811
+def test_storage_restriction(valid_shard_chain, funded_address):  # noqa: F811
     shard_chain = valid_shard_chain
     vm = shard_chain.get_vm()
-    address = shard_chain.funded_address
+    address = funded_address
     other_address = b'\xaa' * 20
     access_list = to_prefix_list_form([[address, b'\x00', b'\xff' * 32]])
 

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -15,13 +15,17 @@ from tests.core.helpers import (
 )
 
 
-def test_apply_transaction(chain):
+def test_apply_transaction(
+        chain,
+        funded_address,
+        funded_address_private_key,
+        funded_address_initial_balance):
     vm = chain.get_vm()
     tx_idx = len(vm.block.transactions)
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
-    from_ = chain.funded_address
-    tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
+    from_ = funded_address
+    tx = new_transaction(vm, from_, recipient, amount, funded_address_private_key)
     computation, _ = vm.apply_transaction(tx)
     access_logs = computation.vm_state.access_logs
 
@@ -29,7 +33,7 @@ def test_apply_transaction(chain):
     tx_gas = tx.gas_price * constants.GAS_TX
     with vm.state.state_db(read_only=True) as state_db:
         assert state_db.get_balance(from_) == (
-            chain.funded_address_initial_balance - amount - tx_gas)
+            funded_address_initial_balance - amount - tx_gas)
         assert state_db.get_balance(recipient) == amount
     block = vm.block
     assert block.transactions[tx_idx] == tx
@@ -46,12 +50,12 @@ def test_mine_block(chain):
         assert state_db.get_balance(block.header.coinbase) == constants.BLOCK_REWARD
 
 
-def test_import_block(chain):
+def test_import_block(chain, funded_address, funded_address_private_key):
     vm = chain.get_vm()
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
-    from_ = chain.funded_address
-    tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
+    from_ = funded_address
+    tx = new_transaction(vm, from_, recipient, amount, funded_address_private_key)
     computation, _ = vm.apply_transaction(tx)
 
     assert not computation.is_error
@@ -60,7 +64,7 @@ def test_import_block(chain):
     assert block.transactions == [tx]
 
 
-def test_get_cumulative_gas_used(chain):
+def test_get_cumulative_gas_used(chain, funded_address, funded_address_private_key):
     vm = chain.get_vm()
 
     # Empty block.
@@ -76,8 +80,8 @@ def test_get_cumulative_gas_used(chain):
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
     vm = chain.get_vm()
-    from_ = chain.funded_address
-    tx = new_transaction(vm, from_, recipient, amount, chain.funded_address_private_key)
+    from_ = funded_address
+    tx = new_transaction(vm, from_, recipient, amount, funded_address_private_key)
 
     vm.apply_transaction(tx)
     block = vm.mine_block()
@@ -89,7 +93,7 @@ def test_get_cumulative_gas_used(chain):
     assert blockgas == constants.GAS_TX
 
 
-def test_create_block(chain):
+def test_create_block(chain, funded_address, funded_address_private_key):
 
     # (1) Empty block.
     # block = vm.mine_block()
@@ -104,8 +108,8 @@ def test_create_block(chain):
     vm = chain.get_vm()
     recipient1 = decode_hex('0x1111111111111111111111111111111111111111')
     amount = 100
-    from_ = chain.funded_address
-    tx1 = new_transaction(vm1, from_, recipient1, amount, chain.funded_address_private_key)
+    from_ = funded_address
+    tx1 = new_transaction(vm1, from_, recipient1, amount, funded_address_private_key)
 
     # Get the witness of tx1
     computation, _ = vm1.apply_transaction(tx1)
@@ -113,7 +117,7 @@ def test_create_block(chain):
 
     # The second transaction
     recipient2 = decode_hex('0x2222222222222222222222222222222222222222')
-    tx2 = new_transaction(vm1, from_, recipient2, amount, chain.funded_address_private_key)
+    tx2 = new_transaction(vm1, from_, recipient2, amount, funded_address_private_key)
 
     # Get the witness of tx2
     computation, block = vm1.apply_transaction(tx2)

--- a/tests/core/vm/test_vm_state.py
+++ b/tests/core/vm/test_vm_state.py
@@ -61,7 +61,10 @@ def test_state_db(state):  # noqa: F811
             state_db.set_balance(address, 0)
 
 
-def test_apply_transaction(chain_without_block_validation):  # noqa: F811
+def test_apply_transaction(  # noqa: F811
+        chain_without_block_validation,
+        funded_address,
+        funded_address_private_key):
     chain = chain_without_block_validation  # noqa: F811
 
     # Don't change these variables
@@ -77,13 +80,13 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     vm_example = chain1.get_vm()
     recipient1 = decode_hex('0x1111111111111111111111111111111111111111')
     amount = 100
-    from_ = chain.funded_address
+    from_ = funded_address
     tx1 = new_transaction(
         vm_example,
         from_,
         recipient1,
         amount,
-        private_key=chain.funded_address_private_key,
+        private_key=funded_address_private_key,
     )
     computation, result_block = vm_example.apply_transaction(tx1)
 
@@ -94,7 +97,7 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
         from_,
         recipient2,
         amount,
-        private_key=chain.funded_address_private_key,
+        private_key=funded_address_private_key,
     )
     computation, result_block = vm_example.apply_transaction(tx2)
     assert len(result_block.transactions) == 2

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -6,7 +6,10 @@ from hypothesis import (
 )
 
 import rlp
-import trie
+from trie import (
+    BinaryTrie,
+    HexaryTrie,
+)
 
 from evm.utils.fixture_tests import (
     assert_rlp_equal,
@@ -20,6 +23,7 @@ from evm.utils.state_access_restriction import (
 )
 from evm.constants import (
     BLANK_ROOT_HASH,
+    EMPTY_SHA3,
     ZERO_HASH32,
 )
 
@@ -51,6 +55,7 @@ from evm.rlp.headers import (
 )
 
 from evm.utils.db import (
+    get_empty_root_hash,
     make_block_hash_to_score_lookup_key,
     make_block_number_to_hash_lookup_key,
 )
@@ -63,20 +68,49 @@ A_ADDRESS = b"\xaa" * 20
 B_ADDRESS = b"\xbb" * 20
 
 
+def set_empty_root(chaindb, header):
+    root_hash = get_empty_root_hash(chaindb)
+    header.transaction_root = root_hash
+    header.receipt_root = root_hash
+    header.state_root = root_hash
+
+
 @pytest.fixture(params=[MainAccountStateDB, ShardingAccountStateDB])
 def chaindb(request):
-    return BaseChainDB(get_db_backend(), account_state_class=request.param)
+    if request.param is MainAccountStateDB:
+        trie_class = HexaryTrie
+    else:
+        trie_class = BinaryTrie
+    return BaseChainDB(
+        get_db_backend(),
+        account_state_class=request.param,
+        trie_class=trie_class,
+    )
 
 
 @pytest.fixture
-def populated_chaindb_and_root_hash(chaindb):
-    state_db = chaindb.get_state_db(BLANK_ROOT_HASH, read_only=False)
+def shard_chaindb(request):
+    return BaseChainDB(
+        get_db_backend(),
+        account_state_class=ShardingAccountStateDB,
+        trie_class=BinaryTrie,
+    )
+
+
+@pytest.fixture
+def populated_shard_chaindb_and_root_hash(shard_chaindb):
+    if shard_chaindb.trie_class is HexaryTrie:
+        root_hash = BLANK_ROOT_HASH
+    else:
+        root_hash = EMPTY_SHA3
+
+    state_db = shard_chaindb.get_state_db(root_hash, read_only=False)
     state_db.set_balance(A_ADDRESS, 1)
     state_db.set_code(B_ADDRESS, b"code")
     state_db.set_storage(B_ADDRESS, big_endian_to_int(b"key1"), 100)
     state_db.set_storage(B_ADDRESS, big_endian_to_int(b"key2"), 200)
     state_db.set_storage(B_ADDRESS, big_endian_to_int(b"key"), 300)
-    return chaindb, state_db.root_hash
+    return shard_chaindb, state_db.root_hash
 
 
 @pytest.fixture(params=[0, 10, 999])
@@ -119,6 +153,7 @@ def test_persist_header_to_db_unknown_parent(chaindb, header, seed):
 
 
 def test_persist_block_to_db(chaindb, block):
+    set_empty_root(chaindb, block.header)
     block_to_hash_key = make_block_hash_to_score_lookup_key(block.hash)
     assert not chaindb.exists(block_to_hash_key)
     chaindb.persist_block_to_db(block)
@@ -144,23 +179,22 @@ def test_get_score(chaindb):
 
 
 def test_get_block_header_by_hash(chaindb, block, header):
+    set_empty_root(chaindb, block.header)
+    set_empty_root(chaindb, header)
     chaindb.persist_block_to_db(block)
     block_header = chaindb.get_block_header_by_hash(block.hash)
     assert_rlp_equal(block_header, header)
 
 
 def test_lookup_block_hash(chaindb, block):
+    set_empty_root(chaindb, block.header)
     chaindb.add_block_number_to_hash_lookup(block.header)
     block_hash = chaindb.lookup_block_hash(block.number)
     assert block_hash == block.hash
 
 
-@pytest.mark.xfail(
-    reason="#289 (switch to binary trie not complete yet)",
-    raises=trie.exceptions.InvalidNode
-)
-def test_get_witness_nodes(populated_chaindb_and_root_hash):
-    chaindb, root_hash = populated_chaindb_and_root_hash
+def test_get_witness_nodes(populated_shard_chaindb_and_root_hash):
+    chaindb, root_hash = populated_shard_chaindb_and_root_hash
     header = CollationHeader(
         shard_id=1,
         expected_period_number=0,
@@ -182,4 +216,4 @@ def test_get_witness_nodes(populated_chaindb_and_root_hash):
 
     witness_nodes = chaindb.get_witness_nodes(header, prefixes)
     assert len(witness_nodes) == len(set(witness_nodes))  # no duplicates
-    assert sorted(witness_nodes) == witness_nodes  # sorted
+    assert sorted(witness_nodes) == sorted(witness_nodes)  # sorted


### PR DESCRIPTION
### What was wrong?
Fix #289
Fix #331 

### How was it fixed?
1. For the sharding VM tests, set `chaindb.trie_class` to `BinaryTrie`.
2. Set empty trie roots to `EMPTY_SHA3`.
3. Made `ShardingAccountStateDB` based on `BinaryTrie`.
4. Updated default roots of `CollationHeader`.
5. Refactored `tests.core.fixture`.

#### Cute Animal Picture
![](https://media.giphy.com/media/igT7zfjmp5bJ6/giphy.gif)
