### PR TITLE
Rename BaseChainDB to ChainDB and establish base API

### DIFF
--- a/docs/building_chains.rst
+++ b/docs/building_chains.rst
@@ -35,11 +35,11 @@ Then to initialize, you can start it up with an in-memory database:
 ::
 
   from evm.db.backends.memory import MemoryDB
-  from evm.db.chain import BaseChainDB
+  from evm.db.chain import ChainDB
   from evm.chains.mainnet import MAINNET_GENESIS_HEADER
 
   # start a fresh in-memory db
-  chaindb = BaseChainDB(MemoryDB())
+  chaindb = ChainDB(MemoryDB())
 
   # initialize a fresh chain
   chain = chain_class.from_genesis_header(chaindb, MAINNET_GENESIS_HEADER)
@@ -74,10 +74,10 @@ headers, you should tell asyncio to execute its run() method:
 
   import asyncio
   from evm.db.backends.memory import MemoryDB
-  from evm.db.chain import BaseChainDB
+  from evm.db.chain import ChainDB
   from evm.chains.mainnet import MAINNET_GENESIS_HEADER
 
-  chain = DemoLightChain.from_genesis_header(BaseChainDB(MemoryDB()), MAINNET_GENESIS_HEADER)
+  chain = DemoLightChain.from_genesis_header(ChainDB(MemoryDB()), MAINNET_GENESIS_HEADER)
   loop = asyncio.get_event_loop()
   loop.run_until_complete(chain.run())
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -60,10 +60,10 @@ To access the Mainnet chain you can use:
   from evm import MainnetChain
   from evm.chains.mainnet import MAINNET_GENESIS_HEADER
   from evm.db.backends.level import LevelDB
-  from evm.db.chain import BaseChainDB
+  from evm.db.chain import ChainDB
 
   # Read the previously saved chain database
-  chaindb = BaseChainDB(LevelDB('/tmp/mainnet.db'))
+  chaindb = ChainDB(LevelDB('/tmp/mainnet.db'))
 
   # Load the saved database into a mainnet chain object
   chain = MainnetChain(chaindb)

--- a/evm/lightchain_shell.py
+++ b/evm/lightchain_shell.py
@@ -10,7 +10,7 @@ import atexit
 import logging
 import threading
 
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.exceptions import CanonicalHeadNotFound
 from evm.chains.ropsten import (
     ROPSTEN_GENESIS_HEADER,
@@ -45,7 +45,7 @@ DemoLightChain = LightChain.configure(
     network_id=ROPSTEN_NETWORK_ID,
 )
 
-chaindb = BaseChainDB(LevelDB(args.db))
+chaindb = ChainDB(LevelDB(args.db))
 peer_pool = PeerPool(LESPeer, chaindb, ROPSTEN_NETWORK_ID, ecies.generate_privkey())
 try:
     chaindb.get_canonical_head()

--- a/evm/p2p/lightchain.py
+++ b/evm/p2p/lightchain.py
@@ -24,7 +24,7 @@ from eth_utils import (
 
 from evm.chains import Chain
 from evm.constants import GENESIS_BLOCK_NUMBER
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.exceptions import (
     BlockNotFound,
 )
@@ -53,7 +53,7 @@ class LightChain(Chain, PeerPoolSubscriber):
     logger = logging.getLogger("evm.p2p.lightchain.LightChain")
     max_consecutive_timeouts = 5
 
-    def __init__(self, chaindb: BaseChainDB, peer_pool: PeerPool) -> None:
+    def __init__(self, chaindb: ChainDB, peer_pool: PeerPool) -> None:
         super(LightChain, self).__init__(chaindb)
         self.peer_pool = peer_pool
         self.peer_pool.subscribe(self)
@@ -345,7 +345,7 @@ def _test():
         network_id=NETWORK_ID,
     )
 
-    chaindb = BaseChainDB(LevelDB(args.db))
+    chaindb = ChainDB(LevelDB(args.db))
     if args.local_geth:
         peer_pool = LocalGethPeerPool(LESPeer, chaindb, NETWORK_ID, ecies.generate_privkey())
     else:

--- a/evm/p2p/peer.py
+++ b/evm/p2p/peer.py
@@ -28,7 +28,7 @@ from trie import HexaryTrie
 
 from evm.constants import GENESIS_BLOCK_NUMBER
 from evm.exceptions import BlockNotFound
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.rlp.accounts import Account
 from evm.rlp.headers import BlockHeader
 from evm.rlp.receipts import Receipt
@@ -80,7 +80,7 @@ _ReceivedMsgCallbackType = Callable[
 async def handshake(remote: Node,
                     privkey: datatypes.PrivateKey,
                     peer_class: 'Type[BasePeer]',
-                    chaindb: BaseChainDB,
+                    chaindb: ChainDB,
                     network_id: int,
                     ) -> 'BasePeer':
     """Perform the auth and P2P handshakes with the given remote.
@@ -133,7 +133,7 @@ class BasePeer:
                  mac_secret: bytes,
                  egress_mac: sha3.keccak_256,
                  ingress_mac: sha3.keccak_256,
-                 chaindb: BaseChainDB,
+                 chaindb: ChainDB,
                  network_id: int,
                  ) -> None:
         self._finished = asyncio.Event()
@@ -596,7 +596,7 @@ class PeerPool:
 
     def __init__(self,
                  peer_class: Type[BasePeer],
-                 chaindb: BaseChainDB,
+                 chaindb: ChainDB,
                  network_id: int,
                  privkey: datatypes.PrivateKey,
                  ) -> None:
@@ -781,7 +781,7 @@ def _test():
     remote = Node(
         keys.PublicKey(decode_hex(args.remoteid)),
         Address('127.0.0.1', 30303, 30303))
-    chaindb = BaseChainDB(MemoryDB())
+    chaindb = ChainDB(MemoryDB())
     chaindb.persist_header_to_db(ROPSTEN_GENESIS_HEADER)
     network_id = RopstenChain.network_id
     loop = asyncio.get_event_loop()

--- a/evm/p2p/state.py
+++ b/evm/p2p/state.py
@@ -23,7 +23,7 @@ from evm.constants import (
     EMPTY_SHA3,
 )
 from evm.db.backends.base import BaseDB
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.rlp.accounts import Account
 from evm.utils.keccak import keccak
 from evm.p2p import eth
@@ -195,7 +195,7 @@ def _test():
     parser.add_argument('-root-hash', type=str, required=True, help='Hex encoded root hash')
     args = parser.parse_args()
 
-    chaindb = BaseChainDB(MemoryDB())
+    chaindb = ChainDB(MemoryDB())
     chaindb.persist_header_to_db(ROPSTEN_GENESIS_HEADER)
     peer_pool = PeerPool(ETHPeer, chaindb, RopstenChain.network_id, ecies.generate_privkey())
     asyncio.ensure_future(peer_pool.run())

--- a/evm/p2p/test_lightchain.py
+++ b/evm/p2p/test_lightchain.py
@@ -11,7 +11,7 @@ from evm.chains.mainnet import (
     MAINNET_VM_CONFIGURATION,
 )
 from evm.db.backends.memory import MemoryDB
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.rlp.headers import BlockHeader
 from evm.p2p.les import (
     LESProtocol,
@@ -275,7 +275,7 @@ def chaindb_mainnet_100():
     here = os.path.dirname(__file__)
     headers_rlp = open(os.path.join(here, 'testdata', 'sample_1000_headers_rlp'), 'r+b').read()
     headers = rlp.decode(headers_rlp, sedes=sedes.CountableList(BlockHeader))
-    chaindb = BaseChainDB(MemoryDB())
+    chaindb = ChainDB(MemoryDB())
     for i in range(0, 101):
         chaindb.persist_header_to_db(headers[i])
     return chaindb

--- a/evm/p2p/test_lightchain_integration.py
+++ b/evm/p2p/test_lightchain_integration.py
@@ -10,7 +10,7 @@ from eth_utils import (
 from evm.chains.ropsten import ROPSTEN_NETWORK_ID, ROPSTEN_GENESIS_HEADER
 from evm.chains.mainnet import MAINNET_VM_CONFIGURATION
 from evm.db.backends.memory import MemoryDB
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.utils.keccak import keccak
 from evm.vm.forks.frontier import FrontierBlock
 
@@ -43,7 +43,7 @@ async def test_lightchain_integration(request, event_loop):
     if not pytest.config.getoption("--integration"):
         pytest.skip("Not asked to run integration tests")
 
-    chaindb = BaseChainDB(MemoryDB())
+    chaindb = ChainDB(MemoryDB())
     chaindb.persist_header_to_db(ROPSTEN_GENESIS_HEADER)
     peer_pool = LocalGethPeerPool(LESPeer, chaindb, ROPSTEN_NETWORK_ID, ecies.generate_privkey())
     chain = IntegrationTestLightChain(chaindb, peer_pool)

--- a/evm/p2p/test_peer.py
+++ b/evm/p2p/test_peer.py
@@ -5,7 +5,7 @@ import pytest
 
 from evm.chains.mainnet import MAINNET_GENESIS_HEADER
 from evm.db.backends.memory import MemoryDB
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.utils.keccak import keccak
 from evm.p2p import auth
 from evm.p2p import constants
@@ -141,7 +141,7 @@ async def test_directly_linked_peers(request, event_loop):
 
 
 def get_fresh_mainnet_chaindb():
-    chaindb = BaseChainDB(MemoryDB())
+    chaindb = ChainDB(MemoryDB())
     chaindb.persist_header_to_db(MAINNET_GENESIS_HEADER)
     return chaindb
 

--- a/evm/rpc/server.py
+++ b/evm/rpc/server.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
         MAINNET_GENESIS_HEADER, MAINNET_VM_CONFIGURATION, MAINNET_NETWORK_ID)
     from evm.chains.ropsten import ROPSTEN_GENESIS_HEADER, ROPSTEN_NETWORK_ID
     from evm.db.backends.level import LevelDB
-    from evm.db.chain import BaseChainDB
+    from evm.db.chain import ChainDB
     from evm.exceptions import CanonicalHeadNotFound
     from evm.p2p import ecies
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -111,7 +111,7 @@ if __name__ == '__main__':
         privkey=ecies.generate_privkey(),
     )
 
-    chaindb = BaseChainDB(LevelDB(args.db))
+    chaindb = ChainDB(LevelDB(args.db))
     try:
         chaindb.get_canonical_head()
     except CanonicalHeadNotFound:

--- a/evm/utils/fixture_tests.py
+++ b/evm/utils/fixture_tests.py
@@ -41,7 +41,7 @@ from evm.vm.forks import (
 )
 
 from evm.db import get_db_backend
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 
 from .numeric import (
     big_endian_to_int,
@@ -628,7 +628,7 @@ def genesis_params_from_fixture(fixture):
 
 
 def new_chain_from_fixture(fixture):
-    db = BaseChainDB(get_db_backend())
+    db = ChainDB(get_db_backend())
 
     vm_config = chain_vm_configuration(fixture)
 

--- a/evm/utils/state.py
+++ b/evm/utils/state.py
@@ -7,7 +7,7 @@ from trie import (
 )
 
 from evm.db.backends.memory import MemoryDB
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 
 
 @to_tuple
@@ -41,7 +41,7 @@ def diff_state_db(expected_state, state_db):
 
 # Make the root of a receipt tree
 def make_trie_root_and_nodes(transactions, trie_class=HexaryTrie):
-    chaindb = BaseChainDB(MemoryDB())
+    chaindb = ChainDB(MemoryDB())
     db = chaindb.db
     transaction_db = trie_class(db)
 

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -18,7 +18,7 @@ from evm.exceptions import (
     ValidationError,
 )
 from evm.db.backends.memory import MemoryDB
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.rlp.headers import (
     BlockHeader,
 )
@@ -196,7 +196,7 @@ class VM(Configurable):
         receipts = []
         for (transaction, transaction_witness) in transaction_packages:
             transaction_witness.update(recent_trie_nodes)
-            witness_db = BaseChainDB(MemoryDB(transaction_witness))
+            witness_db = ChainDB(MemoryDB(transaction_witness))
 
             execution_context = ExecutionContext.from_block_header(block.header, prev_hashes)
             vm_state = cls.get_state_class()(
@@ -218,7 +218,7 @@ class VM(Configurable):
                 pass
 
         # Finalize
-        witness_db = BaseChainDB(MemoryDB(recent_trie_nodes))
+        witness_db = ChainDB(MemoryDB(recent_trie_nodes))
         execution_context = ExecutionContext.from_block_header(block.header, prev_hashes)
         vm_state = cls.get_state_class()(
             chaindb=witness_db,

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -10,7 +10,7 @@ from eth_keys import KeyAPI
 from evm import Chain
 from evm import constants
 from evm.db import get_db_backend
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.vm.forks.frontier import FrontierVM
 
 
@@ -64,7 +64,7 @@ def chain():
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
         ))
-    chain = klass.from_genesis(BaseChainDB(get_db_backend()), genesis_params, genesis_state)
+    chain = klass.from_genesis(ChainDB(get_db_backend()), genesis_params, genesis_state)
     chain.funded_address = funded_addr
     chain.funded_address_initial_balance = initial_balance
     return chain
@@ -129,7 +129,7 @@ def chain_without_block_validation():
             'storage': {},
         }
     }
-    chain = klass.from_genesis(BaseChainDB(get_db_backend()), genesis_params, genesis_state)
+    chain = klass.from_genesis(ChainDB(get_db_backend()), genesis_params, genesis_state)
     chain.funded_address = funded_addr
     chain.funded_address_initial_balance = initial_balance
     chain.funded_address_private_key = private_key

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -5,7 +5,7 @@ import pytest
 
 from evm import constants
 from evm.db.backends.memory import MemoryDB
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 
 from tests.core.helpers import new_transaction
 
@@ -115,7 +115,7 @@ def test_create_block(chain):
     transaction_witness2 = computation.vm_state.access_logs.reads
 
     # Check AccessLogs
-    witness_db = BaseChainDB(MemoryDB(computation.vm_state.access_logs.writes))
+    witness_db = ChainDB(MemoryDB(computation.vm_state.access_logs.writes))
     state_db = witness_db.get_state_db(block.header.state_root, read_only=True)
     assert state_db.get_balance(recipient2) == amount
     with pytest.raises(KeyError):

--- a/tests/core/vm/test_vm_state.py
+++ b/tests/core/vm/test_vm_state.py
@@ -10,7 +10,7 @@ from eth_utils import (
 )
 
 from evm.db.backends.memory import MemoryDB
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.vm.execution_context import (
     ExecutionContext,
 )
@@ -141,7 +141,7 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     post_vm_state = computation.vm_state
 
     # Check AccessLogs
-    witness_db = BaseChainDB(MemoryDB(access_logs2.writes))
+    witness_db = ChainDB(MemoryDB(access_logs2.writes))
     state_db = witness_db.get_state_db(block.header.state_root, read_only=True)
     assert state_db.get_balance(recipient2) == amount
     with pytest.raises(KeyError):
@@ -161,7 +161,7 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
     # Witness_db
     block2 = copy.deepcopy(block0)
 
-    witness_db = BaseChainDB(MemoryDB(access_logs1.reads))
+    witness_db = ChainDB(MemoryDB(access_logs1.reads))
     prev_hashes = vm.get_prev_hashes(
         last_block_hash=prev_block_hash,
         db=vm.chaindb,
@@ -181,7 +181,7 @@ def test_apply_transaction(chain_without_block_validation):  # noqa: F811
 
     # Update witness_db
     recent_trie_nodes = merge(access_logs2.reads, access_logs1.writes)
-    witness_db = BaseChainDB(MemoryDB(recent_trie_nodes))
+    witness_db = ChainDB(MemoryDB(recent_trie_nodes))
     execution_context = ExecutionContext.from_block_header(block.header, prev_hashes)
     # Apply the second transaction
     vm_state2 = FrontierVMState(

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -62,21 +62,21 @@ def block(request, header):
 
 def test_add_block_number_to_hash_lookup(chaindb, block):
     block_number_to_hash_key = make_block_number_to_hash_lookup_key(block.number)
-    assert not chaindb.db.exists(block_number_to_hash_key)
+    assert not chaindb.exists(block_number_to_hash_key)
     chaindb._add_block_number_to_hash_lookup(block.header)
-    assert chaindb.db.exists(block_number_to_hash_key)
+    assert chaindb.exists(block_number_to_hash_key)
 
 
 def test_persist_header_to_db(chaindb, header):
     with pytest.raises(BlockNotFound):
         chaindb.get_block_header_by_hash(header.hash)
     number_to_hash_key = make_block_hash_to_score_lookup_key(header.hash)
-    assert not chaindb.db.exists(number_to_hash_key)
+    assert not chaindb.exists(number_to_hash_key)
 
     chaindb.persist_header_to_db(header)
 
     assert chaindb.get_block_header_by_hash(header.hash) == header
-    assert chaindb.db.exists(number_to_hash_key)
+    assert chaindb.exists(number_to_hash_key)
 
 
 @given(seed=st.binary(min_size=32, max_size=32))
@@ -88,9 +88,9 @@ def test_persist_header_to_db_unknown_parent(chaindb, header, seed):
 
 def test_persist_block_to_db(chaindb, block):
     block_to_hash_key = make_block_hash_to_score_lookup_key(block.hash)
-    assert not chaindb.db.exists(block_to_hash_key)
+    assert not chaindb.exists(block_to_hash_key)
     chaindb.persist_block_to_db(block)
-    assert chaindb.db.exists(block_to_hash_key)
+    assert chaindb.exists(block_to_hash_key)
 
 
 def test_get_score(chaindb):

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -13,7 +13,7 @@ from eth_utils import (
     to_tuple,
 )
 
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 from evm.exceptions import (
     ValidationError,
 )
@@ -253,7 +253,7 @@ def test_state_fixtures(fixture, fixture_vm_class):
         timestamp=fixture['env']['currentTimestamp'],
         parent_hash=fixture['env']['previousHash'],
     )
-    chaindb = BaseChainDB(get_db_backend())
+    chaindb = ChainDB(get_db_backend())
     vm = fixture_vm_class(header=header, chaindb=chaindb)
 
     vm_state = vm.state

--- a/tests/json-fixtures/test_transactions.py
+++ b/tests/json-fixtures/test_transactions.py
@@ -18,7 +18,7 @@ from evm import (
 from evm.db import (
     get_db_backend,
 )
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 
 from evm.exceptions import (
     ValidationError,
@@ -61,7 +61,7 @@ def fixture(fixture_data):
 
 def test_transaction_fixtures(fixture):
     header = BlockHeader(1, fixture['blocknumber'], 100)
-    chain = MainnetChain(BaseChainDB(get_db_backend()), header=header)
+    chain = MainnetChain(ChainDB(get_db_backend()), header=header)
     vm = chain.get_vm()
     TransactionClass = vm.get_transaction_class()
 

--- a/tests/json-fixtures/test_virtual_machine.py
+++ b/tests/json-fixtures/test_virtual_machine.py
@@ -5,7 +5,7 @@ import pytest
 from evm.db import (
     get_db_backend,
 )
-from evm.db.chain import BaseChainDB
+from evm.db.chain import ChainDB
 
 from eth_utils import (
     keccak,
@@ -133,7 +133,7 @@ def vm_class(request):
 
 
 def test_vm_fixtures(fixture, vm_class):
-    chaindb = BaseChainDB(get_db_backend())
+    chaindb = ChainDB(get_db_backend())
     header = BlockHeader(
         coinbase=fixture['env']['currentCoinbase'],
         difficulty=fixture['env']['currentDifficulty'],


### PR DESCRIPTION
### What was wrong?

When I see an object named `BaseXXX` I generally think of it as something that requires inheritance, or at least that you build on top of.  The way that our `BaseChainDB` object is used does not fit this model and the `Base` prefix adds some level of confusion (in-my-humble-ish-opinion)

### How was it fixed?

Established a `BaseChainDB` class which has stub methods for all of the *public* API.

Renamed the original `BaseChainDB -> ChainDB` and re-organized the class methods to be grouped by functionality.

> Note that this is in preparation for the work in trinity to relegate the ChainDB execution to it's own process.

#### Cute Animal Picture

![cute animal friendship 007](https://user-images.githubusercontent.com/824194/35937610-f78c519a-0c03-11e8-855b-3e96a30ac35a.jpg)
