### PR TITLE
p2p: Use a custom BlockHeader implementation to improve performance

### DIFF
--- a/p2p/eth.py
+++ b/p2p/eth.py
@@ -11,7 +11,7 @@ from p2p.protocol import (
     Command,
     Protocol,
 )
-from p2p.rlp import BlockBody, P2PTransaction
+from p2p.rlp import BlockBody, ImmutableBlockHeader, P2PTransaction
 from p2p.sedes import HashOrNumber
 
 
@@ -56,7 +56,7 @@ class GetBlockHeaders(Command):
 
 class BlockHeaders(Command):
     _cmd_id = 4
-    structure = sedes.CountableList(BlockHeader)
+    structure = sedes.CountableList(ImmutableBlockHeader)
 
 
 class GetBlockBodies(Command):
@@ -72,9 +72,9 @@ class BlockBodies(Command):
 class NewBlock(Command):
     _cmd_id = 7
     structure = [
-        ('block', sedes.List([BlockHeader,
+        ('block', sedes.List([ImmutableBlockHeader,
                               sedes.CountableList(P2PTransaction),
-                              sedes.CountableList(BlockHeader)])),
+                              sedes.CountableList(ImmutableBlockHeader)])),
         ('total_difficulty', sedes.big_endian_int)]
 
 

--- a/p2p/rlp.py
+++ b/p2p/rlp.py
@@ -1,8 +1,31 @@
 import rlp
 from rlp import sedes
 
+from eth_utils import keccak
+
 from evm.rlp.headers import BlockHeader
 from evm.rlp.transactions import BaseTransaction
+
+
+class ImmutableBlockHeader(BlockHeader):
+    """Immutable variant of `BlockHeader` that also caches its RLP representation.
+
+    By doing that we can compute the header's hash only once, significantly improving performance
+    when performing a chain sync.
+    """
+    _hash = None
+
+    @classmethod
+    def deserialize(cls, serial, exclude=None, mutable=False, **kwargs):
+        obj = super().deserialize(serial, exclude=exclude, mutable=True, **kwargs)
+        obj._cached_rlp = rlp.codec.encode_raw(serial)
+        return sedes.make_immutable(obj)
+
+    @property
+    def hash(self) -> bytes:
+        if self._hash is None:
+            self._hash = keccak(self._cached_rlp)
+        return self._hash
 
 
 # This is needed because BaseTransaction has several @abstractmethods, which means it can't be
@@ -14,5 +37,5 @@ class P2PTransaction(rlp.Serializable):
 class BlockBody(rlp.Serializable):
     fields = [
         ('transactions', sedes.CountableList(P2PTransaction)),
-        ('uncles', sedes.CountableList(BlockHeader))
+        ('uncles', sedes.CountableList(ImmutableBlockHeader))
     ]


### PR DESCRIPTION
Use an immutable variant of BlockHeader that also caches its RLP
representation.  By doing that we can compute the header's hash only
once, significantly improving performance when performing a chain sync.