### PR TITLE
Piper/rename account db.root hash to account db.state root

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -448,14 +448,14 @@ class Chain(BaseChain):
         if 'state_root' not in genesis_params:
             # If the genesis state_root was not specified, use the value
             # computed from the initialized state database.
-            genesis_params = assoc(genesis_params, 'state_root', account_db.root_hash)
-        elif genesis_params['state_root'] != account_db.root_hash:
+            genesis_params = assoc(genesis_params, 'state_root', account_db.state_root)
+        elif genesis_params['state_root'] != account_db.state_root:
             # If the genesis state_root was specified, validate that it matches
             # the computed state from the initialized state database.
             raise ValidationError(
                 "The provided genesis state root does not match the computed "
                 "genesis state root.  Got {0}.  Expected {1}".format(
-                    account_db.root_hash,
+                    account_db.state_root,
                     genesis_params['state_root'],
                 )
             )

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -551,7 +551,7 @@ class ChainDB(BaseChainDB):
                        read_only: bool) -> BaseAccountDB:
         return AccountDB(
             db=self.journal_db,
-            root_hash=state_root,
+            state_root=state_root,
             read_only=read_only,
         )
 

--- a/evm/tools/test_builder/builder_utils.py
+++ b/evm/tools/test_builder/builder_utils.py
@@ -116,7 +116,7 @@ def get_version_from_git():
 def calc_state_root(state, account_db_class):
     account_db = account_db_class(MemoryDB())
     apply_state_dict(account_db, state)
-    return account_db.root_hash
+    return account_db.state_root
 
 
 def generate_random_keypair():

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -103,35 +103,35 @@ class BaseState(Configurable, metaclass=ABCMeta):
     #
     @contextmanager
     def mutable_account_db(self):
-        state = self._chaindb.get_account_db(self.state_root, read_only=False)
-        yield state
+        account_db = self._chaindb.get_account_db(self.state_root, read_only=False)
+        yield account_db
 
-        if self.state_root != state.root_hash:
-            self.set_state_root(state.root_hash)
+        if self.state_root != account_db.state_root:
+            self.set_state_root(account_db.state_root)
 
         # remove the reference to the underlying `db` object to ensure that no
         # further modifications can occur using the `State` object after
         # leaving the context.
-        state.decommission()
+        account_db.decommission()
 
     #
     # account_db
     #
     @contextmanager
     def account_db(self, read_only=False):
-        state = self._chaindb.get_account_db(
+        account_db = self._chaindb.get_account_db(
             self.state_root,
             read_only,
         )
-        yield state
+        yield account_db
 
-        if self.state_root != state.root_hash:
-            self.set_state_root(state.root_hash)
+        if self.state_root != account_db.state_root:
+            self.set_state_root(account_db.state_root)
 
         # remove the reference to the underlying `db` object to ensure that no
         # further modifications can occur using the `State` object after
         # leaving the context.
-        state.decommission()
+        account_db.decommission()
 
     def set_state_root(self, state_root):
         self.state_root = state_root
@@ -157,7 +157,7 @@ class BaseState(Configurable, metaclass=ABCMeta):
 
         with self.mutable_account_db() as account_db:
             # first revert the database state root.
-            account_db.root_hash = state_root
+            account_db.state_root = state_root
             # now roll the underlying database back
             account_db.discard(changeset_id)
 

--- a/tests/p2p/test_state_sync.py
+++ b/tests/p2p/test_state_sync.py
@@ -28,7 +28,7 @@ def make_random_state(n):
 def test_state_sync():
     account_db, contents = make_random_state(1000)
     dest_db = MemoryDB()
-    scheduler = StateSync(account_db.root_hash, dest_db)
+    scheduler = StateSync(account_db.state_root, dest_db)
     requests = scheduler.next_batch(10)
     while requests:
         results = []
@@ -36,10 +36,11 @@ def test_state_sync():
             results.append([request.node_key, account_db.db[request.node_key]])
         scheduler.process(results)
         requests = scheduler.next_batch(10)
-    account_db = AccountDB(dest_db, account_db.root_hash)
+
+    result_account_db = AccountDB(dest_db, account_db.state_root)
     for addr, account_data in contents.items():
         balance, nonce, storage, code = account_data
-        assert account_db.get_balance(addr) == balance
-        assert account_db.get_nonce(addr) == nonce
-        assert account_db.get_storage(addr, 0) == storage
-        assert account_db.get_code(addr) == code
+        assert result_account_db.get_balance(addr) == balance
+        assert result_account_db.get_nonce(addr) == nonce
+        assert result_account_db.get_storage(addr, 0) == storage
+        assert result_account_db.get_code(addr) == code


### PR DESCRIPTION
link: #611 #507 #599 

### What was wrong?

The `AccountDB` class used the property `AccountDB.root_hash`.  This value represents the `Header.state_root` and is more appropriately named `state_root`.

### How was it fixed?

Renamed it.


#### Cute Animal Picture

![mama_moose_licking_calf-2974-6](https://user-images.githubusercontent.com/824194/39446603-4f9b13a4-4c7c-11e8-9215-8e64bbe539e8.jpg)
