### PR TITLE
Fix gas estimation when a transaction is in the block

### DIFF
--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -210,8 +210,7 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         temp_block = self.generate_block_from_parent_header_and_coinbase(header, header.coinbase)
         prev_hashes = (header.hash, ) + self.previous_hashes
         state = self.get_state(self.chaindb, temp_block, prev_hashes)
-        if state.gas_used > 0:
-            raise Exception("There must not be any gas used in a fresh temporary block")
+        assert state.gas_used == 0, "There must not be any gas used in a fresh temporary block"
 
         snapshot = state.snapshot()
         yield state

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -456,7 +456,9 @@ class BaseVM(Configurable, metaclass=ABCMeta):
             )
 
         execution_context = block_header.create_execution_context(prev_hashes)
-        receipts = self.block.get_receipts(self.chaindb)
+        block = self.get_block_by_header(block_header, chaindb)
+        receipts = block.get_receipts(chaindb)
+
         return self.get_state_class()(
             chaindb,
             execution_context=execution_context,

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -210,6 +210,9 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         temp_block = self.generate_block_from_parent_header_and_coinbase(header, header.coinbase)
         prev_hashes = (header.hash, ) + self.previous_hashes
         state = self.get_state(block_header=temp_block.header, prev_hashes=prev_hashes)
+        if state.gas_used > 0:
+            raise Exception("There must not be any gas used in a fresh temporary block")
+
         snapshot = state.snapshot()
         yield state
         state.revert(snapshot)

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -78,7 +78,10 @@ def fill_block(chain, from_, key, gas, data):
         tx = new_transaction(vm, from_, recipient, amount, key, gas=gas, data=data)
         try:
             chain.apply_transaction(tx)
-        except ValidationError:
-            break
+        except ValidationError as exc:
+            if "Transaction exceeds gas limit" == str(exc):
+                break
+            else:
+                raise exc
 
     assert chain.get_vm().state.gas_used > 0

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -1,5 +1,8 @@
 from eth_utils import decode_hex
 
+from evm.exceptions import (
+    ValidationError,
+)
 from evm.utils.padding import pad32
 from evm.vm.forks.sharding.transactions import ShardingTransaction
 
@@ -62,3 +65,20 @@ def new_sharding_transaction(
         code=decode_hex(code),
         salt=salt,
     )
+
+
+def fill_block(chain, from_, key, gas, data):
+    recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
+    amount = 100
+
+    assert chain.get_vm().state.gas_used == 0
+
+    while True:
+        vm = chain.get_vm()
+        tx = new_transaction(vm, from_, recipient, amount, key, gas=gas, data=data)
+        try:
+            chain.apply_transaction(tx)
+        except ValidationError:
+            break
+
+    assert chain.get_vm().state.gas_used > 0


### PR DESCRIPTION
~Note, please wait for #397 to get merged, before merging this. It's a big one, and I don't want to be responsible for delaying it. :)~ _397 merged, and conflicts resolved via rebase_

## What was wrong?

`chain.estimate_gas(txn)` fails with a `ValidationError`, if there is a transaction already in the block.

`vm.state_in_temp_block()` is designed to make sure that a fresh block is available for estimating gas. However, the receipts created in `vm.get_state()` were always the receipts of the canonical head, rather than the receipts from the `header` passed to `get_state`. So some transactions were added to the temporary block. (and probably some other bad things were happening... it's a little surprising that no tests got triggered)

### How was it fixed?

- Fixed `vm.get_state()` to create the receipt list based on the supplied `header`.
- Added a test to catch the issue, plus an assertion about the state of a temporary block.
- `make lint` fixup, after the latest `flake8` split into trinity (py36) and everything else (py35)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.pbh2.com/wordpress/wp-content/uploads/2013/04/cutest-baby-animals-gifs-sleepy.gif)
