### PR TITLE
Ensure important journal data is persisted

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -470,6 +470,7 @@ class Chain(BaseChain):
         genesis_header = BlockHeader(**genesis_params)
         genesis_chain = cls(chaindb, genesis_header)
         chaindb.persist_block(genesis_chain.get_block())
+        chaindb.persist()
         return cls.from_genesis_header(chaindb, genesis_header)
 
     @classmethod

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -353,6 +353,7 @@ class BaseState(Configurable, metaclass=ABCMeta):
                     uncle_reward,
                     uncle.coinbase,
                 )
+            self._chaindb.persist()
         return block.copy(header=block.header.copy(state_root=self.state_root))
 
     @staticmethod


### PR DESCRIPTION

### What was wrong?

https://github.com/ethereum/py-evm/commit/f6ffc5e5f78557133f348074fb17be2f2bcc383d introduced a regression in which important data wasn't persisted anymore. (See #606)

### How was it fixed?

This is a hacky way to resolve the issue in a short term manner by sprinkling two more `persist()` calls over the code paths that use the journal while we investigate a more robust way forward.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media1.giphy.com/media/7p3e2WCM0VEnm/giphy.gif)
