### PR TITLE
mypy fix for removed BaseCollation

### DIFF
--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -73,9 +73,6 @@ if TYPE_CHECKING:
     from evm.rlp.blocks import (  # noqa: F401
         BaseBlock
     )
-    from evm.rlp.collations import (  # noqa: F401
-        BaseCollation
-    )
     from evm.rlp.transactions import (  # noqa: F401
         BaseTransaction
     )
@@ -185,7 +182,7 @@ class BaseChainDB(metaclass=ABCMeta):
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
-    def persist_block(self, block: Union['BaseBlock', 'BaseCollation']) -> None:
+    def persist_block(self, block: 'BaseBlock') -> None:
         """
         Chain must do follow-up work to persist transactions to db
         """


### PR DESCRIPTION
### What was wrong?

Leftover type hints pointing at the now removed `BaseCollation` class.

### How was it fixed?

Removed.

#### Cute Animal Picture

![6123471-cute_camel-0](https://user-images.githubusercontent.com/824194/38566422-dc4a2d12-3ca0-11e8-8df6-cd2a9a159a26.jpg)
