### PR TITLE
allow for vm configuration that doesn't include block 0

### DIFF
--- a/evm/chains/tester/__init__.py
+++ b/evm/chains/tester/__init__.py
@@ -102,13 +102,10 @@ def _generate_vm_configuration(*fork_start_blocks: ForkStartBlocks,
             "fork configuration"
         )
 
-    # Validate that there is at least one start block for block 0
+    # If no VM is set to start at block 0, default to the frontier VM
     start_blocks = set(start_block for start_block, _ in fork_start_blocks)
     if 0 not in start_blocks:
-        raise ValidationError(
-            "At least one VM must start at block 0.  Got start blocks: "
-            "{0}".format(sorted(start_blocks))
-        )
+        yield 0, MAINNET_VMS['frontier']
 
     ordered_fork_start_blocks = sorted(fork_start_blocks, key=operator.itemgetter(0))
 

--- a/tests/core/tester/test_generate_vm_configuration.py
+++ b/tests/core/tester/test_generate_vm_configuration.py
@@ -35,6 +35,11 @@ class CustomFrontierVM(FrontierVM):
             ((0, Forks.TangerineWhistle), (1, Forks.SpuriousDragon)),
         ),
         (
+            ((1, 'tangerine-whistle'), (2, 'spurious-dragon')),
+            {},
+            ((0, Forks.Frontier), (1, Forks.TangerineWhistle), (2, Forks.SpuriousDragon)),
+        ),
+        (
             ((0, CustomFrontierVM), (1, 'spurious-dragon')),
             {},
             ((0, Forks.Custom), (1, Forks.SpuriousDragon)),
@@ -70,6 +75,11 @@ class CustomFrontierVM(FrontierVM):
         ),
         (
             ((0, 'frontier'), (1, 'homestead')),
+            {},
+            ((0, Forks.Frontier), (1, Forks.Homestead)),
+        ),
+        (
+            ((1, 'homestead'),),
             {},
             ((0, Forks.Frontier), (1, Forks.Homestead)),
         ),


### PR DESCRIPTION
continuation of #521 

### What was wrong?

In my refactor it became invalid to not provide a vm that starts at block 0.  This is actually problematic for how this API is used in `eth-tester`.

### How was it fixed?

Now if no vm is specified for block 0, it defaults to using the frontier vm.

#### Cute Animal Picture

![flying-cat-12](https://user-images.githubusercontent.com/824194/38218199-345a3d8a-368e-11e8-8ed0-b831eb60e3b2.jpg)
