### PR TITLE
Add type hint for BatchDB.cache

### DIFF
--- a/evm/db/batch.py
+++ b/evm/db/batch.py
@@ -1,6 +1,10 @@
 import logging
 from evm.db.backends.base import BaseDB
 
+from typing import (  # noqa: F401
+    Dict,
+)
+
 
 class BatchDB(BaseDB):
     """
@@ -15,7 +19,7 @@ class BatchDB(BaseDB):
 
     def __init__(self, wrapped_db):
         self.wrapped_db = wrapped_db
-        self.cache = {}
+        self.cache = {}  # type: Dict[bytes, bytes]
 
     def __enter__(self):
         return self


### PR DESCRIPTION
### What was wrong?

Type hint was missing making the linting on Travis fail (see e.g. https://travis-ci.org/ethereum/py-evm/jobs/367371776#L510).

### How was it fixed?

Added the type hint.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/38860002-bc199bba-4261-11e8-975d-84e63f891363.jpg)