### PR TITLE
Add support for mainnet syncing to Trinity

### DIFF
--- a/tests/trinity/core/chain-management/test_initialize_data_dir.py
+++ b/tests/trinity/core/chain-management/test_initialize_data_dir.py
@@ -13,7 +13,7 @@ from trinity.utils.chains import (
 
 @pytest.fixture
 def chain_config():
-    return ChainConfig('test_chain')
+    return ChainConfig(network_id=1)
 
 
 @pytest.fixture

--- a/tests/trinity/core/chain-management/test_initialize_database.py
+++ b/tests/trinity/core/chain-management/test_initialize_database.py
@@ -16,7 +16,7 @@ from trinity.utils.chains import (
 
 @pytest.fixture
 def chain_config():
-    _chain_config = ChainConfig('ropsten')
+    _chain_config = ChainConfig(network_id=1)
     initialize_data_dir(_chain_config)
     return _chain_config
 

--- a/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
@@ -13,7 +13,7 @@ from trinity.utils.chains import (
 
 @pytest.fixture
 def chain_config():
-    return ChainConfig('test_chain')
+    return ChainConfig(network_id=1)
 
 
 @pytest.fixture
@@ -64,7 +64,7 @@ NODEKEY = decode_hex('0xd18445cc77139cd8e09110e99c9384f0601bd2dfa5b230cda917df7e
 
 
 def test_full_initialized_data_dir_with_custom_nodekey():
-    chain_config = ChainConfig('test_chain', nodekey=NODEKEY)
+    chain_config = ChainConfig(network_id=1, nodekey=NODEKEY)
 
     os.makedirs(chain_config.data_dir, exist_ok=True)
     os.makedirs(chain_config.database_dir, exist_ok=True)

--- a/tests/trinity/core/chain-management/test_is_database_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_database_initialized.py
@@ -16,7 +16,7 @@ from trinity.utils.chains import (
 
 @pytest.fixture
 def chain_config():
-    _chain_config = ChainConfig('test_chain')
+    _chain_config = ChainConfig(network_id=1)
     initialize_data_dir(_chain_config)
     return _chain_config
 

--- a/tests/trinity/core/chains-utils/test_chain_config_object.py
+++ b/tests/trinity/core/chains-utils/test_chain_config_object.py
@@ -7,7 +7,7 @@ from eth_utils import (
 from eth_keys import keys
 
 from trinity.utils.chains import (
-    get_default_data_dir,
+    get_local_data_dir,
     get_database_dir,
     get_nodekey_path,
     ChainConfig,
@@ -18,16 +18,18 @@ from trinity.utils.filesystem import (
 
 
 def test_chain_config_computed_properties():
-    chain_config = ChainConfig('muffin')
+    data_dir = get_local_data_dir('muffin')
+    chain_config = ChainConfig(network_id=1234, data_dir=data_dir)
 
-    assert chain_config.data_dir == get_default_data_dir('muffin')
-    assert chain_config.database_dir == get_database_dir('muffin')
-    assert chain_config.nodekey_path == get_nodekey_path('muffin')
+    assert chain_config.network_id == 1234
+    assert chain_config.data_dir == data_dir
+    assert chain_config.database_dir == get_database_dir(data_dir)
+    assert chain_config.nodekey_path == get_nodekey_path(data_dir)
 
 
 def test_chain_config_explicit_properties():
     chain_config = ChainConfig(
-        'muffin',
+        network_id=1,
         data_dir='./data-dir',
         nodekey_path='./nodekey'
     )
@@ -55,7 +57,7 @@ def nodekey_path(tmpdir, nodekey_bytes):
 
 def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
     chain_config = ChainConfig(
-        'muffin',
+        network_id=1,
         nodekey_path=nodekey_path,
     )
 
@@ -65,7 +67,7 @@ def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
 @pytest.mark.parametrize('as_bytes', (True, False))
 def test_chain_config_explictely_provided_nodekey(nodekey_bytes, as_bytes):
     chain_config = ChainConfig(
-        'muffin',
+        network_id=1,
         nodekey=nodekey_bytes if as_bytes else keys.PrivateKey(nodekey_bytes),
     )
 

--- a/trinity/chains/mainnet.py
+++ b/trinity/chains/mainnet.py
@@ -1,0 +1,15 @@
+from evm.chains.mainnet import (
+    MAINNET_NETWORK_ID,
+    MAINNET_VM_CONFIGURATION,
+)
+
+from p2p.lightchain import LightChain
+
+from typing import Type
+
+
+MainnetLightChain: Type[LightChain] = LightChain.configure(
+    __name__='MainnetLightChain',
+    vm_configuration=MAINNET_VM_CONFIGURATION,
+    network_id=MAINNET_NETWORK_ID,
+)

--- a/trinity/chains/ropsten.py
+++ b/trinity/chains/ropsten.py
@@ -1,12 +1,15 @@
-from evm.chains.mainnet import MAINNET_VM_CONFIGURATION
-from evm.chains.ropsten import ROPSTEN_NETWORK_ID
+from evm.chains.ropsten import (
+    ROPSTEN_NETWORK_ID,
+    ROPSTEN_VM_CONFIGURATION,
+)
 
 from p2p.lightchain import LightChain
 
 from typing import Type
 
+
 RopstenLightChain: Type[LightChain] = LightChain.configure(
     __name__='RopstenLightChain',
-    vm_configuration=MAINNET_VM_CONFIGURATION,  # TODO: use real ropsten configuration
+    vm_configuration=ROPSTEN_VM_CONFIGURATION,
     network_id=ROPSTEN_NETWORK_ID,
 )

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -1,6 +1,17 @@
 import argparse
 
+from evm.chains.mainnet import (
+    MAINNET_NETWORK_ID,
+)
+from evm.chains.ropsten import (
+    ROPSTEN_NETWORK_ID,
+)
+
 from trinity.__version__ import __version__
+from trinity.constants import (
+    SYNC_FULL,
+    SYNC_LIGHT,
+)
 
 
 DEFAULT_LOG_LEVEL = 'info'
@@ -31,15 +42,39 @@ parser.add_argument(
 #
 # Main parser for running trinity as a node.
 #
-parser.add_argument(
+networkid_parser = parser.add_mutually_exclusive_group()
+networkid_parser.add_argument(
+    '--network-id',
+    type=int,
+    help="Network identifier (1=Mainnet, 3=Ropsten)",
+    default=MAINNET_NETWORK_ID,
+)
+networkid_parser.add_argument(
     '--ropsten',
-    action='store_true',
-    help="Ropsten network: pre configured proof-of-work test network",
+    action='store_const',
+    const=ROPSTEN_NETWORK_ID,
+    dest='network_id',
+    help=(
+        "Ropsten network: pre configured proof-of-work test network.  Shortcut "
+        "for `--networkid=3`"
+    ),
 )
-parser.add_argument(
+
+
+syncmode_parser = parser.add_mutually_exclusive_group()
+syncmode_parser.add_argument(
+    '--sync-mode',
+    choices={SYNC_LIGHT, SYNC_FULL},
+    default=SYNC_LIGHT,
+)
+syncmode_parser.add_argument(
     '--light',  # TODO: consider --sync-mode like geth.
-    action='store_true',
+    action='store_const',
+    const=SYNC_LIGHT,
+    dest='sync_mode',
+    help="Shortcut for `--sync-mode=light`",
 )
+
 parser.add_argument(
     '--trinity-root-dir',
     help=(

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -1,3 +1,2 @@
-ROPSTEN = 'ropsten'
-
+SYNC_FULL = 'full'
 SYNC_LIGHT = 'light'

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -7,6 +7,12 @@ import sys
 from typing import Type
 
 from evm.db.backends.level import LevelDB
+from evm.chains.mainnet import (
+    MAINNET_NETWORK_ID,
+)
+from evm.chains.ropsten import (
+    ROPSTEN_NETWORK_ID,
+)
 
 from p2p.peer import (
     LESPeer,
@@ -54,12 +60,15 @@ from trinity.utils.mp import (
 )
 
 
+PRECONFIGURED_NETWORKS = {MAINNET_NETWORK_ID, ROPSTEN_NETWORK_ID}
+
+
 def main() -> None:
     args = parser.parse_args()
 
     logger, log_queue, listener = setup_trinity_logging(args.log_level.upper())
 
-    if args.network_id not in {1, 3}:
+    if args.network_id not in PRECONFIGURED_NETWORKS:
         raise NotImplementedError(
             "Unsupported network id: {0}.  Only the ropsten and mainnet "
             "networks are supported.".format(args.network_id)

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -1,9 +1,5 @@
 import os
 
-from cytoolz import (
-    get_in,
-)
-
 from eth_utils import (
     decode_hex,
     to_dict,
@@ -12,13 +8,13 @@ from eth_utils import (
 from eth_keys import keys
 from eth_keys.datatypes import PrivateKey
 
+from evm.chains.mainnet import (
+    MAINNET_NETWORK_ID,
+)
 from evm.chains.ropsten import (
     ROPSTEN_NETWORK_ID,
 )
 
-from trinity.constants import (
-    ROPSTEN,
-)
 from .xdg import (
     get_xdg_trinity_root,
 )
@@ -26,40 +22,53 @@ from .xdg import (
 from typing import Union
 
 
+DEFAULT_DATA_DIRS = {
+    ROPSTEN_NETWORK_ID: 'ropsten',
+    MAINNET_NETWORK_ID: 'mainnet',
+}
+
+
 #
 # Filesystem path utils
 #
-def get_default_data_dir(chain_identifier: str) -> str:
+def get_local_data_dir(chain_name: str) -> str:
     """
     Returns the base directory path where data for a given chain will be stored.
     """
     return os.environ.get(
         'TRINITY_DATA_DIR',
-        os.path.join(get_xdg_trinity_root(), chain_identifier),
+        os.path.join(get_xdg_trinity_root(), chain_name),
     )
+
+
+def get_data_dir_for_network_id(network_id: int) -> str:
+    """
+    Returns the data directory for the chain associated with the given network
+    id.  If the network id is unknown, raises a KeyError.
+    """
+    try:
+        return get_local_data_dir(DEFAULT_DATA_DIRS[network_id])
+    except KeyError:
+        raise KeyError("Unknown network id: `{0}`".format(network_id))
 
 
 DATABASE_DIR_NAME = 'chain'
 
 
-def get_database_dir(chain_identifier: str, data_dir: str=None) -> str:
+def get_database_dir(data_dir: str) -> str:
     """
     Returns the directory path where chain data will be stored.
     """
-    if data_dir is None:
-        data_dir = get_default_data_dir(chain_identifier)
     return os.path.join(data_dir, DATABASE_DIR_NAME)
 
 
 NODEKEY_FILENAME = 'nodekey'
 
 
-def get_nodekey_path(chain_identifier: str, data_dir: str=None) -> str:
+def get_nodekey_path(data_dir: str) -> str:
     """
     Returns the path to the private key used for devp2p connections.
     """
-    if data_dir is None:
-        data_dir = get_default_data_dir(chain_identifier)
     return os.environ.get(
         'TRINITY_NODEKEY',
         os.path.join(data_dir, NODEKEY_FILENAME),
@@ -69,12 +78,10 @@ def get_nodekey_path(chain_identifier: str, data_dir: str=None) -> str:
 DATABASE_SOCKET_FILENAME = 'db.ipc'
 
 
-def get_database_socket_path(chain_identifier: str, data_dir: str=None) -> str:
+def get_database_socket_path(data_dir: str) -> str:
     """
     Returns the path to the private key used for devp2p connections.
     """
-    if data_dir is None:
-        data_dir = get_default_data_dir(chain_identifier)
     return os.environ.get(
         'TRINITY_DATABASE_IPC',
         os.path.join(data_dir, DATABASE_SOCKET_FILENAME),
@@ -84,12 +91,10 @@ def get_database_socket_path(chain_identifier: str, data_dir: str=None) -> str:
 JSONRPC_SOCKET_FILENAME = 'jsonrpc.ipc'
 
 
-def get_jsonrpc_socket_path(chain_identifier, data_dir=None):
+def get_jsonrpc_socket_path(data_dir: str) -> str:
     """
     Returns the path to the ipc socket for the JSON-RPC server.
     """
-    if data_dir is None:
-        data_dir = get_default_data_dir(chain_identifier)
     return os.environ.get(
         'TRINITY_JSONRPC_IPC',
         os.path.join(data_dir, JSONRPC_SOCKET_FILENAME),
@@ -106,37 +111,28 @@ def load_nodekey(nodekey_path: str) -> PrivateKey:
     return nodekey
 
 
-# TODO: move this somewhere more appropriate
-CHAIN_CONFIG_DEFAULTS = {
-    ROPSTEN: {
-        'network_id': ROPSTEN_NETWORK_ID,
-    }
-}
-
-
 class ChainConfig:
-    chain_identifier = None
-
     _data_dir = None
     _nodekey_path = None
     _nodekey = None
     _network_id = None
 
     def __init__(self,
-                 chain_identifier: str,
+                 network_id: int,
                  data_dir: str=None,
                  nodekey_path: str=None,
-                 nodekey: PrivateKey=None,
-                 network_id: int=None) -> None:
+                 nodekey: PrivateKey=None) -> None:
+        self.network_id = network_id
+
         # validation
         if nodekey is not None and nodekey_path is not None:
             raise ValueError("It is invalid to provide both a `nodekey` and a `nodekey_path`")
 
         # set values
-        self.chain_identifier = chain_identifier
-
         if data_dir is not None:
             self.data_dir = data_dir
+        else:
+            self.data_dir = get_data_dir_for_network_id(self.network_id)
 
         if nodekey_path is not None:
             self.nodekey_path = nodekey_path
@@ -150,10 +146,7 @@ class ChainConfig:
         for a given chain is stored.  All other chain directories are by
         default relative to this directory.
         """
-        if self._data_dir is None:
-            return get_default_data_dir(self.chain_identifier)
-        else:
-            return self._data_dir
+        return self._data_dir
 
     @data_dir.setter
     def data_dir(self, value: str) -> None:
@@ -161,15 +154,15 @@ class ChainConfig:
 
     @property
     def database_dir(self) -> str:
-        return get_database_dir(self.chain_identifier, self.data_dir)
+        return get_database_dir(self.data_dir)
 
     @property
     def database_ipc_path(self) -> str:
-        return get_database_socket_path(self.chain_identifier, self.data_dir)
+        return get_database_socket_path(self.data_dir)
 
     @property
     def jsonrpc_ipc_path(self) -> str:
-        return get_jsonrpc_socket_path(self.chain_identifier, self.data_dir)
+        return get_jsonrpc_socket_path(self.data_dir)
 
     @property
     def nodekey_path(self) -> str:
@@ -177,7 +170,7 @@ class ChainConfig:
             if self._nodekey is not None:
                 return None
             else:
-                return get_nodekey_path(self.chain_identifier, self.data_dir)
+                return get_nodekey_path(self.data_dir)
         else:
             return self._nodekey_path
 
@@ -212,27 +205,10 @@ class ChainConfig:
                 "`PrivateKey` instance"
             )
 
-    @property
-    def network_id(self) -> int:
-        if self._network_id is not None:
-            return self._network_id
-
-        try:
-            return get_in(
-                [self.chain_identifier, 'network_id'],
-                CHAIN_CONFIG_DEFAULTS,
-                no_default=True,
-            )
-        except KeyError:
-            raise ValueError(
-                "The network_id for the chain '{0}' was not explicitely set and "
-                "is not for a known network.  Please specify a network_id"
-            )
-
     @classmethod
-    def from_parser_args(cls, chain_identifier, parser_args):
+    def from_parser_args(cls, parser_args):
         constructor_kwargs = construct_chain_config_params(parser_args)
-        return cls(chain_identifier, **constructor_kwargs)
+        return cls(**constructor_kwargs)
 
 
 @to_dict
@@ -240,6 +216,8 @@ def construct_chain_config_params(args):
     """
     Helper function for constructing the kwargs to initialize a ChainConfig object.
     """
+    yield 'network_id', args.network_id
+
     if args.data_dir is not None:
         yield 'data_dir', args.data_dir
 


### PR DESCRIPTION
### What was wrong?

No support for syncing with the mainnet.

### How was it fixed?

Added ability to sync with mainnet via `trinity` cli.  Also modified some internals to use `network_id` as the primary identifier for choosing what network you want to use.

#### Cute Animal Picture

![1](https://user-images.githubusercontent.com/824194/37489671-fbf4a734-285d-11e8-9005-af4b5137641e.jpg)
