### PR TITLE
Allow deep property configuration in Configurable classes

### DIFF
--- a/docs/building_chains.rst
+++ b/docs/building_chains.rst
@@ -23,7 +23,7 @@ class:
   import evm.chains.mainnet as mainnet
 
   chain_class = Chain.configure(
-      name='Test Chain',
+      __name__='Test Chain',
       vm_configuration=(
           (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
           (mainnet.constants.HOMESTEAD_MAINNET_BLOCK, HomesteadVM),
@@ -61,7 +61,7 @@ with a vm_configuration, but it also requires a network_id and privkey:
   from p2p.peer import LESPeer, PeerPool
 
   DemoLightChain = LightChain.configure(
-      name='Demo LightChain',
+      __name__='Demo LightChain',
       vm_configuration=MAINNET_VM_CONFIGURATION,
       network_id=MAINNET_NETWORK_ID,
   )

--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -283,13 +283,13 @@ class Chain(BaseChain):
             self.gas_estimator = get_gas_estimator()
 
     @classmethod
-    def configure(cls, name=None, vm_configuration=None, **overrides):
+    def configure(cls, __name__=None, vm_configuration=None, **overrides):
         if 'vms_by_range' in overrides:
             raise ValueError("Cannot override vms_by_range")
 
         if vm_configuration is not None:
             overrides['vms_by_range'] = generate_vms_by_range(vm_configuration)
-        return super().configure(name, **overrides)
+        return super().configure(__name__, **overrides)
 
     #
     # Convenience and Helpers

--- a/evm/opcode.py
+++ b/evm/opcode.py
@@ -1,8 +1,10 @@
 import functools
 import logging
 
+from evm.utils.datatypes import Configurable
 
-class Opcode(object):
+
+class Opcode(Configurable):
     mnemonic = None
     gas_cost = None
 
@@ -21,22 +23,6 @@ class Opcode(object):
     @property
     def logger(self):
         return logging.getLogger('evm.vm.logic.call.{0}'.format(self.mnemonic))
-
-    @classmethod
-    def configure(cls,
-                  name,
-                  **overrides):
-        """
-        Class factory method for simple inline subclassing.
-        """
-        for key in overrides:
-            if not hasattr(cls, key):
-                raise TypeError(
-                    "The Opcode.configure cannot set attributes that are not "
-                    "already present on the base class.  The attribute `{0}` was "
-                    "not found on the base class `{1}`".format(key, cls)
-                )
-        return type(name, (cls,), overrides)
 
     @classmethod
     def as_opcode(cls, logic_fn, mnemonic, gas_cost):

--- a/evm/utils/datatypes.py
+++ b/evm/utils/datatypes.py
@@ -1,21 +1,111 @@
+from cytoolz import (
+    assoc,
+    groupby,
+)
+
+from eth_utils import (
+    to_dict,
+    to_set,
+)
+
+
+def _is_local_prop(prop):
+    return len(prop.split('.')) == 1
+
+
+def _extract_top_level_key(prop):
+    left, _, _ = prop.partition('.')
+    return left
+
+
+def _extract_tail_key(prop):
+    _, _, right = prop.partition('.')
+    return right
+
+
+@to_dict
+def _get_local_overrides(overrides):
+    for prop, value in overrides.items():
+        if _is_local_prop(prop):
+            yield prop, value
+
+
+@to_dict
+def _get_sub_overrides(overrides):
+    for prop, value in overrides.items():
+        if not _is_local_prop(prop):
+            yield prop, value
+
+
+@to_dict
+def _get_sub_overrides_by_prop(overrides):
+    # we only want the overrides that are not top level.
+    sub_overrides = _get_sub_overrides(overrides)
+    key_groups = groupby(_extract_top_level_key, sub_overrides.keys())
+    for top_level_key, props in key_groups.items():
+        yield top_level_key, {_extract_tail_key(prop): overrides[prop] for prop in props}
+
+
+@to_set
+def _get_top_level_keys(overrides):
+    for prop in overrides:
+        yield _extract_top_level_key(prop)
+
+
 class Configurable(object):
     """
     Base class for simple inline subclassing
     """
     @classmethod
     def configure(cls,
-                  name=None,
+                  __name__=None,
                   **overrides):
 
-        if name is None:
-            name = cls.__name__
+        if __name__ is None:
+            __name__ = cls.__name__
 
-        for key in overrides:
-            if not hasattr(cls, key):
+        top_level_keys = _get_top_level_keys(overrides)
+
+        # overrides that are *local* to this class.
+        local_overrides = _get_local_overrides(overrides)
+
+        for key in top_level_keys:
+            if key == '__name__':
+                continue
+            elif not hasattr(cls, key):
                 raise TypeError(
                     "The {0}.configure cannot set attributes that are not "
                     "already present on the base class. The attribute `{1}` was "
                     "not found on the base class `{2}`".format(cls.__name__, key, cls)
                 )
 
-        return type(name, (cls,), overrides)
+        # overrides that are for sub-properties of this class
+        sub_overrides_by_prop = _get_sub_overrides_by_prop(overrides)
+
+        for key, sub_overrides in sub_overrides_by_prop.items():
+            if key in local_overrides:
+                sub_cls = local_overrides[key]
+            elif hasattr(cls, key):
+                sub_cls = getattr(cls, key)
+            else:
+                raise Exception(
+                    "Invariant: the pre-check that all top level keys are "
+                    "present on `cls` should make this code path unreachable"
+                )
+
+            if not isinstance(sub_cls, type) or not issubclass(sub_cls, Configurable):
+                raise TypeError(
+                    "Unable to configure property `{0}` on class `{1}`.  The "
+                    "property being configured must be a subclass of the "
+                    "`Configurable` type.  Instead got the following object "
+                    "instance: {2}".format(
+                        key,
+                        repr(cls),
+                        repr(sub_cls),
+                    )
+                )
+
+            configured_sub_cls = sub_cls.configure(**sub_overrides)
+            local_overrides = assoc(local_overrides, key, configured_sub_cls)
+
+        return type(__name__, (cls,), local_overrides)

--- a/evm/vm/forks/byzantium/__init__.py
+++ b/evm/vm/forks/byzantium/__init__.py
@@ -10,7 +10,7 @@ from .vm_state import ByzantiumVMState
 
 
 ByzantiumVM = SpuriousDragonVM.configure(
-    name='ByzantiumVM',
+    __name__='ByzantiumVM',
     # classes
     _block_class=ByzantiumBlock,
     _state_class=ByzantiumVMState,

--- a/evm/vm/forks/byzantium/opcodes.py
+++ b/evm/vm/forks/byzantium/opcodes.py
@@ -60,12 +60,12 @@ UPDATED_OPCODES = {
     # Call
     #
     opcode_values.STATICCALL: call.StaticCall.configure(
-        name='opcode:STATICCALL',
+        __name__='opcode:STATICCALL',
         mnemonic=mnemonics.STATICCALL,
         gas_cost=GAS_CALL_EIP150,
     )(),
     opcode_values.CALL: call.CallByzantium.configure(
-        name='opcode:CALL',
+        __name__='opcode:CALL',
         mnemonic=mnemonics.CALL,
         gas_cost=GAS_CALL_EIP150,
     )(),
@@ -101,7 +101,7 @@ UPDATED_OPCODES = {
     # Create
     #
     opcode_values.CREATE: system.CreateByzantium.configure(
-        name='opcode:CREATE',
+        __name__='opcode:CREATE',
         mnemonic=mnemonics.CREATE,
         gas_cost=constants.GAS_CREATE,
     )(),

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -12,7 +12,7 @@ from .headers import (
 
 
 FrontierVM = VM.configure(
-    name='FrontierVM',
+    __name__='FrontierVM',
     # classes
     _block_class=FrontierBlock,
     _state_class=FrontierVMState,

--- a/evm/vm/forks/frontier/opcodes.py
+++ b/evm/vm/forks/frontier/opcodes.py
@@ -676,17 +676,17 @@ FRONTIER_OPCODES = {
     # System
     #
     opcode_values.CREATE: system.Create.configure(
-        name='opcode:CREATE',
+        __name__='opcode:CREATE',
         mnemonic=mnemonics.CREATE,
         gas_cost=constants.GAS_CREATE,
     )(),
     opcode_values.CALL: call.Call.configure(
-        name='opcode:CALL',
+        __name__='opcode:CALL',
         mnemonic=mnemonics.CALL,
         gas_cost=constants.GAS_CALL,
     )(),
     opcode_values.CALLCODE: call.CallCode.configure(
-        name='opcode:CALLCODE',
+        __name__='opcode:CALLCODE',
         mnemonic=mnemonics.CALLCODE,
         gas_cost=constants.GAS_CALL,
     )(),

--- a/evm/vm/forks/homestead/__init__.py
+++ b/evm/vm/forks/homestead/__init__.py
@@ -18,7 +18,7 @@ class MetaHomesteadVM(FrontierVM):
 
 
 HomesteadVM = MetaHomesteadVM.configure(
-    name='HomesteadVM',
+    __name__='HomesteadVM',
     # classes
     _block_class=HomesteadBlock,
     _state_class=HomesteadVMState,

--- a/evm/vm/forks/homestead/opcodes.py
+++ b/evm/vm/forks/homestead/opcodes.py
@@ -15,7 +15,7 @@ from evm.vm.forks.frontier.opcodes import FRONTIER_OPCODES
 
 NEW_OPCODES = {
     opcode_values.DELEGATECALL: call.DelegateCall.configure(
-        name='opcode:DELEGATECALL',
+        __name__='opcode:DELEGATECALL',
         mnemonic=mnemonics.DELEGATECALL,
         gas_cost=constants.GAS_CALL,
     )(),

--- a/evm/vm/forks/sharding/__init__.py
+++ b/evm/vm/forks/sharding/__init__.py
@@ -13,7 +13,7 @@ from .headers import (
 from .vm_state import ShardingVMState
 
 ShardingVM = ShardVM.configure(
-    name='ShardingVM',
+    __name__='ShardingVM',
     # classes
     _block_class=Collation,
     _state_class=ShardingVMState,

--- a/evm/vm/forks/sharding/opcodes.py
+++ b/evm/vm/forks/sharding/opcodes.py
@@ -28,7 +28,7 @@ NEW_OPCODES = {
         gas_cost=constants.GAS_BASE,
     ),
     opcode_values.CREATE2: system.Create2.configure(
-        name='opcode:CREATE2',
+        __name__='opcode:CREATE2',
         mnemonic=mnemonics.CREATE2,
         gas_cost=constants.GAS_CREATE2,
     )(),
@@ -46,7 +46,7 @@ REMOVED_OPCODES = [
 
 REPLACED_OPCODES = {
     opcode_values.CALL: call.CallSharding.configure(
-        name='opcode:CALL',
+        __name__='opcode:CALL',
         mnemonic=mnemonics.CALL,
         gas_cost=GAS_CALL_EIP150,
     )(),

--- a/evm/vm/forks/spurious_dragon/__init__.py
+++ b/evm/vm/forks/spurious_dragon/__init__.py
@@ -4,7 +4,7 @@ from .blocks import SpuriousDragonBlock
 from .vm_state import SpuriousDragonVMState
 
 SpuriousDragonVM = HomesteadVM.configure(
-    name='SpuriousDragonVM',
+    __name__='SpuriousDragonVM',
     # classes
     _block_class=SpuriousDragonBlock,
     _state_class=SpuriousDragonVMState,

--- a/evm/vm/forks/spurious_dragon/opcodes.py
+++ b/evm/vm/forks/spurious_dragon/opcodes.py
@@ -37,7 +37,7 @@ UPDATED_OPCODES = {
         gas_cost=GAS_SELFDESTRUCT_EIP150,
     ),
     opcode_values.CALL: call.CallEIP161.configure(
-        name='opcode:CALL',
+        __name__='opcode:CALL',
         mnemonic=mnemonics.CALL,
         gas_cost=GAS_CALL_EIP150,
     )(),

--- a/evm/vm/forks/tangerine_whistle/__init__.py
+++ b/evm/vm/forks/tangerine_whistle/__init__.py
@@ -3,6 +3,6 @@ from evm.vm.forks.homestead import HomesteadVM
 from .vm_state import TangerineWhistleVMState
 
 TangerineWhistleVM = HomesteadVM.configure(
-    name='TangerineWhistleVM',
+    __name__='TangerineWhistleVM',
     _state_class=TangerineWhistleVMState,
 )

--- a/evm/vm/forks/tangerine_whistle/opcodes.py
+++ b/evm/vm/forks/tangerine_whistle/opcodes.py
@@ -46,22 +46,22 @@ UPDATED_OPCODES = {
         gas_cost=constants.GAS_SELFDESTRUCT_EIP150,
     ),
     opcode_values.CREATE: system.CreateEIP150.configure(
-        name='opcode:CREATE',
+        __name__='opcode:CREATE',
         mnemonic=mnemonics.CREATE,
         gas_cost=GAS_CREATE,
     )(),
     opcode_values.CALL: call.CallEIP150.configure(
-        name='opcode:CALL',
+        __name__='opcode:CALL',
         mnemonic=mnemonics.CALL,
         gas_cost=constants.GAS_CALL_EIP150,
     )(),
     opcode_values.CALLCODE: call.CallCodeEIP150.configure(
-        name='opcode:CALLCODE',
+        __name__='opcode:CALLCODE',
         mnemonic=mnemonics.CALLCODE,
         gas_cost=constants.GAS_CALL_EIP150,
     )(),
     opcode_values.DELEGATECALL: call.DelegateCallEIP150.configure(
-        name='opcode:DELEGATECALL',
+        __name__='opcode:DELEGATECALL',
         mnemonic=mnemonics.DELEGATECALL,
         gas_cost=constants.GAS_CALL_EIP150,
     )(),

--- a/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
+++ b/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
@@ -24,7 +24,7 @@ from evm.vm.forks.homestead import HomesteadVM
 
 def test_get_vm_class_for_block_number():
     chain_class = Chain.configure(
-        name='TestChain',
+        __name__='TestChain',
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
             (HOMESTEAD_MAINNET_BLOCK, HomesteadVM),

--- a/tests/core/datatype-utils/test_configurable_class.py
+++ b/tests/core/datatype-utils/test_configurable_class.py
@@ -1,0 +1,119 @@
+import pytest
+
+from evm.utils.datatypes import (
+    Configurable,
+)
+
+
+class Inner(Configurable):
+    attr_a = 'original-a'
+    attr_b = 'original-b'
+
+
+class NonConfigurable:
+    attr_x = 'original-x'
+
+
+class Outer(Configurable):
+    attr_c = 'original-c'
+    attr_d = 'original-d'
+
+    attr_e = Inner
+    attr_f = None
+    attr_g = None
+    attr_h = NonConfigurable
+    attr_j = Inner()
+    attr_k = None
+
+
+def test_single_layer_configuration():
+    result = Inner.configure(
+        attr_a='configured-a',
+    )
+    assert result.attr_a == 'configured-a'
+    assert result.attr_b == 'original-b'
+
+
+def test_positional_name_configuration():
+    result = Inner.configure(
+        'ConfiguredInner',
+        attr_a='configured-a',
+    )
+    assert result.__name__ == 'ConfiguredInner'
+    assert result.attr_a == 'configured-a'
+
+
+def test_keyword_name_configuration():
+    result = Inner.configure(
+        __name__='ConfiguredInner',
+        attr_a='configured-a',
+    )
+    assert result.__name__ == 'ConfiguredInner'
+    assert result.attr_a == 'configured-a'
+
+
+def test_sub_name_configuration():
+    result = Outer.configure(**{
+        'attr_e.__name__': 'ConfiguredInner',
+        'attr_e.attr_a': 'configured-a',
+    })
+    assert result.attr_e.__name__ == 'ConfiguredInner'
+    assert result.attr_e.attr_a == 'configured-a'
+
+
+def test_sub_property_configuration():
+    result = Outer.configure(
+        'ConfiguredOuter',
+        attr_c='configured-c',
+        **{
+            'attr_e.attr_a': 'configured-a',
+            'attr_f': Inner,
+            'attr_f.attr_b': 'configured-b',
+            'attr_g': Inner,
+            'attr_k': NonConfigurable,
+        }
+    )
+
+    assert result.attr_c == 'configured-c'
+    assert result.attr_d == 'original-d'
+
+    assert result.attr_e is not Inner
+    assert issubclass(result.attr_e, Inner)
+    assert result.attr_e.attr_a == 'configured-a'
+    assert result.attr_e.attr_b == 'original-b'
+
+    assert result.attr_f is not Inner
+    assert issubclass(result.attr_f, Inner)
+    assert result.attr_f.attr_a == 'original-a'
+    assert result.attr_f.attr_b == 'configured-b'
+
+    assert result.attr_g is Inner
+
+    assert result.attr_k is NonConfigurable
+
+
+@pytest.mark.parametrize(
+    'key',
+    (
+        'top_level',
+        'top_level.nested_level',
+    )
+)
+def test_error_if_attr_not_present_at_top_level(key):
+    with pytest.raises(TypeError):
+        Inner.configure(**{key: 'value'})
+
+
+def test_error_if_attr_not_present_in_sub_obj():
+    with pytest.raises(TypeError):
+        Outer.configure(**{'attr_e.not_present': 'value'})
+
+
+def test_error_trying_to_configure_non_configurable_class():
+    with pytest.raises(TypeError):
+        Outer.configure(**{'attr_h.attr_x': 'value'})
+
+
+def test_error_trying_to_configure_instance_variable():
+    with pytest.raises(TypeError):
+        Outer.configure(**{'attr_j.attr_a': 'value'})

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -106,7 +106,7 @@ def chain(chaindb, funded_address, funded_address_initial_balance):  # noqa: F81
         }
     }
     klass = Chain.configure(
-        name='TestChain',
+        __name__='TestChain',
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
         ))
@@ -272,7 +272,7 @@ def chain_without_block_validation(
         'validate_block': lambda self, block: None,
     }
     klass = Chain.configure(
-        name='TestChainWithoutBlockValidation',
+        __name__='TestChainWithoutBlockValidation',
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
         ),

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -197,7 +197,7 @@ def shard_chain(shard_chaindb, funded_address, funded_address_initial_balance): 
         }
     }
     klass = Shard.configure(
-        name='TestChain',
+        __name__='TestChain',
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, ShardingVM),
         ))
@@ -223,7 +223,7 @@ def shard_chain_without_block_validation(shard_chaindb):  # noqa: F811
         'validate_block': lambda self, block: None,
     }
     klass = Shard.configure(
-        name='TestShardChainWithoutBlockValidation',
+        __name__='TestShardChainWithoutBlockValidation',
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, ShardingVM),
         ),

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -192,23 +192,23 @@ def get_prev_hashes_testing(self, last_block_hash, db):
 
 
 FrontierVMStateForTesting = FrontierVMState.configure(
-    name='FrontierVMStateForTesting',
+    __name__='FrontierVMStateForTesting',
     get_ancestor_hash=get_block_hash_for_testing,
 )
 HomesteadVMStateForTesting = HomesteadVMState.configure(
-    name='HomesteadVMStateForTesting',
+    __name__='HomesteadVMStateForTesting',
     get_ancestor_hash=get_block_hash_for_testing,
 )
 TangerineWhistleVMStateForTesting = TangerineWhistleVMState.configure(
-    name='TangerineWhistleVMStateForTesting',
+    __name__='TangerineWhistleVMStateForTesting',
     get_ancestor_hash=get_block_hash_for_testing,
 )
 SpuriousDragonVMStateForTesting = SpuriousDragonVMState.configure(
-    name='SpuriousDragonVMStateForTesting',
+    __name__='SpuriousDragonVMStateForTesting',
     get_ancestor_hash=get_block_hash_for_testing,
 )
 ByzantiumVMStateForTesting = ByzantiumVMState.configure(
-    name='ByzantiumVMStateForTesting',
+    __name__='ByzantiumVMStateForTesting',
     get_ancestor_hash=get_block_hash_for_testing,
 )
 ShardingVMStateForTesting = ShardingVMState.configure(
@@ -217,27 +217,27 @@ ShardingVMStateForTesting = ShardingVMState.configure(
 )
 
 FrontierVMForTesting = FrontierVM.configure(
-    name='FrontierVMForTesting',
+    __name__='FrontierVMForTesting',
     _state_class=FrontierVMStateForTesting,
     get_prev_hashes=get_prev_hashes_testing,
 )
 HomesteadVMForTesting = HomesteadVM.configure(
-    name='HomesteadVMForTesting',
+    __name__='HomesteadVMForTesting',
     _state_class=HomesteadVMStateForTesting,
     get_prev_hashes=get_prev_hashes_testing,
 )
 TangerineWhistleVMForTesting = TangerineWhistleVM.configure(
-    name='TangerineWhistleVMForTesting',
+    __name__='TangerineWhistleVMForTesting',
     _state_class=TangerineWhistleVMStateForTesting,
     get_prev_hashes=get_prev_hashes_testing,
 )
 SpuriousDragonVMForTesting = SpuriousDragonVM.configure(
-    name='SpuriousDragonVMForTesting',
+    __name__='SpuriousDragonVMForTesting',
     _state_class=SpuriousDragonVMStateForTesting,
     get_prev_hashes=get_prev_hashes_testing,
 )
 ByzantiumVMForTesting = ByzantiumVM.configure(
-    name='ByzantiumVMForTesting',
+    __name__='ByzantiumVMForTesting',
     _state_class=ByzantiumVMStateForTesting,
     get_prev_hashes=get_prev_hashes_testing,
 )

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -212,7 +212,7 @@ ByzantiumVMStateForTesting = ByzantiumVMState.configure(
     get_ancestor_hash=get_block_hash_for_testing,
 )
 ShardingVMStateForTesting = ShardingVMState.configure(
-    name='ShardingVMStateForTesting',
+    __name__='ShardingVMStateForTesting',
     get_ancestor_hash=get_block_hash_for_testing,
 )
 
@@ -242,7 +242,7 @@ ByzantiumVMForTesting = ByzantiumVM.configure(
     get_prev_hashes=get_prev_hashes_testing,
 )
 ShardingVMForTesting = ShardingVM.configure(
-    name='ShardingVMForTesting',
+    __name__='ShardingVMForTesting',
     _state_class=ShardingVMStateForTesting,
     get_prev_hashes=get_prev_hashes_testing,
 )

--- a/tests/json-fixtures/test_virtual_machine.py
+++ b/tests/json-fixtures/test_virtual_machine.py
@@ -106,17 +106,17 @@ def get_block_hash_for_testing(self, block_number):
 
 
 HomesteadComputationForTesting = HomesteadComputation.configure(
-    name='HomesteadComputationForTesting',
+    __name__='HomesteadComputationForTesting',
     apply_message=apply_message_for_testing,
     apply_create_message=apply_create_message_for_testing,
 )
 HomesteadVMStateForTesting = HomesteadVMState.configure(
-    name='HomesteadVMStateForTesting',
+    __name__='HomesteadVMStateForTesting',
     get_ancestor_hash=get_block_hash_for_testing,
     computation_class=HomesteadComputationForTesting,
 )
 HomesteadVMForTesting = HomesteadVM.configure(
-    name='HomesteadVMForTesting',
+    __name__='HomesteadVMForTesting',
     _state_class=HomesteadVMStateForTesting,
 )
 

--- a/tests/p2p/test_lightchain_integration.py
+++ b/tests/p2p/test_lightchain_integration.py
@@ -21,7 +21,7 @@ from integration_test_helpers import FakeAsyncChainDB, LocalGethPeerPool
 
 
 IntegrationTestLightChain = LightChain.configure(
-    name='IntegrationTest LightChain',
+    __name__='IntegrationTest LightChain',
     vm_configuration=MAINNET_VM_CONFIGURATION,
     network_id=ROPSTEN_NETWORK_ID,
     max_consecutive_timeouts=1,

--- a/trinity/chains/ropsten.py
+++ b/trinity/chains/ropsten.py
@@ -5,7 +5,7 @@ from p2p.lightchain import LightChain
 
 
 RopstenLightChain = LightChain.configure(
-    name='RopstenLightChain',
+    __name__='RopstenLightChain',
     vm_configuration=MAINNET_VM_CONFIGURATION,  # TODO: use real ropsten configuration
     network_id=ROPSTEN_NETWORK_ID,
 )


### PR DESCRIPTION
### What was wrong?

Currently, if you wanted to use the `MainnetChain` with a different set of opcodes, you would be required to duplicate a *lot* of code to properly reconfigure all the way down to the correct deeply burried objects to swap out the opcodes.

### How was it fixed?

This pull requests gets us a step closer to being able to do that easily, by allowing configuration of sub-properties.

```python
class Inner(Configurable):
    attr_a = 'value-a'

class Outer(Configurable):
    attr_b = Inner


NewClass = Outer.configure(**{'attr_b.attr_a': 'new-value-a'})
assert NewClaass.attr_b.attr_a == 'new-value-a'
```

This allows us to *reach* into sub-properties that are also of the `Configurable` type and do sub-configuration. 

#### Cute Animal Picture

![flying_cat-630x438](https://user-images.githubusercontent.com/824194/36914266-efd9c29e-1e09-11e8-8fc4-ca61a3d2b8b3.png)
