### PR TITLE
Refactor JournalDB for efficiency

### DIFF
--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -588,6 +588,11 @@ class ChainDB(BaseChainDB):
             rlp.encode(transaction),
         )
 
+    def remove_pending_transaction(self, transaction: 'BaseTransaction') -> None:
+        tx_lookup_key = make_transaction_hash_to_data_lookup_key(transaction.hash)
+        if self.db.exists(tx_lookup_key):
+            self.db.delete(tx_lookup_key)
+
     def add_transaction(self,
                         block_header: BlockHeader,
                         index_key: int,

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -357,6 +357,7 @@ class ChainDB(BaseChainDB):
             else:
                 new_headers = tuple()
 
+        self.db.persist()
         return new_headers
 
     def _set_as_canonical_chain_head(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -389,7 +389,7 @@ class ChainDB(BaseChainDB):
         for h in new_canonical_headers:
             self._add_block_number_to_hash_lookup(h)
 
-        self.db.set(CANONICAL_HEAD_HASH_DB_KEY, header.hash)
+        self.base_db.set(CANONICAL_HEAD_HASH_DB_KEY, header.hash)
 
         return new_canonical_headers
 
@@ -619,10 +619,10 @@ class ChainDB(BaseChainDB):
     # Snapshot and revert API
     #
     def snapshot(self) -> UUID:
-        return self.db.snapshot()
+        return self.db.record()
 
     def revert(self, checkpoint: UUID) -> None:
-        self.db.revert(checkpoint)
+        self.db.discard(checkpoint)
 
     def commit(self, checkpoint: UUID) -> None:
         self.db.commit(checkpoint)
@@ -631,7 +631,7 @@ class ChainDB(BaseChainDB):
         self.db.persist()
 
     def clear(self) -> None:
-        self.db.clear()
+        self.db.reset()
 
     #
     # State Database API

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -256,14 +256,14 @@ class BaseChainDB(metaclass=ABCMeta):
         raise NotImplementedError("ChainDB classes must implement this method")
 
     #
-    # Snapshot and revert API
+    # Record and discard API
     #
     @abstractmethod
-    def snapshot(self) -> UUID:
+    def record(self) -> UUID:
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
-    def revert(self, checkpoint: UUID) -> None:
+    def discard(self, checkpoint: UUID) -> None:
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
@@ -616,16 +616,16 @@ class ChainDB(BaseChainDB):
             self.db[key] = value
 
     #
-    # Snapshot and revert API
+    # Record and discard API
     #
-    def snapshot(self) -> UUID:
+    def record(self) -> UUID:
         return self.journal_db.record()
 
-    def revert(self, checkpoint: UUID) -> None:
-        self.journal_db.discard(checkpoint)
+    def discard(self, changeset_id: UUID) -> None:
+        self.journal_db.discard(changeset_id)
 
-    def commit(self, checkpoint: UUID) -> None:
-        self.journal_db.commit(checkpoint)
+    def commit(self, changeset_id: UUID) -> None:
+        self.journal_db.commit(changeset_id)
 
     def persist(self) -> None:
         self.journal_db.persist()
@@ -685,6 +685,7 @@ class NonJournaledAsyncChainDB(AsyncChainDB):
 
     def __init__(self, db, account_state_class=MainAccountStateDB, trie_class=HexaryTrie):
         self.db = db
+        self.journal_db = db
         self.account_state_class = account_state_class
         self.set_trie(trie_class)
 

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -626,6 +626,9 @@ class ChainDB(BaseChainDB):
     def commit(self, checkpoint: UUID) -> None:
         self.db.commit(checkpoint)
 
+    def persist(self) -> None:
+        self.db.persist()
+
     def clear(self) -> None:
         self.db.clear()
 

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -582,17 +582,13 @@ class ChainDB(BaseChainDB):
         lookup_key = make_transaction_hash_to_data_lookup_key(transaction_hash)
         if self.db.exists(lookup_key):
             self.db.delete(lookup_key)
+            self.db.persist()
 
     def add_pending_transaction(self, transaction: 'BaseTransaction') -> None:
         self.db.set(
             make_transaction_hash_to_data_lookup_key(transaction.hash),
             rlp.encode(transaction),
         )
-
-    def remove_pending_transaction(self, transaction: 'BaseTransaction') -> None:
-        tx_lookup_key = make_transaction_hash_to_data_lookup_key(transaction.hash)
-        if self.db.exists(tx_lookup_key):
-            self.db.delete(tx_lookup_key)
 
     def add_transaction(self,
                         block_header: BlockHeader,

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -244,7 +244,7 @@ class JournalDB(BaseDB):
 
             # Ensure the journal automatically restarts recording after
             # it has been persisted to the underlying db
-            self.record()
+            self.reset()
 
     def persist(self) -> None:
         """

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -247,9 +247,9 @@ class JournalDB(BaseDB):
             # ensure new root checkpoint
             self.journal.create_checkpoint()
 
-    def commit_all(self):
+    def persist(self):
         """
-        Collapses all outstanding changes
+        Persist all changes in underlying db
         """
         self.commit(self.journal.root_checkpoint_id)
 

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -253,3 +253,10 @@ class JournalDB(BaseDB):
         Cleare the entire journal.
         """
         self.journal = Journal()
+
+    # temporary aliases to assist refactoring
+    def snapshot(self):
+        return self.record()
+
+    def revert(self, changeset):
+        return self.discard(changeset)

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -163,6 +163,8 @@ class JournalDB(BaseDB):
     subsequent changesets into the previous changeset giving precidence to later
     changesets in case of conflicting keys.
 
+    Nothing is written to the underlying db until `persist()` is called.
+
     The added memory footprint for a JournalDB is one key/value stored per
     database key which is changed.  Subsequent changes to the same key within
     the same changeset will not increase the journal size since we only need

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -211,7 +211,7 @@ class JournalDB(BaseDB):
         """
         return self.journal.create_checkpoint()
 
-    def forget(self, changeset):
+    def discard(self, changeset):
         """
         Throws away all journaled data starting at the given changeset
         """

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -173,7 +173,9 @@ class JournalDB(BaseDB):
     def get(self, key: bytes) -> bytes:
 
         val = self.journal[key]
-        if val is None:
+        if val is DELETED_ENTRY:
+            raise KeyError(key)
+        elif val is None:
             return self.wrapped_db[key]
         else:
             return val

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -3,6 +3,7 @@ from typing import Dict  # noqa: F401
 import uuid
 
 from cytoolz import (
+    first,
     merge,
     last,
 )
@@ -25,6 +26,13 @@ class Journal(BaseDB):
         # to a dictionary of key:value pairs wher the `value` is the original
         # value for the given key at the moment this checkpoint was created.
         self.journal_data = collections.OrderedDict()
+
+    @property
+    def root_checkpoint_id(self):
+        """
+        Returns the checkpoint_id of the latest checkpoint
+        """
+        return first(self.journal_data.keys())
 
     @property
     def latest_id(self):
@@ -244,8 +252,7 @@ class JournalDB(BaseDB):
         """
         Collapses all outstanding changes
         """
-        while not self.journal.is_empty():
-            self.commit(self.journal.latest_id)
+        self.commit(self.journal.root_checkpoint_id)
 
 
     def clear(self):

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -134,18 +134,12 @@ class Journal(BaseDB):
         self.latest[key] = value
 
     def exists(self, key):
-        for changeset_data in reversed(self.journal_data.values()):
-            try:
-                value = changeset_data[key]
-            except KeyError:
-                continue
-            else:
-                if value is None:
-                    return False
-                else:
-                    return True
-        else:
+        try:
+            self.get(key)
+        except KeyError:
             return False
+        else:
+            return True
 
     def delete(self, key):
         self.latest[key] = None

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -170,14 +170,11 @@ class JournalDB(BaseDB):
     to track the original value for any given key within any given checkpoint.
     """
     wrapped_db = None
-    journal = None
+    journal = None  # type: Journal
 
     def __init__(self, wrapped_db: BaseDB) -> None:
         self.wrapped_db = wrapped_db
-        self.journal = Journal()
-        # Not sure if that's the right thing to do but for now assume
-        # we just start recording right away.
-        self.record()
+        self.clear()
 
     #TODO: Discuss potential inefficiency issue
     def get(self, key: bytes) -> bytes:
@@ -247,6 +244,8 @@ class JournalDB(BaseDB):
                     except KeyError:
                         pass
 
+            # ensure new root checkpoint
+            self.journal.create_checkpoint()
 
     def commit_all(self):
         """
@@ -255,11 +254,13 @@ class JournalDB(BaseDB):
         self.commit(self.journal.root_checkpoint_id)
 
 
+    #TODO: rename to reset
     def clear(self):
         """
         Cleare the entire journal.
         """
         self.journal = Journal()
+        self.record()
 
     # temporary aliases to assist refactoring
     def snapshot(self):

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -167,6 +167,9 @@ class JournalDB(BaseDB):
     def __init__(self, wrapped_db: BaseDB) -> None:
         self.wrapped_db = wrapped_db
         self.journal = Journal()
+        # Not sure if that's the right thing to do but for now assume
+        # we just start recording right away.
+        self.record()
 
     #TODO: Discuss potential inefficiency issue
     def get(self, key: bytes) -> bytes:
@@ -202,19 +205,18 @@ class JournalDB(BaseDB):
                 str(checkpoint)
             ))
 
-    def snapshot(self):
+    def record(self):
         """
-        Takes a snapshot of the database by creating a checkpoint.
+        Starts a new recording and returns an id for the associated changeset
         """
         return self.journal.create_checkpoint()
 
-    def revert(self, checkpoint):
+    def forget(self, changeset):
         """
-        Reverts the database back to the checkpoint.  Reversions are done
-        simply by throwing away the journaled data.
+        Throws away all journaled data starting at the given changeset
         """
-        self._validate_checkpoint(checkpoint)
-        self.journal.pop_checkpoint(checkpoint)
+        self._validate_checkpoint(changeset)
+        self.journal.pop_checkpoint(changeset)
 
     def commit(self, checkpoint):
         """

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -86,6 +86,7 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         self.block = block
         self.receipts.append(receipt)
 
+        self.chaindb.remove_pending_transaction(transaction)
         self.chaindb.persist()
         self.clear_journal()
 

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -87,7 +87,6 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         self.receipts.append(receipt)
 
         self.chaindb.persist()
-        self.clear_journal()
 
         return computation, self.block
 

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -86,7 +86,6 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         self.block = block
         self.receipts.append(receipt)
 
-        self.chaindb.remove_pending_transaction(transaction)
         self.chaindb.persist()
         self.clear_journal()
 

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -86,6 +86,7 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         self.block = block
         self.receipts.append(receipt)
 
+        self.chaindb.persist()
         self.clear_journal()
 
         return computation, self.block

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -141,27 +141,27 @@ class BaseState(Configurable, metaclass=ABCMeta):
         Perform a full snapshot of the current state.
 
         Snapshots are a combination of the state_root at the time of the
-        snapshot and the checkpoint_id returned from the journaled DB.
+        snapshot and the id of the changeset from the journaled DB.
         """
-        return (self.state_root, self._chaindb.snapshot())
+        return (self.state_root, self._chaindb.record())
 
     def revert(self, snapshot):
         """
         Revert the VM to the state at the snapshot
         """
-        state_root, checkpoint_id = snapshot
+        state_root, changeset_id = snapshot
 
         with self.mutable_state_db() as state_db:
             # first revert the database state root.
             state_db.root_hash = state_root
 
         # now roll the underlying database back
-        self._chaindb.revert(checkpoint_id)
+        self._chaindb.discard(changeset_id)
 
     def commit(self, snapshot):
         """
         Commits the journal to the point where the snapshot was taken.  This
-        will destroy any journal checkpoints *after* the snapshot checkpoint.
+        will merge in any changesets that were recorded *after* the snapshot changeset.
         """
         _, checkpoint_id = snapshot
         self._chaindb.commit(checkpoint_id)

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -116,7 +116,7 @@ def test_revert_removes_journal_entries(journal_db):
     # Forget everything from b2 (inclusive) and what follows
     journal_db.discard(changeset_b2)
     assert len(journal_db.journal.journal_data) == 2
-    assert journal_db.journal.has_checkpoint(changeset_b2) is False
+    assert journal_db.journal.has_changeset(changeset_b2) is False
 
 
 def test_commit_merges_changeset_into_previous(journal_db):
@@ -130,7 +130,7 @@ def test_commit_merges_changeset_into_previous(journal_db):
     journal_db.commit(changeset)
 
     assert len(journal_db.journal.journal_data) == 1
-    assert journal_db.journal.has_checkpoint(changeset) is False
+    assert journal_db.journal.has_changeset(changeset) is False
 
 
 def test_committing_middle_changeset_merges_in_subsequent_changesets(journal_db):
@@ -154,9 +154,9 @@ def test_committing_middle_changeset_merges_in_subsequent_changesets(journal_db)
     journal_db.commit(changeset_b)
     assert journal_db.get(b'1') == b'test-c'
     assert len(journal_db.journal.journal_data) == 2
-    assert journal_db.journal.has_checkpoint(changeset_a)
-    assert journal_db.journal.has_checkpoint(changeset_b) is False
-    assert journal_db.journal.has_checkpoint(changeset_c) is False
+    assert journal_db.journal.has_changeset(changeset_a)
+    assert journal_db.journal.has_changeset(changeset_b) is False
+    assert journal_db.journal.has_changeset(changeset_c) is False
 
 
 def test_persist_writes_to_underlying_db(journal_db, memory_db):

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -160,3 +160,10 @@ def test_commit_all_writes_to_underlying_db(journal_db, memory_db):
     assert len(journal_db.journal.journal_data) == 0
     assert memory_db.get(b'1') == b'test-b'
 
+def test_returns_key_from_underlying_db_if_missing(journal_db, memory_db):
+    changeset = journal_db.record()
+    memory_db.set(b'1', b'test-a')
+
+    assert memory_db.exists(b'1')
+
+    assert journal_db.get(b'1') == b'test-a'

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -2,13 +2,16 @@ import pytest
 from evm.db.backends.memory import MemoryDB
 from evm.db.journal import JournalDB
 
+
 @pytest.fixture
 def memory_db():
     return MemoryDB()
 
+
 @pytest.fixture
 def journal_db(memory_db):
     return JournalDB(memory_db)
+
 
 def test_delete_removes_data_from_underlying_db_after_persist(journal_db, memory_db):
     memory_db.set(b'1', b'test-a')
@@ -88,9 +91,10 @@ def test_revert_clears_reverted_journal_entries(journal_db):
 
     assert journal_db.get(b'1') == b'test-a'
 
+
 def test_revert_removes_journal_entries(journal_db):
 
-    changeset_a = journal_db.record()
+    changeset_a = journal_db.record()  # noqa: F841
     assert len(journal_db.journal.journal_data) == 2
 
     changeset_b = journal_db.record()
@@ -103,10 +107,10 @@ def test_revert_removes_journal_entries(journal_db):
     changeset_b2 = journal_db.record()
     assert len(journal_db.journal.journal_data) == 3
 
-    changeset_c = journal_db.record()
+    changeset_c = journal_db.record()  # noqa: F841
     assert len(journal_db.journal.journal_data) == 4
 
-    changeset_d = journal_db.record()
+    changeset_d = journal_db.record()  # noqa: F841
     assert len(journal_db.journal.journal_data) == 5
 
     # Forget everything from b2 (inclusive) and what follows
@@ -127,6 +131,7 @@ def test_commit_merges_changeset_into_previous(journal_db):
 
     assert len(journal_db.journal.journal_data) == 1
     assert journal_db.journal.has_checkpoint(changeset) is False
+
 
 def test_committing_middle_changeset_merges_in_subsequent_changesets(journal_db):
 
@@ -155,12 +160,12 @@ def test_committing_middle_changeset_merges_in_subsequent_changesets(journal_db)
 
 
 def test_persist_writes_to_underlying_db(journal_db, memory_db):
-    changeset = journal_db.record()
+    changeset = journal_db.record()  # noqa: F841
     journal_db.set(b'1', b'test-a')
     assert journal_db.get(b'1') == b'test-a'
     assert memory_db.exists(b'1') is False
 
-    changeset_b = journal_db.record()
+    changeset_b = journal_db.record()  # noqa: F841
 
     journal_db.set(b'1', b'test-b')
     assert journal_db.get(b'1') == b'test-b'
@@ -173,7 +178,7 @@ def test_persist_writes_to_underlying_db(journal_db, memory_db):
 
 def test_journal_restarts_after_write(journal_db, memory_db):
     journal_db.set(b'1', b'test-a')
-    
+
     journal_db.persist()
 
     assert memory_db.get(b'1') == b'test-a'
@@ -186,7 +191,7 @@ def test_journal_restarts_after_write(journal_db, memory_db):
 
 
 def test_returns_key_from_underlying_db_if_missing(journal_db, memory_db):
-    changeset = journal_db.record()
+    changeset = journal_db.record()  # noqa: F841
     memory_db.set(b'1', b'test-a')
 
     assert memory_db.exists(b'1')

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -157,8 +157,23 @@ def test_commit_all_writes_to_underlying_db(journal_db, memory_db):
     assert memory_db.exists(b'1') is False
 
     journal_db.commit_all()
-    assert len(journal_db.journal.journal_data) == 0
+    assert len(journal_db.journal.journal_data) == 1
     assert memory_db.get(b'1') == b'test-b'
+
+
+def test_journal_restarts_after_write(journal_db, memory_db):
+    journal_db.set(b'1', b'test-a')
+    
+    journal_db.commit_all()
+
+    assert memory_db.get(b'1') == b'test-a'
+
+    journal_db.set(b'1', b'test-b')
+
+    journal_db.commit_all()
+
+    assert memory_db.get(b'1') == b'test-b'
+
 
 def test_returns_key_from_underlying_db_if_missing(journal_db, memory_db):
     changeset = journal_db.record()

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -22,7 +22,7 @@ def test_snapshot_and_revert_with_set(journal_db):
 
     assert journal_db.get(b'1') == b'test-b'
 
-    journal_db.forget(changeset)
+    journal_db.discard(changeset)
 
     assert journal_db.get(b'1') == b'test-a'
 
@@ -39,7 +39,7 @@ def test_snapshot_and_revert_with_delete(journal_db):
 
     assert journal_db.exists(b'1') is False
 
-    journal_db.forget(changeset)
+    journal_db.discard(changeset)
 
     assert journal_db.exists(b'1') is True
     assert journal_db.get(b'1') == b'test-a'
@@ -66,7 +66,7 @@ def test_revert_clears_reverted_journal_entries(journal_db):
 
     assert journal_db.get(b'1') == b'test-e'
 
-    journal_db.forget(changeset_b)
+    journal_db.discard(changeset_b)
 
     assert journal_db.get(b'1') == b'test-c'
 
@@ -74,7 +74,7 @@ def test_revert_clears_reverted_journal_entries(journal_db):
 
     assert journal_db.exists(b'1') is False
 
-    journal_db.forget(changeset_a)
+    journal_db.discard(changeset_a)
 
     assert journal_db.get(b'1') == b'test-a'
 
@@ -87,7 +87,7 @@ def test_revert_removes_journal_entries(journal_db):
     assert len(journal_db.journal.journal_data) == 3
 
     # Forget *latest* changeset and prove it's the only one removed
-    journal_db.forget(changeset_b)
+    journal_db.discard(changeset_b)
     assert len(journal_db.journal.journal_data) == 2
 
     changeset_b2 = journal_db.record()
@@ -100,7 +100,7 @@ def test_revert_removes_journal_entries(journal_db):
     assert len(journal_db.journal.journal_data) == 5
 
     # Forget everything from b2 (inclusive) and what follows
-    journal_db.forget(changeset_b2)
+    journal_db.discard(changeset_b2)
     assert len(journal_db.journal.journal_data) == 2
     assert journal_db.journal.has_checkpoint(changeset_b2) is False
 

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -2,10 +2,15 @@ import pytest
 from evm.db.backends.memory import MemoryDB
 from evm.db.journal import JournalDB
 
+@pytest.fixture
+def memory_db():
+    return MemoryDB()
 
 @pytest.fixture
-def journal_db():
-    return JournalDB(MemoryDB())
+def journal_db(memory_db):
+    db = JournalDB(memory_db)
+    db.snapshot()
+    return db
 
 
 def test_snapshot_and_revert_with_set(journal_db):
@@ -74,3 +79,52 @@ def test_revert_clears_reverted_journal_entries(journal_db):
     journal_db.revert(snapshot_a)
 
     assert journal_db.get(b'1') == b'test-a'
+
+def test_commit_shrinks_snapshot_count(journal_db, memory_db):
+
+    snapshot = journal_db.snapshot()
+    assert len(journal_db.journal.journal_data) == 2
+
+    journal_db.set(b'1', b'test-a')
+    assert journal_db.get(b'1') == b'test-a'
+
+    journal_db.commit(snapshot)
+
+    assert len(journal_db.journal.journal_data) == 1
+    assert journal_db.journal.has_checkpoint(snapshot) is False
+
+
+def test_can_have_empty_snapshots(journal_db, memory_db):
+
+    assert len(journal_db.journal.journal_data) == 1
+
+    snapshot = journal_db.snapshot()
+    assert len(journal_db.journal.journal_data) == 2
+    
+    snapshot2 = journal_db.snapshot()
+    assert len(journal_db.journal.journal_data) == 3
+
+    journal_db.set(b'1', b'test-a')
+    assert journal_db.get(b'1') == b'test-a'
+    assert memory_db.exists(b'1') is False
+
+    journal_db.commit_all()
+    assert len(journal_db.journal.journal_data) == 0
+    assert memory_db.get(b'1') == b'test-a'
+
+
+# def test_can_commit_snapshots_in_between(journal_db, memory_db):
+#     snapshot = journal_db.snapshot()
+#     journal_db.set(b'1', b'test-a')
+#     assert journal_db.get(b'1') == b'test-a'
+#     assert memory_db.exists(b'1') is False
+
+#     snapshot2 = journal_db.snapshot()
+
+#     journal_db.set(b'1', b'test-b')
+#     assert journal_db.get(b'1') == b'test-b'
+#     assert memory_db.exists(b'1') is False
+
+#     journal_db.commit(snapshot)
+#     raise Exception((snapshot, journal_db.journal.journal_data))
+#     assert memory_db.get(b'1') == b'test-a'

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -19,6 +19,7 @@ def test_delete_removes_data_from_underlying_db_after_persist(journal_db, memory
     assert memory_db.exists(b'1') is True
 
     journal_db.delete(b'1')
+    assert memory_db.exists(b'1') is True
     journal_db.persist()
 
     assert memory_db.exists(b'1') is False
@@ -147,10 +148,6 @@ def test_committing_middle_changeset_merges_in_subsequent_changesets(journal_db)
     changeset_c = journal_db.record()
     assert len(journal_db.journal.journal_data) == 4
 
-    # TODO: Clarify
-    # This seems counterintuitive to me. Why does commiting to changeset_b
-    # Mean we are implicitly commiting to subsequent changesets?
-    # Why don't we just merge b into a but keep c seperate?
     journal_db.commit(changeset_b)
     assert journal_db.get(b'1') == b'test-c'
     assert len(journal_db.journal.journal_data) == 2

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -144,7 +144,7 @@ def test_committing_middle_changeset_merges_in_subsequent_changesets(journal_db)
     assert journal_db.journal.has_checkpoint(changeset_c) is False
 
 
-def test_commit_all_writes_to_underlying_db(journal_db, memory_db):
+def test_persist_writes_to_underlying_db(journal_db, memory_db):
     changeset = journal_db.record()
     journal_db.set(b'1', b'test-a')
     assert journal_db.get(b'1') == b'test-a'
@@ -156,7 +156,7 @@ def test_commit_all_writes_to_underlying_db(journal_db, memory_db):
     assert journal_db.get(b'1') == b'test-b'
     assert memory_db.exists(b'1') is False
 
-    journal_db.commit_all()
+    journal_db.persist()
     assert len(journal_db.journal.journal_data) == 1
     assert memory_db.get(b'1') == b'test-b'
 
@@ -164,13 +164,13 @@ def test_commit_all_writes_to_underlying_db(journal_db, memory_db):
 def test_journal_restarts_after_write(journal_db, memory_db):
     journal_db.set(b'1', b'test-a')
     
-    journal_db.commit_all()
+    journal_db.persist()
 
     assert memory_db.get(b'1') == b'test-a'
 
     journal_db.set(b'1', b'test-b')
 
-    journal_db.commit_all()
+    journal_db.persist()
 
     assert memory_db.get(b'1') == b'test-b'
 

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -10,6 +10,16 @@ def memory_db():
 def journal_db(memory_db):
     return JournalDB(memory_db)
 
+def test_delete_removes_data_from_underlying_db_after_persist(journal_db, memory_db):
+    memory_db.set(b'1', b'test-a')
+
+    assert memory_db.exists(b'1') is True
+
+    journal_db.delete(b'1')
+    journal_db.persist()
+
+    assert memory_db.exists(b'1') is False
+
 
 def test_snapshot_and_revert_with_set(journal_db):
     journal_db.set(b'1', b'test-a')


### PR DESCRIPTION
### What was wrong?

As discussed in #561 the current implementation of the `JournalDB` imposes efficiency problems on the system as every `set` and `delete` operation causes an extra `get` operation on the underlying db.

### How was it fixed?

The new `JounalDB` works as follows.

`.record()` - starts recording and returns a `changeset_id` where all changes are recorded in. Nothing is written to the db. Any `set` and `delete` actions that are recorded into the active changeset. No extra `get` calls are made on the underlying database.

`.discard(changeset_id)` - throws away all changes that were recorded in the given changeset. Again, the underlying db isn't hit for any of this.

`commit(changeset_id)` - merges the given changeset into the previous changeset. If the previous changeset is the root changeset, the changes are written back to the underlying db.

`persist()` - collapses all changesets, writes them to the db and starts a new recording.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1506726303195-92eb8c09e128?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=41fe8369ad5bd0517da7bc9ce48f77fb&auto=format&fit=crop&w=1350&q=80)


### Initial discussion moved below




@pipermerriam I gave this journaldb stuff another look this morning.

I have a better understanding now how the `JournalDB` is used. For instance, before a transaction is applied we take a snapshot and if the transaction errors we can revert to the snapshot and in case everything goes through we commit the changes.

With this in mind it sure makes sense to design this similar to how files are used e.g.

```python
with db.record():
  db.set(...)
  db.delete(...)

  # write changes at the end of the block or discard in case of error
```

In such a scenario tho, working with snapshot ids (or maybe record ids?!) would be completely abstracted away from us.

Looking at all call sites I can see that working out for places like `apply_message` in the computations but there seem to be other places that seem more tightly coupled to the concept of working with bare snapshot/record ids.

E.g. there are places where we combine the `state_root` with the snapshot to get a *full snapshot*

```python
(self.state_root, self._chaindb.snapshot())
```

So, am I right to assume that we would still keep the functionality of taking bare ids + commiting and have the contextmanager API sit on top as a higher level API to be used in places that can benefit from it?

I'm holding back to follow down further that path for now because I first want to make sure I got the basics right.

So, what I did now is that I took your work and try to approach things from a test-driven side. I added tests to prove when and how things are written back to the underlying database.

I added a couple more assertions in these tests to prove the inner workings e.g. that commiting a snapshot will merge and remove it etc. The tests reach into some supposed to be private APIs but I *think* I once read you rather have tests reaching into private APIs than exposing public APIs that are only used for tests. This is all WIP stuff anyway.

**Here's comes the most important part**

I actually *think* that we may need to change the whole snapshot terminology for the new model.

In the old model a snapshot was truly a snapshot of a state that we could revert to. That's actually not really the case with the new model. When we say `db.revert(snapshot)` we don't really revert everything *to the point* of `snapshot`. 

What we really do is that we throw away the *changes* that were recorded in `snapshot` (including subsequent points). So, essentially this just means that we are back at the point we were *before* we took the `snapshot` (aka recording) simply because we throw away a *change set*.

So, wouldn't it make more sense to call the API something like `db.forget(changeset)`?

I think this would go well together with renaming `snapshot()` to `record()`. Because, isn't that essentially what we do in the new model? We start recording changes that we either throw away (`forget`) or commit.

I followed down that path a bit and started renaming APIs just to see what that would look like. I also added an API `commit_all` which is basically the part that collapses all changesets to the point where they get written to the underlying database.

I also made it so that the `JournalDB` starts recording implicitly and maybe that would go well together with an API to retrieve the root changeset.

>I think the core concept here is that committing doesn't commit to the underlying database, it just commits to no longer reverting a given checkpoint (or any of the later checkpoints)

Conceptionally, I don't understand why commiting checkpoint `C1` out of `C1`, `C2`, `C3` means we are also commiting to not revert the later checkpoints `C2`, `C3`. Why would it be wrong if commiting `C1` would not make assumptions about what may happen to `C2` and `C3` just yet?

Alright that's it for now. Waiting for your feedback now. Hope it's not totally off.