### PR TITLE
Add type hints for most of evm/utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ venv*
 
 # vscode
 .vscode/**
+
+# monkeytype
+monkeytype.sqlite3

--- a/evm/utils/address.py
+++ b/evm/utils/address.py
@@ -10,17 +10,17 @@ from evm.validation import (
 )
 
 
-def force_bytes_to_address(value):
+def force_bytes_to_address(value: bytes) -> bytes:
     trimmed_value = value[-20:]
     padded_value = trimmed_value.rjust(20, b'\x00')
     return padded_value
 
 
-def generate_contract_address(address, nonce):
+def generate_contract_address(address: bytes, nonce: bytes) -> bytes:
     return keccak(rlp.encode([address, nonce]))[-20:]
 
 
-def generate_CREATE2_contract_address(salt, code):
+def generate_CREATE2_contract_address(salt: bytes, code: bytes) -> bytes:
     """
     If contract is created by transaction, `salt` is specified by `transaction.salt`.
     If contract is created by contract, `salt` is set by the creator contract.

--- a/evm/utils/bn128.py
+++ b/evm/utils/bn128.py
@@ -6,8 +6,10 @@ from evm.exceptions import (
     ValidationError,
 )
 
+from typing import Tuple
 
-def validate_point(x, y):
+
+def validate_point(x: int, y: int) -> Tuple[bn128.FQ, bn128.FQ, bn128.FQ]:
     FQ = bn128.FQ
 
     if x >= bn128.field_modulus:

--- a/evm/utils/chain.py
+++ b/evm/utils/chain.py
@@ -5,8 +5,13 @@ from evm.validation import (
     validate_vm_block_numbers,
 )
 
+from evm.vm import VM
 
-def generate_vms_by_range(vm_configuration):
+from collections import OrderedDict
+from typing import Tuple, Type
+
+
+def generate_vms_by_range(vm_configuration: Tuple[Tuple[int, Type[VM]]]) -> OrderedDict:
     validate_vm_block_numbers(tuple(
         block_number
         for block_number, _

--- a/evm/utils/db.py
+++ b/evm/utils/db.py
@@ -8,42 +8,49 @@ from evm.constants import (
     EMPTY_SHA3,
 )
 
+from evm.rlp.headers import BlockHeader
 
-def make_block_number_to_hash_lookup_key(block_number):
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from evm.db.chain import BaseChainDB  # noqa: F401
+
+
+def make_block_number_to_hash_lookup_key(block_number: int) -> bytes:
     number_to_hash_key = b'block-number-to-hash:%d' % block_number
     return number_to_hash_key
 
 
-def make_block_hash_to_score_lookup_key(block_hash):
+def make_block_hash_to_score_lookup_key(block_hash: bytes) -> bytes:
     return b'block-hash-to-score:%s' % block_hash
 
 
-def make_transaction_hash_to_data_lookup_key(transaction_hash):
+def make_transaction_hash_to_data_lookup_key(transaction_hash: bytes) -> bytes:
     '''
     Look up a transaction that is pending, after being issued locally
     '''
     return b'transaction-hash-to-data:%s' % transaction_hash
 
 
-def make_transaction_hash_to_block_lookup_key(transaction_hash):
+def make_transaction_hash_to_block_lookup_key(transaction_hash: bytes) -> bytes:
     return b'transaction-hash-to-block:%s' % transaction_hash
 
 
-def get_parent_header(block_header, db):
+def get_parent_header(block_header: BlockHeader, db: 'BaseChainDB') -> BlockHeader:
     """
     Returns the header for the parent block.
     """
     return db.get_block_header_by_hash(block_header.parent_hash)
 
 
-def get_block_header_by_hash(block_hash, db):
+def get_block_header_by_hash(block_hash: BlockHeader, db: 'BaseChainDB') -> BlockHeader:
     """
     Returns the header for the parent block.
     """
     return db.get_block_header_by_hash(block_hash)
 
 
-def get_empty_root_hash(db):
+def get_empty_root_hash(db: 'BaseChainDB') -> bytes:
     root_hash = None
     if db.trie_class is HexaryTrie:
         root_hash = BLANK_ROOT_HASH

--- a/evm/utils/env.py
+++ b/evm/utils/env.py
@@ -5,6 +5,7 @@ extracting environment variables.
 
 import os
 
+from typing import Any, Type, Iterable, List, Union, TypeVar
 
 # No set literals because we support Python 2.6.
 TRUE_VALUES = set((
@@ -22,7 +23,7 @@ class empty(object):
     pass
 
 
-def get_env_value(name, required=False, default=empty):
+def get_env_value(name: str, required: bool=False, default: Any=empty) -> str:
     """
     Core function for extracting the environment variable.
 
@@ -45,7 +46,7 @@ def get_env_value(name, required=False, default=empty):
     return value
 
 
-def env_int(name, required=False, default=empty):
+def env_int(name: str, required: bool=False, default: Union[Type[empty], int]=empty) -> int:
     """Pulls an environment variable out of the environment and casts it to an
     integer. If the name is not present in the environment and no default is
     specified then a ``ValueError`` will be raised. Similarly, if the
@@ -73,7 +74,7 @@ def env_int(name, required=False, default=empty):
     return int(value)
 
 
-def env_float(name, required=False, default=empty):
+def env_float(name: str, required: bool=False, default: Union[Type[empty], float]=empty) -> float:
     """Pulls an environment variable out of the environment and casts it to an
     float. If the name is not present in the environment and no default is
     specified then a ``ValueError`` will be raised. Similarly, if the
@@ -101,7 +102,10 @@ def env_float(name, required=False, default=empty):
     return float(value)
 
 
-def env_bool(name, truthy_values=TRUE_VALUES, required=False, default=empty):
+def env_bool(name: str,
+             truthy_values: Iterable[Any]=TRUE_VALUES,
+             required: bool=False,
+             default: Union[Type[empty], bool]=empty) -> bool:
     """Pulls an environment variable out of the environment returning it as a
     boolean. The strings ``'True'`` and ``'true'`` are the default *truthy*
     values. If not present in the environment and no default is specified,
@@ -129,7 +133,7 @@ def env_bool(name, truthy_values=TRUE_VALUES, required=False, default=empty):
     return value in TRUE_VALUES
 
 
-def env_string(name, required=False, default=empty):
+def env_string(name: str, required: bool=False, default: Union[Type[empty], str]=empty) -> str:
     """Pulls an environment variable out of the environment returning it as a
     string. If not present in the environment and no default is specified, an
     empty string is returned.
@@ -152,7 +156,10 @@ def env_string(name, required=False, default=empty):
     return value
 
 
-def env_list(name, separator=',', required=False, default=empty):
+def env_list(name: str,
+             separator: str =',',
+             required: bool=False,
+             default: Union[Type[empty], List]=empty) -> List:
     """Pulls an environment variable out of the environment, splitting it on a
     separator, and returning it as a list. Extra whitespace on the list values
     is stripped. List values that evaluate as falsy are removed. If not present
@@ -180,7 +187,13 @@ def env_list(name, separator=',', required=False, default=empty):
     return list(filter(bool, [v.strip() for v in value.split(separator)]))
 
 
-def get(name, required=False, default=empty, type=None):
+T = TypeVar('T')
+
+
+def get(name: str,
+        required: bool=False,
+        default: Union[Type[empty], T]=empty,
+        type: Type[T]=None) -> Any:
     """Generic getter for environment variables. Handles defaults,
     required-ness, and what type to expect.
 
@@ -215,4 +228,11 @@ def get(name, required=False, default=empty, type=None):
         'list': env_list,
         list: env_list,
     }.get(type, env_string)
-    return fn(name, default=default, required=required)
+
+    # Ideally, using mypy_extensions, we'd be able to type `fn` as something like
+    # Callable[
+    #   [str, DefaultNamedArg(Union[Type[empty], T], 'default'), DefaultNamedArg(bool, 'required')],
+    #   T
+    # ]
+    # That doesn't work though, hence we ignore the next line to make it work for now
+    return fn(name, default=default, required=required)  # type: ignore

--- a/evm/utils/headers.py
+++ b/evm/utils/headers.py
@@ -12,8 +12,10 @@ from evm.rlp.headers import (
     BlockHeader,
 )
 
+from typing import Callable, Tuple, Optional
 
-def compute_gas_limit_bounds(parent):
+
+def compute_gas_limit_bounds(parent: BlockHeader) -> Tuple[int, int]:
     """
     Compute the boundaries for the block gas limit based on the parent block.
     """
@@ -23,7 +25,7 @@ def compute_gas_limit_bounds(parent):
     return lower_bound, upper_bound
 
 
-def compute_gas_limit(parent_header, gas_limit_floor):
+def compute_gas_limit(parent_header: BlockHeader, gas_limit_floor: int) -> int:
     """
     A simple strategy for adjusting the gas limit.
 
@@ -74,11 +76,11 @@ def compute_gas_limit(parent_header, gas_limit_floor):
 
 
 def generate_header_from_parent_header(
-        compute_difficulty_fn,
-        parent_header,
-        coinbase,
-        timestamp=None,
-        extra_data=b''):
+        compute_difficulty_fn: Callable[[BlockHeader, int], int],
+        parent_header: BlockHeader,
+        coinbase: bytes,
+        timestamp: Optional[int] = None,
+        extra_data: bytes = b'') -> BlockHeader:
     """
     Generate BlockHeader from state_root and parent_header
     """

--- a/evm/utils/numeric.py
+++ b/evm/utils/numeric.py
@@ -17,12 +17,12 @@ from evm.utils.padding import (
 )
 
 
-def int_to_big_endian(value):
+def int_to_big_endian(value: int) -> bytes:
     byte_length = math.ceil(value.bit_length() / 8)
     return (value).to_bytes(byte_length, byteorder='big')
 
 
-def big_endian_to_int(value):
+def big_endian_to_int(value: bytes) -> int:
     return int.from_bytes(value, byteorder='big')
 
 
@@ -60,7 +60,7 @@ def int_to_bytes32(value):
 byte_to_int = ord
 
 
-def ceilXX(value, ceiling):
+def ceilXX(value: int, ceiling: int) -> int:
     remainder = value % ceiling
     if remainder == 0:
         return value
@@ -93,11 +93,11 @@ def safe_ord(value):
         return ord(value)
 
 
-def is_even(value):
+def is_even(value: int) -> bool:
     return value % 2 == 0
 
 
-def is_odd(value):
+def is_odd(value: int) -> bool:
     return value % 2 == 1
 
 

--- a/evm/utils/padding.py
+++ b/evm/utils/padding.py
@@ -7,12 +7,12 @@ ZERO_BYTE = b'\x00'
 
 
 @curry
-def zpad_right(value, to_size):
+def zpad_right(value: bytes, to_size: int) -> bytes:
     return value.ljust(to_size, ZERO_BYTE)
 
 
 @curry
-def zpad_left(value, to_size):
+def zpad_left(value: bytes, to_size: int) -> bytes:
     return value.rjust(to_size, ZERO_BYTE)
 
 

--- a/evm/utils/spoof.py
+++ b/evm/utils/spoof.py
@@ -1,9 +1,14 @@
+from evm.rlp.transactions import BaseTransaction
+
+from typing import Callable, Union, Any
+
+
 class SpoofAttributes:
-    def __init__(self, spoof_target, **overrides):
+    def __init__(self, spoof_target: BaseTransaction, **overrides: Any) -> None:
         self.spoof_target = spoof_target
         self.overrides = overrides
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Union[int, Callable, bytes]:
         if attr in self.overrides:
             return self.overrides[attr]
         else:
@@ -11,7 +16,7 @@ class SpoofAttributes:
 
 
 class SpoofTransaction(SpoofAttributes):
-    def __init__(self, transaction, **overrides):
+    def __init__(self, transaction: BaseTransaction, **overrides: Any) -> None:
         if 'get_sender' not in overrides:
             current_sender = transaction.get_sender()
             overrides['get_sender'] = lambda: current_sender

--- a/evm/utils/state_access_restriction.py
+++ b/evm/utils/state_access_restriction.py
@@ -16,6 +16,8 @@ from evm.utils.numeric import (
     int_to_big_endian,
 )
 
+from typing import Dict, Any  # noqa
+
 
 def is_accessible(key, access_prefix_list):
     """Check if a key is specified in an access prefix list."""
@@ -32,7 +34,7 @@ def remove_redundant_prefixes(prefix_list):
     this function will return just `["eth"]` as it's sufficient to match all
     strings that are covered by both `eth` and `ethereum`.
     """
-    root = {}
+    root = {}  # type: Dict[str, Any]
 
     if b'' in prefix_list:
         yield b''

--- a/evm/utils/transactions.py
+++ b/evm/utils/transactions.py
@@ -15,25 +15,28 @@ from evm.utils.numeric import (
 )
 
 
+from evm.rlp.transactions import BaseTransaction
+
+
 EIP155_CHAIN_ID_OFFSET = 35
 V_OFFSET = 27
 
 
-def is_eip_155_signed_transaction(transaction):
+def is_eip_155_signed_transaction(transaction: BaseTransaction) -> bool:
     if transaction.v >= EIP155_CHAIN_ID_OFFSET:
         return True
     else:
         return False
 
 
-def extract_chain_id(v):
+def extract_chain_id(v: int) -> int:
     if is_even(v):
         return (v - EIP155_CHAIN_ID_OFFSET - 1) // 2
     else:
         return (v - EIP155_CHAIN_ID_OFFSET) // 2
 
 
-def extract_signature_v(v):
+def extract_signature_v(v: int) -> int:
     if is_even(v):
         return V_OFFSET + 1
     else:
@@ -63,7 +66,7 @@ def create_transaction_signature(unsigned_txn, private_key, chain_id=None):
     return v, r, s
 
 
-def validate_transaction_signature(transaction):
+def validate_transaction_signature(transaction: BaseTransaction) -> None:
     if is_eip_155_signed_transaction(transaction):
         v = extract_signature_v(transaction.v)
     else:
@@ -82,7 +85,7 @@ def validate_transaction_signature(transaction):
         raise ValidationError("Invalid Signature")
 
 
-def extract_transaction_sender(transaction):
+def extract_transaction_sender(transaction: BaseTransaction) -> bytes:
     if is_eip_155_signed_transaction(transaction):
         if is_even(transaction.v):
             v = 28

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -213,10 +213,10 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         return token
 
     def send_find_node(self, node: kademlia.Node, target_node_id: int) -> None:
-        target_node_id = int_to_big_endian(
+        node_id = int_to_big_endian(
             target_node_id).rjust(kademlia.k_pubkey_size // 8, b'\0')
         self.logger.debug('>>> find_node to %s', node)
-        message = _pack(CMD_FIND_NODE.id, [target_node_id], self.privkey)
+        message = _pack(CMD_FIND_NODE.id, [node_id], self.privkey)
         self.send(node, message)
 
     def send_pong(self, node: kademlia.Node, token: AnyStr) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -74,4 +74,5 @@ setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
 # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
 commands=
     mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p p2p
+    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p evm.utils
     mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p trinity


### PR DESCRIPTION
### What was wrong

`evm/utils` lacks type hints (see #132)

### How was it fixed

This PR adds most of the needed type hints for `evm/utils`. I left out some parts that I I want to follow up later. Also some type hints that were set to `Any` can probably be tighten up if one gives it more thought. I believe this will be an iterative process until we have 100 % coverage.

 #### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1437622368342-7a3d73a34c8f?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=a6c7403def67925a904f16b7ee87695b&auto=format&fit=crop&w=1920&q=80)


