### PR TITLE
p2p: Redesign the fast-sync mechanism

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -1,18 +1,14 @@
 import asyncio
 import logging
+import math
 import operator
-import secrets
 import time
-from typing import Any, Awaitable, Callable, cast, Dict, Generator, List, Set, Tuple  # noqa: F401
+from typing import (  # noqa: F401
+    Any, Awaitable, Callable, cast, Dict, Generator, List, Set, Tuple, Union)
 
-from cytoolz.itertoolz import unique
+from cytoolz.itertoolz import partition_all, unique
 
-from eth_utils import (
-    encode_hex,
-    to_list,
-)
-
-from evm.constants import EMPTY_UNCLE_HASH
+from evm.constants import BLANK_ROOT_HASH, EMPTY_UNCLE_HASH
 from evm.db.chain import AsyncChainDB
 from evm.db.trie import make_trie_root_and_nodes
 from evm.rlp.headers import BlockHeader
@@ -37,20 +33,11 @@ class ChainSyncer(PeerPoolSubscriber):
         self.peer_pool.subscribe(self)
         self.cancel_token = CancelToken('ChainSyncer')
         self._running_peers = set()  # type: Set[ETHPeer]
-        self._peers_with_pending_requests = set()  # type: Set[ETHPeer]
         self._syncing = False
         self._sync_requests = asyncio.Queue()  # type: asyncio.Queue[ETHPeer]
         self._new_headers = asyncio.Queue()  # type: asyncio.Queue[List[BlockHeader]]
-        self._body_requests = asyncio.Queue()  # type: asyncio.Queue[List[BlockHeader]]
-        self._receipt_requests = asyncio.Queue()  # type: asyncio.Queue[List[BlockHeader]]
-        # A mapping from (transaction_root, uncles_hash) to (block_header, request time) so that
-        # we can keep track of pending block bodies and retry them when necessary.
-        self._pending_bodies = {}  # type: Dict[Tuple[bytes, bytes], Tuple[BlockHeader, float]]
-        # A mapping from receipt_root to (block_header, request time) so that we can keep track of
-        # pending block receipts and retry them when necessary.
-        self._pending_receipts = {}  # type: Dict[bytes, Tuple[BlockHeader, float]]
-        asyncio.ensure_future(self.body_downloader())
-        asyncio.ensure_future(self.receipt_downloader())
+        self._downloaded_receipts = asyncio.Queue()  # type: asyncio.Queue[List[bytes]]
+        self._downloaded_bodies = asyncio.Queue()  # type: asyncio.Queue[List[Tuple[bytes, bytes]]]
 
     def register_peer(self, peer: BasePeer) -> None:
         asyncio.ensure_future(self.handle_peer(cast(ETHPeer, peer)))
@@ -127,6 +114,8 @@ class ChainSyncer(PeerPoolSubscriber):
         self._syncing = True
         try:
             await self._sync(peer)
+        except OperationCancelled:
+            pass
         finally:
             self._syncing = False
 
@@ -139,22 +128,18 @@ class ChainSyncer(PeerPoolSubscriber):
                 peer.head_td, peer, head_td)
             return
 
+        self.logger.info("Starting sync with %s", peer)
         # FIXME: Fetch a batch of headers, in reverse order, starting from our current head, and
         # find the common ancestor between our chain and the peer's.
         start_at = max(0, head.block_number - eth.MAX_HEADERS_FETCH)
-        self.logger.debug("Asking %s for header batch starting at %d", peer, start_at)
         peer.sub_proto.send_get_block_headers(start_at, eth.MAX_HEADERS_FETCH, reverse=False)
         while True:
-            # TODO: Consider stalling header fetching if there are more than X blocks/receipts
-            # pending, to avoid timeouts caused by us not being able to process (decode/store)
-            # blocks/receipts fast enough.
+            self.logger.info("Fetching chain segment starting at #%d", start_at)
             try:
                 headers = await wait_with_token(
                     self._new_headers.get(), peer.wait_until_finished(),
                     token=self.cancel_token,
                     timeout=self._reply_timeout)
-            except OperationCancelled:
-                break
             except TimeoutError:
                 self.logger.warn("Timeout waiting for header batch from %s, aborting sync", peer)
                 await peer.stop()
@@ -164,142 +149,111 @@ class ChainSyncer(PeerPoolSubscriber):
                 self.logger.info("%s disconnected, aborting sync", peer)
                 break
 
+            self.logger.info("Got headers segment starting at #%d", start_at)
+
             # TODO: Process headers for consistency.
+
+            await self._download_block_parts(
+                [header for header in headers if not _is_body_empty(header)],
+                self.request_bodies,
+                self._downloaded_bodies,
+                _body_key,
+                'body')
+
+            self.logger.info("Got block bodies for chain segment starting at #%d", start_at)
+
+            missing_receipts = [header for header in headers if not _is_receipts_empty(header)]
+            # Post-Byzantium blocks may have identical receipt roots (e.g. when they have the same
+            # number of transactions and all succeed/failed: ropsten blocks 2503212 and 2503284),
+            # so we do this to avoid requesting the same receipts multiple times.
+            missing_receipts = list(unique(missing_receipts, key=_receipts_key))
+            await self._download_block_parts(
+                missing_receipts,
+                self.request_receipts,
+                self._downloaded_receipts,
+                _receipts_key,
+                'receipt')
+
+            self.logger.info("Got block receipts for chain segment starting at #%d", start_at)
+
             for header in headers:
                 await self.chaindb.coro_persist_header(header)
                 start_at = header.block_number + 1
 
-            self._body_requests.put_nowait(headers)
-            self._receipt_requests.put_nowait(headers)
-
-            self.logger.debug("Asking %s for header batch starting at %d", peer, start_at)
-            # TODO: Instead of requesting sequential batches from a single peer, request a header
-            # skeleton and make concurrent requests, using as many peers as possible, to fill the
-            # skeleton.
+            self.logger.info("Imported chain segment, new head: #%d", start_at - 1)
             peer.sub_proto.send_get_block_headers(start_at, eth.MAX_HEADERS_FETCH, reverse=False)
 
-    async def _downloader(self,
-                          queue: 'asyncio.Queue[List[BlockHeader]]',
-                          filter_func: Callable[[List[BlockHeader]], List[BlockHeader]],
-                          request_func: Callable[[List[BlockHeader]], Awaitable[None]],
-                          pending: Dict[Any, Tuple[BlockHeader, float]],
-                          batch_size: int,
-                          part_name: str) -> None:
-        batch = []  # type: List[BlockHeader]
-        while True:
+    async def _download_block_parts(
+            self,
+            headers: List[BlockHeader],
+            request_func: Callable[[List[BlockHeader]], int],
+            download_queue: 'Union[asyncio.Queue[List[bytes]], asyncio.Queue[List[Tuple[bytes, bytes]]]]',  # noqa: E501
+            key_func: Callable[[BlockHeader], Union[bytes, Tuple[bytes, bytes]]],
+            part_name: str) -> None:
+        missing = headers.copy()
+        # The ETH protocol doesn't guarantee that we'll get all body parts requested, so we need
+        # to keep track of the number of pending replies and missing items to decide when to retry
+        # them. See request_receipts() for more info.
+        pending_replies = request_func(missing)
+        while missing:
+            if pending_replies == 0:
+                pending_replies = request_func(missing)
+
             try:
-                headers = await wait_with_token(
-                    queue.get(),
+                downloaded = await wait_with_token(
+                    download_queue.get(),
                     token=self.cancel_token,
-                    # Use a shorter timeout here because this only causes the actual retry
-                    # coroutine (self._retry_timedout) to go through the pending ones and retry
-                    # any items that are pending for more than self._reply_timeout seconds.
-                    timeout=self._reply_timeout / 2)
-                batch.extend(headers)
+                    timeout=self._reply_timeout)
             except TimeoutError:
-                # We use a timeout above to make sure we periodically retry timedout items
-                # even when there's no new items coming through.
-                pass
-            except OperationCancelled:
-                return
-            else:
-                # Re-apply the filter function on all items because one of the things it may do is
-                # drop items that have the same receipt_root.
-                batch = filter_func(batch)
-                if len(batch) >= batch_size:
-                    await request_func(batch[:batch_size])
-                    batch = batch[batch_size:]
+                pending_replies = request_func(missing)
+                continue
 
-            await self._retry_timedout(request_func, pending, batch_size, part_name)
+            pending_replies -= 1
+            unexpected = set(downloaded).difference(
+                [key_func(header) for header in missing])
+            for item in unexpected:
+                self.logger.warn("Got unexpected %s: %s", part_name, unexpected)
+            missing = [
+                header for header in missing
+                if key_func(header) not in downloaded]
 
-    async def _retry_timedout(self,
-                              request_func: Callable[[List[BlockHeader]], Awaitable[None]],
-                              pending: Dict[Any, Tuple[BlockHeader, float]],
-                              batch_size: int,
-                              part_name: str) -> None:
-        now = time.time()
-        timed_out = [
-            header
-            for header, req_time
-            in pending.values()
-            if now - req_time > self._reply_timeout
-        ]
-        while timed_out:
-            self.logger.warn(
-                "Re-requesting %d timed out %s out of %d pending ones",
-                len(timed_out), part_name, len(pending))
-            await request_func(timed_out[:batch_size])
-            timed_out = timed_out[batch_size:]
+    def _request_block_parts(
+            self,
+            headers: List[BlockHeader],
+            request_func: Callable[[ETHPeer, List[BlockHeader]], None]) -> int:
+        length = math.ceil(len(headers) / len(self.peer_pool.peers))
+        batches = list(partition_all(length, headers))
+        for peer, batch in zip(self.peer_pool.peers, batches):
+            request_func(cast(ETHPeer, peer), batch)
+        return len(batches)
 
-    async def body_downloader(self) -> None:
-        await self._downloader(
-            self._body_requests,
-            self._skip_empty_bodies,
-            self.request_bodies,
-            self._pending_bodies,
-            eth.MAX_BODIES_FETCH,
-            'bodies')
-
-    async def receipt_downloader(self) -> None:
-        await self._downloader(
-            self._receipt_requests,
-            self._skip_empty_and_duplicated_receipts,
-            self.request_receipts,
-            self._pending_receipts,
-            eth.MAX_RECEIPTS_FETCH,
-            'receipts')
-
-    @to_list
-    def _skip_empty_bodies(self, headers: List[BlockHeader]) -> Generator[BlockHeader, None, None]:
-        for header in headers:
-            if (header.transaction_root != self.chaindb.empty_root_hash or
-                    header.uncles_hash != EMPTY_UNCLE_HASH):
-                yield header
-
-    async def request_bodies(self, headers: List[BlockHeader]) -> None:
-        peer = await self.get_idle_peer()
-        peer.sub_proto.send_get_block_bodies([header.hash for header in headers])
-        self._peers_with_pending_requests.add(peer)
+    def _send_get_block_bodies(self, peer: ETHPeer, headers: List[BlockHeader]) -> None:
         self.logger.debug("Requesting %d block bodies to %s", len(headers), peer)
-        now = time.time()
-        for header in headers:
-            key = (header.transaction_root, header.uncles_hash)
-            self._pending_bodies[key] = (header, now)
+        peer.sub_proto.send_get_block_bodies([header.hash for header in headers])
 
-    @to_list
-    def _skip_empty_and_duplicated_receipts(
-            self, headers: List[BlockHeader]) -> Generator[BlockHeader, None, None]:
-        # Post-Byzantium blocks may have identical receipt roots (e.g. when they have the same
-        # number of transactions and all succeed/failed: ropsten blocks 2503212 and 2503284), so
-        # we have an extra check here to avoid requesting those receipts multiple times.
-        headers = list(unique(headers, key=operator.attrgetter('receipt_root')))
-        for header in headers:
-            if (header.receipt_root != self.chaindb.empty_root_hash and
-                    header.receipt_root not in self._pending_receipts):
-                yield header
-
-    async def request_receipts(self, headers: List[BlockHeader]) -> None:
-        peer = await self.get_idle_peer()
-        peer.sub_proto.send_get_receipts([header.hash for header in headers])
-        self._peers_with_pending_requests.add(peer)
+    def _send_get_receipts(self, peer: ETHPeer, headers: List[BlockHeader]) -> None:
         self.logger.debug("Requesting %d block receipts to %s", len(headers), peer)
-        now = time.time()
-        for header in headers:
-            self._pending_receipts[header.receipt_root] = (header, now)
+        peer.sub_proto.send_get_receipts([header.hash for header in headers])
 
-    async def get_idle_peer(self) -> ETHPeer:
-        """Return a random peer which we're not already expecting a response from."""
-        while True:
-            idle_peers = [
-                peer
-                for peer in self.peer_pool.peers
-                if peer not in self._peers_with_pending_requests
-            ]
-            if idle_peers:
-                return cast(ETHPeer, secrets.choice(idle_peers))
-            else:
-                self.logger.debug("No idle peers availabe, sleeping a bit")
-                await asyncio.sleep(0.2)
+    def request_bodies(self, headers: List[BlockHeader]) -> int:
+        """Ask our peers for bodies for the given headers.
+
+        See request_receipts() for details of how this is done.
+        """
+        return self._request_block_parts(headers, self._send_get_block_bodies)
+
+    def request_receipts(self, headers: List[BlockHeader]) -> int:
+        """Ask our peers for receipts for the given headers.
+
+        We partition the given list of headers in batches and request each to one of our connected
+        peers. This is done because geth enforces a byte-size cap when replying to a GetReceipts
+        msg, and we then need to re-request the items that didn't fit, so by splitting the
+        requests across all our peers we reduce the likelyhood of having to make multiple
+        serialized requests to ask for missing items (which happens quite frequently in practice).
+
+        Returns the number of requests made.
+        """
+        return self._request_block_parts(headers, self._send_get_receipts)
 
     async def wait_until_finished(self) -> None:
         start_at = time.time()
@@ -351,37 +305,53 @@ class ChainSyncer(PeerPoolSubscriber):
     async def _handle_block_receipts(
             self, peer: ETHPeer, receipts: List[List[eth.Receipt]]) -> None:
         self.logger.debug("Got Receipts for %d blocks from %s", len(receipts), peer)
-        self._peers_with_pending_requests.remove(peer)
         loop = asyncio.get_event_loop()
         iterator = map(make_trie_root_and_nodes, receipts)
         receipts_tries = await wait_with_token(
             loop.run_in_executor(None, list, iterator),
             token=self.cancel_token)
         for receipt_root, trie_dict_data in receipts_tries:
-            if receipt_root not in self._pending_receipts:
-                self.logger.warning(
-                    "Got unexpected receipt root: %s",
-                    encode_hex(receipt_root),
-                )
-                continue
             await self.chaindb.coro_persist_trie_data_dict(trie_dict_data)
-            self._pending_receipts.pop(receipt_root)
+        receipt_roots = [receipt_root for receipt_root, _ in receipts_tries]
+        self._downloaded_receipts.put_nowait(receipt_roots)
 
     async def _handle_block_bodies(self, peer: ETHPeer, bodies: List[eth.BlockBody]) -> None:
-        self.logger.debug("Got %d BlockBodies from %s", len(bodies), peer)
-        self._peers_with_pending_requests.remove(peer)
+        self.logger.debug("Got Bodies for %d blocks from %s", len(bodies), peer)
         loop = asyncio.get_event_loop()
         iterator = map(make_trie_root_and_nodes, [body.transactions for body in bodies])
         transactions_tries = await wait_with_token(
             loop.run_in_executor(None, list, iterator),
             token=self.cancel_token)
-        for i, body in enumerate(bodies):
-            tx_root, trie_dict_data = transactions_tries[i]
+        body_keys = []
+        for (body, (tx_root, trie_dict_data)) in zip(bodies, transactions_tries):
             await self.chaindb.coro_persist_trie_data_dict(trie_dict_data)
-            # TODO: Add transactions to canonical chain; blocked by
-            # https://github.com/ethereum/py-evm/issues/337
             uncles_hash = await self.chaindb.coro_persist_uncles(body.uncles)
-            self._pending_bodies.pop((tx_root, uncles_hash), None)
+            body_keys.append((tx_root, uncles_hash))
+        self._downloaded_bodies.put_nowait(body_keys)
+
+
+def _body_key(header: BlockHeader) -> Tuple[bytes, bytes]:
+    """Return the unique key of the body for the given header.
+
+    i.e. a two-tuple with the transaction root and uncles hash.
+    """
+    return cast(Tuple[bytes, bytes], (header.transaction_root, header.uncles_hash))
+
+
+def _receipts_key(header: BlockHeader) -> bytes:
+    """Return the unique key of the list of receipts for the given header.
+
+    i.e. the header's receipt root.
+    """
+    return header.receipt_root
+
+
+def _is_body_empty(header: BlockHeader) -> bool:
+    return header.transaction_root == BLANK_ROOT_HASH and header.uncles_hash == EMPTY_UNCLE_HASH
+
+
+def _is_receipts_empty(header: BlockHeader) -> bool:
+    return header.receipt_root == BLANK_ROOT_HASH
 
 
 def _test() -> None:


### PR DESCRIPTION
We now fetch a batch of headers and then all the bodies/receipts for those
headers before persisting them. This makes the code a lot easier to follow
but also guarantees our ChainDB always has full blocks for everything up to
the current chain head.