### PR TITLE
Shorten test ids for blob serialization tests

### DIFF
--- a/tests/core/test_blob_utils.py
+++ b/tests/core/test_blob_utils.py
@@ -127,6 +127,10 @@ BLOB_SERIALIZATION_TEST_DATA = [  # [(blobs, unpadded_body), ...]
         ])
     )
 ]
+
+# By default, tests parametrized with above values have test ids which are too long to print (as
+# they contain the test data). Therefore, the following ids should be specified explicitly
+# instead:
 BLOB_SERIALIZATION_TEST_IDS = [
     "BLOB_SERIALIZATION_TEST_DATA[{}]".format(i)
     for i, _ in enumerate(BLOB_SERIALIZATION_TEST_DATA)

--- a/tests/core/test_blob_utils.py
+++ b/tests/core/test_blob_utils.py
@@ -127,6 +127,10 @@ BLOB_SERIALIZATION_TEST_DATA = [  # [(blobs, unpadded_body), ...]
         ])
     )
 ]
+BLOB_SERIALIZATION_TEST_IDS = [
+    "BLOB_SERIALIZATION_TEST_DATA[{}]".format(i)
+    for i, _ in enumerate(BLOB_SERIALIZATION_TEST_DATA)
+]
 
 
 def test_chunk_iteration():
@@ -201,12 +205,20 @@ def test_chunk_root_calculation():
     assert calc_chunk_root(body) == calc_merkle_root(chunks)
 
 
-@pytest.mark.parametrize("blobs,unpadded_body", BLOB_SERIALIZATION_TEST_DATA)
+@pytest.mark.parametrize(
+    "blobs,unpadded_body",
+    BLOB_SERIALIZATION_TEST_DATA,
+    ids=BLOB_SERIALIZATION_TEST_IDS,
+)
 def test_blob_serialization(blobs, unpadded_body):
     assert serialize_blobs(blobs) == zpad_right(unpadded_body, COLLATION_SIZE)
 
 
-@pytest.mark.parametrize("blobs,unpadded_body", BLOB_SERIALIZATION_TEST_DATA)
+@pytest.mark.parametrize(
+    "blobs,unpadded_body",
+    BLOB_SERIALIZATION_TEST_DATA,
+    ids=BLOB_SERIALIZATION_TEST_IDS,
+)
 def test_blob_iteration(blobs, unpadded_body):
     body = zpad_right(unpadded_body, COLLATION_SIZE)
     deserialized_blobs = list(deserialize_blobs(body))


### PR DESCRIPTION
### What was wrong?

As pointed out by @gsalgado Travis crashed sometimes (?) when executing the blob serialization tests, due to a very long reported test name. The test name was auto generated by `@pytest.mark.parametrize` using a 1MB collation body as parameter.

### How was it fixed?

Pass an explicit test id to `@pytest.mark.parametrize` at the relevant tests.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/38926721-3a6483f2-4336-11e8-9b2e-58f116962a63.jpg)

