### PR TITLE
Get rid of APIs related to pending transactions

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -162,20 +162,6 @@ class BaseChain(Configurable, metaclass=ABCMeta):
         raise NotImplementedError("Chain classes must implement this method")
 
     @abstractmethod
-    def add_pending_transaction(self, transaction):
-        """
-        Adds a transaction to the set of pending transactions.
-        """
-        raise NotImplementedError("Chain classes must implement this method")
-
-    @abstractmethod
-    def get_pending_transaction(self, transaction_hash):
-        """
-        Retrieves a transaction from the set of pending transactions.
-        """
-        raise NotImplementedError("Chain classes must implement this method")
-
-    @abstractmethod
     def create_transaction(self, *args, **kwargs):
         """
         Creates a transaction object.
@@ -340,12 +326,6 @@ class Chain(BaseChain):
                 block_num,
                 index,
             ))
-
-    def add_pending_transaction(self, transaction):
-        return self.chaindb.add_pending_transaction(transaction)
-
-    def get_pending_transaction(self, transaction_hash):
-        return self.get_vm().get_pending_transaction(transaction_hash)
 
     def create_transaction(self, *args, **kwargs):
         """

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -60,7 +60,6 @@ from evm.utils.db import (
     make_block_hash_to_score_lookup_key,
     make_block_number_to_hash_lookup_key,
     make_transaction_hash_to_block_lookup_key,
-    make_transaction_hash_to_data_lookup_key,
 )
 from evm.utils.hexadecimal import (
     encode_hex,
@@ -217,18 +216,7 @@ class BaseChainDB(metaclass=ABCMeta):
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
-    def get_pending_transaction(
-            self,
-            transaction_hash: bytes,
-            transaction_class: Type['BaseTransaction']) -> Type['BaseTransaction']:
-        raise NotImplementedError("ChainDB classes must implement this method")
-
-    @abstractmethod
     def get_transaction_index(self, transaction_hash: bytes) -> Tuple[int, int]:
-        raise NotImplementedError("ChainDB classes must implement this method")
-
-    @abstractmethod
-    def add_pending_transaction(self, transaction: 'BaseTransaction') -> None:
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
@@ -537,17 +525,6 @@ class ChainDB(BaseChainDB):
             raise TransactionNotFound(
                 "No transaction is at index {} of block {}".format(transaction_index, block_number))
 
-    def get_pending_transaction(
-            self,
-            transaction_hash: bytes,
-            transaction_class: Type['BaseTransaction']) -> Type['BaseTransaction']:
-        try:
-            data = self.db.get(make_transaction_hash_to_data_lookup_key(transaction_hash))
-            return rlp.decode(data, sedes=transaction_class)
-        except KeyError:
-            raise TransactionNotFound(
-                "Transaction with hash {} not found".format(encode_hex(transaction_hash)))
-
     def get_transaction_index(self, transaction_hash: bytes) -> Tuple[int, int]:
         try:
             encoded_key = self.db.get(make_transaction_hash_to_block_lookup_key(transaction_hash))
@@ -576,17 +553,6 @@ class ChainDB(BaseChainDB):
         self.db.set(
             make_transaction_hash_to_block_lookup_key(transaction_hash),
             rlp.encode(transaction_key),
-        )
-
-        # because transaction is now in canonical chain, can now remove from pending txn lookups
-        lookup_key = make_transaction_hash_to_data_lookup_key(transaction_hash)
-        if self.db.exists(lookup_key):
-            self.db.delete(lookup_key)
-
-    def add_pending_transaction(self, transaction: 'BaseTransaction') -> None:
-        self.db.set(
-            make_transaction_hash_to_data_lookup_key(transaction.hash),
-            rlp.encode(transaction),
         )
 
     def add_transaction(self,

--- a/evm/utils/db.py
+++ b/evm/utils/db.py
@@ -25,13 +25,6 @@ def make_block_hash_to_score_lookup_key(block_hash: bytes) -> bytes:
     return b'block-hash-to-score:%s' % block_hash
 
 
-def make_transaction_hash_to_data_lookup_key(transaction_hash: bytes) -> bytes:
-    '''
-    Look up a transaction that is pending, after being issued locally
-    '''
-    return b'transaction-hash-to-data:%s' % transaction_hash
-
-
 def make_transaction_hash_to_block_lookup_key(transaction_hash: bytes) -> bytes:
     return b'transaction-hash-to-block:%s' % transaction_hash
 

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -347,9 +347,6 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         """
         return cls.get_block_class().get_transaction_class()
 
-    def get_pending_transaction(self, transaction_hash):
-        return self.chaindb.get_pending_transaction(transaction_hash, self.get_transaction_class())
-
     def create_transaction(self, *args, **kwargs):
         """
         Proxy for instantiating a transaction for this VM.

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -54,32 +54,16 @@ def test_import_block(chain, tx):
     computation, _ = vm.apply_transaction(tx)
     assert not computation.is_error
 
-    # add pending so that we can confirm it gets removed when imported to a block
-    chain.add_pending_transaction(tx)
-
     block = chain.import_block(vm.block)
     assert block.transactions == (tx,)
     assert chain.get_block_by_hash(block.hash) == block
     assert chain.get_canonical_block_by_number(block.number) == block
     assert chain.get_canonical_transaction(tx.hash) == tx
 
-    with pytest.raises(TransactionNotFound):
-        # after mining, the transaction shouldn't be in the pending set anymore
-        chain.get_pending_transaction(tx.hash)
-
-
-def test_get_pending_transaction(chain, tx):
-    chain.add_pending_transaction(tx)
-    assert chain.get_pending_transaction(tx.hash) == tx
-
 
 def test_empty_transaction_lookups(chain):
-
     with pytest.raises(TransactionNotFound):
         chain.get_canonical_transaction(b'\0' * 32)
-
-    with pytest.raises(TransactionNotFound):
-        chain.get_pending_transaction(b'\0' * 32)
 
 
 @pytest.fixture(


### PR DESCRIPTION
When working on something else I came across those APIs that were only used in a couple tests



Removed them!