### PR TITLE
Set fixed pytest cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ docs/modules.rst
 
 # pytest
 .cache/
+.pytest_cache/
 
 # fixtures
 fixtures/**


### PR DESCRIPTION

What was wrong?

The directory was renamed to `.pytest_cache` in Pytest 3.4.0 so the directory was coming up in version control when using a newer Pytest version

### How was it fixed?

Configured it to be set to `.cache` as it was before.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1493818464321-b33c72d3ba12?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=c75580f78437c825198bea1e4a6bbb8d&auto=format&fit=crop&w=1350&q=80)
