### PR TITLE
Import keccak() from eth_hash instead of eth_utils

### DIFF
--- a/evm/consensus/pow.py
+++ b/evm/consensus/pow.py
@@ -10,9 +10,8 @@ from pyethash import (
 from eth_typing import (
     Hash32
 )
-from eth_utils import (
-    keccak,
-)
+
+from eth_hash.auto import keccak
 
 from evm.utils.hexadecimal import (
     encode_hex,

--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -12,9 +12,7 @@ from trie import (
     HexaryTrie,
 )
 
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm.constants import (
     BLANK_ROOT_HASH,

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -23,10 +23,11 @@ from trie import (
 )
 
 from eth_utils import (
-    keccak,
     to_list,
     to_tuple,
 )
+
+from eth_hash.auto import keccak
 
 from evm.constants import (
     GENESIS_PARENT_HASH,

--- a/evm/db/hash_trie.py
+++ b/evm/db/hash_trie.py
@@ -1,6 +1,4 @@
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 
 class HashTrie(object):

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -16,9 +16,10 @@ from eth_typing import (
     Hash32
 )
 from eth_utils import (
-    keccak,
     to_dict,
 )
+
+from eth_hash.auto import keccak
 
 from evm.constants import (
     ZERO_ADDRESS,

--- a/evm/rlp/transactions.py
+++ b/evm/rlp/transactions.py
@@ -16,9 +16,7 @@ from eth_typing import (
     Address
 )
 
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm.exceptions import (
     ValidationError,

--- a/evm/tools/fixture_tests.py
+++ b/evm/tools/fixture_tests.py
@@ -20,7 +20,6 @@ from eth_utils import (
     decode_hex,
     is_0x_prefixed,
     to_bytes,
-    keccak,
     to_canonical_address,
     to_normalized_address,
     to_tuple,
@@ -29,6 +28,8 @@ from eth_utils import (
 from eth_utils.curried import (
     hexstr_if_str,
 )
+
+from eth_hash.auto import keccak
 
 from evm import MainnetChain
 from evm.constants import (

--- a/evm/utils/address.py
+++ b/evm/utils/address.py
@@ -1,8 +1,6 @@
 import rlp
 
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 
 def force_bytes_to_address(value: bytes) -> bytes:

--- a/evm/utils/blobs.py
+++ b/evm/utils/blobs.py
@@ -12,8 +12,10 @@ from typing import (
 from eth_utils import (
     apply_to_return_value,
     int_to_big_endian,
-    keccak,
 )
+
+from eth_hash.auto import keccak
+
 from evm.utils.padding import (
     zpad_right,
 )

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -11,9 +11,10 @@ from typing import List  # noqa: F401
 import rlp
 
 from eth_utils import (
-    keccak,
     to_tuple,
 )
+
+from eth_hash.auto import keccak
 
 from evm.constants import (
     GENESIS_PARENT_HASH,

--- a/evm/vm/forks/frontier/blocks.py
+++ b/evm/vm/forks/frontier/blocks.py
@@ -11,9 +11,7 @@ from eth_bloom import (
     BloomFilter,
 )
 
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm.constants import (
     EMPTY_UNCLE_HASH,

--- a/evm/vm/forks/frontier/computation.py
+++ b/evm/vm/forks/frontier/computation.py
@@ -1,6 +1,4 @@
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm import constants
 from evm import precompiles

--- a/evm/vm/forks/frontier/state.py
+++ b/evm/vm/forks/frontier/state.py
@@ -5,9 +5,7 @@ from trie import (
     HexaryTrie,
 )
 
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm import constants
 from evm.constants import (

--- a/evm/vm/forks/homestead/computation.py
+++ b/evm/vm/forks/homestead/computation.py
@@ -1,6 +1,4 @@
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm import constants
 from evm.exceptions import (

--- a/evm/vm/forks/spurious_dragon/computation.py
+++ b/evm/vm/forks/spurious_dragon/computation.py
@@ -1,6 +1,4 @@
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm import constants
 from evm.exceptions import (

--- a/evm/vm/logic/sha3.py
+++ b/evm/vm/logic/sha3.py
@@ -1,6 +1,4 @@
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm import constants
 from evm.utils.numeric import (

--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -15,9 +15,7 @@ from eth_keys import (
     keys,
 )
 
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from p2p import ecies
 from p2p import kademlia

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -20,7 +20,6 @@ from typing import (
 import rlp
 from eth_utils import (
     encode_hex,
-    keccak,
     text_if_str,
     to_bytes,
     to_list,
@@ -28,6 +27,8 @@ from eth_utils import (
 
 from eth_keys import keys
 from eth_keys import datatypes
+
+from eth_hash.auto import keccak
 
 from p2p.cancel_token import CancelToken
 from p2p import kademlia

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -26,13 +26,14 @@ from eth_utils import (
     big_endian_to_int,
     decode_hex,
     encode_hex,
-    keccak,
 )
 
 from eth_keys import (
     datatypes,
     keys,
 )
+
+from eth_hash.auto import keccak
 
 from p2p.cancel_token import CancelToken, wait_with_token
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -23,13 +23,14 @@ from cryptography.hazmat.primitives.constant_time import bytes_eq
 from eth_utils import (
     decode_hex,
     encode_hex,
-    keccak,
 )
 
 from eth_keys import (
     datatypes,
     keys,
 )
+
+from eth_hash.auto import keccak
 
 from trie import HexaryTrie
 

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -19,8 +19,9 @@ from trie.exceptions import SyncRequestAlreadyProcessed
 
 from eth_utils import (
     encode_hex,
-    keccak,
 )
+
+from eth_hash.auto import keccak
 
 from evm.constants import (
     BLANK_ROOT_HASH,

--- a/tests/core/test_blob_utils.py
+++ b/tests/core/test_blob_utils.py
@@ -4,6 +4,8 @@ from itertools import (
     zip_longest,
 )
 
+from eth_hash.auto import keccak
+
 from evm.utils.blobs import (
     calc_chunk_root,
     calc_merkle_root,
@@ -17,9 +19,6 @@ from evm.utils.padding import (
 
 from evm.utils.padding import zpad_left
 from evm.utils.numeric import int_to_big_endian
-from eth_utils import (
-    keccak,
-)
 
 from evm.constants import (
     CHUNK_SIZE,

--- a/tests/database/test_account_db.py
+++ b/tests/database/test_account_db.py
@@ -1,8 +1,6 @@
 import pytest
 
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm.exceptions import (
     ValidationError,

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -11,9 +11,7 @@ from trie import (
     HexaryTrie,
 )
 
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm.db import (
     get_db_backend,

--- a/tests/fillers/build_json.py
+++ b/tests/fillers/build_json.py
@@ -11,9 +11,7 @@ from evm.tools.test_builder.builder_utils import (
     get_test_name,
 )
 
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm.utils.hexadecimal import (
     encode_hex,

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -13,9 +13,11 @@ from evm.db import (
 )
 
 from eth_utils import (
-    keccak,
+    to_bytes,
     to_tuple,
 )
+
+from eth_hash.auto import keccak
 
 from evm.db.chain import ChainDB
 from evm.db.account import (
@@ -183,7 +185,7 @@ def get_block_hash_for_testing(self, block_number):
     elif block_number < self.block_number - 256:
         return b''
     else:
-        return keccak(text="{0}".format(block_number))
+        return keccak(to_bytes(text="{0}".format(block_number)))
 
 
 def get_prev_hashes_testing(self, last_block_hash, db):

--- a/tests/json-fixtures/test_virtual_machine.py
+++ b/tests/json-fixtures/test_virtual_machine.py
@@ -8,9 +8,10 @@ from evm.db import (
 from evm.db.chain import ChainDB
 
 from eth_utils import (
-    keccak,
     to_bytes,
 )
+
+from eth_hash.auto import keccak
 
 from evm.exceptions import (
     VMError,

--- a/tests/p2p/peer_helpers.py
+++ b/tests/p2p/peer_helpers.py
@@ -1,9 +1,7 @@
 import asyncio
 import os
 
-from eth_utils import (
-    keccak,
-)
+from eth_hash.auto import keccak
 
 from evm.chains.mainnet import MAINNET_GENESIS_HEADER
 from evm.db.backends.memory import MemoryDB

--- a/tests/p2p/test_discovery.py
+++ b/tests/p2p/test_discovery.py
@@ -5,9 +5,10 @@ import rlp
 
 from eth_utils import (
     decode_hex,
-    keccak,
     to_bytes,
 )
+
+from eth_hash.auto import keccak
 
 from eth_keys import keys
 

--- a/tests/p2p/test_lightchain_integration.py
+++ b/tests/p2p/test_lightchain_integration.py
@@ -5,8 +5,9 @@ import rlp
 from eth_utils import (
     decode_hex,
     encode_hex,
-    keccak,
 )
+
+from eth_hash.auto import keccak
 
 from evm.chains.ropsten import ROPSTEN_NETWORK_ID, ROPSTEN_GENESIS_HEADER
 from evm.chains.mainnet import MAINNET_VM_CONFIGURATION


### PR DESCRIPTION
The eth_utils version was intended to be a convenience wrapper adding
support for arg types other than bytes, but that has a significant
performance overhead and is not needed in py-evm, so import directly
from eth_hash

Yet another change in our efforts to address #542 