### PR TITLE
Upgrade mypy to version 0.580

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ matrix:
     - python: "3.6"
       env: TOX_POSARGS="-e flake8py36"
     - python: "3.5"
-      env: TOX_POSARGS="-e mypy"
+      env: TOX_POSARGS="-e mypy35"
+    - python: "3.6"
+      env: TOX_POSARGS="-e mypy36"
     #
     # Python 3.5
     #

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ bumpversion==0.5.3
 flake8==3.5.0
 hypothesis==3.44.26
 ipython>=6.2.1,<7.0.0
-mypy>=0.560
+mypy>=0.580
 pytest-asyncio==0.8.0
 pytest-cov==2.5.1
 pytest-logging>=2015.11.4

--- a/tox.ini
+++ b/tox.ini
@@ -68,11 +68,17 @@ commands=
     flake8 {toxinidir}/trinity
     flake8 {toxinidir}/tests/trinity --exclude=""
 
-[testenv:mypy]
+[testenv:mypy35]
 basepython=python3.5
 setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
 # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
 commands=
-    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p p2p
     mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p evm
+
+[testenv:mypy36]
+basepython=python3.6
+setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
+# TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
+commands=
+    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p p2p
     mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p trinity


### PR DESCRIPTION
Fixes #497

### What was wrong?

`mypy` was still on version `0.560`.

### How was it fixed?

Upgraded to `0.580`. We had to split CI task to support this. We now run one CI job against `mypy` on Python 3.5 for the `evm` and another one on Python 3.6 for `trinity` and `p2p`. Similar to what we do with the `flake8` jobs. 

Unrelated, did we ever consider to run both `flake8` and `mypy` in one `lint` job so that we are down to just one job per Python version? We would go from 4 jobs (`flake8py35`, `flake8py36`, `mypy35`, `mypy36`) to 2 jobs (`lintpy35`, `lintpy36`).


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1507496607271-83ac3d3ab818?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=c30f254cf2f101f542fdf650df675cdc&auto=format&fit=crop&w=1291&q=80)
