### PR TITLE
Remove block_class from VM

### DIFF
--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -52,7 +52,6 @@ class BaseVM(Configurable, metaclass=ABCMeta):
     network.
     """
     chaindb = None
-    _block_class = None
     _state_class = None
 
     def __init__(self, header, chaindb):
@@ -345,12 +344,9 @@ class BaseVM(Configurable, metaclass=ABCMeta):
     @classmethod
     def get_block_class(cls):
         """
-        Return the class that this VM uses for blocks.
+        Return the class that the state class uses for blocks.
         """
-        if cls._block_class is None:
-            raise AttributeError("No `_block_class` has been set for this VM")
-
-        return cls._block_class
+        return cls.get_state_class().get_block_class()
 
     @classmethod
     def get_block_by_header(cls, block_header, db):

--- a/evm/vm/forks/byzantium/__init__.py
+++ b/evm/vm/forks/byzantium/__init__.py
@@ -5,14 +5,12 @@ from .headers import (
     configure_byzantium_header,
     compute_byzantium_difficulty,
 )
-from .blocks import ByzantiumBlock
 from .state import ByzantiumState
 
 
 ByzantiumVM = SpuriousDragonVM.configure(
     __name__='ByzantiumVM',
     # classes
-    _block_class=ByzantiumBlock,
     _state_class=ByzantiumState,
     # Methods
     create_header_from_parent=staticmethod(create_byzantium_header_from_parent),

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from evm.vm import VM
 
-from .blocks import FrontierBlock
 from .state import FrontierState
 from .headers import (
     create_frontier_header_from_parent,
@@ -14,7 +13,6 @@ from .headers import (
 FrontierVM = VM.configure(
     __name__='FrontierVM',
     # classes
-    _block_class=FrontierBlock,
     _state_class=FrontierState,
     # helpers
     create_header_from_parent=staticmethod(create_frontier_header_from_parent),

--- a/evm/vm/forks/homestead/__init__.py
+++ b/evm/vm/forks/homestead/__init__.py
@@ -3,7 +3,6 @@ from evm.chains.mainnet.constants import (
 )
 from evm.vm.forks.frontier import FrontierVM
 
-from .blocks import HomesteadBlock
 from .headers import (
     create_homestead_header_from_parent,
     compute_homestead_difficulty,
@@ -20,7 +19,6 @@ class MetaHomesteadVM(FrontierVM):  # type: ignore
 HomesteadVM = MetaHomesteadVM.configure(
     __name__='HomesteadVM',
     # classes
-    _block_class=HomesteadBlock,
     _state_class=HomesteadState,
     # method overrides
     create_header_from_parent=staticmethod(create_homestead_header_from_parent),

--- a/evm/vm/forks/sharding/__init__.py
+++ b/evm/vm/forks/sharding/__init__.py
@@ -6,7 +6,6 @@ from evm.vm.forks.byzantium.headers import (
     compute_byzantium_difficulty,
 )
 
-from .collations import Collation
 from .headers import (
     create_sharding_header_from_parent,
 )
@@ -15,7 +14,6 @@ from .state import ShardingState
 ShardingVM = ShardVM.configure(
     __name__='ShardingVM',
     # classes
-    _block_class=Collation,
     _state_class=ShardingState,
     # TODO: Replace them after we apply Collation structure
     create_header_from_parent=staticmethod(create_sharding_header_from_parent),

--- a/evm/vm/forks/spurious_dragon/__init__.py
+++ b/evm/vm/forks/spurious_dragon/__init__.py
@@ -1,11 +1,9 @@
 from ..homestead import HomesteadVM
 
-from .blocks import SpuriousDragonBlock
 from .state import SpuriousDragonState
 
 SpuriousDragonVM = HomesteadVM.configure(
     __name__='SpuriousDragonVM',
     # classes
-    _block_class=SpuriousDragonBlock,
     _state_class=SpuriousDragonState,
 )

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -237,6 +237,18 @@ class BaseState(Configurable, metaclass=ABCMeta):
         return cls.transaction_context_class
 
     #
+    # Block class
+    #
+    @classmethod
+    def get_block_class(cls) -> Type['BaseBlock']:
+        """
+
+        """
+        if cls.block_class is None:
+            raise AttributeError("No `block_class_class` has been set for this VMState")
+        return cls.block_class
+
+    #
     # Execution
     #
     def apply_transaction(
@@ -288,7 +300,7 @@ class BaseState(Configurable, metaclass=ABCMeta):
         # Create a new Block object
         block_header = block.header.clone()
         transactions = list(block.transactions)
-        block = self.block_class(block_header, transactions)
+        block = self.get_block_class()(block_header, transactions)
 
         block.transactions.append(transaction)
 

--- a/tests/p2p/test_lightchain_integration.py
+++ b/tests/p2p/test_lightchain_integration.py
@@ -11,7 +11,7 @@ from eth_utils import (
 from evm.chains.ropsten import ROPSTEN_NETWORK_ID, ROPSTEN_GENESIS_HEADER
 from evm.chains.mainnet import MAINNET_VM_CONFIGURATION
 from evm.db.backends.memory import MemoryDB
-from evm.vm.forks.frontier import FrontierBlock
+from evm.vm.forks.frontier.blocks import FrontierBlock
 
 from p2p import ecies
 from p2p.lightchain import LightChain


### PR DESCRIPTION
### What was wrong?

Both the `VM` and the `VMState` had the `block_class` defined.

### How was it fixed?

This removes the `block_class` from `VM` and delegates to the `get_block_class` API of the `VMState` instead. Fixes #513 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1459262838948-3e2de6c1ec80?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ca3293a6b039645f96f8f47c9b0435e6&auto=format&fit=crop&w=1349&q=80)
