### PR TITLE
Remove JournalDB usage from ChainDB

### DIFF
--- a/evm/db/state.py
+++ b/evm/db/state.py
@@ -2,6 +2,7 @@ from abc import (
     ABCMeta,
     abstractmethod
 )
+from uuid import UUID
 
 from lru import LRU
 
@@ -124,6 +125,25 @@ class BaseAccountStateDB(metaclass=ABCMeta):
     #
     @abstractmethod
     def account_is_empty(self, address):
+        raise NotImplementedError("Must be implemented by subclass")
+
+    #
+    # Record and discard API
+    #
+    @abstractmethod
+    def record(self) -> UUID:
+        raise NotImplementedError("Must be implemented by subclass")
+
+    @abstractmethod
+    def discard(self, checkpoint: UUID) -> None:
+        raise NotImplementedError("Must be implemented by subclass")
+
+    @abstractmethod
+    def commit(self, checkpoint: UUID) -> None:
+        raise NotImplementedError("Must be implemented by subclass")
+
+    @abstractmethod
+    def clear(self) -> None:
         raise NotImplementedError("Must be implemented by subclass")
 
 
@@ -326,3 +346,24 @@ class MainAccountStateDB(BaseAccountStateDB):
         self._trie[address] = rlp_account
         cache_key = (self._unwrapped_db, self.root_hash, address)
         account_cache[cache_key] = rlp_account
+
+    #
+    # Record and discard API
+    #
+    def record(self) -> UUID:
+        return self._unwrapped_db.record()
+
+    def discard(self, changeset_id: UUID) -> None:
+        self._unwrapped_db.discard(changeset_id)
+
+    def commit(self, changeset_id: UUID) -> None:
+        self._unwrapped_db.commit(changeset_id)
+
+    def persist(self) -> None:
+        self._unwrapped_db.persist()
+
+    def clear(self) -> None:
+        self._unwrapped_db.reset()
+
+    def exists(self, key: bytes) -> bool:
+        return self._unwrapped_db.exists(key)

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -86,8 +86,6 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         self.block = block
         self.receipts.append(receipt)
 
-        self.chaindb.persist()
-
         return computation, self.block
 
     def execute_bytecode(self,


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/py-evm/commit/f6ffc5e5f78557133f348074fb17be2f2bcc383d introduced a regression where not all important data was written into the db (See #606).

### How was it fixed?

This is an alternative approach to #607 that tries to address the problem with a less hacky solution. At its core, this PR doesn't really address the problem differently than #607 because it still boils down to another `persist()` call after block finalization.

However, this PR already paves the way for a more isolated usage of the `JournalDB` which *should* only be used for the transaction processing. This PR doesn't take it that far but it already removes the journaling APIs from the `ChainDB` entirely and introduces them on the `MainAccountStateDB` instead.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1486174070967-b0f1610f76de?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=821a14f7addefb1caa4780ae27c65052&auto=format&fit=crop&w=1350&q=80)
