### PR TITLE
Piper/remove multi trie support

### DIFF
--- a/docs/api.state.rst
+++ b/docs/api.state.rst
@@ -19,7 +19,6 @@ configured.
 - ``block_class``: The `~evm.rlp.blocks.Block` class for blocks in this VM ruleset.
 - ``computation_class``: The `~evm.vm.computation.BaseComputation` class for vm
   execution.
-- ``trie_class``: The class that is used to house the state trie.
 - ``transaction_context_class``: The
   `~evm.vm.transaction_context.TransactionContext` class for vm execution.
 

--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -19,6 +19,7 @@ from evm.consensus.pow import (
     check_pow,
 )
 from evm.constants import (
+    BLANK_ROOT_HASH,
     MAX_UNCLE_DEPTH,
 )
 from evm.db.chain import AsyncChainDB
@@ -436,7 +437,7 @@ class Chain(BaseChain):
         """
         Initializes the Chain from a genesis state.
         """
-        state_db = chaindb.get_state_db(chaindb.empty_root_hash, read_only=False)
+        state_db = chaindb.get_state_db(BLANK_ROOT_HASH, read_only=False)
 
         if genesis_state is None:
             genesis_state = {}

--- a/evm/utils/db.py
+++ b/evm/utils/db.py
@@ -1,13 +1,3 @@
-from trie import (
-    BinaryTrie,
-    HexaryTrie,
-)
-
-from evm.constants import (
-    BLANK_ROOT_HASH,
-    EMPTY_SHA3,
-)
-
 from evm.rlp.headers import BlockHeader
 
 from typing import TYPE_CHECKING
@@ -41,23 +31,6 @@ def get_block_header_by_hash(block_hash: BlockHeader, db: 'BaseChainDB') -> Bloc
     Returns the header for the parent block.
     """
     return db.get_block_header_by_hash(block_hash)
-
-
-def get_empty_root_hash(db: 'BaseChainDB') -> bytes:
-    root_hash = None
-    if db.trie_class is HexaryTrie:
-        root_hash = BLANK_ROOT_HASH
-    elif db.trie_class is BinaryTrie:
-        root_hash = EMPTY_SHA3
-    elif db.trie_class is None:
-        raise AttributeError(
-            "BaseChainDB must declare a trie_class."
-        )
-    else:
-        raise NotImplementedError(
-            "db.trie_class {} is not supported.".format(db.trie_class)
-        )
-    return root_hash
 
 
 def apply_state_dict(account_db, state_dict):

--- a/evm/vm/forks/frontier/state.py
+++ b/evm/vm/forks/frontier/state.py
@@ -1,10 +1,6 @@
 from __future__ import absolute_import
 from typing import Type  # noqa: F401
 
-from trie import (
-    HexaryTrie,
-)
-
 from eth_hash.auto import keccak
 
 from evm import constants
@@ -215,7 +211,6 @@ def _make_frontier_receipt(state, transaction, computation):
 class FrontierState(BaseState, FrontierTransactionExecutor):
     block_class = FrontierBlock
     computation_class = FrontierComputation
-    trie_class = HexaryTrie
     transaction_context_class = FrontierTransactionContext  # type: Type[BaseTransactionContext]
 
     def make_receipt(self, transaction, computation):

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -52,7 +52,6 @@ class BaseState(Configurable, metaclass=ABCMeta):
 
     block_class = None  # type: Type[BaseBlock]
     computation_class = None  # type: Type[BaseComputation]
-    trie_class = None
     transaction_context_class = None  # type: Type[BaseTransactionContext]
 
     def __init__(self, chaindb, execution_context, state_root, gas_used):

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -6,21 +6,17 @@ from hypothesis import (
 )
 
 import rlp
-from trie import (
-    BinaryTrie,
-    HexaryTrie,
-)
 
 from eth_hash.auto import keccak
 
+from evm.constants import (
+    BLANK_ROOT_HASH,
+)
 from evm.db import (
     get_db_backend,
 )
 from evm.db.chain import (
     ChainDB,
-)
-from evm.db.account import (
-    AccountDB,
 )
 from evm.exceptions import (
     BlockNotFound,
@@ -33,7 +29,6 @@ from evm.tools.fixture_tests import (
     assert_rlp_equal,
 )
 from evm.utils.db import (
-    get_empty_root_hash,
     make_block_hash_to_score_lookup_key,
     make_block_number_to_hash_lookup_key,
 )
@@ -50,25 +45,16 @@ B_ADDRESS = b"\xbb" * 20
 
 
 def set_empty_root(chaindb, header):
-    root_hash = get_empty_root_hash(chaindb)
     return header.copy(
-        transaction_root=root_hash,
-        receipt_root=root_hash,
-        state_root=root_hash,
+        transaction_root=BLANK_ROOT_HASH,
+        receipt_root=BLANK_ROOT_HASH,
+        state_root=BLANK_ROOT_HASH,
     )
 
 
-@pytest.fixture(params=[AccountDB])
+@pytest.fixture
 def chaindb(request):
-    if request.param is AccountDB:
-        trie_class = HexaryTrie
-    else:
-        trie_class = BinaryTrie
-    return ChainDB(
-        get_db_backend(),
-        account_state_class=request.param,
-        trie_class=trie_class,
-    )
+    return ChainDB(get_db_backend())
 
 
 @pytest.fixture(params=[0, 10, 999])

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -4,10 +4,6 @@ import pytest
 
 from eth_keys import keys
 
-from trie import (
-    HexaryTrie,
-)
-
 from evm.db import (
     get_db_backend,
 )
@@ -20,9 +16,6 @@ from eth_utils import (
 from eth_hash.auto import keccak
 
 from evm.db.chain import ChainDB
-from evm.db.account import (
-    AccountDB,
-)
 from evm.exceptions import (
     ValidationError,
 )
@@ -266,8 +259,6 @@ def fixture_vm_class(fixture_data):
 
 
 def test_state_fixtures(fixture, fixture_vm_class):
-    account_state_class = AccountDB
-    trie_class = HexaryTrie
     header = BlockHeader(
         coinbase=fixture['env']['currentCoinbase'],
         difficulty=fixture['env']['currentDifficulty'],
@@ -277,11 +268,7 @@ def test_state_fixtures(fixture, fixture_vm_class):
         parent_hash=fixture['env']['previousHash'],
     )
 
-    chaindb = ChainDB(
-        get_db_backend(),
-        account_state_class=account_state_class,
-        trie_class=trie_class
-    )
+    chaindb = ChainDB(get_db_backend())
     vm = fixture_vm_class(header=header, chaindb=chaindb)
 
     state = vm.state


### PR DESCRIPTION
link: #599 and #615 and #611 

### What was wrong?

During the sharding work, support for different types of underlying `trie` classes was introduced as part of the work to support lighter witnesses.

### How was it fixed?

Dropped the support since this is no longer part of the immediate roadmap.

#### Cute Animal Picture

![cute-goats-and-camel-pals](https://user-images.githubusercontent.com/824194/39440076-ffc16c12-4c66-11e8-9eb1-693d9e57d1df.jpg)
