### PR TITLE
Add an lru cache to BaseVM.get_prev_hashes()

### DIFF
--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -8,6 +8,8 @@ import contextlib
 import logging
 import rlp
 
+import functools
+
 from eth_utils import (
     keccak,
     to_tuple,
@@ -364,6 +366,7 @@ class BaseVM(Configurable, metaclass=ABCMeta):
 
     @classmethod
     @to_tuple
+    @functools.lru_cache(maxsize=32)
     def get_prev_hashes(cls, last_block_hash, db):
         if last_block_hash == GENESIS_PARENT_HASH:
             return

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -365,8 +365,8 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         return cls.get_block_class().from_header(block_header, db)
 
     @classmethod
-    @to_tuple
     @functools.lru_cache(maxsize=32)
+    @to_tuple
     def get_prev_hashes(cls, last_block_hash, db):
         if last_block_hash == GENESIS_PARENT_HASH:
             return


### PR DESCRIPTION
Not sure what maxsize to use, but assuming that method is used most of the time
to lookup the state of the current head, I think a large maxsize won't provide any benefit. The main motivation for the cache was actually to reduce the number of times we perform this during the importing of a single block, and it reduced the total time by 30% in that case.

Part of the fixes for #542