### PR TITLE
p2p: StateDownloader no longer sends requests to peers with pending requests

### DIFF
--- a/p2p/state.py
+++ b/p2p/state.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import secrets
 import time
 from typing import (  # noqa: F401
     Any,
@@ -8,6 +9,8 @@ from typing import (  # noqa: F401
     List,
     Set,
 )
+
+from cytoolz.itertoolz import partition_all
 
 import rlp
 
@@ -52,12 +55,24 @@ class StateDownloader(PeerPoolSubscriber):
         self.root_hash = root_hash
         self.scheduler = StateSync(root_hash, state_db)
         self._running_peers = set()  # type: Set[ETHPeer]
+        self._peers_with_pending_requests = {}  # type: Dict[ETHPeer, float]
         self.cancel_token = CancelToken('StateDownloader')
         if token is not None:
             self.cancel_token = self.cancel_token.chain(token)
 
     def register_peer(self, peer: BasePeer) -> None:
         asyncio.ensure_future(self.handle_peer(cast(ETHPeer, peer)))
+
+    @property
+    def idle_peers(self) -> List[ETHPeer]:
+        peers = set([cast(ETHPeer, peer) for peer in self.peer_pool.peers])
+        return list(peers.difference(self._peers_with_pending_requests))
+
+    async def get_idle_peer(self) -> ETHPeer:
+        while not self.idle_peers:
+            self.logger.debug("Waiting for an idle peer...")
+            await wait_with_token(asyncio.sleep(0.02), token=self.cancel_token)
+        return secrets.choice(self.idle_peers)
 
     async def handle_peer(self, peer: ETHPeer) -> None:
         """Handle the lifecycle of the given peer."""
@@ -79,12 +94,19 @@ class StateDownloader(PeerPoolSubscriber):
             # Run self._handle_msg() with ensure_future() instead of awaiting for it so that we
             # can keep consuming msgs while _handle_msg() performs cpu-intensive tasks in separate
             # processes.
-            asyncio.ensure_future(self._handle_msg(cmd, msg))
+            asyncio.ensure_future(self._handle_msg(peer, cmd, msg))
 
-    async def _handle_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
+    async def _handle_msg(
+            self, peer: ETHPeer, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
         loop = asyncio.get_event_loop()
         if isinstance(cmd, eth.NodeData):
-            self.logger.debug("Processing NodeData with %d entries", len(msg))
+            self.logger.debug("Got %d NodeData entries from %s", len(msg), peer)
+
+            # Check before we remove because sometimes a reply may come after our timeout and in
+            # that case we won't be expecting it anymore.
+            if peer in self._peers_with_pending_requests:
+                self._peers_with_pending_requests.pop(peer)
+
             node_keys = await loop.run_in_executor(None, list, map(keccak, msg))
             for node_key, node in zip(node_keys, msg):
                 self._total_processed_nodes += 1
@@ -108,17 +130,26 @@ class StateDownloader(PeerPoolSubscriber):
             await asyncio.sleep(0.1)
 
     async def request_nodes(self, node_keys: List[bytes]) -> None:
-        # FIXME: Need a better criteria to select peers here.
-        peer = await wait_with_token(self.peer_pool.get_random_peer(), token=self.cancel_token)
-        now = time.time()
-        for node_key in node_keys:
-            self._pending_nodes[node_key] = now
-        self.logger.debug("Requesting %d trie nodes", len(node_keys))
-        cast(ETHPeer, peer).sub_proto.send_get_node_data(node_keys)
+        batches = list(partition_all(eth.MAX_STATE_FETCH, node_keys))
+        for batch in batches:
+            peer = await self.get_idle_peer()
+            now = time.time()
+            for node_key in batch:
+                self._pending_nodes[node_key] = now
+            self.logger.debug("Requesting %d trie nodes to %s", len(batch), peer)
+            peer.sub_proto.send_get_node_data(batch)
+            self._peers_with_pending_requests[peer] = now
 
     async def _periodically_retry_timedout(self):
         while True:
             now = time.time()
+            # First, update our list of peers with pending requests by removing those for which a
+            # request timed out. This loop mutates the dict, so we iterate on a copy of it.
+            for peer, last_req_time in list(self._peers_with_pending_requests.items()):
+                if now - last_req_time > self._reply_timeout:
+                    self._peers_with_pending_requests.pop(peer)
+
+            # Now re-send requests for nodes that timed out.
             oldest_request_time = now
             timed_out = []
             for node_key, req_time in self._pending_nodes.items():
@@ -129,8 +160,12 @@ class StateDownloader(PeerPoolSubscriber):
             if timed_out:
                 self.logger.debug("Re-requesting %d trie nodes", len(timed_out))
                 self._total_timeouts += len(timed_out)
-                await self.request_nodes(timed_out)
+                try:
+                    await self.request_nodes(timed_out)
+                except OperationCancelled:
+                    break
 
+            # Finally, sleep until the time our oldest request is scheduled to timeout.
             now = time.time()
             sleep_duration = (oldest_request_time + self._reply_timeout) - now
             try:
@@ -153,22 +188,17 @@ class StateDownloader(PeerPoolSubscriber):
             # triggered.
             await wait_with_token(asyncio.sleep(0), token=self.cancel_token)
 
-            max_pending = len(self.peer_pool.peers) * eth.MAX_STATE_FETCH
-            # Request new nodes if we haven't reached the limit of pending nodes.
-            if len(self._pending_nodes) < max_pending:
-                requests = self.scheduler.next_batch(eth.MAX_STATE_FETCH)
-                if not requests:
-                    # Although we frequently yield control above, to let our msg handler process
-                    # received nodes (scheduling new requests), there may be cases when the
-                    # pending nodes take a while to arrive thus causing the scheduler to run out
-                    # of new requests for a while.
-                    self.logger.debug("Scheduler queue is empty, sleeping a bit")
-                    await wait_with_token(asyncio.sleep(0.5), token=self.cancel_token)
-                else:
-                    await self.request_nodes([request.node_key for request in requests])
-            else:
-                self.logger.debug("Pending trie nodes limit reached, sleeping a bit")
+            requests = self.scheduler.next_batch(eth.MAX_STATE_FETCH)
+            if not requests:
+                # Although we frequently yield control above, to let our msg handler process
+                # received nodes (scheduling new requests), there may be cases when the
+                # pending nodes take a while to arrive thus causing the scheduler to run out
+                # of new requests for a while.
+                self.logger.info("Scheduler queue is empty, sleeping a bit")
                 await wait_with_token(asyncio.sleep(0.5), token=self.cancel_token)
+                continue
+
+            await self.request_nodes([request.node_key for request in requests])
 
         self.logger.info("Finished state sync with root hash %s", encode_hex(self.root_hash))
 


### PR DESCRIPTION
This way we make better use of peers with higher throughput and achieve
much faster syncs