### PR TITLE
Fix weirdness in how VM.state.apply_transaction was executed

### DIFF
--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -74,8 +74,7 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         """
         Apply the transaction to the vm in the current block.
         """
-        computation, block, trie_data_dict = self.get_state_class().apply_transaction(
-            self.state,
+        computation, block, trie_data_dict = self.state.apply_transaction(
             transaction,
             self.block,
         )

--- a/tests/sharding/fixtures.py
+++ b/tests/sharding/fixtures.py
@@ -66,6 +66,8 @@ def vmc():
     )
     provider = EthereumTesterProvider(eth_tester)
     w3 = Web3(provider)
+    if hasattr(w3.eth, "enable_unaudited_features"):
+        w3.eth.enable_unaudited_features()
 
     # setup vmc's web3.eth.contract instance
     vmc_tx = create_vmc_tx(


### PR DESCRIPTION
### What was wrong?

The `VM.apply_transaction` was invoking the `VMState.apply_transaction` in a very odd way, accessing the method on the class and passing in the `state` for the `self` argument, when it could instead simply invoke the method directly from the `state` variable.

### How was it fixed?

Changed to directly invoke the method.

#### Cute Animal Picture

![unlikely-animal-buddies-6](https://user-images.githubusercontent.com/824194/37998283-3e19da36-31db-11e8-9def-e3a91f12bc87.jpg)

