### PR TITLE
Fix doc generation task

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,28 +177,3 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.5', None),
 }
-
-# -- autodoc on any sphinx-build, to support RTD ---------------------------
-
-
-def run_apidoc(_):
-    from sphinx.apidoc import main
-    import os
-    import sys
-    sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-    cur_dir = os.path.abspath(os.path.dirname(__file__))
-    package = os.path.join(cur_dir, "..")
-    main([
-        None,
-        '-o',
-        cur_dir,
-        '--force',
-        package,
-        package + "/tests/*",
-        package + "/setup.py",
-        package + '/.eggs/*',
-    ])
-
-
-def setup(app):
-    app.connect('builder-inited', run_apidoc)


### PR DESCRIPTION
### What was wrong?

I tried working on the docs but running `make html` in `docs` just left me with

```
$ make html
Running Sphinx v1.7.2
loading translations [en]... done
making output directory...
loading pickled environment... not yet created
loading intersphinx inventory from https://docs.python.org/3.5/objects.inv...
usage: sphinx-build [OPTIONS] -o <OUTPUT_PATH> <MODULE_PATH> [EXCLUDE_PATTERN, ...]
sphinx-build: error: the following arguments are required: -o/--output-dir
Makefile:20: recipe for target 'html' failed
make: *** [html] Error 2
```

### How was it fixed?

I admit that I have never worked with `sphinx` before so there's a high chance that I'm doing it completely wrong. I tried to figure out if there's a @carver pattern to the rescue and noticed that I can build the docs for `eth-account` without problems.

In the end it boiled down to simply deleting some code in `conf.py` that was getting in the way. After I deleted the code I was able to build the docs with `make html` and they also looked correct when I served them.

There's a comment on the code that I deleted that indicates that it is important to support readthedocs.io but `eth-account` also hosts on readthedocs.io and doesn't have this code either so I'm not sure if that still holds.

There's a high chance that this actually isn't the right way of fixing docs generation (or that there's nothing broken at all and I'm just doing it wrong) in which case I hope to receive some additional pointers to explore the right way forward :)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1517589204928-39139972edef?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=7e1f61396cfec608cc98a736894a8d32&auto=format&fit=crop&w=1350&q=80)
