### PR TITLE
Piper/relocate and rename account db

### DIFF
--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -23,7 +23,7 @@ from evm.constants import (
 from evm.db.immutable import (
     ImmutableDB,
 )
-from evm.exceptions import DecommissionedStateDB
+from evm.exceptions import DecommissionedAccountDB
 from evm.rlp.accounts import (
     Account,
 )
@@ -49,7 +49,7 @@ from .hash_trie import HashTrie
 account_cache = LRU(2048)
 
 
-class BaseAccountStateDB(metaclass=ABCMeta):
+class BaseAccountDB(metaclass=ABCMeta):
 
     @abstractmethod
     def __init__(self) -> None:
@@ -147,7 +147,7 @@ class BaseAccountStateDB(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclass")
 
 
-class MainAccountStateDB(BaseAccountStateDB):
+class AccountDB(BaseAccountDB):
 
     def __init__(self, db, root_hash=BLANK_ROOT_HASH, read_only=False):
         # Keep a reference to the original db instance to use it as part of _get_account()'s cache
@@ -162,7 +162,7 @@ class MainAccountStateDB(BaseAccountStateDB):
     @property
     def _trie(self):
         if self.__trie is None:
-            raise DecommissionedStateDB()
+            raise DecommissionedAccountDB()
         return self.__trie
 
     @_trie.setter

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -45,9 +45,9 @@ from evm.db.backends.base import (
 from evm.db.journal import (
     JournalDB,
 )
-from evm.db.state import (
-    BaseAccountStateDB,
-    MainAccountStateDB,
+from evm.db.account import (
+    BaseAccountDB,
+    AccountDB,
 )
 from evm.rlp.headers import (
     BlockHeader,
@@ -110,7 +110,7 @@ class BaseChainDB(metaclass=ABCMeta):
 
     def __init__(self,
                  db: BaseDB,
-                 account_state_class: Type[BaseAccountStateDB] = MainAccountStateDB,
+                 account_state_class: Type[BaseAccountDB] = AccountDB,
                  trie_class: Type[HexaryTrie] = HexaryTrie) -> None:
 
         self.db = db
@@ -248,7 +248,7 @@ class BaseChainDB(metaclass=ABCMeta):
     @abstractmethod
     def get_state_db(self,
                      state_root: bytes,
-                     read_only: bool) -> BaseAccountStateDB:
+                     read_only: bool) -> BaseAccountDB:
         raise NotImplementedError("ChainDB classes must implement this method")
 
 
@@ -573,7 +573,7 @@ class ChainDB(BaseChainDB):
     #
     def get_state_db(self,
                      state_root: bytes,
-                     read_only: bool) -> BaseAccountStateDB:
+                     read_only: bool) -> BaseAccountDB:
         return self.account_state_class(
             db=self.journal_db,
             root_hash=state_root,

--- a/evm/exceptions.py
+++ b/evm/exceptions.py
@@ -172,7 +172,8 @@ class OutOfBoundsRead(VMError):
     pass
 
 
-class DecommissionedStateDB(Exception):
+class DecommissionedAccountDB(Exception):
     """
-    Raised when an attempt was made to use a StateDB object used after leaving the context.
+    Raised when an attempt was made to use a AccountDB object used after
+    leaving the context.
     """

--- a/evm/tools/test_builder/test_builder.py
+++ b/evm/tools/test_builder/test_builder.py
@@ -11,8 +11,8 @@ from typing import (  # noqa: F401
     List,
 )
 
-from evm.db.state import (
-    MainAccountStateDB,
+from evm.db.account import (
+    AccountDB,
 )
 from evm.tools.fixture_tests import (
     hash_log_entries,
@@ -108,11 +108,11 @@ ALL_NETWORKS = [
 ]
 
 ACCOUNT_STATE_DB_CLASSES = {
-    "Frontier": MainAccountStateDB,
-    "Homestead": MainAccountStateDB,
-    "EIP150": MainAccountStateDB,
-    "EIP158": MainAccountStateDB,
-    "Byzantium": MainAccountStateDB,
+    "Frontier": AccountDB,
+    "Homestead": AccountDB,
+    "EIP150": AccountDB,
+    "EIP158": AccountDB,
+    "Byzantium": AccountDB,
 }
 assert all(network in ACCOUNT_STATE_DB_CLASSES for network in ALL_NETWORKS)
 

--- a/evm/vm/computation.py
+++ b/evm/vm/computation.py
@@ -19,8 +19,8 @@ from eth_typing import (
     Address
 )
 
-from evm.db.state import (
-    BaseAccountStateDB
+from evm.db.account import (
+    BaseAccountDB
 )
 from evm.constants import (
     GAS_MEMORY,
@@ -372,7 +372,7 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
             return self._gas_meter.gas_remaining
 
     @contextmanager
-    def state_db(self, read_only: bool = False) -> Iterator[BaseAccountStateDB]:
+    def state_db(self, read_only: bool = False) -> Iterator[BaseAccountDB]:
         with self.state.state_db(read_only) as state_db:
             yield state_db
 

--- a/tests/core/chain-object/test_build_block_incrementally.py
+++ b/tests/core/chain-object/test_build_block_incrementally.py
@@ -20,7 +20,6 @@ def test_building_block_incrementally_with_single_transaction(
         funded_address,
         funded_address_private_key):
     head_hash = chain.get_canonical_head().hash
-
     tx = new_transaction(
         chain.get_vm(),
         from_=funded_address,

--- a/tests/core/vm/test_vm_state.py
+++ b/tests/core/vm/test_vm_state.py
@@ -6,7 +6,7 @@ from eth_utils import (
     decode_hex,
 )
 
-from evm.exceptions import DecommissionedStateDB
+from evm.exceptions import DecommissionedAccountDB
 from evm.vm.forks.spurious_dragon.state import SpuriousDragonState
 
 from tests.core.helpers import new_transaction
@@ -37,7 +37,7 @@ def test_state_db(state):
     with state.mutable_state_db() as state_db:
         pass
 
-    with pytest.raises(DecommissionedStateDB):
+    with pytest.raises(DecommissionedAccountDB):
         state_db.increment_nonce(address)
 
     state.read_only_state_db.get_balance(address)

--- a/tests/database/test_account_db.py
+++ b/tests/database/test_account_db.py
@@ -9,8 +9,8 @@ from evm.exceptions import (
 )
 
 from evm.db.backends.memory import MemoryDB
-from evm.db.state import (
-    MainAccountStateDB,
+from evm.db.account import (
+    AccountDB,
 )
 
 from evm.constants import (
@@ -24,7 +24,7 @@ INVALID_ADDRESS = b'aa' * 20
 
 
 @pytest.mark.parametrize("state", [
-    MainAccountStateDB(MemoryDB()),
+    AccountDB(MemoryDB()),
 ])
 def test_balance(state):
     assert state.get_balance(ADDRESS) == 0
@@ -50,7 +50,7 @@ def test_balance(state):
 
 
 @pytest.mark.parametrize("state", [
-    MainAccountStateDB(MemoryDB()),
+    AccountDB(MemoryDB()),
 ])
 def test_nonce(state):
     assert state.get_nonce(ADDRESS) == 0
@@ -74,7 +74,7 @@ def test_nonce(state):
 
 
 @pytest.mark.parametrize("state", [
-    MainAccountStateDB(MemoryDB()),
+    AccountDB(MemoryDB()),
 ])
 def test_code(state):
     assert state.get_code(ADDRESS) == b''
@@ -94,7 +94,7 @@ def test_code(state):
 
 
 @pytest.mark.parametrize("state", [
-    MainAccountStateDB(MemoryDB()),
+    AccountDB(MemoryDB()),
 ])
 def test_storage(state):
     assert state.get_storage(ADDRESS, 0) == 0
@@ -117,7 +117,7 @@ def test_storage(state):
 
 
 @pytest.mark.parametrize("state", [
-    MainAccountStateDB(MemoryDB()),
+    AccountDB(MemoryDB()),
 ])
 def test_storage_deletion(state):
     state.set_storage(ADDRESS, 0, 123)
@@ -131,7 +131,7 @@ def test_storage_deletion(state):
 
 
 @pytest.mark.parametrize("state", [
-    MainAccountStateDB(MemoryDB()),
+    AccountDB(MemoryDB()),
 ])
 def test_accounts(state):
     assert not state.account_exists(ADDRESS)

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -21,8 +21,8 @@ from evm.db import (
 from evm.db.chain import (
     ChainDB,
 )
-from evm.db.state import (
-    MainAccountStateDB,
+from evm.db.account import (
+    AccountDB,
 )
 from evm.exceptions import (
     BlockNotFound,
@@ -60,9 +60,9 @@ def set_empty_root(chaindb, header):
     )
 
 
-@pytest.fixture(params=[MainAccountStateDB])
+@pytest.fixture(params=[AccountDB])
 def chaindb(request):
-    if request.param is MainAccountStateDB:
+    if request.param is AccountDB:
         trie_class = HexaryTrie
     else:
         trie_class = BinaryTrie

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -18,8 +18,8 @@ from eth_utils import (
 )
 
 from evm.db.chain import ChainDB
-from evm.db.state import (
-    MainAccountStateDB,
+from evm.db.account import (
+    AccountDB,
 )
 from evm.exceptions import (
     ValidationError,
@@ -261,7 +261,7 @@ def fixture_vm_class(fixture_data):
 
 
 def test_state_fixtures(fixture, fixture_vm_class):
-    account_state_class = MainAccountStateDB
+    account_state_class = AccountDB
     trie_class = HexaryTrie
     header = BlockHeader(
         coinbase=fixture['env']['currentCoinbase'],

--- a/tests/p2p/test_state_sync.py
+++ b/tests/p2p/test_state_sync.py
@@ -2,13 +2,13 @@ import os
 import random
 
 from evm.db.backends.memory import MemoryDB
-from evm.db.state import MainAccountStateDB
+from evm.db.account import AccountDB
 
 from p2p.state import StateSync
 
 
 def make_random_state(n):
-    state_db = MainAccountStateDB(MemoryDB())
+    state_db = AccountDB(MemoryDB())
     contents = {}
     for _ in range(n):
         addr = os.urandom(20)
@@ -36,7 +36,7 @@ def test_state_sync():
             results.append([request.node_key, state_db.db[request.node_key]])
         scheduler.process(results)
         requests = scheduler.next_batch(10)
-    dest_state = MainAccountStateDB(dest_db, state_db.root_hash)
+    dest_state = AccountDB(dest_db, state_db.root_hash)
     for addr, account_data in contents.items():
         balance, nonce, storage, code = account_data
         assert dest_state.get_balance(addr) == balance


### PR DESCRIPTION
link: #599 and #611 

### What was wrong?

The use of the word "state" in the `AccountStateDB` makes thing a bit confusing now that we have a `State` object.

### How was it fixed?

Renamed to `AccountDB`

#### Cute Animal Picture

![funny camel_1](https://user-images.githubusercontent.com/824194/39438704-44cb09c6-4c62-11e8-9271-5506a783274f.jpg)
