### PR TITLE
Add xfail=strict to pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 python_paths= .
+xfail_strict=true


### PR DESCRIPTION
### What was wrong?

Tests were green for xfail tests that were unexpectedly passing.

### How was it fixed?

Added `xfail_strict=true` to `pytest.ini`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ59TLluLvzETxk84WAjrssUWFrMIHo59A7CXk2wRRoWA4p2w4GEA)
