### PR TITLE
p2p: Use a separate Transaction class in Commands

### DIFF
--- a/p2p/eth.py
+++ b/p2p/eth.py
@@ -6,12 +6,12 @@ from rlp import sedes
 
 from evm.rlp.headers import BlockHeader
 from evm.rlp.receipts import Receipt
-from evm.rlp.transactions import BaseTransaction
 
 from p2p.protocol import (
     Command,
     Protocol,
 )
+from p2p.rlp import BlockBody, P2PTransaction
 from p2p.sedes import HashOrNumber
 
 
@@ -41,7 +41,7 @@ class NewBlockHashes(Command):
 
 class Transactions(Command):
     _cmd_id = 2
-    structure = sedes.CountableList(BaseTransaction)
+    structure = sedes.CountableList(P2PTransaction)
 
 
 class GetBlockHeaders(Command):
@@ -64,13 +64,6 @@ class GetBlockBodies(Command):
     structure = sedes.CountableList(sedes.binary)
 
 
-class BlockBody(rlp.Serializable):
-    fields = [
-        ('transactions', sedes.CountableList(BaseTransaction)),
-        ('uncles', sedes.CountableList(BlockHeader))
-    ]
-
-
 class BlockBodies(Command):
     _cmd_id = 6
     structure = sedes.CountableList(BlockBody)
@@ -80,7 +73,7 @@ class NewBlock(Command):
     _cmd_id = 7
     structure = [
         ('block', sedes.List([BlockHeader,
-                              sedes.CountableList(BaseTransaction),
+                              sedes.CountableList(P2PTransaction),
                               sedes.CountableList(BlockHeader)])),
         ('total_difficulty', sedes.big_endian_int)]
 

--- a/p2p/les.py
+++ b/p2p/les.py
@@ -10,13 +10,13 @@ from eth_utils import (
 
 from evm.rlp.headers import BlockHeader
 from evm.rlp.receipts import Receipt
-from evm.rlp.transactions import BaseTransaction
 
 from p2p.protocol import (
     Command,
     Protocol,
     _DecodedMsgType,
 )
+from p2p.rlp import BlockBody
 from p2p.sedes import HashOrNumber
 
 from .constants import LES_ANNOUNCE_SIMPLE
@@ -164,19 +164,12 @@ class GetBlockBodies(Command):
     ]
 
 
-class LESBlockBody(rlp.Serializable):
-    fields = [
-        ('transactions', rlp.sedes.CountableList(BaseTransaction)),
-        ('uncles', rlp.sedes.CountableList(BlockHeader))
-    ]
-
-
 class BlockBodies(Command):
     _cmd_id = 5
     structure = [
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
-        ('bodies', sedes.CountableList(LESBlockBody)),
+        ('bodies', sedes.CountableList(BlockBody)),
     ]
 
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -58,6 +58,7 @@ from p2p.exceptions import (
     UnreachablePeer,
 )
 from p2p.cancel_token import CancelToken, wait_with_token
+from p2p.rlp import BlockBody
 from p2p.utils import (
     gen_request_id,
     get_devp2p_cmd_id,
@@ -530,7 +531,7 @@ class LESPeer(BasePeer):
         return reply['headers'][0]
 
     async def get_block_by_hash(
-            self, block_hash: bytes, cancel_token: CancelToken) -> les.LESBlockBody:
+            self, block_hash: bytes, cancel_token: CancelToken) -> BlockBody:
         request_id = gen_request_id()
         self.sub_proto.send_get_block_bodies([block_hash], request_id)
         reply = await self._wait_for_reply(request_id, cancel_token)

--- a/p2p/rlp.py
+++ b/p2p/rlp.py
@@ -1,0 +1,18 @@
+import rlp
+from rlp import sedes
+
+from evm.rlp.headers import BlockHeader
+from evm.rlp.transactions import BaseTransaction
+
+
+# This is needed because BaseTransaction has several @abstractmethods, which means it can't be
+# instantiated.
+class P2PTransaction(rlp.Serializable):
+    fields = BaseTransaction.fields.copy()
+
+
+class BlockBody(rlp.Serializable):
+    fields = [
+        ('transactions', sedes.CountableList(P2PTransaction)),
+        ('uncles', sedes.CountableList(BlockHeader))
+    ]


### PR DESCRIPTION
Needed because BaseTransaction now uses metaclass=ABCMeta and thus
cannot be instantiated.