### PR TITLE
Return header instead of block from vm.apply_txn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	tox -eflake8py3{5,6}
+	tox -elint-py36
 
 test:
 	py.test --tb native tests

--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -493,7 +493,7 @@ class Chain(BaseChain):
         transactions = base_block.transactions + (transaction, )
         receipts = base_block.get_receipts(self.chaindb) + (receipt, )
 
-        new_block = vm.seal_block(base_block, new_header, transactions, receipts)
+        new_block = vm.set_block_transactions(base_block, new_header, transactions, receipts)
 
         self.header = new_block.header
 

--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -23,7 +23,6 @@ from evm.constants import (
     MAX_UNCLE_DEPTH,
 )
 from evm.db.chain import AsyncChainDB
-from evm.db.trie import make_trie_root_and_nodes
 from evm.estimators import (
     get_gas_estimator,
 )

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -409,7 +409,7 @@ class ChainDB(BaseChainDB):
     #
     # Transaction and Receipt API
     #
-    @to_list
+    @to_tuple
     def get_receipts(self, header: BlockHeader, receipt_class: Type[Receipt]) -> Iterable[Receipt]:
         receipt_db = HexaryTrie(db=self.db, root_hash=header.receipt_root)
         for receipt_idx in itertools.count():

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -183,11 +183,16 @@ class BaseVM(Configurable, metaclass=ABCMeta):
             receipts = tuple()
             header_with_txns = self.block.header
 
-        self.block = self.seal_block(self.block, header_with_txns, block.transactions, receipts)
+        self.block = self.set_block_transactions(
+            self.block,
+            header_with_txns,
+            block.transactions,
+            receipts,
+        )
 
         return self.mine_block()
 
-    def seal_block(self, base_block, new_header, transactions, receipts):
+    def set_block_transactions(self, base_block, new_header, transactions, receipts):
 
         tx_root_hash, tx_kv_nodes = make_trie_root_and_nodes(transactions)
         self.chaindb.persist_trie_data_dict(tx_kv_nodes)

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -183,7 +183,6 @@ class BaseVM(Configurable, metaclass=ABCMeta):
             receipts = tuple()
             header_with_txns = self.block.header
 
-
         self.block = self.seal_block(self.block, header_with_txns, block.transactions, receipts)
 
         return self.mine_block()

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -55,11 +55,10 @@ def test_import_block_validation(valid_chain, funded_address, funded_address_ini
 
 
 def test_import_block(chain, tx):
-    vm = chain.get_vm()
-    *_, computation = vm.apply_transaction(tx)
+    new_block, _, computation = chain.apply_transaction(tx)
     assert computation.is_success
 
-    block = chain.import_block(vm.block)
+    block = chain.import_block(new_block)
     assert block.transactions == (tx,)
     assert chain.get_block_by_hash(block.hash) == block
     assert chain.get_canonical_block_by_number(block.number) == block

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -307,7 +307,10 @@ def test_state_fixtures(fixture, fixture_vm_class):
         )
 
     try:
-        block, _, computation = vm.apply_transaction(transaction)
+        header, receipt, computation = vm.apply_transaction(transaction)
+        transactions = vm.block.transactions + (transaction, )
+        receipts = vm.block.get_receipts(chaindb) + (receipt, )
+        block = vm.seal_block(vm.block, header, transactions, receipts)
     except ValidationError as err:
         block = vm.block
         transaction_error = err

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -310,7 +310,7 @@ def test_state_fixtures(fixture, fixture_vm_class):
         header, receipt, computation = vm.apply_transaction(transaction)
         transactions = vm.block.transactions + (transaction, )
         receipts = vm.block.get_receipts(chaindb) + (receipt, )
-        block = vm.seal_block(vm.block, header, transactions, receipts)
+        block = vm.set_block_transactions(vm.block, header, transactions, receipts)
     except ValidationError as err:
         block = vm.block
         transaction_error = err

--- a/tox.ini
+++ b/tox.ini
@@ -63,8 +63,9 @@ basepython=python3.6
 setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
 commands=
     flake8 {toxinidir}/eth_typing
+    flake8 {toxinidir}/evm
     flake8 {toxinidir}/p2p
     flake8 {toxinidir}/trinity
-    flake8 {toxinidir}/tests/trinity --exclude=""
+    flake8 {toxinidir}/tests
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
     mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p eth_typing -p p2p -p trinity


### PR DESCRIPTION
### What was wrong?

Related to #599 & #507 - VM returns partially-completed block objects as a result of `apply_transaction()`

### How was it fixed?

Return the header instead, and let `chain` deal with building the block (at the appropriate time). As a bonus, we build fewer block objects during `vm.import_block()`.

*TODO in follow-up PR: decide how to deal with the exact some problem with `header` which is only partially formed (no state/receipt root) -- maybe this is where a `TransactionDiff` comes in`*

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://mediad.publicbroadcasting.net/p/wvtf/files/201310/Deer02.jpg)