### PR TITLE
Fix broken ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,6 @@
+# https://docs.readthedocs.io/en/latest/yaml-config.html
+python:
+  version: 3.5
+  pip_install: True
+  extra_requirements:
+    - docs

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ deps = {
         "flake8==3.5.0",
         "mypy>=0.580",
     ],
-    'doc': [
+    'docs': [
         "py-evm>=0.2.0-alpha.14",
         "pytest~=3.2",
         "Sphinx>=1.5.5,<2.0.0",
@@ -72,7 +72,7 @@ deps['dev'] = (
     deps['p2p'] +
     deps['trinity'] +
     deps['test'] +
-    deps['doc']
+    deps['docs']
 )
 
 # As long as evm, p2p and trinity are managed together in the py-evm


### PR DESCRIPTION
### What was wrong?

ReadTheDocs can't build the docs anymore hence the last online version dates 4 months back.

### How was it fixed?

Add `.readthedocs.yml` with the right settings (hopefully).
Ideally I'd test this on a separate branch directly here in the repo but I don't have write access yet so I hope these settings should just cut it.

#### ~~Cute~~ Majestic Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1523973814736-0ac95210c2fe?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=3d9229c4474132f4768fa5e92a8e3c3b&auto=format&fit=crop&w=634&q=80)
