### PR TITLE
fix vm trace logger

### DIFF
--- a/evm/utils/logging.py
+++ b/evm/utils/logging.py
@@ -11,7 +11,7 @@ class TraceLogger(Logger):
         Logger.__init__(self, name, level)
 
     def trace(self, message: str, *args: Any, **kwargs: Any) -> None:
-        self.log(TRACE_LEVEL_NUM, message, args, **kwargs)
+        self.log(TRACE_LEVEL_NUM, message, *args, **kwargs)
 
 
 def setup_trace_logging() -> None:


### PR DESCRIPTION
### What was wrong?

The `trace` logger was broken in how it passed up the `args` to the main logger.

### How was it fixed?

Added a `*`

#### Cute Animal Picture

![moose-moose-30565840-468-440](https://user-images.githubusercontent.com/824194/39479531-c955adc0-4d22-11e8-841a-3b8394ed2b7d.jpg)
