### PR TITLE
Drop NonJournaledAsyncChainDB

### DIFF
--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -648,12 +648,3 @@ class AsyncChainDB(ChainDB):
 
     async def coro_persist_trie_data_dict(self, *args, **kwargs):
         raise NotImplementedError()
-
-
-class NonJournaledAsyncChainDB(AsyncChainDB):
-
-    def __init__(self, db, account_state_class=MainAccountStateDB, trie_class=HexaryTrie):
-        self.db = db
-        self.journal_db = db
-        self.account_state_class = account_state_class
-        self.set_trie(trie_class)

--- a/tests/p2p/integration_test_helpers.py
+++ b/tests/p2p/integration_test_helpers.py
@@ -3,7 +3,7 @@ from typing import Type
 from eth_utils import decode_hex
 from eth_keys import datatypes, keys
 
-from evm.db.chain import AsyncChainDB, NonJournaledAsyncChainDB
+from evm.db.chain import AsyncChainDB
 
 from p2p import kademlia
 from p2p.peer import BasePeer, HardCodedNodesPeerPool
@@ -28,7 +28,7 @@ class LocalGethPeerPool(HardCodedNodesPeerPool):
                             kademlia.Address('127.0.0.1', 30303, 30303))
 
 
-class FakeAsyncChainDB(NonJournaledAsyncChainDB):
+class FakeAsyncChainDB(AsyncChainDB):
     async def coro_get_score(self, *args, **kwargs):
         return self.get_score(*args, **kwargs)
 


### PR DESCRIPTION
That was a hackish optimization to use when testing fast-sync. It's no
longer needed as ChainDB no longer uses a journal