### PR TITLE
Fix wrong trie class in generating transaction trie in Sharding

### DIFF
--- a/evm/vm/forks/sharding/vm_state.py
+++ b/evm/vm/forks/sharding/vm_state.py
@@ -240,7 +240,10 @@ class ShardingVMState(ShardingTransactionExecutor, ByzantiumVMState):
         block.transaction_fee_sum += transaction_fee
 
         # Get trie roots and changed key-values.
-        tx_root_hash, tx_kv_nodes = make_trie_root_and_nodes(block.transactions)
+        tx_root_hash, tx_kv_nodes = make_trie_root_and_nodes(
+            block.transactions,
+            trie_class=BinaryTrie,
+        )
         receipt_root_hash, receipt_kv_nodes = make_trie_root_and_nodes(
             self.receipts,
             trie_class=BinaryTrie,


### PR DESCRIPTION
### What was wrong?
Didn't set Binary Trie when generating transaction trie in Sharding(default to Hexary Trie) and result in node parsing error when trying to fetch value with Hexary Trie data in a Binary Trie.

### How was it fixed?
Specify Binary Trie as trie_class in `make_trie_root_and_nodes`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-2.jpg)