### PR TITLE
Remove dead clear_journal method

### DIFF
--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -418,17 +418,6 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
-    # Snapshot and Revert
-    #
-    def clear_journal(self):
-        """
-        Clear the journal.  This should be called at any point of VM execution
-        where the statedb is being committed, such as after a transaction has
-        been applied to a block.
-        """
-        self.chaindb.clear()
-
-    #
     # State
     #
     @classmethod


### PR DESCRIPTION
### What was wrong?

`BaseVM` had an unused `clear_journal` method left.

### How was it fixed?

Removed it

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1484557985045-edf25e08da73?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=f5f9b3de26b8a518a94c0fc1ba6aa31a&auto=format&fit=crop&w=1267&q=80)
