### PR TITLE
Piper/add support for custom genesis data in trinity

### DIFF
--- a/evm/chains/mainnet/__init__.py
+++ b/evm/chains/mainnet/__init__.py
@@ -38,7 +38,7 @@ MainnetChain = Chain.configure(
 )
 
 
-MAINNET_GENESIS_HEADER = BlockHeader(
+MAINNET_GENESIS_PARAMS = dict(
     difficulty=17179869184,
     extra_data=decode_hex("0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa"),
     gas_limit=5000,
@@ -54,3 +54,6 @@ MAINNET_GENESIS_HEADER = BlockHeader(
     timestamp=0,
     transaction_root=constants.BLANK_ROOT_HASH,
 )
+
+
+MAINNET_GENESIS_HEADER = BlockHeader(**MAINNET_GENESIS_PARAMS)

--- a/evm/chains/ropsten/__init__.py
+++ b/evm/chains/ropsten/__init__.py
@@ -34,7 +34,7 @@ RopstenChain = Chain.configure(
 )
 
 
-ROPSTEN_GENESIS_HEADER = BlockHeader(
+ROPSTEN_GENESIS_PARAMS = dict(
     difficulty=1048576,
     extra_data=decode_hex("0x3535353535353535353535353535353535353535353535353535353535353535"),
     gas_limit=16777216,
@@ -50,3 +50,6 @@ ROPSTEN_GENESIS_HEADER = BlockHeader(
     timestamp=0,
     transaction_root=constants.BLANK_ROOT_HASH,
 )
+
+
+ROPSTEN_GENESIS_HEADER = BlockHeader(**ROPSTEN_GENESIS_PARAMS)

--- a/tests/trinity/conftest.py
+++ b/tests/trinity/conftest.py
@@ -4,6 +4,8 @@ import pytest
 import tempfile
 import uuid
 
+from evm import constants as evm_constants
+
 from trinity.rpc.main import (
     RPCServer,
 )
@@ -68,3 +70,23 @@ def ipc_server(jsonrpc_ipc_pipe_path, event_loop):
         yield
     finally:
         event_loop.run_until_complete(ipc_server.stop())
+
+
+@pytest.fixture
+def custom_network_genesis_params():
+    return dict(
+        difficulty=12345,
+        extra_data=b"\xde\xad\xbe\xef" * 8,
+        gas_limit=1234567,
+        gas_used=0,
+        bloom=0,
+        mix_hash=evm_constants.ZERO_HASH32,
+        nonce=evm_constants.GENESIS_NONCE,
+        block_number=0,
+        parent_hash=evm_constants.ZERO_HASH32,
+        receipt_root=evm_constants.BLANK_ROOT_HASH,
+        uncles_hash=evm_constants.EMPTY_UNCLE_HASH,
+        state_root=evm_constants.BLANK_ROOT_HASH,
+        timestamp=0,
+        transaction_root=evm_constants.BLANK_ROOT_HASH,
+    )

--- a/tests/trinity/core/chain-management/test_initialize_database.py
+++ b/tests/trinity/core/chain-management/test_initialize_database.py
@@ -1,6 +1,5 @@
 import pytest
 
-# TODO: use a custom chain class only for testing.
 from evm.db.backends.level import LevelDB
 from evm.db.chain import ChainDB
 
@@ -11,22 +10,42 @@ from trinity.chains import (
 )
 from trinity.utils.chains import (
     ChainConfig,
+    PRECONFIGURED_NETWORKS,
+    get_local_data_dir,
 )
 
 
-@pytest.fixture
-def chain_config():
-    _chain_config = ChainConfig(network_id=1)
+@pytest.fixture(params=tuple(PRECONFIGURED_NETWORKS.keys()))
+def preconfigured_chain_config(request):
+    _chain_config = ChainConfig(network_id=request.param)
     initialize_data_dir(_chain_config)
     return _chain_config
 
 
+def test_initialize_database_for_preconfigured_network(preconfigured_chain_config):
+    chain_config = preconfigured_chain_config
+    chaindb = ChainDB(LevelDB(db_path=chain_config.database_dir))
+
+    assert not is_database_initialized(chaindb)
+    initialize_database(chain_config, chaindb)
+    assert is_database_initialized(chaindb)
+
+
 @pytest.fixture
-def chaindb(chain_config):
-    return ChainDB(LevelDB(db_path=chain_config.database_dir))
+def custom_network_chain_config(custom_network_genesis_params):
+    _chain_config = ChainConfig(
+        network_id=42,
+        genesis_params=custom_network_genesis_params,
+        data_dir=get_local_data_dir('methuselah'),
+    )
+    initialize_data_dir(_chain_config)
+    return _chain_config
 
 
-def test_initialize_database(chain_config, chaindb):
+def test_initialize_database_for_custom_network(custom_network_chain_config):
+    chain_config = custom_network_chain_config
+    chaindb = ChainDB(LevelDB(db_path=chain_config.database_dir))
+
     assert not is_database_initialized(chaindb)
     initialize_database(chain_config, chaindb)
     assert is_database_initialized(chaindb)

--- a/tests/trinity/core/chains-utils/test_chain_config_object.py
+++ b/tests/trinity/core/chains-utils/test_chain_config_object.py
@@ -11,25 +11,34 @@ from trinity.utils.chains import (
     get_database_dir,
     get_nodekey_path,
     ChainConfig,
+    DEFAULT_DATA_DIRS,
+    PRECONFIGURED_NETWORKS,
 )
 from trinity.utils.filesystem import (
     is_same_path,
 )
 
 
-def test_chain_config_computed_properties():
-    data_dir = get_local_data_dir('muffin')
-    chain_config = ChainConfig(network_id=1234, data_dir=data_dir)
+@pytest.fixture(params=tuple(PRECONFIGURED_NETWORKS.keys()))
+def preconfigured_network_id(request):
+    return request.param
 
-    assert chain_config.network_id == 1234
+
+def test_chain_config_computed_properties_on_preconfigured_network(preconfigured_network_id):
+    network_id = preconfigured_network_id
+    data_dir = get_local_data_dir(DEFAULT_DATA_DIRS[network_id])
+    chain_config = ChainConfig(network_id=network_id, data_dir=data_dir)
+
+    assert chain_config.network_id == network_id
     assert chain_config.data_dir == data_dir
     assert chain_config.database_dir == get_database_dir(data_dir)
     assert chain_config.nodekey_path == get_nodekey_path(data_dir)
 
 
-def test_chain_config_explicit_properties():
+def test_chain_config_explicit_properties(preconfigured_network_id):
+    network_id = preconfigured_network_id
     chain_config = ChainConfig(
-        network_id=1,
+        network_id=network_id,
         data_dir='./data-dir',
         nodekey_path='./nodekey'
     )
@@ -55,9 +64,10 @@ def nodekey_path(tmpdir, nodekey_bytes):
     return str(nodekey_file)
 
 
-def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
+def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path, preconfigured_network_id):
+    network_id = preconfigured_network_id
     chain_config = ChainConfig(
-        network_id=1,
+        network_id=network_id,
         nodekey_path=nodekey_path,
     )
 
@@ -65,10 +75,29 @@ def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
 
 
 @pytest.mark.parametrize('as_bytes', (True, False))
-def test_chain_config_explictely_provided_nodekey(nodekey_bytes, as_bytes):
+def test_chain_config_explictely_provided_nodekey(nodekey_bytes,
+                                                  as_bytes,
+                                                  preconfigured_network_id):
+    network_id = preconfigured_network_id
     chain_config = ChainConfig(
-        network_id=1,
+        network_id=network_id,
         nodekey=nodekey_bytes if as_bytes else keys.PrivateKey(nodekey_bytes),
     )
 
     assert chain_config.nodekey.to_bytes() == nodekey_bytes
+
+
+def test_chain_config_computed_properties_on_custom_network(custom_network_genesis_params):
+    data_dir = get_local_data_dir('muffin')
+    chain_config = ChainConfig(
+        network_id=42,
+        data_dir=data_dir,
+        genesis_params=custom_network_genesis_params,
+    )
+
+    assert chain_config.network_id == 42
+    assert chain_config.data_dir == data_dir
+    assert chain_config.database_dir == get_database_dir(data_dir)
+    assert chain_config.nodekey_path == get_nodekey_path(data_dir)
+
+    assert custom_network_genesis_params == chain_config.genesis_params

--- a/trinity/chains/dev.py
+++ b/trinity/chains/dev.py
@@ -1,0 +1,17 @@
+from evm.vm.forks import ByzantiumVM
+
+from p2p.lightchain import LightChain
+
+from typing import Type
+
+
+DEV_VM_CONFIGURATION = (
+    # Note: All forks are excluded other than the latest mainnet rules
+    (0, ByzantiumVM),
+)
+
+
+DevLightChain: Type[LightChain] = LightChain.configure(
+    __name__='DevLightChain',
+    vm_configuration=DEV_VM_CONFIGURATION,
+)

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -106,6 +106,14 @@ mode_parser.add_argument(
 # Chain configuration
 #
 chain_parser.add_argument(
+    '--genesis',
+    help=(
+        "JSON string or filesystem path to a json document which contains the "
+        "genesis parameters for a chain.  This value is **required** when "
+        "initializing a custom chain"
+    )
+)
+chain_parser.add_argument(
     '--data-dir',
     help=(
         "The directory where chain data is stored"

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -68,12 +68,6 @@ def main() -> None:
 
     logger, log_queue, listener = setup_trinity_logging(args.log_level.upper())
 
-    if args.network_id not in PRECONFIGURED_NETWORKS:
-        raise NotImplementedError(
-            "Unsupported network id: {0}.  Only the ropsten and mainnet "
-            "networks are supported.".format(args.network_id)
-        )
-
     if args.sync_mode != SYNC_LIGHT:
         raise NotImplementedError(
             "Only light sync is supported.  Run with `--sync-mode=light` or `--light`"
@@ -162,6 +156,13 @@ def run_networking_process(
     chaindb = manager.get_chaindb()  # type: ignore
 
     if not is_database_initialized(chaindb):
+        if not chain_config.is_preconfigured_network and not chain_config.has_genesis_params:
+            raise ValueError(
+                "The network id '{0}' is not in the list of supported "
+                "preconfigured networks and no genesis params were provided. "
+                "Please supply genesis parameters using `--genesis` command line "
+                "flag.".format(chain_config.network_id)
+            )
         initialize_database(chain_config, chaindb)
 
     chain_class = get_chain_protocol_class(chain_config, sync_mode=sync_mode)

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -120,8 +120,9 @@ class ChainConfig:
     def __init__(self,
                  network_id: int,
                  data_dir: str=None,
-                 nodekey_path: str=None,
-                 nodekey: PrivateKey=None) -> None:
+                 nodekey_path: str = None,
+                 nodekey: PrivateKey = None,
+                 genesis: dict = None) -> None:
         self.network_id = network_id
 
         # validation

--- a/trinity/utils/genesis.py
+++ b/trinity/utils/genesis.py
@@ -1,0 +1,61 @@
+from evm import constants as evm_constants
+
+from cytoolz import (
+    compose,
+)
+from cytoolz.curried import (
+    assoc,
+)
+
+from eth_utils import (
+    to_bytes,
+    to_canonical_address,
+    to_int,
+)
+from eth_utils.curried import (
+    apply_key_map,
+    apply_formatters_to_dict,
+    hexstr_if_str,
+)
+
+
+#
+# Genesis param helpers
+#
+GENESIS_PARAMS_KEY_MAP = {
+    'extraData': 'extra_data',
+    'gasLimit': 'gas_limit',
+    'gasUsed': 'gas_used',
+    'logsBloom': 'bloom',
+    'mixhash': 'mix_hash',
+    'parentHash': 'parent_hash',
+    'receiptsRoot': 'receipt_root',
+    'sha3Uncles': 'uncles_hash',
+    'stateRoot': 'state_root',
+    'transactionsRoot': 'transaction_root',
+}
+GENESIS_PARAMS_NORMALIZERS = {
+    'parent_hash': hexstr_if_str(to_bytes),
+    'uncles_hash': hexstr_if_str(to_bytes),
+    'coinbase': to_canonical_address,
+    'state_root': hexstr_if_str(to_bytes),
+    'transaction_root': hexstr_if_str(to_bytes),
+    'receipt_root': hexstr_if_str(to_bytes),
+    'bloom': hexstr_if_str(to_int),
+    'difficulty': hexstr_if_str(to_int),
+    'block_number': hexstr_if_str(to_int),
+    'gas_limit': hexstr_if_str(to_int),
+    'gas_used': hexstr_if_str(to_int),
+    'timestamp': hexstr_if_str(to_int),
+    'extra_data': hexstr_if_str(to_bytes),
+    'mix_hash': hexstr_if_str(to_bytes),
+    'nonce': hexstr_if_str(to_bytes),
+}
+format_genesis_params = apply_formatters_to_dict(GENESIS_PARAMS_NORMALIZERS)
+
+
+normalize_genesis_params = compose(
+    format_genesis_params,
+    assoc(key='block_number', value=evm_constants.GENESIS_BLOCK_NUMBER),
+    apply_key_map(GENESIS_PARAMS_KEY_MAP),
+)


### PR DESCRIPTION
### What was wrong?

Needed support for running *custom* chains with custom genesis data.

### How was it fixed?

Added new cli flag `--genesis` which can be used to supply the genesis block parameters. This value is used during chain initialization.

TODO:

- [ ] decide whether this flag should be allowed in normal top level `trinity` command or if it should only be allowed in `trinity init` (which doesn't currently exist).
- [ ] add dynamic selection of `PeerPool` class since `HardCodedNodesPeerPool` doesn't support custom network ids.

#### Cute Animal Picture

![flying-cats](https://user-images.githubusercontent.com/824194/37937364-94e4ed58-3116-11e8-9c10-871145b7f45b.jpeg)
