### PR TITLE
Make mypy check bodies of untyped functions as well

### DIFF
--- a/p2p/cancel_token.py
+++ b/p2p/cancel_token.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Awaitable, List  # noqa: F401
+from typing import Any, Awaitable, cast, List  # noqa: F401
 
 from p2p.exceptions import OperationCancelled
 
@@ -66,7 +66,7 @@ class CancelToken:
 
 async def _wait_for_first(futures):
     for future in asyncio.as_completed(futures):
-        await future
+        await cast(asyncio.Future, future)
         return
 
 

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -89,7 +89,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
     def pubkey(self) -> datatypes.PublicKey:
         return self.privkey.public_key
 
-    def _get_handler(self, cmd) -> Callable[[kademlia.Node, List[Any], AnyStr], None]:
+    def _get_handler(self, cmd: Command) -> Callable[[kademlia.Node, List[Any], AnyStr], None]:
         if cmd == CMD_PING:
             return self.recv_ping
         elif cmd == CMD_PONG:
@@ -172,7 +172,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         nodes, _ = payload
         self.kademlia.recv_neighbours(node, _extract_nodes_from_payload(nodes))
 
-    def recv_ping(self, node: kademlia.Node, _, message_hash: AnyStr) -> None:
+    def recv_ping(self, node: kademlia.Node, _: Any, message_hash: AnyStr) -> None:
         self.kademlia.recv_ping(node, message_hash)
 
     def recv_find_node(self, node: kademlia.Node, payload: List[Any], _: AnyStr) -> None:

--- a/p2p/ecies.py
+++ b/p2p/ecies.py
@@ -85,7 +85,7 @@ def encrypt(data: bytes, pubkey: datatypes.PublicKey, shared_mac_data: bytes = b
     return msg + tag
 
 
-def decrypt(data: bytes, privkey: datatypes.PrivateKey, shared_mac_data: bytes = b''):
+def decrypt(data: bytes, privkey: datatypes.PrivateKey, shared_mac_data: bytes = b'') -> bytes:
     """Decrypt data with ECIES method using the given private key
 
     1) generate shared-secret = kdf( ecdhAgree(myPrivKey, msg[1:65]) )

--- a/p2p/lightchain.py
+++ b/p2p/lightchain.py
@@ -126,7 +126,7 @@ class LightChain(Chain, PeerPoolSubscriber):
             self.logger.debug("No connected peers, sleeping a bit")
             await asyncio.sleep(0.5)
 
-        def peer_block_height(peer: LESPeer):
+        def peer_block_height(peer: LESPeer) -> int:
             last_announced = self._last_processed_announcements.get(peer)
             if last_announced is None:
                 return -1

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -1,4 +1,5 @@
 import enum
+from typing import cast, Dict
 
 from cytoolz import assoc
 
@@ -7,6 +8,7 @@ from rlp import sedes
 from p2p.protocol import (
     Command,
     Protocol,
+    _DecodedMsgType,
 )
 
 from .constants import (
@@ -48,14 +50,14 @@ class Disconnect(Command):
     _cmd_id = 1
     structure = [('reason', sedes.big_endian_int)]
 
-    def get_reason_name(self, reason_id):
+    def get_reason_name(self, reason_id: int) -> str:
         try:
             return DisconnectReason(reason_id).name
         except ValueError:
             return "unknown reason"
 
-    def decode(self, data):
-        raw_decoded = super(Disconnect, self).decode(data)
+    def decode(self, data: bytes) -> _DecodedMsgType:
+        raw_decoded = cast(Dict[str, int], super(Disconnect, self).decode(data))
         return assoc(raw_decoded, 'reason_name', self.get_reason_name(raw_decoded['reason']))
 
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -308,7 +308,7 @@ class BasePeer:
         self.logger.debug("Successfully decoded %s msg: %s", cmd, decoded_msg)
         return cmd, decoded_msg
 
-    def handle_p2p_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType):
+    def handle_p2p_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
         """Handle the base protocol (P2P) messages."""
         if isinstance(cmd, Disconnect):
             msg = cast(Dict[str, Any], msg)
@@ -324,7 +324,7 @@ class BasePeer:
         else:
             raise UnexpectedMessage("Unexpected msg: {} ({})".format(cmd, msg))
 
-    def handle_sub_proto_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType):
+    def handle_sub_proto_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
         self.sub_proto_msg_queue.put_nowait((cmd, msg))
 
     def process_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
@@ -477,7 +477,7 @@ class LESPeer(BasePeer):
         # TODO: Disconnect if the remote doesn't serve headers.
         self.head_info = cmd.as_head_info(msg)
 
-    def handle_sub_proto_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType):
+    def handle_sub_proto_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
         if isinstance(msg, dict):
             request_id = msg.get('request_id')
             if request_id is not None and request_id in self._pending_replies:
@@ -488,7 +488,7 @@ class LESPeer(BasePeer):
                 return
         super().handle_sub_proto_msg(cmd, msg)
 
-    async def _wait_for_reply(self, request_id: int, cancel_token: CancelToken):
+    async def _wait_for_reply(self, request_id: int, cancel_token: CancelToken) -> Dict[str, Any]:
         reply = None
         got_reply = asyncio.Event()
 

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -24,7 +24,12 @@ if TYPE_CHECKING:
     from p2p.peer import ChainInfo, BasePeer  # noqa: F401
 
 
-_DecodedMsgType = Union[Dict[str, Any], List[bytes], bytes]
+_DecodedMsgType = Union[
+    Dict[str, Any],
+    List[bytes],
+    List[Tuple[bytes, bytes]],
+    bytes,
+]
 
 
 class Command:

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -27,7 +27,6 @@ from evm.constants import (
     EMPTY_SHA3,
 )
 from evm.db.backends.base import BaseDB
-from evm.db.chain import ChainDB
 from evm.rlp.accounts import Account
 
 from p2p import eth
@@ -124,7 +123,7 @@ class StateDownloader(PeerPoolSubscriber):
         self.logger.debug("Requesting %d trie nodes", len(requests))
         await self.request_nodes([request.node_key for request in requests])
 
-    async def request_nodes(self, node_keys: List[bytes]):
+    async def request_nodes(self, node_keys: List[bytes]) -> None:
         peer = await self.get_random_peer()
         now = time.time()
         for node_key in node_keys:
@@ -196,6 +195,7 @@ def _test():
     from evm.chains.ropsten import RopstenChain, ROPSTEN_GENESIS_HEADER
     from evm.db.backends.level import LevelDB
     from evm.db.backends.memory import MemoryDB
+    from tests.p2p.integration_test_helpers import FakeAsyncChainDB
     logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 
     parser = argparse.ArgumentParser()
@@ -203,7 +203,7 @@ def _test():
     parser.add_argument('-root-hash', type=str, required=True, help='Hex encoded root hash')
     args = parser.parse_args()
 
-    chaindb = ChainDB(MemoryDB())
+    chaindb = FakeAsyncChainDB(MemoryDB())
     chaindb.persist_header_to_db(ROPSTEN_GENESIS_HEADER)
     peer_pool = PeerPool(ETHPeer, chaindb, RopstenChain.network_id, ecies.generate_privkey())
     asyncio.ensure_future(peer_pool.run())

--- a/tests/p2p/test_cancel_token.py
+++ b/tests/p2p/test_cancel_token.py
@@ -63,6 +63,16 @@ def test_token_chain_trigger_last():
 
 
 @pytest.mark.asyncio
+async def test_token_wait(event_loop):
+    token = CancelToken('token')
+    event_loop.call_soon(token.trigger)
+    done, pending = await asyncio.wait([token.wait()], timeout=0.1)
+    assert len(done) == 1
+    assert len(pending) == 0
+    assert token.triggered
+
+
+@pytest.mark.asyncio
 async def test_wait_cancel_pending_tasks_on_completion(event_loop):
     token = CancelToken('token')
     token2 = CancelToken('token2')

--- a/tox.ini
+++ b/tox.ini
@@ -63,5 +63,5 @@ deps=mypy
 setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
 # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
 commands=
-    mypy --follow-imports=silent --ignore-missing-imports -p p2p
-    mypy --follow-imports=silent --ignore-missing-imports -p trinity
+    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p p2p
+    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p trinity

--- a/trinity/cli.py
+++ b/trinity/cli.py
@@ -3,6 +3,7 @@ import atexit
 import logging
 import traceback
 import threading
+from typing import Dict  # noqa: F401
 
 from p2p.lightchain import LightChain
 
@@ -42,7 +43,7 @@ def ipython_shell(namespace=None, banner=None, debug=False):
         from IPython.terminal.embed import InteractiveShellEmbed
         kwargs = dict(user_ns=namespace)
     else:
-        from IPython.frontend.terminal.embed import InteractiveShellEmbed
+        from IPython.frontend.terminal.embed import InteractiveShellEmbed  # type: ignore
         kwargs = dict(user_ns=namespace)
     if banner:
         kwargs = dict(banner1=banner)
@@ -66,7 +67,7 @@ def python_shell(namespace=None, banner=None, debug=False):
     if namespace:
         default_ns.update(namespace)
     # Configure kwargs to pass banner
-    kwargs = dict()
+    kwargs = dict()  # type: Dict[str, str]
     if banner:
         kwargs = dict(banner=banner)
     shell = code.InteractiveConsole(default_ns)

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -1,13 +1,15 @@
 import json
 import logging
+from typing import Dict  # noqa: F401
 
 from evm.exceptions import (
     ValidationError,
 )
 
-from trinity.rpc.modules import (
+from trinity.rpc.modules import (  # noqa: F401
     Eth,
     EVM,
+    RPCModule,
 )
 
 REQUIRED_REQUEST_KEYS = {
@@ -56,7 +58,7 @@ class RPCServer:
     )
 
     def __init__(self, chain):
-        self.modules = {}
+        self.modules = {}  # type: Dict[str, RPCModule]
         self.chain = chain
         for M in self.module_classes:
             self.modules[M.__name__.lower()] = M(chain)

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -24,7 +24,7 @@ def setup_trinity_logging(level):
     logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
 
-    listener = handlers.QueueListener(log_queue, logger)
+    listener = handlers.QueueListener(log_queue, handler)
 
     return logger, log_queue, listener
 


### PR DESCRIPTION
By default it only checks the code of a func/method if it is typed, so
I changed the command line we use in TOX to ask it to check untyped defs
as well.

Also added an extra switch to disallow incomplete type annotations (i.e.
require func/methods to annotate all args and return value).

Those new checks caught a few bugs, that I've fixed as well