### PR TITLE
Use the latest eth-utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "cryptography>=2.0.3",
         "cytoolz==0.9.0,<1.0.0",
         "eth-bloom>=0.5.2",
-        "eth-utils>=0.7.1",
+        "eth-utils>=1.0.0b1",
         "pyethash>=0.1.27",
         "py-ecc==1.4.2",
         "rlp==0.4.7",


### PR DESCRIPTION
### What was wrong?
When installing requires for `py-evm`, the version of `eth_utils` installed is not the latest one. This results in the import error in `eth_account` in CI, since it requires the newer `eth_utils`

### How was it fixed?
Modify the version of `eth_account` in `setup.py `

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent-tpe1-1.xx.fbcdn.net/v/t1.0-9/27544749_869048609956208_9038779871357973015_n.jpg?oh=9c9d9f39f97ec766202c6b56f75d6d95&oe=5B20E026)
