### PR TITLE
p2p: Revert from eth-hash to pysha3 to fix performance issues

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -7,16 +7,14 @@ import time
 import traceback
 from typing import (Any, cast, Callable, Dict, Generator, List, Optional, Tuple, Type)  # noqa: F401
 
+import sha3
+
 import rlp
 from rlp import sedes
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.constant_time import bytes_eq
-
-from eth_hash.main import (
-    PreImage,
-)
 
 from eth_utils import (
     decode_hex,
@@ -135,8 +133,8 @@ class BasePeer:
                  writer: asyncio.StreamWriter,
                  aes_secret: bytes,
                  mac_secret: bytes,
-                 egress_mac: PreImage,
-                 ingress_mac: PreImage,
+                 egress_mac: sha3.keccak_256,
+                 ingress_mac: sha3.keccak_256,
                  chaindb: AsyncChainDB,
                  network_id: int,
                  ) -> None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,3 @@ pytest-logging>=2015.11.4
 pytest-xdist==1.18.1
 pytest==3.1.2
 tox==2.7.0
-eth-hash[pycryptodome]>=0.1.0a4,<1.0.0

--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,12 @@ setup(
         'trinity': [
             "leveldb>=0.194,<1.0.0",
             "coincurve>=7.0.0,<8.0.0",
-            "eth-hash[pycryptodome]>=0.1.0a4,<1.0.0",
             "web3>=4.0.0b11,<5.0.0",
         ],
         'p2p': [
             "aiohttp>=2.3.1,<3.0.0",
             "async_lru>=0.1.0,<1.0.0",
+            "pysha3>=1.0.0,<2.0.0",
         ],
     },
     setup_requires=['setuptools-markdown'],


### PR DESCRIPTION
See https://github.com/ethereum/eth-hash/issues/10 for more info

This is what was causing fast-sync to slow to a crawl after running for only a few minutes. With this change we should be able to actually complete a full-node sync

This is intended as a temporary solution while we work on a fix for eth-hash