### PR TITLE
MAINT: updated requirements-dev.txt w/ leveldb

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 bumpversion==0.5.3
 flake8==3.5.0
 hypothesis==3.44.26
-leveldb==0.194
+leveldb>=0.194,<1.0.0
 pytest-asyncio==0.8.0
 pytest-cov==2.5.1
 pytest-logging>=2015.11.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 bumpversion==0.5.3
 flake8==3.5.0
 hypothesis==3.44.26
+leveldb==0.194
 pytest-asyncio==0.8.0
 pytest-cov==2.5.1
 pytest-logging>=2015.11.4


### PR DESCRIPTION
### What was wrong?

trinity.rpc.server imports evm.db.backends.level which in turns imports the leveldb package, but package is missing in local environment because it's not listed as a requirement

### How was it fixed?

added leveldb  package into requirements-dev.txt

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/63/15/72/6315722b4e5d55ce394f249eaa7580d6.jpg)
