### PR TITLE
Remove apply_state_dict API

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -40,6 +40,9 @@ from evm.validation import (
 from evm.rlp.headers import (
     BlockHeader,
 )
+from evm.utils.db import (
+    apply_state_dict,
+)
 from evm.utils.chain import (
     generate_vms_by_range,
 )
@@ -438,7 +441,8 @@ class Chain(BaseChain):
         if genesis_state is None:
             genesis_state = {}
 
-        state_db.apply_state_dict(genesis_state)
+        # mutation
+        apply_state_dict(state_db, genesis_state)
 
         if 'state_root' not in genesis_params:
             # If the genesis state_root was not specified, use the value

--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -58,10 +58,6 @@ class BaseAccountDB(metaclass=ABCMeta):
         )
 
     @abstractmethod
-    def apply_state_dict(self, state_dict):
-        raise NotImplementedError("Must be implemented by subclasses")
-
-    @abstractmethod
     def decommission(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
@@ -168,15 +164,6 @@ class AccountDB(BaseAccountDB):
     @_trie.setter
     def _trie(self, value):
         self.__trie = value
-
-    def apply_state_dict(self, state_dict):
-        for account, account_data in state_dict.items():
-            self.set_balance(account, account_data["balance"])
-            self.set_nonce(account, account_data["nonce"])
-            self.set_code(account, account_data["code"])
-
-            for slot, value in account_data["storage"].items():
-                self.set_storage(account, slot, value)
 
     def decommission(self):
         self.db = None

--- a/evm/tools/test_builder/builder_utils.py
+++ b/evm/tools/test_builder/builder_utils.py
@@ -17,6 +17,10 @@ from eth_utils import (
     to_text,
     int_to_big_endian,
 )
+
+from evm.utils.db import (
+    apply_state_dict,
+)
 from evm.utils.padding import (
     pad32,
 )
@@ -111,7 +115,7 @@ def get_version_from_git():
 
 def calc_state_root(state, account_state_db_class):
     state_db = account_state_db_class(MemoryDB())
-    state_db.apply_state_dict(state)
+    apply_state_dict(state_db, state)
     return state_db.root_hash
 
 

--- a/evm/utils/db.py
+++ b/evm/utils/db.py
@@ -58,3 +58,15 @@ def get_empty_root_hash(db: 'BaseChainDB') -> bytes:
             "db.trie_class {} is not supported.".format(db.trie_class)
         )
     return root_hash
+
+
+def apply_state_dict(account_db, state_dict):
+    for account, account_data in state_dict.items():
+        account_db.set_balance(account, account_data["balance"])
+        account_db.set_nonce(account, account_data["nonce"])
+        account_db.set_code(account, account_data["code"])
+
+        for slot, value in account_data["storage"].items():
+            account_db.set_storage(account, slot, value)
+
+    return account_db

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -48,6 +48,9 @@ from evm.tools.fixture_tests import (
     normalize_statetest_fixture,
     should_run_slow_tests,
 )
+from evm.utils.db import (
+    apply_state_dict,
+)
 
 from eth_typing.enums import (
     ForkName
@@ -281,7 +284,7 @@ def test_state_fixtures(fixture, fixture_vm_class):
 
     state = vm.state
     with state.mutable_state_db() as state_db:
-        state_db.apply_state_dict(fixture['pre'])
+        apply_state_dict(state_db, fixture['pre'])
     # Update state_root manually
     vm.block = vm.block.copy(header=vm.block.header.copy(state_root=state.state_root))
     if 'secretKey' in fixture['transaction']:


### PR DESCRIPTION
### What was wrong?

The `AccoutDB.apply_state_dict` API was just a convenience API used mostly in testing.  The only place it was used outside of testing was during setup of genesis state.

### How was it fixed?

Removed it from the `AccountDB` in favor of a stand-alone utility function.

#### Cute Animal Picture

![1370329710-0](https://user-images.githubusercontent.com/824194/39441313-c095f162-4c6a-11e8-86dc-4e88e384a9f8.jpg)

