### PR TITLE
Adjust how MainnetTesterChain configures VMs to not require updates for every fork rule

### DIFF
--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -51,6 +51,7 @@ class BaseVM(Configurable, metaclass=ABCMeta):
     the individual VM classes for each fork of the protocol rules within that
     network.
     """
+    fork = None
     chaindb = None
     _state_class = None
 

--- a/evm/vm/forks/byzantium/__init__.py
+++ b/evm/vm/forks/byzantium/__init__.py
@@ -9,7 +9,10 @@ from .state import ByzantiumState
 
 
 ByzantiumVM = SpuriousDragonVM.configure(
+    # class name
     __name__='ByzantiumVM',
+    # fork name
+    fork='byzantium',
     # classes
     _state_class=ByzantiumState,
     # Methods

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -11,7 +11,10 @@ from .headers import (
 
 
 FrontierVM = VM.configure(
+    # class name
     __name__='FrontierVM',
+    # fork name
+    fork='frontier',
     # classes
     _state_class=FrontierState,
     # helpers

--- a/evm/vm/forks/homestead/__init__.py
+++ b/evm/vm/forks/homestead/__init__.py
@@ -17,7 +17,10 @@ class MetaHomesteadVM(FrontierVM):  # type: ignore
 
 
 HomesteadVM = MetaHomesteadVM.configure(
+    # class name
     __name__='HomesteadVM',
+    # fork name
+    fork='homestead',
     # classes
     _state_class=HomesteadState,
     # method overrides

--- a/evm/vm/forks/spurious_dragon/__init__.py
+++ b/evm/vm/forks/spurious_dragon/__init__.py
@@ -3,7 +3,10 @@ from ..homestead import HomesteadVM
 from .state import SpuriousDragonState
 
 SpuriousDragonVM = HomesteadVM.configure(
+    # class name
     __name__='SpuriousDragonVM',
+    # fork name
+    fork='spurious-dragon',
     # classes
     _state_class=SpuriousDragonState,
 )

--- a/evm/vm/forks/tangerine_whistle/__init__.py
+++ b/evm/vm/forks/tangerine_whistle/__init__.py
@@ -3,6 +3,10 @@ from evm.vm.forks.homestead import HomesteadVM
 from .state import TangerineWhistleState
 
 TangerineWhistleVM = HomesteadVM.configure(
+    # class name
     __name__='TangerineWhistleVM',
+    # fork name
+    fork='tangerine-whistle',
+    # classes
     _state_class=TangerineWhistleState,
 )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
+addopts= --showlocals
 python_paths= .
 xfail_strict=true


### PR DESCRIPTION
link: https://github.com/ethereum/web3.py/issues/729

### What was wrong?

The way that `evm.chains.tester.MainnetTesterChain` was done, it would require an update to the fork block number configuration for every new set of fork rules.  It also didn't allow extension with custom vms.

### How was it fixed?

- Modified the `BaseVM` class to have a record of the *name* of the fork.
- Modified the helper function which generates the VM fork rules to derive it's available VMs from the `MainnetChain`
- Simplified the logic some so that it expects very explicitly defined start blocks and doesn't try to be *smart*.


#### Cute Animal Picture

![40052](https://user-images.githubusercontent.com/824194/38154334-b8ccbf00-342e-11e8-8ec8-4a269a5f0ba2.jpg)

