### PR TITLE
Add more type hints

### DIFF
--- a/evm/__init__.py
+++ b/evm/__init__.py
@@ -1,11 +1,15 @@
-import logging
 import pkg_resources
 import sys
 
 from evm.utils.logging import (
-    trace,
-    TRACE_LEVEL_NUM,
+    setup_trace_logging
 )
+
+#
+#  Setup TRACE level logging.
+#
+# This needs to be done before the other imports
+setup_trace_logging()
 
 from evm.vm import (  # noqa: F401
     VM,
@@ -16,15 +20,6 @@ from evm.chains import (  # noqa: F401
     MainnetTesterChain,
     RopstenChain,
 )
-
-#
-#  Setup TRACE level logging.
-#
-logging.addLevelName(TRACE_LEVEL_NUM, 'TRACE')
-# Need to ignore the following two lines since dynamically adding properties isn't allowed by mypy
-logging.TRACE = TRACE_LEVEL_NUM  # type: ignore
-logging.Logger.trace = trace  # type: ignore
-
 
 #
 #  Ensure we can reach 1024 frames of recursion

--- a/evm/utils/logging.py
+++ b/evm/utils/logging.py
@@ -1,6 +1,19 @@
+import logging
+from logging import Logger
+from typing import Any
+
 TRACE_LEVEL_NUM = 5
 
 
-def trace(self, message, *args, **kwargs):
-    if self.isEnabledFor(TRACE_LEVEL_NUM):
-        self._log(TRACE_LEVEL_NUM, message, args, **kwargs)
+class TraceLogger(Logger):
+
+    def init(self, name: str, level: int) -> None:
+        Logger.__init__(self, name, level)
+
+    def trace(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.log(TRACE_LEVEL_NUM, message, args, **kwargs)
+
+
+def setup_trace_logging() -> None:
+    logging.setLoggerClass(TraceLogger)
+    logging.addLevelName(TRACE_LEVEL_NUM, 'TRACE')

--- a/evm/vm/gas_meter.py
+++ b/evm/vm/gas_meter.py
@@ -1,4 +1,7 @@
 import logging
+from typing import (
+    cast
+)
 
 from evm.exceptions import (
     ValidationError,
@@ -7,17 +10,20 @@ from evm.exceptions import (
 from evm.validation import (
     validate_uint256,
 )
+from evm.utils.logging import (
+    TraceLogger
+)
 
 
 class GasMeter(object):
-    start_gas = None
+    start_gas = None  # type: int
 
-    gas_refunded = None
-    gas_remaining = None
+    gas_refunded = None  # type: int
+    gas_remaining = None  # type: int
 
-    logger = logging.getLogger('evm.gas.GasMeter')
+    logger = cast(TraceLogger, logging.getLogger('evm.gas.GasMeter'))
 
-    def __init__(self, start_gas):
+    def __init__(self, start_gas: int) -> None:
         validate_uint256(start_gas, title="Start Gas")
 
         self.start_gas = start_gas
@@ -28,7 +34,7 @@ class GasMeter(object):
     #
     # Write API
     #
-    def consume_gas(self, amount, reason):
+    def consume_gas(self, amount: int, reason: str) -> None:
         if amount < 0:
             raise ValidationError("Gas consumption amount must be positive")
 
@@ -49,7 +55,7 @@ class GasMeter(object):
             reason,
         )
 
-    def return_gas(self, amount):
+    def return_gas(self, amount: int) -> None:
         if amount < 0:
             raise ValidationError("Gas return amount must be positive")
 
@@ -62,7 +68,7 @@ class GasMeter(object):
             self.gas_remaining,
         )
 
-    def refund_gas(self, amount):
+    def refund_gas(self, amount: int) -> None:
         if amount < 0:
             raise ValidationError("Gas refund amount must be positive")
 

--- a/evm/vm/memory.py
+++ b/evm/vm/memory.py
@@ -17,13 +17,13 @@ class Memory(object):
     """
     VM Memory
     """
-    bytes = None
+    _bytes = None  # type: bytearray
     logger = logging.getLogger('evm.vm.memory.Memory')
 
     def __init__(self):
-        self.bytes = bytearray()
+        self._bytes = bytearray()
 
-    def extend(self, start_position, size):
+    def extend(self, start_position: int, size: int) -> None:
         if size == 0:
             return
 
@@ -32,12 +32,12 @@ class Memory(object):
             return
 
         size_to_extend = new_size - len(self)
-        self.bytes.extend(itertools.repeat(0, size_to_extend))
+        self._bytes.extend(itertools.repeat(0, size_to_extend))
 
-    def __len__(self):
-        return len(self.bytes)
+    def __len__(self) -> int:
+        return len(self._bytes)
 
-    def write(self, start_position, size, value):
+    def write(self, start_position: int, size: int, value: bytes) -> None:
         """
         Write `value` into memory.
         """
@@ -48,17 +48,17 @@ class Memory(object):
             validate_length(value, length=size)
             validate_lte(start_position + size, maximum=len(self))
 
-            if len(self.bytes) < start_position + size:
-                self.bytes.extend(itertools.repeat(
+            if len(self._bytes) < start_position + size:
+                self._bytes.extend(itertools.repeat(
                     0,
-                    len(self.bytes) - (start_position + size),
+                    len(self._bytes) - (start_position + size),
                 ))
 
             for idx, v in enumerate(value):
-                self.bytes[start_position + idx] = v
+                self._bytes[start_position + idx] = v
 
-    def read(self, start_position, size):
+    def read(self, start_position: int, size: int) -> bytes:
         """
         Read a value from memory.
         """
-        return bytes(self.bytes[start_position:start_position + size])
+        return bytes(self._bytes[start_position:start_position + size])

--- a/evm/vm/message.py
+++ b/evm/vm/message.py
@@ -22,7 +22,7 @@ class Message(object):
     sender = None
     value = None
     data = None
-    gas = None
+    gas = None  # type: int
     access_list = None
     depth = None
 

--- a/evm/vm_state.py
+++ b/evm/vm_state.py
@@ -5,7 +5,8 @@ from abc import (
 from contextlib import contextmanager
 import logging
 from typing import (  # noqa: F401
-    Type
+    Type,
+    TYPE_CHECKING
 )
 
 from cytoolz import (
@@ -24,15 +25,17 @@ from evm.db.trie import (
 from evm.utils.datatypes import (
     Configurable,
 )
-from evm.rlp.blocks import (  # noqa: F401
-    BaseBlock,
-)
-from evm.computation import (  # noqa: F401
-    BaseComputation,
-)
-from evm.transaction_context import (  # noqa: F401
-    BaseTransactionContext,
-)
+
+if TYPE_CHECKING:
+    from evm.rlp.blocks import (  # noqa: F401
+        BaseBlock,
+    )
+    from evm.computation import (  # noqa: F401
+        BaseComputation,
+    )
+    from evm.transaction_context import (  # noqa: F401
+        BaseTransactionContext,
+    )
 
 
 class BaseVMState(Configurable, metaclass=ABCMeta):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import logging
 import sys
 
+# from evm.utils.logging import TRACE_LEVEL_NUM
+
 import pytest
 
 
@@ -10,7 +12,7 @@ def vm_logger():
 
     handler = logging.StreamHandler(sys.stdout)
 
-    # level = logging.TRACE
+    # level = TRACE_LEVEL_NUM
     # level = logging.DEBUG
     level = logging.INFO
 
@@ -32,7 +34,7 @@ def vm_file_logger(request):
 
     logger = logging.getLogger('evm')
 
-    level = logging.TRACE
+    level = TRACE_LEVEL_NUM
     #level = logging.DEBUG
     #level = logging.INFO
 

--- a/tests/core/memory/test_memory.py
+++ b/tests/core/memory/test_memory.py
@@ -23,7 +23,7 @@ def memory32():
 def test_write(memory32):
     # Test that write creates 32byte string == value padded with zeros
     memory32.write(start_position=0, size=4, value=b'1010')
-    assert memory32.bytes == b'1010' + bytearray(28)
+    assert memory32._bytes == b'1010' + bytearray(28)
 
 
 @pytest.mark.parametrize("start_position", (-1, 2**256, 'a', b'1010'))
@@ -57,13 +57,13 @@ def test_write_rejects_values_beyond_memory_size(memory32):
 def test_extend_appropriately_extends_memory(memory):
     # Test extends to 32 byte array: 0 < (start_position + size) <= 32
     memory.extend(start_position=0, size=10)
-    assert memory.bytes == bytearray(32)
+    assert memory._bytes == bytearray(32)
     # Test will extend past length if params require: 32 < (start_position + size) <= 64
     memory.extend(start_position=30, size=32)
-    assert memory.bytes == bytearray(64)
+    assert memory._bytes == bytearray(64)
     # Test won't extend past length unless params require: 32 < (start_position + size) <= 64
     memory.extend(start_position=48, size=10)
-    assert memory.bytes == bytearray(64)
+    assert memory._bytes == bytearray(64)
 
 
 def test_read_returns_correct_bytes_from_memory(memory32):

--- a/tests/core/vm/test_base_computation.py
+++ b/tests/core/vm/test_base_computation.py
@@ -120,15 +120,15 @@ def test_extend_memory_size_must_be_uint256(computation):
 
 
 def test_extend_memory_stays_the_same_if_size_is_0(computation):
-    assert len(computation._memory.bytes) == 0
+    assert len(computation._memory._bytes) == 0
     computation.extend_memory(1, 0)
-    assert len(computation._memory.bytes) == 0
+    assert len(computation._memory._bytes) == 0
 
 
 def test_extend_memory_increases_memory_by_32(computation):
     assert computation._gas_meter.gas_remaining == 100
     computation.extend_memory(0, 1)
-    assert len(computation._memory.bytes) == 32
+    assert len(computation._memory._bytes) == 32
     # 32 bytes of memory cost 3 gas
     assert computation._gas_meter.gas_remaining == 97
 
@@ -136,9 +136,9 @@ def test_extend_memory_increases_memory_by_32(computation):
 def test_extend_memory_doesnt_increase_until_32_bytes_are_used(computation):
     computation.extend_memory(0, 1)
     computation.extend_memory(1, 1)
-    assert len(computation._memory.bytes) == 32
+    assert len(computation._memory._bytes) == 32
     computation.extend_memory(2, 32)
-    assert len(computation._memory.bytes) == 64
+    assert len(computation._memory._bytes) == 64
     assert computation._gas_meter.gas_remaining == 94
 
 


### PR DESCRIPTION
### What was wrong?

Missing type hints

### How was it fixed?

This adds type hints for `evm/computation` and some related classes. 

However, apart from just adding type hints, this introduces some supportive changes.

1. Instead of mutating `Logger` to add a `trace` method it introduces a `TraceLogger` and calls the `logging.setLoggerClass(...)` API to register it.

2. At places where we request a logger via `logging.getLogger('some.logger')` we do a `cast(TraceLogger, logging.getLogger('some.logger')` to give `mypy` a hint about the type (a `cast` doesn't do anything apart from hinting `mypy` what to assume about the type).

3. All the wiring of the trace logging was moved to a `setup_trace_logging` API in `evm.utils.logging`

4. I still left the `logging.TRACE = TRACE_LEVEL_NUM` but I'm actually tempted to get rid of that as well and just import `TRACE_LEVEL_NUM` where we currently use `logging.TRACE` to get rid of that `type: ignore` as well. Thoughts?

5. `mypy` forbids the usage of the variable name `bytes` in `Memory` so I changed it to `_bytes` because I also believe treating it as *private* is aligned with our intentions.

Btw, totally unrelated but as someone who is new to the code base I must say that these type hints make it so much easier for me to understand the code and see what is going on in these APIs.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1518467166778-b88f373ffec7?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=fc36d68d6a46de388290adee9eecb950&auto=format&fit=crop&w=1489&q=80)
