### PR TITLE
memory_read and memory_write

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ linux-docs: build-docs
 	xdg-open docs/_build/html/index.html
 
 release: clean
-	python3 setup.py sdist bdist_wheel upload
+	python setup.py sdist bdist_wheel upload
 
 sdist: clean
-	python3 setup.py sdist bdist_wheel
+	python setup.py sdist bdist_wheel
 	ls -l dist

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ linux-docs: build-docs
 	xdg-open docs/_build/html/index.html
 
 release: clean
-	python setup.py sdist bdist_wheel upload
+	python3 setup.py sdist bdist_wheel upload
 
 sdist: clean
-	python setup.py sdist bdist_wheel
+	python3 setup.py sdist bdist_wheel
 	ls -l dist

--- a/evm/computation.py
+++ b/evm/computation.py
@@ -66,7 +66,7 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
     msg = None
     transaction_context = None
 
-    memory = None
+    _memory = None
     stack = None
     gas_meter = None
 
@@ -92,7 +92,7 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
         self.msg = message
         self.transaction_context = transaction_context
 
-        self.memory = Memory()
+        self._memory = Memory()
         self.stack = Stack()
         self.gas_meter = GasMeter(message.gas)
 
@@ -133,6 +133,10 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
     def should_erase_return_data(self):
         return self.is_error and self._error.erases_return_data
 
+    @property
+    def memory_bytes(self):
+        return self._memory.bytes
+
     #
     # Execution
     #
@@ -163,7 +167,7 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
         validate_uint256(start_position, title="Memory start position")
         validate_uint256(size, title="Memory size")
 
-        before_size = ceil32(len(self.memory))
+        before_size = ceil32(len(self._memory))
         after_size = ceil32(start_position + size)
 
         before_cost = memory_gas_cost(before_size)
@@ -190,7 +194,13 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
                     ))
                 )
 
-            self.memory.extend(start_position, size)
+            self._memory.extend(start_position, size)
+    
+    def memory_write(self, start_position, size, value):
+        return self._memory.write(start_position, size, value)
+
+    def memory_read(self, start_position, size):
+        return self._memory.read(start_position, size)        
 
     #
     # Computed properties.

--- a/evm/computation.py
+++ b/evm/computation.py
@@ -133,10 +133,6 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
     def should_erase_return_data(self):
         return self.is_error and self._error.erases_return_data
 
-    @property
-    def memory_bytes(self):
-        return self._memory.bytes
-
     #
     # Execution
     #

--- a/evm/computation.py
+++ b/evm/computation.py
@@ -191,12 +191,12 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
                 )
 
             self._memory.extend(start_position, size)
-    
+
     def memory_write(self, start_position, size, value):
         return self._memory.write(start_position, size, value)
 
     def memory_read(self, start_position, size):
-        return self._memory.read(start_position, size)        
+        return self._memory.read(start_position, size)
 
     #
     # Computed properties.

--- a/evm/logic/call.py
+++ b/evm/logic/call.py
@@ -56,7 +56,7 @@ class BaseCall(Opcode, metaclass=ABCMeta):
         computation.extend_memory(memory_input_start_position, memory_input_size)
         computation.extend_memory(memory_output_start_position, memory_output_size)
 
-        call_data = computation.memory.read(memory_input_start_position, memory_input_size)
+        call_data = computation.memory_read(memory_input_start_position, memory_input_size)
 
         #
         # Message gas allocation and fees
@@ -121,7 +121,7 @@ class BaseCall(Opcode, metaclass=ABCMeta):
 
             if not child_computation.should_erase_return_data:
                 actual_output_size = min(memory_output_size, len(child_computation.output))
-                computation.memory.write(
+                computation.memory_write(
                     memory_output_start_position,
                     actual_output_size,
                     child_computation.output[:actual_output_size],
@@ -373,7 +373,7 @@ class CallSharding(CallByzantium):
         computation.extend_memory(memory_input_start_position, memory_input_size)
         computation.extend_memory(memory_output_start_position, memory_output_size)
 
-        call_data = computation.memory.read(memory_input_start_position, memory_input_size)
+        call_data = computation.memory_read(memory_input_start_position, memory_input_size)
 
         #
         # Message gas allocation and fees
@@ -438,7 +438,7 @@ class CallSharding(CallByzantium):
 
             if not child_computation.should_erase_return_data:
                 actual_output_size = min(memory_output_size, len(child_computation.output))
-                computation.memory.write(
+                computation.memory_write(
                     memory_output_start_position,
                     actual_output_size,
                     child_computation.output[:actual_output_size],

--- a/evm/logic/context.py
+++ b/evm/logic/context.py
@@ -69,7 +69,7 @@ def calldatacopy(computation):
     value = computation.msg.data[calldata_start_position: calldata_start_position + size]
     padded_value = value.ljust(size, b'\x00')
 
-    computation.memory.write(mem_start_position, size, padded_value)
+    computation.memory_write(mem_start_position, size, padded_value)
 
 
 def codesize(computation):
@@ -99,7 +99,7 @@ def codecopy(computation):
 
     padded_code_bytes = code_bytes.ljust(size, b'\x00')
 
-    computation.memory.write(mem_start_position, size, padded_code_bytes)
+    computation.memory_write(mem_start_position, size, padded_code_bytes)
 
 
 def gasprice(computation):
@@ -142,7 +142,7 @@ def extcodecopy(computation):
     code_bytes = code[code_start_position:code_start_position + size]
     padded_code_bytes = code_bytes.ljust(size, b'\x00')
 
-    computation.memory.write(mem_start_position, size, padded_code_bytes)
+    computation.memory_write(mem_start_position, size, padded_code_bytes)
 
 
 def returndatasize(computation):
@@ -177,7 +177,7 @@ def returndatacopy(computation):
 
     value = computation.return_data[returndata_start_position: returndata_start_position + size]
 
-    computation.memory.write(mem_start_position, size, value)
+    computation.memory_write(mem_start_position, size, value)
 
 
 def sighash(computation):

--- a/evm/logic/logging.py
+++ b/evm/logic/logging.py
@@ -28,7 +28,7 @@ def log_XX(computation, topic_count):
     )
 
     computation.extend_memory(mem_start_position, size)
-    log_data = computation.memory.read(mem_start_position, size)
+    log_data = computation.memory_read(mem_start_position, size)
 
     computation.add_log_entry(
         account=computation.msg.storage_address,

--- a/evm/logic/memory.py
+++ b/evm/logic/memory.py
@@ -10,7 +10,7 @@ def mstore(computation):
 
     computation.extend_memory(start_position, 32)
 
-    computation.memory.write(start_position, 32, normalized_value)
+    computation.memory_write(start_position, 32, normalized_value)
 
 
 def mstore8(computation):
@@ -22,7 +22,7 @@ def mstore8(computation):
 
     computation.extend_memory(start_position, 1)
 
-    computation.memory.write(start_position, 1, normalized_value)
+    computation.memory_write(start_position, 1, normalized_value)
 
 
 def mload(computation):
@@ -30,7 +30,7 @@ def mload(computation):
 
     computation.extend_memory(start_position, 32)
 
-    value = computation.memory.read(start_position, 32)
+    value = computation.memory_read(start_position, 32)
     computation.stack.push(value)
 
 

--- a/evm/logic/memory.py
+++ b/evm/logic/memory.py
@@ -35,4 +35,4 @@ def mload(computation):
 
 
 def msize(computation):
-    computation.stack.push(len(computation.memory))
+    computation.stack.push(len(computation._memory))

--- a/evm/logic/sha3.py
+++ b/evm/logic/sha3.py
@@ -13,7 +13,7 @@ def sha3(computation):
 
     computation.extend_memory(start_position, size)
 
-    sha3_bytes = computation.memory.read(start_position, size)
+    sha3_bytes = computation.memory_read(start_position, size)
     word_count = ceil32(len(sha3_bytes)) // 32
 
     gas_cost = constants.GAS_SHA3WORD * word_count

--- a/evm/logic/system.py
+++ b/evm/logic/system.py
@@ -29,7 +29,7 @@ def return_op(computation):
 
     computation.extend_memory(start_position, size)
 
-    output = computation.memory.read(start_position, size)
+    output = computation.memory_read(start_position, size)
     computation.output = bytes(output)
     raise Halt('RETURN')
 
@@ -39,7 +39,7 @@ def revert(computation):
 
     computation.extend_memory(start_position, size)
 
-    output = computation.memory.read(start_position, size)
+    output = computation.memory_read(start_position, size)
     computation.output = bytes(output)
     raise Revert(computation.output)
 
@@ -122,7 +122,7 @@ class Create(Opcode):
             computation.stack.push(0)
             return
 
-        call_data = computation.memory.read(start_position, size)
+        call_data = computation.memory_read(start_position, size)
 
         create_msg_gas = self.max_child_gas_modifier(
             computation.gas_meter.gas_remaining
@@ -202,7 +202,7 @@ class Create2(CreateEIP150):
             computation.stack.push(0)
             return
 
-        call_data = computation.memory.read(start_position, size)
+        call_data = computation.memory_read(start_position, size)
 
         create_msg_gas = self.max_child_gas_modifier(
             computation.gas_meter.gas_remaining

--- a/tests/core/vm/test_base_computation.py
+++ b/tests/core/vm/test_base_computation.py
@@ -120,15 +120,15 @@ def test_extend_memory_size_must_be_uint256(computation):
 
 
 def test_extend_memory_stays_the_same_if_size_is_0(computation):
-    assert len(computation.memory_bytes) == 0
+    assert len(computation._memory.bytes) == 0
     computation.extend_memory(1, 0)
-    assert len(computation.memory_bytes) == 0
+    assert len(computation._memory.bytes) == 0
 
 
 def test_extend_memory_increases_memory_by_32(computation):
     assert computation.gas_meter.gas_remaining == 100
     computation.extend_memory(0, 1)
-    assert len(computation.memory_bytes) == 32
+    assert len(computation._memory.bytes) == 32
     # 32 bytes of memory cost 3 gas
     assert computation.gas_meter.gas_remaining == 97
 
@@ -136,9 +136,9 @@ def test_extend_memory_increases_memory_by_32(computation):
 def test_extend_memory_doesnt_increase_until_32_bytes_are_used(computation):
     computation.extend_memory(0, 1)
     computation.extend_memory(1, 1)
-    assert len(computation.memory_bytes) == 32
+    assert len(computation._memory.bytes) == 32
     computation.extend_memory(2, 32)
-    assert len(computation.memory_bytes) == 64
+    assert len(computation._memory.bytes) == 64
     assert computation.gas_meter.gas_remaining == 94
 
 

--- a/tests/core/vm/test_base_computation.py
+++ b/tests/core/vm/test_base_computation.py
@@ -120,15 +120,15 @@ def test_extend_memory_size_must_be_uint256(computation):
 
 
 def test_extend_memory_stays_the_same_if_size_is_0(computation):
-    assert len(computation.memory.bytes) == 0
+    assert len(computation.memory_bytes) == 0
     computation.extend_memory(1, 0)
-    assert len(computation.memory.bytes) == 0
+    assert len(computation.memory_bytes) == 0
 
 
 def test_extend_memory_increases_memory_by_32(computation):
     assert computation.gas_meter.gas_remaining == 100
     computation.extend_memory(0, 1)
-    assert len(computation.memory.bytes) == 32
+    assert len(computation.memory_bytes) == 32
     # 32 bytes of memory cost 3 gas
     assert computation.gas_meter.gas_remaining == 97
 
@@ -136,9 +136,9 @@ def test_extend_memory_increases_memory_by_32(computation):
 def test_extend_memory_doesnt_increase_until_32_bytes_are_used(computation):
     computation.extend_memory(0, 1)
     computation.extend_memory(1, 1)
-    assert len(computation.memory.bytes) == 32
+    assert len(computation.memory_bytes) == 32
     computation.extend_memory(2, 32)
-    assert len(computation.memory.bytes) == 64
+    assert len(computation.memory_bytes) == 64
     assert computation.gas_meter.gas_remaining == 94
 
 


### PR DESCRIPTION
#### What is wrong?
Currently, the Computation object houses lots of information and sub-APIs for things like maniputlating the stack, consuming gas, etc. This creates a lot of public API surface area since we are effectively support two public APIs for anything needed from a sub-property of the Computation object.

Computation.memory is the API for getting at the Memory
Computation.memory.read is the API for reading from memory.

#### How can it be fixed
Computation.memory -> Computation._memory
Computation.memory.read() -> Computation.memory_read()
Computation.memory.write() -> Computation.memory_write()

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
