### PR TITLE
Redesign receipt/tx trie generation on block imports

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -210,13 +210,6 @@ class BaseChain(Configurable, metaclass=ABCMeta):
     # Execution API
     #
     @abstractmethod
-    def apply_transaction(self, transaction):
-        """
-        Applies the transaction to the current head block of the Chain.
-        """
-        raise NotImplementedError("Chain classes must implement this method")
-
-    @abstractmethod
     def estimate_gas(self, transaction, at_header=None):
         """
         Generate a gas estimation for the given transaction using the
@@ -487,18 +480,6 @@ class Chain(BaseChain):
     #
     # Mining and Execution API
     #
-    def apply_transaction(self, transaction):
-        """
-        Applies the transaction to the current head block of the Chain.
-        """
-        vm = self.get_vm()
-        computation, block = vm.apply_transaction(transaction)
-
-        # Update header
-        self.header = block.header
-
-        return computation
-
     def estimate_gas(self, transaction, at_header=None):
         if at_header is None:
             at_header = self.get_canonical_head()

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -3,12 +3,12 @@ from abc import (
     ABCMeta,
     abstractmethod
 )
-
 import contextlib
-import logging
-import rlp
-
 import functools
+import logging
+from typing import List  # noqa: F401
+
+import rlp
 
 from eth_utils import (
     keccak,
@@ -28,6 +28,7 @@ from evm.exceptions import (
 from evm.rlp.headers import (
     BlockHeader,
 )
+from evm.rlp.receipts import Receipt  # noqa: F401
 from evm.utils.datatypes import (
     Configurable,
 )
@@ -62,7 +63,7 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         self.chaindb = chaindb
         block_class = self.get_block_class()
         self.block = block_class.from_header(header=header, chaindb=self.chaindb)
-        self.receipts = []
+        self.receipts = []  # type: List[Receipt]
 
     #
     # Logging
@@ -218,7 +219,10 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         header = self.block.header
         temp_block = self.generate_block_from_parent_header_and_coinbase(header, header.coinbase)
         prev_hashes = (header.hash, ) + self.previous_hashes
-        state = self.get_state(self.chaindb, temp_block, prev_hashes)
+        gas_used = 0
+        if self.receipts:
+            gas_used = self.receipts[-1].gas_used
+        state = self.get_state(self.chaindb, temp_block, prev_hashes, gas_used)
         assert state.gas_used == 0, "There must not be any gas used in a fresh temporary block"
 
         snapshot = state.snapshot()
@@ -444,7 +448,7 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         return cls._state_class
 
     @classmethod
-    def get_state(cls, chaindb, block, prev_hashes, receipts=None):
+    def get_state(cls, chaindb, block, prev_hashes, gas_used):
         """
         Return state object
 
@@ -454,23 +458,24 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         :return: state with root defined in block
         """
         execution_context = block.header.create_execution_context(prev_hashes)
-        if receipts is None:
-            receipts = block.get_receipts(chaindb)
 
         return cls.get_state_class()(
             chaindb,
             execution_context=execution_context,
             state_root=block.header.state_root,
-            receipts=receipts,
+            gas_used=gas_used,
         )
 
     @property
     def state(self):
         """Return current state property
         """
+        gas_used = 0
+        if self.receipts:
+            gas_used = self.receipts[-1].gas_used
         return self.get_state(
             chaindb=self.chaindb,
             block=self.block,
             prev_hashes=self.previous_hashes,
-            receipts=list(self.receipts),
+            gas_used=gas_used,
         )

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -185,6 +185,7 @@ def test_estimate_gas(
         # assert chain.estimate_gas(tx, chain.get_canonical_head()) == expected
 
 
+# XXX: This test is failing; need to figure out why.
 def test_estimate_gas_on_full_block(chain, funded_address_private_key, funded_address):
 
     def estimation_txn(chain, from_, from_key, data):

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -34,17 +34,6 @@ def tx(chain, funded_address, funded_address_private_key):
     return new_transaction(vm, from_, recipient, amount, funded_address_private_key)
 
 
-def test_apply_transaction(chain, tx):
-    vm = chain.get_vm()
-
-    computation = chain.apply_transaction(tx)
-
-    # Check if the state is updated.
-    vm = chain.get_vm()
-    assert vm.state.state_root == computation.state.state_root
-    assert vm.state.read_only_state_db.get_balance(tx.to) == tx.value
-
-
 def test_import_block_validation(valid_chain, funded_address, funded_address_initial_balance):
     block = rlp.decode(valid_block_rlp, sedes=FrontierBlock)
     imported_block = valid_chain.import_block(block)

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -185,7 +185,6 @@ def test_estimate_gas(
         # assert chain.estimate_gas(tx, chain.get_canonical_head()) == expected
 
 
-# XXX: This test is failing; need to figure out why.
 def test_estimate_gas_on_full_block(chain, funded_address_private_key, funded_address):
 
     def estimation_txn(chain, from_, from_key, data):

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -35,17 +35,17 @@ def fill_block(chain, from_, key, gas, data):
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
 
-    assert chain.get_vm().state.gas_used == 0
+    vm = chain.get_vm()
+    assert vm.state.gas_used == 0
 
     while True:
-        vm = chain.get_vm()
         tx = new_transaction(vm, from_, recipient, amount, key, gas=gas, data=data)
         try:
-            chain.apply_transaction(tx)
+            vm.apply_transaction(tx)
         except ValidationError as exc:
             if "Transaction exceeds gas limit" == str(exc):
                 break
             else:
                 raise exc
 
-    assert chain.get_vm().state.gas_used > 0
+    assert vm.state.gas_used > 0

--- a/tests/core/vm/test_vm_state.py
+++ b/tests/core/vm/test_vm_state.py
@@ -106,7 +106,7 @@ def test_apply_transaction(  # noqa: F811
         chaindb=chaindb1,
         execution_context=execution_context,
         state_root=block1.header.state_root,
-        receipts=[],
+        gas_used=0,
     )
     parent_hash = copy.deepcopy(prev_hashes[0])
 
@@ -124,7 +124,7 @@ def test_apply_transaction(  # noqa: F811
         chaindb=chaindb1,
         execution_context=execution_context,
         state_root=block.header.state_root,
-        receipts=computation.state.receipts,
+        gas_used=computation.state.gas_used,
     )
     computation, block, _ = state1.apply_transaction(
         tx2,


### PR DESCRIPTION
We used to generate the tries for all block's transactions/receipts
after applying every transaction, but that is way too expensive. Now the
trie data is only generated once, after we've applied all transactions