### PR TITLE
Move transaction_root validation out of ChainDB.persist_block()

### DIFF
--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -417,17 +417,11 @@ class ChainDB(BaseChainDB):
         )
 
     def persist_block(self, block):
-        '''
-        Chain must do follow-up work to persist transactions to db
+        '''Persist the given block's header and uncles.
+
+        Assumes all block transactions have been persisted already.
         '''
         new_canonical_headers = self.persist_header(block.header)
-
-        # Persist the transaction bodies
-        transaction_db = self.trie_class(self.db, root_hash=self.empty_root_hash)
-        for i, transaction in enumerate(block.transactions):
-            index_key = rlp.encode(i, sedes=rlp.sedes.big_endian_int)
-            transaction_db[index_key] = rlp.encode(transaction)
-        assert transaction_db.root_hash == block.header.transaction_root
 
         for header in new_canonical_headers:
             for index, transaction_hash in enumerate(self.get_block_transaction_hashes(header)):

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -18,6 +18,7 @@ from evm.constants import (
     MAX_PREV_HEADER_DEPTH,
     MAX_UNCLES,
 )
+from evm.db.trie import make_trie_root_and_nodes
 from evm.exceptions import (
     BlockNotFound,
     ValidationError,
@@ -262,6 +263,12 @@ class BaseVM(Configurable, metaclass=ABCMeta):
                         parent_header.timestamp,
                     )
                 )
+
+        tx_root_hash, _ = make_trie_root_and_nodes(block.transactions)
+        if tx_root_hash != block.header.transaction_root:
+            raise ValidationError(
+                "Block's transaction_root ({0}) does not match expected value: {1}".format(
+                    block.header.transaction_root, tx_root_hash))
 
         if len(block.uncles) > MAX_UNCLES:
             raise ValidationError(


### PR DESCRIPTION
IIUC, `BaseVM.apply_transaction()` takes care of persisting the tx trie to the DB, and `ChainDB.persist_block()` was generating the trie just to assert the transaction_root is what we expect 