### PR TITLE
p2p: Cleanly break out of read loop when remote disconnects

### DIFF
--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -48,3 +48,7 @@ class OperationCancelled(Exception):
 
 class NoMatchingPeerCapabilities(Exception):
     pass
+
+
+class RemoteDisconnected(Exception):
+    pass


### PR DESCRIPTION
Peer used to simply close its network transport upon receiving a
Disconnect msg, which causes us to exit the read loop because our
next readexactly() call will then raise an IncompleteReadError, but
then it looks like the remote simply sent an EOF, which is not actually
the case.

Now when we receive a Disconnect msg we raise an exception, which gets
caught in Peer.read_loop(), causing it to return and the peer to finish
cleanly.