### PR TITLE
Convert addresses and hashes to NewTypes

### DIFF
--- a/eth_typing/__init__.py
+++ b/eth_typing/__init__.py
@@ -1,0 +1,8 @@
+from .enums import (  # noqa: F401
+    ForkName
+)
+
+from .misc import (  # noqa: F401
+    Address,
+    Hash32
+)

--- a/eth_typing/misc.py
+++ b/eth_typing/misc.py
@@ -1,0 +1,6 @@
+from typing import NewType
+
+
+Address = NewType('Address', bytes)
+
+Hash32 = NewType('Hash32', bytes)

--- a/evm/consensus/pow.py
+++ b/evm/consensus/pow.py
@@ -7,6 +7,9 @@ from pyethash import (
     mkcache_bytes,
 )
 
+from eth_typing import (
+    Hash32
+)
 from eth_utils import (
     keccak,
 )
@@ -48,8 +51,8 @@ def get_cache(block_number: int) -> bytes:
 
 
 def check_pow(block_number: int,
-              mining_hash: bytes,
-              mix_hash: bytes,
+              mining_hash: Hash32,
+              mix_hash: Hash32,
               nonce: bytes,
               difficulty: int) -> None:
     validate_length(mix_hash, 32, title="Mix Hash")

--- a/evm/constants.py
+++ b/evm/constants.py
@@ -1,3 +1,7 @@
+from eth_typing import (
+    Address,
+    Hash32
+)
 from eth_utils import denoms
 
 
@@ -14,9 +18,9 @@ EMPTY_WORD = NULL_BYTE * 32
 
 UINT_160_CEILING = 2**160
 
-CREATE_CONTRACT_ADDRESS = b''
-ZERO_ADDRESS = 20 * b'\x00'
-ZERO_HASH32 = 32 * b'\x00'
+CREATE_CONTRACT_ADDRESS = Address(b'')
+ZERO_ADDRESS = Address(20 * b'\x00')
+ZERO_HASH32 = Hash32(32 * b'\x00')
 
 
 #
@@ -137,7 +141,7 @@ SECPK1_G = (SECPK1_Gx, SECPK1_Gy)
 # Block and Header
 #
 # keccak(rlp.encode([]))
-EMPTY_UNCLE_HASH = b'\x1d\xccM\xe8\xde\xc7]z\xab\x85\xb5g\xb6\xcc\xd4\x1a\xd3\x12E\x1b\x94\x8at\x13\xf0\xa1B\xfd@\xd4\x93G'  # noqa: E501
+EMPTY_UNCLE_HASH = Hash32(b'\x1d\xccM\xe8\xde\xc7]z\xab\x85\xb5g\xb6\xcc\xd4\x1a\xd3\x12E\x1b\x94\x8at\x13\xf0\xa1B\xfd@\xd4\x93G')  # noqa: E501
 
 
 #
@@ -154,8 +158,8 @@ GENESIS_EXTRA_DATA = b''
 #
 # Sha3 Keccak
 #
-EMPTY_SHA3 = b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04]\x85\xa4p"  # noqa: E501
-BLANK_ROOT_HASH = b'V\xe8\x1f\x17\x1b\xccU\xa6\xff\x83E\xe6\x92\xc0\xf8n\x5bH\xe0\x1b\x99l\xad\xc0\x01b/\xb5\xe3c\xb4!'  # noqa: E501
+EMPTY_SHA3 = Hash32(b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04]\x85\xa4p")  # noqa: E501
+BLANK_ROOT_HASH = Hash32(b'V\xe8\x1f\x17\x1b\xccU\xa6\xff\x83E\xe6\x92\xc0\xf8n\x5bH\xe0\x1b\x99l\xad\xc0\x01b/\xb5\xe3c\xb4!')  # noqa: E501
 
 
 GAS_MOD_EXP_QUADRATIC_DENOMINATOR = 20

--- a/evm/rlp/blocks.py
+++ b/evm/rlp/blocks.py
@@ -8,6 +8,10 @@ from typing import (  # noqa: F401
 
 import rlp
 
+from eth_typing import (
+    Hash32
+)
+
 from evm.utils.datatypes import (
     Configurable,
 )
@@ -44,7 +48,7 @@ class BaseBlock(rlp.Serializable, Configurable, metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def hash(self) -> bytes:
+    def hash(self) -> Hash32:
         raise NotImplementedError("Must be implemented by subclasses")
 
     @property

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -12,6 +12,10 @@ from cytoolz import (
     first,
     sliding_window,
 )
+from eth_typing import (
+    Address,
+    Hash32
+)
 from eth_utils import (
     keccak,
     to_dict,
@@ -82,16 +86,16 @@ class BlockHeader(rlp.Serializable):
                  block_number: int,
                  gas_limit: int,
                  timestamp: int=None,
-                 coinbase: bytes=ZERO_ADDRESS,
-                 parent_hash: bytes=ZERO_HASH32,
-                 uncles_hash: bytes=EMPTY_UNCLE_HASH,
-                 state_root: bytes=BLANK_ROOT_HASH,
-                 transaction_root: bytes=BLANK_ROOT_HASH,
-                 receipt_root: bytes=BLANK_ROOT_HASH,
+                 coinbase: Address=ZERO_ADDRESS,
+                 parent_hash: Hash32=ZERO_HASH32,
+                 uncles_hash: Hash32=EMPTY_UNCLE_HASH,
+                 state_root: Hash32=BLANK_ROOT_HASH,
+                 transaction_root: Hash32=BLANK_ROOT_HASH,
+                 receipt_root: Hash32=BLANK_ROOT_HASH,
                  bloom: int=0,
                  gas_used: int=0,
                  extra_data: bytes=b'',
-                 mix_hash: bytes=ZERO_HASH32,
+                 mix_hash: Hash32=ZERO_HASH32,
                  nonce: bytes=GENESIS_NONCE) -> None:
         if timestamp is None:
             timestamp = int(time.time())
@@ -120,11 +124,11 @@ class BlockHeader(rlp.Serializable):
         )
 
     @property
-    def hash(self) -> bytes:
+    def hash(self) -> Hash32:
         return keccak(rlp.encode(self))
 
     @property
-    def mining_hash(self) -> bytes:
+    def mining_hash(self) -> Hash32:
         return keccak(
             rlp.encode(self, BlockHeader.exclude(['mix_hash', 'nonce'])))
 
@@ -138,7 +142,7 @@ class BlockHeader(rlp.Serializable):
                     gas_limit: int,
                     difficulty: int,
                     timestamp: int,
-                    coinbase: bytes=ZERO_ADDRESS,
+                    coinbase: Address=ZERO_ADDRESS,
                     nonce: bytes=None,
                     extra_data: bytes=None,
                     transaction_root: bytes=None,

--- a/evm/rlp/transactions.py
+++ b/evm/rlp/transactions.py
@@ -12,6 +12,10 @@ from rlp.sedes import (
     binary,
 )
 
+from eth_typing import (
+    Address
+)
+
 from eth_utils import (
     keccak,
 )
@@ -51,7 +55,7 @@ class BaseTransaction(rlp.Serializable, metaclass=ABCMeta):
         return keccak(rlp.encode(self))
 
     @property
-    def sender(self) -> bytes:
+    def sender(self) -> Address:
         """
         Convenience property for the return value of `get_sender`
         """
@@ -101,7 +105,7 @@ class BaseTransaction(rlp.Serializable, metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @abstractmethod
-    def get_sender(self) -> bytes:
+    def get_sender(self) -> Address:
         """
         Get the 20-byte address which sent this transaction.
         """

--- a/evm/utils/headers.py
+++ b/evm/utils/headers.py
@@ -1,5 +1,9 @@
 import time
+from typing import Callable, Tuple, Optional
 
+from eth_typing import (
+    Address
+)
 from evm.constants import (
     GENESIS_GAS_LIMIT,
     GAS_LIMIT_EMA_DENOMINATOR,
@@ -11,8 +15,6 @@ from evm.constants import (
 from evm.rlp.headers import (
     BlockHeader,
 )
-
-from typing import Callable, Tuple, Optional
 
 
 def compute_gas_limit_bounds(parent: BlockHeader) -> Tuple[int, int]:
@@ -78,7 +80,7 @@ def compute_gas_limit(parent_header: BlockHeader, gas_limit_floor: int) -> int:
 def generate_header_from_parent_header(
         compute_difficulty_fn: Callable[[BlockHeader, int], int],
         parent_header: BlockHeader,
-        coinbase: bytes,
+        coinbase: Address,
         timestamp: Optional[int] = None,
         extra_data: bytes = b'') -> BlockHeader:
     """

--- a/evm/vm/computation.py
+++ b/evm/vm/computation.py
@@ -15,6 +15,10 @@ from typing import (  # noqa: F401
     Tuple,
 )
 
+from eth_typing import (
+    Address
+)
+
 from evm.db.state import (
     BaseAccountStateDB
 )
@@ -299,7 +303,7 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
                 self.return_data = child_computation.output
         self.children.append(child_computation)
 
-    def register_account_for_deletion(self, beneficiary: bytes) -> None:
+    def register_account_for_deletion(self, beneficiary: Address) -> None:
         validate_canonical_address(beneficiary, title="Self destruct beneficiary address")
 
         if self.msg.storage_address in self.accounts_to_delete:
@@ -309,7 +313,7 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
             )
         self.accounts_to_delete[self.msg.storage_address] = beneficiary
 
-    def add_log_entry(self, account: bytes, topics: List[int], data: bytes) -> None:
+    def add_log_entry(self, account: Address, topics: List[int], data: bytes) -> None:
         validate_canonical_address(account, title="Log entry address")
         for topic in topics:
             validate_uint256(topic, title="Log entry topic")

--- a/evm/vm/forks/frontier/constants.py
+++ b/evm/vm/forks/frontier/constants.py
@@ -1,4 +1,8 @@
-CREATE_CONTRACT_ADDRESS = b''
+from eth_typing import (
+    Address
+)
+
+CREATE_CONTRACT_ADDRESS = Address(b'')
 
 
 #

--- a/p2p/rlp.py
+++ b/p2p/rlp.py
@@ -1,6 +1,9 @@
 import rlp
 from rlp import sedes
 
+from eth_typing import (
+    Hash32
+)
 from eth_utils import keccak
 
 from evm.rlp.headers import BlockHeader
@@ -22,7 +25,7 @@ class ImmutableBlockHeader(BlockHeader):
         return sedes.make_immutable(obj)
 
     @property
-    def hash(self) -> bytes:
+    def hash(self) -> Hash32:
         if self._hash is None:
             self._hash = keccak(self._cached_rlp)
         return self._hash


### PR DESCRIPTION
### What was wrong?

As discussed in #499 for certain usages of `bytes` (and potentially others) we can benefit from introducing a NewType so that the type system forbids calling an API that expects an `Address` with just any other arbitrary bytes.

### How was it fixed?

Implemented `Address` and `Hash32` NewType and used where appropriate. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1508814389023-fe39a089973a?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ceb4b3fffb4f76afb97bb48035d250d1&auto=format&fit=crop&w=1350&q=80)
