### PR TITLE
p2p: Redesign handling of timeouts in ChainSyncer

### DIFF
--- a/tests/p2p/integration_test_helpers.py
+++ b/tests/p2p/integration_test_helpers.py
@@ -1,14 +1,24 @@
+from typing import Type
+
 from eth_utils import decode_hex
-from eth_keys import keys
+from eth_keys import datatypes, keys
 
 from evm.db.chain import AsyncChainDB
 
 from p2p import kademlia
-from p2p.peer import HardCodedNodesPeerPool
+from p2p.peer import BasePeer, HardCodedNodesPeerPool
 
 
 class LocalGethPeerPool(HardCodedNodesPeerPool):
-    min_peers = 1
+
+    def __init__(self,
+                 peer_class: Type[BasePeer],
+                 chaindb: AsyncChainDB,
+                 network_id: int,
+                 privkey: datatypes.PrivateKey,
+                 ) -> None:
+        min_peers = 1
+        super().__init__(peer_class, chaindb, network_id, privkey, min_peers)
 
     def get_nodes_to_connect(self):
         nodekey = keys.PrivateKey(decode_hex(


### PR DESCRIPTION
We were seeing timeouts too frequently and because of that I'd introduced
an eager retry mechanism, but it turns out those timeouts were because we
had too many cpu-intensive tasks that were blocking the main thread and
thus preventing the asyncio main loop from processing received msgs fast
enough. Now that those cpu-intensive tasks are performed in sub-processes,
we rarely see timeouts and in those cases it generally means the peer has
disconnected so instead of retrying we simply abort the sync with that
peer, which causes it to be resumed with a different peer.

Depends on #492