### PR TITLE
Rename state_db to account_db

### DIFF
--- a/docs/api.computation.rst
+++ b/docs/api.computation.rst
@@ -142,7 +142,7 @@ Methods and Properties
 
     STUB
 
-.. method:: state_db(self, read_only=False)
+.. method:: account_db(self, read_only=False)
 
     STUB
 

--- a/docs/api.state.rst
+++ b/docs/api.state.rst
@@ -52,17 +52,17 @@ Methods and Properties
     Returns the current ``gas_used`` from the current block.
 
 
-.. attribute:: read_only_state_db
+.. attribute:: read_only_account_db
 
     Returns a read-only version of the account database.
 
 
-.. method:: mutable_state_db()
+.. method:: mutable_account_db()
 
     Returns the account database.
 
 
-.. method:: state_db(read_only=False)
+.. method:: account_db(read_only=False)
 
     Returns the account database.
 

--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -437,25 +437,25 @@ class Chain(BaseChain):
         """
         Initializes the Chain from a genesis state.
         """
-        state_db = chaindb.get_state_db(BLANK_ROOT_HASH, read_only=False)
+        account_db = chaindb.get_account_db(BLANK_ROOT_HASH, read_only=False)
 
         if genesis_state is None:
             genesis_state = {}
 
         # mutation
-        apply_state_dict(state_db, genesis_state)
+        apply_state_dict(account_db, genesis_state)
 
         if 'state_root' not in genesis_params:
             # If the genesis state_root was not specified, use the value
             # computed from the initialized state database.
-            genesis_params = assoc(genesis_params, 'state_root', state_db.root_hash)
-        elif genesis_params['state_root'] != state_db.root_hash:
+            genesis_params = assoc(genesis_params, 'state_root', account_db.root_hash)
+        elif genesis_params['state_root'] != account_db.root_hash:
             # If the genesis state_root was specified, validate that it matches
             # the computed state from the initialized state database.
             raise ValidationError(
                 "The provided genesis state root does not match the computed "
                 "genesis state root.  Got {0}.  Expected {1}".format(
-                    state_db.root_hash,
+                    account_db.root_hash,
                     genesis_params['state_root'],
                 )
             )

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -221,9 +221,9 @@ class BaseChainDB(metaclass=ABCMeta):
     # State Database API
     #
     @abstractmethod
-    def get_state_db(self,
-                     state_root: bytes,
-                     read_only: bool) -> BaseAccountDB:
+    def get_account_db(self,
+                       state_root: bytes,
+                       read_only: bool) -> BaseAccountDB:
         raise NotImplementedError("ChainDB classes must implement this method")
 
 
@@ -546,9 +546,9 @@ class ChainDB(BaseChainDB):
     #
     # State Database API
     #
-    def get_state_db(self,
-                     state_root: bytes,
-                     read_only: bool) -> BaseAccountDB:
+    def get_account_db(self,
+                       state_root: bytes,
+                       read_only: bool) -> BaseAccountDB:
         return AccountDB(
             db=self.journal_db,
             root_hash=state_root,

--- a/evm/tools/fixture_tests.py
+++ b/evm/tools/fixture_tests.py
@@ -38,7 +38,7 @@ from evm.constants import (
 from evm.db import get_db_backend
 from evm.db.chain import ChainDB
 from evm.utils.state import (
-    diff_state_db,
+    diff_account_db,
 )
 from evm.utils.rlp import (
     diff_rlp_object,
@@ -477,22 +477,22 @@ def normalize_blockchain_fixtures(fixture):
 #
 # State Setup
 #
-def setup_state_db(desired_state, state_db):
+def setup_account_db(desired_state, account_db):
     for account, account_data in desired_state.items():
         for slot, value in account_data['storage'].items():
-            state_db.set_storage(account, slot, value)
+            account_db.set_storage(account, slot, value)
 
         nonce = account_data['nonce']
         code = account_data['code']
         balance = account_data['balance']
 
-        state_db.set_nonce(account, nonce)
-        state_db.set_code(account, code)
-        state_db.set_balance(account, balance)
+        account_db.set_nonce(account, nonce)
+        account_db.set_code(account, code)
+        account_db.set_balance(account, balance)
 
 
-def verify_state_db(expected_state, state_db):
-    diff = diff_state_db(expected_state, state_db)
+def verify_account_db(expected_state, account_db):
+    diff = diff_account_db(expected_state, account_db)
     if diff:
         error_messages = []
         for account, field, actual_value, expected_value in diff:

--- a/evm/tools/test_builder/builder_utils.py
+++ b/evm/tools/test_builder/builder_utils.py
@@ -113,10 +113,10 @@ def get_version_from_git():
     return to_text(version)
 
 
-def calc_state_root(state, account_state_db_class):
-    state_db = account_state_db_class(MemoryDB())
-    apply_state_dict(state_db, state)
-    return state_db.root_hash
+def calc_state_root(state, account_db_class):
+    account_db = account_db_class(MemoryDB())
+    apply_state_dict(account_db, state)
+    return account_db.root_hash
 
 
 def generate_random_keypair():

--- a/evm/tools/test_builder/test_builder.py
+++ b/evm/tools/test_builder/test_builder.py
@@ -286,8 +286,8 @@ def fill_state_test(filler):
         result = normalize_state(expect["result"])
         post_state = deep_merge(pre_state, result)
         for network in networks:
-            account_state_db_class = ACCOUNT_STATE_DB_CLASSES[network]
-            post_state_root = calc_state_root(post_state, account_state_db_class)
+            account_db_class = ACCOUNT_STATE_DB_CLASSES[network]
+            post_state_root = calc_state_root(post_state, account_db_class)
             post[network].append({
                 "hash": encode_hex(post_state_root),
                 "indexes": indexes,

--- a/evm/utils/state.py
+++ b/evm/utils/state.py
@@ -4,15 +4,15 @@ from eth_utils import (
 
 
 @to_tuple
-def diff_state_db(expected_state, state_db):
+def diff_account_db(expected_state, account_db):
     for account, account_data in sorted(expected_state.items()):
         expected_nonce = account_data['nonce']
         expected_code = account_data['code']
         expected_balance = account_data['balance']
 
-        actual_nonce = state_db.get_nonce(account)
-        actual_code = state_db.get_code(account)
-        actual_balance = state_db.get_balance(account)
+        actual_nonce = account_db.get_nonce(account)
+        actual_code = account_db.get_code(account)
+        actual_balance = account_db.get_balance(account)
 
         if actual_nonce != expected_nonce:
             yield (account, 'nonce', actual_nonce, expected_nonce)
@@ -22,7 +22,7 @@ def diff_state_db(expected_state, state_db):
             yield (account, 'balance', actual_balance, expected_balance)
 
         for slot, expected_storage_value in sorted(account_data['storage'].items()):
-            actual_storage_value = state_db.get_storage(account, slot)
+            actual_storage_value = account_db.get_storage(account, slot)
             if actual_storage_value != expected_storage_value:
                 yield (
                     account,

--- a/evm/vm/computation.py
+++ b/evm/vm/computation.py
@@ -372,9 +372,9 @@ class BaseComputation(Configurable, metaclass=ABCMeta):
             return self._gas_meter.gas_remaining
 
     @contextmanager
-    def state_db(self, read_only: bool = False) -> Iterator[BaseAccountDB]:
-        with self.state.state_db(read_only) as state_db:
-            yield state_db
+    def account_db(self, read_only: bool = False) -> Iterator[BaseAccountDB]:
+        with self.state.account_db(read_only) as account_db:
+            yield account_db
 
     #
     # Context Manager API

--- a/evm/vm/forks/frontier/computation.py
+++ b/evm/vm/forks/frontier/computation.py
@@ -39,16 +39,16 @@ class FrontierComputation(BaseComputation):
             raise StackDepthLimit("Stack depth limit reached")
 
         if self.msg.should_transfer_value and self.msg.value:
-            with self.state.mutable_state_db() as state_db:
-                sender_balance = state_db.get_balance(self.msg.sender)
+            with self.state.mutable_account_db() as account_db:
+                sender_balance = account_db.get_balance(self.msg.sender)
 
                 if sender_balance < self.msg.value:
                     raise InsufficientFunds(
                         "Insufficient funds: {0} < {1}".format(sender_balance, self.msg.value)
                     )
 
-                state_db.delta_balance(self.msg.sender, -1 * self.msg.value)
-                state_db.delta_balance(self.msg.storage_address, self.msg.value)
+                account_db.delta_balance(self.msg.sender, -1 * self.msg.value)
+                account_db.delta_balance(self.msg.storage_address, self.msg.value)
 
             self.logger.debug(
                 "TRANSFERRED: %s from %s -> %s",
@@ -57,8 +57,8 @@ class FrontierComputation(BaseComputation):
                 encode_hex(self.msg.storage_address),
             )
 
-        with self.state.mutable_state_db() as state_db:
-            state_db.touch_account(self.msg.storage_address)
+        with self.state.mutable_account_db() as account_db:
+            account_db.touch_account(self.msg.storage_address)
 
         computation = self.apply_computation(
             self.state,
@@ -97,6 +97,6 @@ class FrontierComputation(BaseComputation):
                         len(contract_code),
                         encode_hex(keccak(contract_code))
                     )
-                    with self.state.mutable_state_db() as state_db:
-                        state_db.set_code(self.msg.storage_address, contract_code)
+                    with self.state.mutable_account_db() as account_db:
+                        account_db.set_code(self.msg.storage_address, contract_code)
             return computation

--- a/evm/vm/forks/frontier/validation.py
+++ b/evm/vm/forks/frontier/validation.py
@@ -5,7 +5,7 @@ from evm.exceptions import (
 
 def validate_frontier_transaction(state, transaction):
     gas_cost = transaction.gas * transaction.gas_price
-    sender_balance = state.read_only_state_db.get_balance(transaction.sender)
+    sender_balance = state.read_only_account_db.get_balance(transaction.sender)
 
     if sender_balance < gas_cost:
         raise ValidationError(
@@ -20,5 +20,5 @@ def validate_frontier_transaction(state, transaction):
     if state.gas_used + transaction.gas > state.gas_limit:
         raise ValidationError("Transaction exceeds gas limit")
 
-    if state.read_only_state_db.get_nonce(transaction.sender) != transaction.nonce:
+    if state.read_only_account_db.get_nonce(transaction.sender) != transaction.nonce:
         raise ValidationError("Invalid transaction nonce")

--- a/evm/vm/forks/homestead/computation.py
+++ b/evm/vm/forks/homestead/computation.py
@@ -50,8 +50,8 @@ class HomesteadComputation(FrontierComputation):
                             encode_hex(keccak(contract_code))
                         )
 
-                    with self.state.mutable_state_db() as state_db:
-                        state_db.set_code(self.msg.storage_address, contract_code)
+                    with self.state.mutable_account_db() as account_db:
+                        account_db.set_code(self.msg.storage_address, contract_code)
                     self.state.commit(snapshot)
             else:
                 self.state.commit(snapshot)

--- a/evm/vm/forks/homestead/headers.py
+++ b/evm/vm/forks/homestead/headers.py
@@ -77,12 +77,12 @@ def configure_homestead_header(vm, **header_params):
         # header.state_root after we're done.
         if vm.support_dao_fork and changeset.block_number == vm.dao_fork_block_number:
             state = vm.state
-            with state.mutable_state_db() as state_db:
+            with state.mutable_account_db() as account_db:
                 for account in dao_drain_list:
                     account = decode_hex(account)
-                    balance = state_db.get_balance(account)
-                    state_db.delta_balance(dao_refund_contract, balance)
-                    state_db.set_balance(account, 0)
+                    balance = account_db.get_balance(account)
+                    account_db.delta_balance(dao_refund_contract, balance)
+                    account_db.set_balance(account, 0)
 
             # Update state_root manually
             changeset.state_root = state.state_root

--- a/evm/vm/forks/spurious_dragon/computation.py
+++ b/evm/vm/forks/spurious_dragon/computation.py
@@ -23,8 +23,8 @@ class SpuriousDragonComputation(HomesteadComputation):
         snapshot = self.state.snapshot()
 
         # EIP161 nonce incrementation
-        with self.state.mutable_state_db() as state_db:
-            state_db.increment_nonce(self.msg.storage_address)
+        with self.state.mutable_account_db() as account_db:
+            account_db.increment_nonce(self.msg.storage_address)
 
         computation = self.apply_message()
 
@@ -64,8 +64,8 @@ class SpuriousDragonComputation(HomesteadComputation):
                             encode_hex(keccak(contract_code))
                         )
 
-                    with self.state.mutable_state_db() as state_db:
-                        state_db.set_code(self.msg.storage_address, contract_code)
+                    with self.state.mutable_account_db() as account_db:
+                        account_db.set_code(self.msg.storage_address, contract_code)
                     self.state.commit(snapshot)
             else:
                 self.state.commit(snapshot)

--- a/evm/vm/forks/spurious_dragon/state.py
+++ b/evm/vm/forks/spurious_dragon/state.py
@@ -23,13 +23,13 @@ class SpuriousDragonState(HomesteadState):
         #
         touched_accounts = collect_touched_accounts(computation)
 
-        with self.mutable_state_db() as state_db:
+        with self.mutable_account_db() as account_db:
             for account in touched_accounts:
-                if state_db.account_exists(account) and state_db.account_is_empty(account):
+                if account_db.account_exists(account) and account_db.account_is_empty(account):
                     self.logger.debug(
                         "CLEARING EMPTY ACCOUNT: %s",
                         encode_hex(account),
                     )
-                    state_db.delete_account(account)
+                    account_db.delete_account(account)
 
         return computation

--- a/evm/vm/logic/call.py
+++ b/evm/vm/logic/call.py
@@ -65,8 +65,8 @@ class BaseCall(Opcode, metaclass=ABCMeta):
         computation.consume_gas(child_msg_gas_fee, reason=self.mnemonic)
 
         # Pre-call checks
-        with computation.state_db(read_only=True) as state_db:
-            sender_balance = state_db.get_balance(computation.msg.storage_address)
+        with computation.account_db(read_only=True) as account_db:
+            sender_balance = account_db.get_balance(computation.msg.storage_address)
 
         insufficient_funds = should_transfer_value and sender_balance < value
         stack_too_deep = computation.msg.depth + 1 > constants.STACK_DEPTH_LIMIT
@@ -91,11 +91,11 @@ class BaseCall(Opcode, metaclass=ABCMeta):
             computation.return_gas(child_msg_gas)
             computation.stack_push(0)
         else:
-            with computation.state_db(read_only=True) as state_db:
+            with computation.account_db(read_only=True) as account_db:
                 if code_address:
-                    code = state_db.get_code(code_address)
+                    code = account_db.get_code(code_address)
                 else:
-                    code = state_db.get_code(to)
+                    code = account_db.get_code(to)
 
             child_msg_kwargs = {
                 'gas': child_msg_gas,
@@ -133,8 +133,8 @@ class BaseCall(Opcode, metaclass=ABCMeta):
 
 class Call(BaseCall):
     def compute_msg_extra_gas(self, computation, gas, to, value):
-        with computation.state_db(read_only=True) as state_db:
-            account_exists = state_db.account_exists(to)
+        with computation.account_db(read_only=True) as account_db:
+            account_exists = account_db.account_exists(to)
 
         transfer_gas_fee = constants.GAS_CALLVALUE if value else 0
         create_gas_fee = constants.GAS_NEWACCOUNT if not account_exists else 0
@@ -291,10 +291,10 @@ def compute_eip150_msg_gas(computation, gas, extra_gas, value, mnemonic, callsti
 #
 class CallEIP161(CallEIP150):
     def compute_msg_extra_gas(self, computation, gas, to, value):
-        with computation.state_db(read_only=True) as state_db:
+        with computation.account_db(read_only=True) as account_db:
             account_is_dead = (
-                not state_db.account_exists(to) or
-                state_db.account_is_empty(to)
+                not account_db.account_exists(to) or
+                account_db.account_is_empty(to)
             )
 
         transfer_gas_fee = constants.GAS_CALLVALUE if value else 0

--- a/evm/vm/logic/context.py
+++ b/evm/vm/logic/context.py
@@ -13,8 +13,8 @@ from evm.utils.numeric import (
 
 def balance(computation):
     addr = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
-    with computation.state_db(read_only=True) as state_db:
-        balance = state_db.get_balance(addr)
+    with computation.account_db(read_only=True) as account_db:
+        balance = account_db.get_balance(addr)
     computation.stack_push(balance)
 
 
@@ -108,8 +108,8 @@ def gasprice(computation):
 
 def extcodesize(computation):
     account = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
-    with computation.state_db(read_only=True) as state_db:
-        code_size = len(state_db.get_code(account))
+    with computation.account_db(read_only=True) as account_db:
+        code_size = len(account_db.get_code(account))
 
     computation.stack_push(code_size)
 
@@ -132,8 +132,8 @@ def extcodecopy(computation):
         reason='EXTCODECOPY: word gas cost',
     )
 
-    with computation.state_db(read_only=True) as state_db:
-        code = state_db.get_code(account)
+    with computation.account_db(read_only=True) as account_db:
+        code = account_db.get_code(account)
 
     code_bytes = code[code_start_position:code_start_position + size]
     padded_code_bytes = code_bytes.ljust(size, b'\x00')

--- a/evm/vm/logic/storage.py
+++ b/evm/vm/logic/storage.py
@@ -8,8 +8,8 @@ from evm.utils.hexadecimal import (
 def sstore(computation):
     slot, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
 
-    with computation.state_db(read_only=True) as state_db:
-        current_value = state_db.get_storage(
+    with computation.account_db(read_only=True) as account_db:
+        current_value = account_db.get_storage(
             address=computation.msg.storage_address,
             slot=slot,
         )
@@ -43,8 +43,8 @@ def sstore(computation):
     if gas_refund:
         computation.refund_gas(gas_refund)
 
-    with computation.state_db() as state_db:
-        state_db.set_storage(
+    with computation.account_db() as account_db:
+        account_db.set_storage(
             address=computation.msg.storage_address,
             slot=slot,
             value=value,
@@ -54,8 +54,8 @@ def sstore(computation):
 def sload(computation):
     slot = computation.stack_pop(type_hint=constants.UINT256)
 
-    with computation.state_db(read_only=True) as state_db:
-        value = state_db.get_storage(
+    with computation.account_db(read_only=True) as account_db:
+        value = account_db.get_storage(
             address=computation.msg.storage_address,
             slot=slot,
         )

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -47,14 +47,14 @@ class StateDownloader(PeerPoolSubscriber):
     _total_timeouts = 0
 
     def __init__(self,
-                 state_db: BaseDB,
+                 account_db: BaseDB,
                  root_hash: bytes,
                  peer_pool: PeerPool,
                  token: CancelToken = None) -> None:
         self.peer_pool = peer_pool
         self.peer_pool.subscribe(self)
         self.root_hash = root_hash
-        self.scheduler = StateSync(root_hash, state_db)
+        self.scheduler = StateSync(root_hash, account_db)
         self._running_peers = set()  # type: Set[ETHPeer]
         self._peers_with_pending_requests = {}  # type: Dict[ETHPeer, float]
         self.cancel_token = CancelToken('StateDownloader')

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -46,11 +46,11 @@ def test_import_block_validation(valid_chain, funded_address, funded_address_ini
     tx = imported_block.transactions[0]
     assert tx.value == 10
     vm = valid_chain.get_vm()
-    state_db = vm.state.read_only_state_db
-    assert state_db.get_balance(
+    account_db = vm.state.read_only_account_db
+    assert account_db.get_balance(
         decode_hex("095e7baea6a6c7c4c2dfeb977efac326af552d87")) == tx.value
     tx_gas = tx.gas_price * constants.GAS_TX
-    assert state_db.get_balance(funded_address) == (
+    assert account_db.get_balance(funded_address) == (
         funded_address_initial_balance - tx.value - tx_gas)
 
 

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -22,7 +22,7 @@ def new_transaction(
 
     The transaction will be signed with the given private key.
     """
-    nonce = vm.state.read_only_state_db.get_nonce(from_)
+    nonce = vm.state.read_only_account_db.get_nonce(from_)
     tx = vm.create_unsigned_transaction(
         nonce=nonce, gas_price=gas_price, gas=gas, to=to, value=amount, data=data)
     if private_key:

--- a/tests/core/vm/test_frontier_computation.py
+++ b/tests/core/vm/test_frontier_computation.py
@@ -24,8 +24,8 @@ CANONICAL_ADDRESS_B = to_canonical_address("0xcd1722f3947def4cf144679da39c4c32bd
 @pytest.fixture
 def state(chain_without_block_validation):
     state = chain_without_block_validation.get_vm().state
-    with state.mutable_state_db() as state_db:
-        state_db.set_balance(CANONICAL_ADDRESS_A, 1000)
+    with state.mutable_account_db() as account_db:
+        account_db.set_balance(CANONICAL_ADDRESS_A, 1000)
     return state
 
 

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -29,10 +29,10 @@ def test_apply_transaction(
 
     assert not computation.is_error
     tx_gas = tx.gas_price * constants.GAS_TX
-    state_db = vm.state.read_only_state_db
-    assert state_db.get_balance(from_) == (
+    account_db = vm.state.read_only_account_db
+    assert account_db.get_balance(from_) == (
         funded_address_initial_balance - amount - tx_gas)
-    assert state_db.get_balance(recipient) == amount
+    assert account_db.get_balance(recipient) == amount
     block = vm.block
     assert block.transactions[tx_idx] == tx
     assert block.header.gas_used == constants.GAS_TX
@@ -41,7 +41,8 @@ def test_apply_transaction(
 def test_mine_block_issues_block_reward(chain):
     block = chain.mine_block()
     vm = chain.get_vm()
-    assert vm.state.read_only_state_db.get_balance(block.header.coinbase) == constants.BLOCK_REWARD
+    coinbase_balance = vm.state.read_only_account_db.get_balance(block.header.coinbase)
+    assert coinbase_balance == constants.BLOCK_REWARD
 
 
 def test_import_block(chain, funded_address, funded_address_private_key):

--- a/tests/core/vm/test_vm_state.py
+++ b/tests/core/vm/test_vm_state.py
@@ -29,26 +29,26 @@ def test_block_properties(chain_without_block_validation):
     assert vm.state.gas_limit == block.header.gas_limit
 
 
-def test_state_db(state):
+def test_account_db(state):
     address = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     initial_state_root = state.state_root
 
-    # test cannot write to state_db after context exits
-    with state.mutable_state_db() as state_db:
+    # test cannot write to account_db after context exits
+    with state.mutable_account_db() as account_db:
         pass
 
     with pytest.raises(DecommissionedAccountDB):
-        state_db.increment_nonce(address)
+        account_db.increment_nonce(address)
 
-    state.read_only_state_db.get_balance(address)
+    state.read_only_account_db.get_balance(address)
     assert state.state_root == initial_state_root
 
-    with state.mutable_state_db() as state_db:
-        state_db.set_balance(address, 10)
+    with state.mutable_account_db() as account_db:
+        account_db.set_balance(address, 10)
     assert state.state_root != initial_state_root
 
     with pytest.raises(TypeError):
-        state.read_only_state_db.set_balance(address, 0)
+        state.read_only_account_db.set_balance(address, 0)
 
 
 def test_apply_transaction(

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -18,7 +18,7 @@ from evm.tools.fixture_tests import (
     generate_fixture_tests,
     filter_fixtures,
     normalize_blockchain_fixtures,
-    verify_state_db,
+    verify_account_db,
     assert_rlp_equal,
 )
 
@@ -110,4 +110,4 @@ def test_blockchain_fixtures(fixture_data, fixture):
     latest_block_hash = chain.get_canonical_block_by_number(chain.get_block().number - 1).hash
     assert latest_block_hash == fixture['lastblockhash']
 
-    verify_state_db(fixture['postState'], chain.get_vm().state.read_only_state_db)
+    verify_account_db(fixture['postState'], chain.get_vm().state.read_only_account_db)

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -272,8 +272,8 @@ def test_state_fixtures(fixture, fixture_vm_class):
     vm = fixture_vm_class(header=header, chaindb=chaindb)
 
     state = vm.state
-    with state.mutable_state_db() as state_db:
-        apply_state_dict(state_db, fixture['pre'])
+    with state.mutable_account_db() as account_db:
+        apply_state_dict(account_db, fixture['pre'])
     # Update state_root manually
     vm.block = vm.block.copy(header=vm.block.header.copy(state_root=state.state_root))
     if 'secretKey' in fixture['transaction']:

--- a/tests/json-fixtures/test_virtual_machine.py
+++ b/tests/json-fixtures/test_virtual_machine.py
@@ -24,8 +24,8 @@ from evm.tools.fixture_tests import (
     generate_fixture_tests,
     load_fixture,
     filter_fixtures,
-    setup_state_db,
-    verify_state_db,
+    setup_account_db,
+    verify_account_db,
     hash_log_entries,
 )
 from evm.vm.forks import (
@@ -187,9 +187,9 @@ def test_vm_fixtures(fixture, vm_class, computation_getter):
     )
     vm = vm_class(header=header, chaindb=chaindb)
     state = vm.state
-    with state.mutable_state_db() as state_db:
-        setup_state_db(fixture['pre'], state_db)
-        code = state_db.get_code(fixture['exec']['address'])
+    with state.mutable_account_db() as account_db:
+        setup_account_db(fixture['pre'], account_db)
+        code = account_db.get_code(fixture['exec']['address'])
     # Update state_root manually
     vm.block = vm.block.copy(header=vm.block.header.copy(state_root=state.state_root))
 
@@ -253,13 +253,13 @@ def test_vm_fixtures(fixture, vm_class, computation_getter):
             assert data == child_computation.msg.data or child_computation.msg.code
             assert gas_limit == child_computation.msg.gas
             assert value == child_computation.msg.value
-        post_state = fixture['post']
+        expected_account_db = fixture['post']
     else:
         #
         # Error checks
         #
         assert computation.is_error
         assert isinstance(computation._error, VMError)
-        post_state = fixture['pre']
+        expected_account_db = fixture['pre']
 
-    verify_state_db(post_state, vm.state.read_only_state_db)
+    verify_account_db(expected_account_db, vm.state.read_only_account_db)

--- a/tests/p2p/test_state_sync.py
+++ b/tests/p2p/test_state_sync.py
@@ -8,38 +8,38 @@ from p2p.state import StateSync
 
 
 def make_random_state(n):
-    state_db = AccountDB(MemoryDB())
+    account_db = AccountDB(MemoryDB())
     contents = {}
     for _ in range(n):
         addr = os.urandom(20)
-        state_db.touch_account(addr)
+        account_db.touch_account(addr)
         balance = random.randint(0, 10000)
-        state_db.set_balance(addr, balance)
+        account_db.set_balance(addr, balance)
         nonce = random.randint(0, 10000)
-        state_db.set_nonce(addr, nonce)
+        account_db.set_nonce(addr, nonce)
         storage = random.randint(0, 10000)
-        state_db.set_storage(addr, 0, storage)
+        account_db.set_storage(addr, 0, storage)
         code = b'not-real-code'
-        state_db.set_code(addr, code)
+        account_db.set_code(addr, code)
         contents[addr] = (balance, nonce, storage, code)
-    return state_db, contents
+    return account_db, contents
 
 
 def test_state_sync():
-    state_db, contents = make_random_state(1000)
+    account_db, contents = make_random_state(1000)
     dest_db = MemoryDB()
-    scheduler = StateSync(state_db.root_hash, dest_db)
+    scheduler = StateSync(account_db.root_hash, dest_db)
     requests = scheduler.next_batch(10)
     while requests:
         results = []
         for request in requests:
-            results.append([request.node_key, state_db.db[request.node_key]])
+            results.append([request.node_key, account_db.db[request.node_key]])
         scheduler.process(results)
         requests = scheduler.next_batch(10)
-    dest_state = AccountDB(dest_db, state_db.root_hash)
+    account_db = AccountDB(dest_db, account_db.root_hash)
     for addr, account_data in contents.items():
         balance, nonce, storage, code = account_data
-        assert dest_state.get_balance(addr) == balance
-        assert dest_state.get_nonce(addr) == nonce
-        assert dest_state.get_storage(addr, 0) == storage
-        assert dest_state.get_code(addr) == code
+        assert account_db.get_balance(addr) == balance
+        assert account_db.get_nonce(addr) == nonce
+        assert account_db.get_storage(addr, 0) == storage
+        assert account_db.get_code(addr) == code

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -44,9 +44,9 @@ def state_at_block(chain, at_block, read_only=True):
     at_header = get_header(chain, at_block)
     vm = chain.get_vm(at_header)
     if read_only:
-        yield vm.state.read_only_state_db
+        yield vm.state.read_only_account_db
     else:
-        with vm.state.mutable_state_db() as state:
+        with vm.state.mutable_account_db() as state:
             yield state
 
 


### PR DESCRIPTION
### What was wrong?

The name `state_db` was used for API method names and variable names when the actual class is now the `AccountDB`

### How was it fixed?

Changed naming conventions to use `account_db`

#### Cute Animal Picture

![20060402_egy_7018](https://user-images.githubusercontent.com/824194/39445256-b37c3948-4c77-11e8-8114-954bb3076546.jpg)

