### PR TITLE
Implement abc.abstractmethod pattern

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -1,4 +1,10 @@
 from __future__ import absolute_import
+
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 import logging
 
 from cytoolz import (
@@ -50,7 +56,7 @@ from evm.utils.rlp import (
 )
 
 
-class BaseChain(Configurable):
+class BaseChain(Configurable, metaclass=ABCMeta):
     """
     The base class for all Chain objects
     """
@@ -58,6 +64,7 @@ class BaseChain(Configurable):
     # Chain Initialization API
     #
     @classmethod
+    @abstractmethod
     def from_genesis(cls,
                      chaindb,
                      genesis_params,
@@ -68,6 +75,7 @@ class BaseChain(Configurable):
         raise NotImplementedError("Chain classes must implement this method")
 
     @classmethod
+    @abstractmethod
     def from_genesis_header(cls, chaindb, genesis_header):
         """
         Initializes the chain from the genesis header.
@@ -77,6 +85,7 @@ class BaseChain(Configurable):
     #
     # Header API
     #
+    @abstractmethod
     def get_canonical_head(self):
         """
         Returns the block header at the canonical chain head.
@@ -85,6 +94,7 @@ class BaseChain(Configurable):
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def get_block_header_by_hash(self, block_hash):
         """
         Returns the requested block header as specified by block hash.
@@ -93,6 +103,7 @@ class BaseChain(Configurable):
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def create_header_from_parent(self, parent_header, **header_params):
         """
         Creates a new header descending from the given `parent_header`,
@@ -103,6 +114,7 @@ class BaseChain(Configurable):
     #
     # Block API
     #
+    @abstractmethod
     def get_block(self):
         """
         Returns the block at the tip of the chain.
@@ -140,6 +152,7 @@ class BaseChain(Configurable):
     #
     # Transaction API
     #
+    @abstractmethod
     def get_canonical_transaction(self, transaction_hash):
         """
         Return the transaction for the given hash.  Raises
@@ -148,24 +161,28 @@ class BaseChain(Configurable):
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def add_pending_transaction(self, transaction):
         """
         Adds a transaction to the set of pending transactions.
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def get_pending_transaction(self, transaction_hash):
         """
         Retrieves a transaction from the set of pending transactions.
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def create_transaction(self, *args, **kwargs):
         """
         Creates a transaction object.
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def create_unsigned_transaction(self, *args, **kwargs):
         """
         Creates an unsigned transaction object.
@@ -175,12 +192,14 @@ class BaseChain(Configurable):
     #
     # VM API
     #
+    @abstractmethod
     def get_vm_class_for_block_number(self, block_number):
         """
         Returns the VM class for the given block number.
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def get_vm(self, header=None):
         """
         Returns the VM instance for the given block number.
@@ -190,12 +209,14 @@ class BaseChain(Configurable):
     #
     # Execution API
     #
+    @abstractmethod
     def apply_transaction(self, transaction):
         """
         Applies the transaction to the current head block of the Chain.
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def estimate_gas(self, transaction, at_header=None):
         """
         Generate a gas estimation for the given transaction using the
@@ -203,12 +224,14 @@ class BaseChain(Configurable):
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def import_block(self, block, perform_validation=True):
         """
         Imports a complete block.
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def mine_block(self, *args, **kwargs):
         """
         Mines the current block. Proxies to the current Virtual Machine.
@@ -216,6 +239,7 @@ class BaseChain(Configurable):
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def get_chain_at_block_parent(self, block):
         """
         Returns a `Chain` instance with the given block's parent at the chain head.
@@ -225,6 +249,7 @@ class BaseChain(Configurable):
     #
     # Validation API
     #
+    @abstractmethod
     def validate_block(self, block):
         """
         Performs validation on a block that is either being mined or imported.
@@ -237,18 +262,21 @@ class BaseChain(Configurable):
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def validate_uncles(self, block):
         """
         Run validation on the block uncles.
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def validate_seal(self, header):
         """
         Validate the seal on the given header.
         """
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
     def validate_gaslimit(self, header):
         """
         Validate the gas limit on the given header.

--- a/evm/computation.py
+++ b/evm/computation.py
@@ -2,6 +2,11 @@ import itertools
 import logging
 from contextlib import contextmanager
 
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 from evm.constants import (
     GAS_MEMORY,
     GAS_MEMORY_QUADRATIC_DENOMINATOR,
@@ -53,7 +58,7 @@ def memory_gas_cost(size_in_bytes):
     return total_cost
 
 
-class BaseComputation(Configurable):
+class BaseComputation(Configurable, metaclass=ABCMeta):
     """
     The execution computation
     """
@@ -373,12 +378,14 @@ class BaseComputation(Configurable):
     #
     # State Transition
     #
+    @abstractmethod
     def apply_message(self):
         """
         Execution of an VM message.
         """
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def apply_create_message(self):
         """
         Execution of an VM message to create a new contract.

--- a/evm/db/backends/base.py
+++ b/evm/db/backends/base.py
@@ -1,19 +1,30 @@
-class BaseDB:
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
+
+class BaseDB(metaclass=ABCMeta):
+
+    @abstractmethod
     def get(self, key):
         raise NotImplementedError(
             "The `get` method must be implemented by subclasses of BaseDB"
         )
 
+    @abstractmethod
     def set(self, key, value):
         raise NotImplementedError(
             "The `set` method must be implemented by subclasses of BaseDB"
         )
 
+    @abstractmethod
     def exists(self, key):
         raise NotImplementedError(
             "The `exists` method must be implemented by subclasses of BaseDB"
         )
 
+    @abstractmethod
     def delete(self, key):
         raise NotImplementedError(
             "The `delete` method must be implemented by subclasses of BaseDB"

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -1,5 +1,11 @@
 import itertools
 
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
+
 import rlp
 
 from trie import (
@@ -63,7 +69,7 @@ class TransactionKey(rlp.Serializable):
     ]
 
 
-class BaseChainDB:
+class BaseChainDB(metaclass=ABCMeta):
     trie_class = None
     empty_root_hash = None
 
@@ -93,12 +99,14 @@ class BaseChainDB:
     #
     # Canonical chain API
     #
+    @abstractmethod
     def get_canonical_head(self):
         """
         Returns the current block header at the head of the chain.
         """
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def get_canonical_block_header_by_number(self, block_number):
         """
         Returns the block header with the given number in the canonical chain.
@@ -111,6 +119,7 @@ class BaseChainDB:
     #
     # Block Header API
     #
+    @abstractmethod
     def get_block_header_by_hash(self, block_hash):
         """
         Returns the requested block header as specified by block hash.
@@ -119,12 +128,14 @@ class BaseChainDB:
         """
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def header_exists(self, block_hash):
         """
         Returns True if the header with the given block hash is in our DB.
         """
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def persist_header(self, header):
         """
         :returns: iterable of headers newly on the canonical chain
@@ -133,18 +144,22 @@ class BaseChainDB:
 
     #
     # Block API
+    @abstractmethod
     def lookup_block_hash(self, block_number):
         """
         Return the block hash for the given block number.
         """
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def get_block_uncles(self, uncles_hash):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def get_score(self, block_hash):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def persist_block(self, block):
         """
         Chain must do follow-up work to persist transactions to db
@@ -154,39 +169,50 @@ class BaseChainDB:
     #
     # Transaction and Receipt API
     #
+    @abstractmethod
     def get_receipts(self, header, receipt_class):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def get_block_transaction_hashes(self, block_header):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def get_block_transactions(self, block_header, transaction_class):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def get_transaction_by_index(self, block_number, transaction_index, transaction_class):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def get_pending_transaction(self, transaction_hash, transaction_class):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def get_transaction_index(self, transaction_hash):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def add_pending_transaction(self, transaction):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def add_transaction(self, block_header, index_key, transaction):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def add_receipt(self, block_header, index_key, receipt):
         raise NotImplementedError("ChainDB classes must implement this method")
 
     #
     # Raw Database API
     #
+    @abstractmethod
     def exists(self, key):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def persist_trie_data_dict(self, trie_data_dict):
         """
         Store raw trie data to db from a dict
@@ -196,21 +222,26 @@ class BaseChainDB:
     #
     # Snapshot and revert API
     #
+    @abstractmethod
     def snapshot(self):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def revert(self, checkpoint):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def commit(self, checkpoint):
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
     def clear(self):
         raise NotImplementedError("ChainDB classes must implement this method")
 
     #
     # State Database API
     #
+    @abstractmethod
     def get_state_db(self, state_root, read_only, access_list=None):
         raise NotImplementedError("ChainDB classes must implement this method")
 

--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -1,3 +1,8 @@
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 import rlp
 
 from trie import (
@@ -50,37 +55,46 @@ from evm.utils.state_access_restriction import (
 from .hash_trie import HashTrie
 
 
-class BaseAccountStateDB:
+class BaseAccountStateDB(metaclass=ABCMeta):
 
+    @abstractmethod
     def apply_state_dict(self, state_dict):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def decommission(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
-    @property
+    # We need to ignore this until https://github.com/python/mypy/issues/4165 is resolved
+    @property  # type: ignore
+    @abstractmethod
     def root_hash(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
-    @root_hash.setter
+    @root_hash.setter  # type: ignore
+    @abstractmethod
     def root_hash(self, value):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
     # Storage
     #
+    @abstractmethod
     def get_storage(self, address, slot):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def set_storage(self, address, slot, value):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
     # Balance
     #
+    @abstractmethod
     def get_balance(self, address):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def set_balance(self, address, balance):
         raise NotImplementedError("Must be implemented by subclasses")
 
@@ -90,21 +104,26 @@ class BaseAccountStateDB:
     #
     # Code
     #
+    @abstractmethod
     def set_code(self, address, code):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def get_code(self, address):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def get_code_hash(self, address):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def delete_code(self, address):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
     # Account Methods
     #
+    @abstractmethod
     def account_is_empty(self, address):
         raise NotImplementedError("Must be implemented by subclass")
 

--- a/evm/logic/call.py
+++ b/evm/logic/call.py
@@ -1,3 +1,8 @@
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 from evm import constants
 
 from evm.exceptions import (
@@ -13,10 +18,12 @@ from evm.utils.address import (
 )
 
 
-class BaseCall(Opcode):
+class BaseCall(Opcode, metaclass=ABCMeta):
+    @abstractmethod
     def compute_msg_extra_gas(self, computation, gas, to, value):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def get_call_params(self, computation):
         raise NotImplementedError("Must be implemented by subclasses")
 

--- a/evm/opcode.py
+++ b/evm/opcode.py
@@ -1,10 +1,15 @@
 import functools
 import logging
 
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 from evm.utils.datatypes import Configurable
 
 
-class Opcode(Configurable):
+class Opcode(Configurable, metaclass=ABCMeta):
     mnemonic = None
     gas_cost = None
 
@@ -14,6 +19,7 @@ class Opcode(Configurable):
         if self.gas_cost is None:
             raise TypeError("Opcode class {0} missing opcode gas_cost".format(type(self)))
 
+    @abstractmethod
     def __call__(self, computation):
         """
         Hook for performing the actual VM execution.

--- a/evm/rlp/blocks.py
+++ b/evm/rlp/blocks.py
@@ -1,3 +1,8 @@
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 import rlp
 
 from evm.utils.datatypes import (
@@ -5,7 +10,7 @@ from evm.utils.datatypes import (
 )
 
 
-class BaseBlock(rlp.Serializable, Configurable):
+class BaseBlock(rlp.Serializable, Configurable, metaclass=ABCMeta):
 
     # TODO: Remove this once https://github.com/ethereum/pyrlp/issues/45 is
     # fixed.
@@ -22,6 +27,7 @@ class BaseBlock(rlp.Serializable, Configurable):
         return cls.transaction_class
 
     @classmethod
+    @abstractmethod
     def from_header(cls, header, chaindb):
         """
         Returns the block denoted by the given block header.
@@ -29,10 +35,12 @@ class BaseBlock(rlp.Serializable, Configurable):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @property
+    @abstractmethod
     def hash(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @property
+    @abstractmethod
     def number(self):
         raise NotImplementedError("Must be implemented by subclasses")
 

--- a/evm/rlp/collations.py
+++ b/evm/rlp/collations.py
@@ -1,3 +1,8 @@
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 import rlp
 
 from evm.utils.datatypes import (
@@ -5,7 +10,7 @@ from evm.utils.datatypes import (
 )
 
 
-class BaseCollation(rlp.Serializable, Configurable):
+class BaseCollation(rlp.Serializable, Configurable, metaclass=ABCMeta):
 
     # TODO: Remove this once https://github.com/ethereum/pyrlp/issues/45 is
     # fixed.
@@ -22,6 +27,7 @@ class BaseCollation(rlp.Serializable, Configurable):
         return cls.transaction_class
 
     @classmethod
+    @abstractmethod
     def from_header(cls, header, chaindb):
         """
         Returns the collation denoted by the given collation header.
@@ -29,18 +35,22 @@ class BaseCollation(rlp.Serializable, Configurable):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @property
+    @abstractmethod
     def hash(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @property
+    @abstractmethod
     def shard_id(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @property
+    @abstractmethod
     def expected_period_number(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @property
+    @abstractmethod
     def number(self):
         raise NotImplementedError("Must be implemented by subclasses")
 

--- a/evm/rlp/transactions.py
+++ b/evm/rlp/transactions.py
@@ -1,3 +1,8 @@
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 import rlp
 from rlp.sedes import (
     big_endian_int,
@@ -22,7 +27,7 @@ from evm.utils.state_access_restriction import (
 )
 
 
-class BaseTransaction(rlp.Serializable):
+class BaseTransaction(rlp.Serializable, metaclass=ABCMeta):
     fields = [
         ('nonce', big_endian_int),
         ('gas_price', big_endian_int),
@@ -85,6 +90,7 @@ class BaseTransaction(rlp.Serializable):
         else:
             return True
 
+    @abstractmethod
     def check_signature_validity(self):
         """
         Checks signature validity, raising a ValidationError if the signature
@@ -92,6 +98,7 @@ class BaseTransaction(rlp.Serializable):
         """
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def get_sender(self):
         """
         Get the 20-byte address which sent this transaction.
@@ -101,6 +108,7 @@ class BaseTransaction(rlp.Serializable):
     #
     # Get gas costs
     #
+    @abstractmethod
     def get_intrinsic_gas(self):
         """
         Compute the baseline gas cost for this transaction.  This is the amount
@@ -120,6 +128,7 @@ class BaseTransaction(rlp.Serializable):
     #
     # Conversion to and creation of unsigned transactions.
     #
+    @abstractmethod
     def get_message_for_signing(self):
         """
         Return the bytestring that should be signed in order to create a signed transactions
@@ -127,6 +136,7 @@ class BaseTransaction(rlp.Serializable):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @classmethod
+    @abstractmethod
     def create_unsigned_transaction(self, *args, **kwargs):
         """
         Create an unsigned transaction.
@@ -134,7 +144,7 @@ class BaseTransaction(rlp.Serializable):
         raise NotImplementedError("Must be implemented by subclasses")
 
 
-class BaseUnsignedTransaction(rlp.Serializable):
+class BaseUnsignedTransaction(rlp.Serializable, metaclass=ABCMeta):
     fields = [
         ('nonce', big_endian_int),
         ('gas_price', big_endian_int),
@@ -154,6 +164,7 @@ class BaseUnsignedTransaction(rlp.Serializable):
         """
         pass
 
+    @abstractmethod
     def as_signed_transaction(self, private_key):
         """
         Return a version of this transaction which has been signed using the
@@ -208,6 +219,7 @@ class BaseShardingTransaction(rlp.Serializable):
     #
     # Base gas costs
     #
+    @abstractmethod
     def get_intrinsic_gas(self):
         """
         Compute the baseline gas cost for this transaction.  This is the amount

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -1,4 +1,8 @@
 from __future__ import absolute_import
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
 
 import contextlib
 import logging
@@ -40,7 +44,7 @@ from evm.vm.message import (
 )
 
 
-class BaseVM(Configurable):
+class BaseVM(Configurable, metaclass=ABCMeta):
     """
     The VM class represents the Chain rules for a specific protocol definition
     such as the Frontier or Homestead network.  Define a Chain which specifies
@@ -389,6 +393,7 @@ class BaseVM(Configurable):
     # Headers
     #
     @classmethod
+    @abstractmethod
     def create_header_from_parent(cls, parent_header, **header_params):
         """
         Creates and initializes a new block header from the provided
@@ -396,6 +401,7 @@ class BaseVM(Configurable):
         """
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def configure_header(self, **header_params):
         """
         Setup the current header with the provided parameters.  This can be
@@ -405,6 +411,7 @@ class BaseVM(Configurable):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @classmethod
+    @abstractmethod
     def compute_difficulty(cls, parent_header, timestamp):
         raise NotImplementedError("Must be implemented by subclasses")
 

--- a/evm/vm_state.py
+++ b/evm/vm_state.py
@@ -1,6 +1,11 @@
 from contextlib import contextmanager
 import logging
 
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 from cytoolz import (
     merge,
 )
@@ -19,7 +24,7 @@ from evm.utils.datatypes import (
 )
 
 
-class BaseVMState(Configurable):
+class BaseVMState(Configurable, metaclass=ABCMeta):
     #
     # Set from __init__
     #
@@ -297,12 +302,14 @@ class BaseVMState(Configurable):
     def add_receipt(self, receipt):
         self.receipts.append(receipt)
 
+    @abstractmethod
     def execute_transaction(self, transaction):
         """
         Execute the transaction in the vm.
         """
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     def make_receipt(self, transaction, computation):
         """
         Make receipt.
@@ -340,13 +347,16 @@ class BaseVMState(Configurable):
         return block
 
     @staticmethod
+    @abstractmethod
     def get_block_reward():
         raise NotImplementedError("Must be implemented by subclasses")
 
     @staticmethod
+    @abstractmethod
     def get_uncle_reward(block_number, uncle):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @classmethod
+    @abstractmethod
     def get_nephew_reward(cls):
         raise NotImplementedError("Must be implemented by subclasses")

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -5,6 +5,11 @@ import random
 import struct
 import time
 import traceback
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
+
 from typing import (Any, cast, Callable, Dict, Generator, List, Optional, Tuple, Type)  # noqa: F401
 
 import rlp
@@ -116,7 +121,7 @@ async def handshake(remote: Node,
     return peer
 
 
-class BasePeer:
+class BasePeer(metaclass=ABCMeta):
     logger = logging.getLogger("p2p.peer.Peer")
     conn_idle_timeout = CONN_IDLE_TIMEOUT
     reply_timeout = REPLY_TIMEOUT
@@ -161,12 +166,14 @@ class BasePeer:
         mac_cipher = Cipher(algorithms.AES(mac_secret), modes.ECB(), default_backend())
         self.mac_enc = mac_cipher.encryptor().update
 
+    @abstractmethod
     async def send_sub_proto_handshake(self):
-        raise NotImplementedError()
+        raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
     async def process_sub_proto_handshake(
             self, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
-        raise NotImplementedError()
+        raise NotImplementedError("Must be implemented by subclasses")
 
     async def do_sub_proto_handshake(self):
         """Perform the handshake for the sub-protocol agreed with the remote peer.
@@ -617,10 +624,11 @@ class ETHPeer(BasePeer):
         self.head_hash = msg['best_hash']
 
 
-class PeerPoolSubscriber:
+class PeerPoolSubscriber(metaclass=ABCMeta):
 
+    @abstractmethod
     def register_peer(self, peer: BasePeer) -> None:
-        raise NotImplementedError()
+        raise NotImplementedError("Must be implemented by subclasses")
 
 
 class PeerPool:

--- a/tests/core/vm/test_base_computation.py
+++ b/tests/core/vm/test_base_computation.py
@@ -28,6 +28,14 @@ CANONICAL_ADDRESS_A = to_canonical_address("0x0f572e5295c57f15886f9b263e2f6d2d6c
 CANONICAL_ADDRESS_B = to_canonical_address("0xcd1722f3947def4cf144679da39c4c32bdc35681")
 
 
+class DummyComputation(BaseComputation):
+    def apply_message(self):
+        pass
+
+    def apply_create_message(self):
+        pass
+
+
 @pytest.fixture
 def transaction_context():
     tx_context = BaseTransactionContext(
@@ -52,7 +60,7 @@ def message():
 
 @pytest.fixture
 def computation(message, transaction_context):
-    computation = BaseComputation(
+    computation = DummyComputation(
         vm_state=None,
         message=message,
         transaction_context=transaction_context,
@@ -83,7 +91,7 @@ def test_is_origin_computation(computation, transaction_context):
         code=b'',
         gas=100,
     )
-    computation2 = BaseComputation(
+    computation2 = DummyComputation(
         vm_state=None,
         message=message2,
         transaction_context=transaction_context,

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -19,6 +19,14 @@ from p2p.auth import (
 from p2p.peer import BasePeer
 
 
+class DummyPeer(BasePeer):
+    def process_sub_proto_handshake(self):
+        pass
+
+    def send_sub_proto_handshake(self):
+        pass
+
+
 @pytest.mark.asyncio
 async def test_handshake():
     # This data comes from https://gist.github.com/fjl/3a78780d17c755d22df2
@@ -125,13 +133,13 @@ async def test_handshake():
         (object,),
         {"write": responder_reader.feed_data}
     )
-    initiator_peer = BasePeer(
+    initiator_peer = DummyPeer(
         remote=initiator.remote, privkey=initiator.privkey, reader=initiator_reader,
         writer=initiator_writer, aes_secret=initiator_aes_secret, mac_secret=initiator_mac_secret,
         egress_mac=initiator_egress_mac, ingress_mac=initiator_ingress_mac, chaindb=None,
         network_id=1)
     initiator_peer.base_protocol.send_handshake()
-    responder_peer = BasePeer(
+    responder_peer = DummyPeer(
         remote=responder.remote, privkey=responder.privkey, reader=responder_reader,
         writer=responder_writer, aes_secret=aes_secret, mac_secret=mac_secret,
         egress_mac=egress_mac, ingress_mac=ingress_mac, chaindb=None, network_id=1)


### PR DESCRIPTION

### What was wrong?

Abstract methods did not use the `abc.abstractmethod` decorator (see #466)

### How was it fixed?

Added decorator

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1504006833117-8886a355efbf?ixlib=rb-0.3.5&s=c71b5a0ea806ecf816128bc2100d5dba&auto=format&fit=crop&w=1350&q=80)
