### PR TITLE
add structure to the trinity cli commands

### DIFF
--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -24,14 +24,37 @@ LOG_LEVEL_CHOICES = (
 parser = argparse.ArgumentParser(description='Trinity')
 
 #
-# Version: `trinity --version`
+# subparser for sub commands
 #
-parser.add_argument('--version', action='version', version=__version__)
+subparser = parser.add_subparsers(dest='subcommand')
+
+#
+# Argument Groups
+#
+trinity_parser = parser.add_argument_group('sync mode')
+logging_parser = parser.add_argument_group('logging')
+network_parser = parser.add_argument_group('network')
+syncing_parser = parser.add_argument_group('sync mode')
+chain_parser = parser.add_argument_group('chain')
+
+
+#
+# Trinity Globals
+#
+trinity_parser.add_argument('--version', action='version', version=__version__)
+trinity_parser.add_argument(
+    '--trinity-root-dir',
+    help=(
+        "The filesystem path to the base directory that trinity will store it's "
+        "information.  Default: $XDG_DATA_HOME/.local/share/trinity"
+    ),
+)
+
 
 #
 # Logging configuration
 #
-parser.add_argument(
+logging_parser.add_argument(
     '-l',
     '--log-level',
     choices=LOG_LEVEL_CHOICES,
@@ -42,7 +65,7 @@ parser.add_argument(
 #
 # Main parser for running trinity as a node.
 #
-networkid_parser = parser.add_mutually_exclusive_group()
+networkid_parser = network_parser.add_mutually_exclusive_group()
 networkid_parser.add_argument(
     '--network-id',
     type=int,
@@ -61,13 +84,16 @@ networkid_parser.add_argument(
 )
 
 
-syncmode_parser = parser.add_mutually_exclusive_group()
-syncmode_parser.add_argument(
+#
+# Sync Mode
+#
+mode_parser = syncing_parser.add_mutually_exclusive_group()
+mode_parser.add_argument(
     '--sync-mode',
     choices={SYNC_LIGHT, SYNC_FULL},
     default=SYNC_LIGHT,
 )
-syncmode_parser.add_argument(
+mode_parser.add_argument(
     '--light',  # TODO: consider --sync-mode like geth.
     action='store_const',
     const=SYNC_LIGHT,
@@ -75,34 +101,28 @@ syncmode_parser.add_argument(
     help="Shortcut for `--sync-mode=light`",
 )
 
-parser.add_argument(
-    '--trinity-root-dir',
-    help=(
-        "The filesystem path to the base directory that trinity will store it's "
-        "information.  Default: $XDG_DATA_HOME/.local/share/trinity"
-    ),
-)
-parser.add_argument(
+
+#
+# Chain configuration
+#
+chain_parser.add_argument(
     '--data-dir',
     help=(
         "The directory where chain data is stored"
     ),
 )
-parser.add_argument(
+chain_parser.add_argument(
     '--nodekey',
     help=(
         "Hexadecimal encoded private key to use for the nodekey"
     )
 )
-parser.add_argument(
+chain_parser.add_argument(
     '--nodekey-path',
     help=(
         "The filesystem path to the file which contains the nodekey"
     )
 )
-
-# setup the subparser for sub commands
-subparser = parser.add_subparsers(dest='subcommand')
 
 
 #


### PR DESCRIPTION
### What was wrong?

Before, this is what got output when running `trinity --help`

```bash
$ trinity --help
usage: trinity [-h] [--version] [-l {debug,info}]
               [--network-id NETWORK_ID | --ropsten]
               [--sync-mode {full,light} | --light]
               [--trinity-root-dir TRINITY_ROOT_DIR] [--data-dir DATA_DIR]
               [--nodekey NODEKEY] [--nodekey-path NODEKEY_PATH]
               {console,attach} ...

Trinity

positional arguments:
  {console,attach}
    console             run the chain and start the trinity REPL
    attach              open an REPL attached to a currently running chain

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -l {debug,info}, --log-level {debug,info}
                        Sets the logging level
  --network-id NETWORK_ID
                        Network identifier (1=Mainnet, 3=Ropsten)
  --ropsten             Ropsten network: pre configured proof-of-work test
                        network. Shortcut for `--networkid=3`
  --sync-mode {full,light}
  --light               Shortcut for `--sync-mode=light`
  --trinity-root-dir TRINITY_ROOT_DIR
                        The filesystem path to the base directory that trinity
                        will store it's information. Default:
                        $XDG_DATA_HOME/.local/share/trinity
  --data-dir DATA_DIR   The directory where chain data is stored
  --nodekey NODEKEY     Hexadecimal encoded private key to use for the nodekey
  --nodekey-path NODEKEY_PATH
                        The filesystem path to the file which contains the
                        nodekey
```

### How was it fixed?

Used `argparse` API to group commands.

```bash
$ trinity --help
usage: trinity [-h] [--version] [--trinity-root-dir TRINITY_ROOT_DIR]
               [-l {debug,info}] [--network-id NETWORK_ID | --ropsten]
               [--sync-mode {full,light} | --light] [--data-dir DATA_DIR]
               [--nodekey NODEKEY] [--nodekey-path NODEKEY_PATH]
               {console,attach} ...

Trinity

positional arguments:
  {console,attach}
    console             run the chain and start the trinity REPL
    attach              open an REPL attached to a currently running chain

optional arguments:
  -h, --help            show this help message and exit

sync mode:
  --version             show program's version number and exit
  --trinity-root-dir TRINITY_ROOT_DIR
                        The filesystem path to the base directory that trinity
                        will store it's information. Default:
                        $XDG_DATA_HOME/.local/share/trinity

logging:
  -l {debug,info}, --log-level {debug,info}
                        Sets the logging level

network:
  --network-id NETWORK_ID
                        Network identifier (1=Mainnet, 3=Ropsten)
  --ropsten             Ropsten network: pre configured proof-of-work test
                        network. Shortcut for `--networkid=3`

sync mode:
  --sync-mode {full,light}
  --light               Shortcut for `--sync-mode=light`

chain:
  --data-dir DATA_DIR   The directory where chain data is stored
  --nodekey NODEKEY     Hexadecimal encoded private key to use for the nodekey
  --nodekey-path NODEKEY_PATH
                        The filesystem path to the file which contains the
                        nodekey
```

#### Cute Animal Picture

![flying-kittens](https://user-images.githubusercontent.com/824194/37932588-1f4cf474-3106-11e8-8ab8-1d8557b5499b.jpg)

