### PR TITLE
docs: evm.chains.mainnet.constants error 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,8 +70,4 @@ monkeytype.sqlite3
 test_env.ipynb
 test_env.py
 test_env2.ipynb
-.ipynb_checkpoints/**  
-
-
-
-
+.ipynb_checkpoints/**

--- a/.gitignore
+++ b/.gitignore
@@ -70,4 +70,5 @@ monkeytype.sqlite3
 test_env.ipynb
 test_env.py
 test_env2.ipynb
+test_env3.ipynb
 .ipynb_checkpoints/**

--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,4 @@ monkeytype.sqlite3
 test_env.ipynb
 test_env.py
 test_env2.ipynb
-.ipynb_checkpoints/** 
-
+.ipynb_checkpoints/**  

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ venv*
 
 # monkeytype
 monkeytype.sqlite3
+test_env.ipynb
+test_env.py
+test_env2.ipynb
+.ipynb_checkpoints/**

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ test_env.ipynb
 test_env.py
 test_env2.ipynb
 .ipynb_checkpoints/**  
+
+
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,9 @@ venv*
 
 # monkeytype
 monkeytype.sqlite3
+
+#test python
 test_env.ipynb
 test_env.py
 test_env2.ipynb
-.ipynb_checkpoints/**
+.ipynb_checkpoints/** 

--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,3 @@ venv*
 
 # monkeytype
 monkeytype.sqlite3
-
-#test python
-test_env.ipynb
-test_env.py
-test_env2.ipynb
-test_env3.ipynb
-.ipynb_checkpoints/**

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ test_env.ipynb
 test_env.py
 test_env2.ipynb
 .ipynb_checkpoints/** 
+

--- a/docs/building_chains.rst
+++ b/docs/building_chains.rst
@@ -20,13 +20,13 @@ class:
   from evm import constants, Chain
   from evm.vm.forks.frontier import FrontierVM
   from evm.vm.forks.homestead import HomesteadVM
-  import evm.chains.mainnet as mainnet
+  from evm.chains.mainnet import HOMESTEAD_MAINNET_BLOCK
 
   chain_class = Chain.configure(
       __name__='Test Chain',
       vm_configuration=(
           (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
-          (mainnet.constants.HOMESTEAD_MAINNET_BLOCK, HomesteadVM),
+          (HOMESTEAD_MAINNET_BLOCK, HomesteadVM),
       ),
   )
 


### PR DESCRIPTION
### What was wrong?
in "evm.chains.mainnet.__init.py"
there is import `from evm import constants`
which make `import evm.chains.mainnet as mainnet` throw error 
because  `evm.constants` did't contain `HOMESTEAD_MAINNET_BLOCK`
 
### How was it fixed?
just import `from evm.chains.mainnet import HOMESTEAD_MAINNET_BLOCK`
instead of  `import evm.chains.mainnet as mainnet`
and call `HOMESTEAD_MAINNET_BLOCK` in `vm_configuration`

then every thing will work fine 


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
