### PR TITLE
p2p: Testing P2P handshake

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -60,3 +60,7 @@ ROPSTEN_BOOTNODES = [
     # 'enode://6332792c4a00e3e4ee0926ed89e0d27ef985424d97b6a45bf0f23e51f0dcb5e66b875777506458aea7af6f9e4ffb69f43f3778ee73c81ed9d34c51c4b16b0b0f@52.232.243.152:30303',  # noqa: E501
     # 'enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@192.81.208.223:30303',  # noqa: E501
 ]
+
+# Default configuration
+# Minimum peers number, we'll try to keep open connections to at least this number of peers
+DEFAULT_MIN_PEERS = 5

--- a/tests/p2p/dumb_peer.py
+++ b/tests/p2p/dumb_peer.py
@@ -1,0 +1,16 @@
+from p2p import protocol
+from p2p.peer import (
+    ETHPeer,
+)
+
+
+class DumbPeer(ETHPeer):
+    async def send_sub_proto_handshake(self):
+        pass
+
+    async def process_sub_proto_handshake(
+            self, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
+        pass
+
+    async def do_sub_proto_handshake(self):
+        pass

--- a/tests/p2p/test_server.py
+++ b/tests/p2p/test_server.py
@@ -6,16 +6,18 @@ from eth_keys import keys
 
 from evm.db.chain import ChainDB
 from evm.db.backends.memory import MemoryDB
+
+from p2p.peer import (
+    ETHPeer,
+)
 from p2p.kademlia import (
     Node,
     Address,
 )
-from p2p.peer import (
-    ETHPeer,
-)
 from p2p.server import Server
 
 from auth_constants import eip8_values
+from dumb_peer import DumbPeer
 
 
 def get_open_port():
@@ -29,44 +31,89 @@ def get_open_port():
 
 port = get_open_port()
 SERVER_ADDRESS = Address('127.0.0.1', udp_port=port, tcp_port=port)
-INITIATOR_PUBKEY = keys.PrivateKey(eip8_values['initiator_private_key']).public_key
+RECEIVER_PRIVKEY = keys.PrivateKey(eip8_values['receiver_private_key'])
+RECEIVER_PUBKEY = RECEIVER_PRIVKEY.public_key
+RECEIVER_REMOTE = Node(RECEIVER_PUBKEY, SERVER_ADDRESS)
+
+INITIATOR_PRIVKEY = keys.PrivateKey(eip8_values['initiator_private_key'])
+INITIATOR_PUBKEY = INITIATOR_PRIVKEY.public_key
 INITIATOR_ADDRESS = Address('127.0.0.1', get_open_port() + 1)
 INITIATOR_REMOTE = Node(INITIATOR_PUBKEY, INITIATOR_ADDRESS)
 
 
-@pytest.fixture
-def server():
-    privkey = keys.PrivateKey(eip8_values['receiver_private_key'])
+def get_server(privkey, address, bootstrap_nodes=None, peer_class=DumbPeer):
+    if bootstrap_nodes is None:
+        bootstrap_nodes = []
     chaindb = ChainDB(MemoryDB())
-    server = Server(privkey, SERVER_ADDRESS, chaindb, [], 1)
+    server = Server(
+        privkey,
+        address,
+        chaindb,
+        bootstrap_nodes,
+        1,
+        min_peers=1,
+        peer_class=peer_class,
+    )
     return server
 
 
-# FIXME: Instead of starting an actual server and send data over the wire, this test should create
-# StreamReaders and StreamWriters and connect them directly, like in test_auth.py. That way we
-# don't need those "strategically" placed sleep() calls.
+@pytest.fixture
+def server():
+    server = get_server(RECEIVER_PRIVKEY, SERVER_ADDRESS, bootstrap_nodes=[], peer_class=ETHPeer)
+    return server
+
+
 @pytest.mark.asyncio
-async def test_server_authenticates_incoming_connections(server, event_loop):
+async def test_server_authenticates_incoming_connections(monkeypatch, server, event_loop):
+    async def mock_do_p2p_handshake(self):
+        pass
+
+    # Only test the authentication in this test.
+    monkeypatch.setattr(ETHPeer, 'do_p2p_handshake', mock_do_p2p_handshake)
+
     await server.start()
-    await send_auth_msg_to_server(SERVER_ADDRESS, eip8_values['auth_init_ciphertext'])
-    # Yield control just so that the server has a chance to process the auth msg and respond to
-    # the remote.
-    await asyncio.sleep(0.2)
 
-    # TODO: Assert that the server sent the expected ACK msg to the remote and that the remote
-    # hasn't disconnected after processing that msg.
+    # Send auth init message to the server.
+    reader, writer = await asyncio.open_connection(SERVER_ADDRESS.ip, SERVER_ADDRESS.tcp_port)
+    writer.write(eip8_values['auth_init_ciphertext'])
+    await writer.drain()
 
-    # The sole connected node is our initiator
+    # Await the server replying auth ack.
+    await reader.read(len(eip8_values['auth_ack_ciphertext']))
+
+    # The sole connected node is our initiator.
     assert len(server.peer_pool.connected_nodes) == 1
     initiator_peer = server.peer_pool.connected_nodes[INITIATOR_REMOTE]
     assert isinstance(initiator_peer, ETHPeer)
-    assert initiator_peer.privkey == keys.PrivateKey(eip8_values['receiver_private_key'])
-
-    server._server.close()
-    await server._server.wait_closed()
+    assert initiator_peer.privkey == RECEIVER_PRIVKEY
+    await server.stop()
 
 
-async def send_auth_msg_to_server(address, messages):
-    reader, writer = await asyncio.open_connection(address.ip, address.udp_port)
-    writer.write(messages)
-    await writer.drain()
+@pytest.mark.asyncio
+async def test_two_servers(event_loop):
+    # Start server.
+    server_1 = get_server(
+        RECEIVER_PRIVKEY,
+        SERVER_ADDRESS,
+    )
+    server_2 = get_server(
+        INITIATOR_PRIVKEY,
+        INITIATOR_ADDRESS,
+    )
+
+    await server_1.start()
+    await server_2.start()
+
+    nodes = [RECEIVER_REMOTE]
+    await server_2.peer_pool._connect_to_nodes(nodes)
+
+    assert len(server_1.peer_pool.connected_nodes) == 1
+    assert len(server_2.peer_pool.connected_nodes) == 1
+
+    # Stop the servers.
+    await server_1.stop()
+    await server_2.stop()
+
+    # Check if they are disconnected.
+    assert len(server_1.peer_pool.connected_nodes) == 0
+    assert len(server_2.peer_pool.connected_nodes) == 0


### PR DESCRIPTION
### What was wrong?
After auth handshake, the server should apply P2P handshake.

### How was it fixed?
1. Add `Server.apply_p2p_handshake(peer)` function to apply p2p handshake.
2. Add `tests/p2p/test_server.py::test_two_servers` for simulating two servers. `server_1` is the bootstrap node for `server_2`, `server_2` will try to connect to `server_1`.
3. Use `DumbPeer` instead of `ETHPeer` for testing. (**No sub-protocol handshake yet**)
4. Add a testing daemon in `server.py` (basically, referred to `chain.py`).
    * Run `server_1` (the bootstrap node):
        ```bash
        python -m p2p.server -debug -server-address 127.0.0.1:33333 -privkey b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291
        ```
    * Run `server_2`:
        ```bash
        python -m p2p.server -debug -server-address 127.0.0.1:30303 -bootstrap enode://ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f@127.0.0.1:33333 -privkey 49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee
        ```

    * Result of `server_1`:
        ```bash
        ➜ python -m p2p.server -debug -server-address 127.0.0.1:33333 -privkey b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291
        19:00:59 INFO: Running PeerPool...
        19:00:59 WARNING: Cannot get 5 nodes as RoutingTable contains only 0 nodes
        19:00:59 DEBUG: no peer connected
        19:00:59 INFO: lookup finished for 85658218438996085151406112006981061491734845553074397258703399980243123788092: []
        19:00:59 INFO: Running server...
        19:00:59 INFO: enode://ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f@127.0.0.1:33333
        19:01:00 DEBUG: no peer connected
        19:01:01 WARNING: Cannot get 5 nodes as RoutingTable contains only 0 nodes
        19:01:01 DEBUG: no peer connected
        19:01:02 DEBUG: no peer connected
        19:01:03 WARNING: Cannot get 5 nodes as RoutingTable contains only 0 nodes
        19:01:03 DEBUG: no peer connected
        19:01:04 DEBUG: Receiving handshake...
        19:01:04 DEBUG: peers: 1
        ```
    * Result of `server_2`:
        ```bash
        ➜ python -m p2p.server -debug -server-address 127.0.0.1:30303 -bootstrap enode://ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f@127.0.0.1:33333 -privkey 49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee
        19:01:04 INFO: Running PeerPool...
        19:01:04 WARNING: Cannot get 5 nodes as RoutingTable contains only 0 nodes
        19:01:04 DEBUG: no peer connected
        19:01:04 INFO: lookup finished for 6337412118514148720559954161251210272405612403602241289921825684304857839603: []
        19:01:04 INFO: Running server...
        19:01:04 INFO: enode://fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877@127.0.0.1:30303
        19:01:04 INFO: Successfully connected to DumbPeer <Node(0xca63@127.0.0.1)>
        19:01:05 DEBUG: peers: 1
        ````


#### Cute Animal Picture

![raccoon](https://user-images.githubusercontent.com/9263930/39122204-be4b8f78-4726-11e8-84e7-2383f3562a26.jpg)
