### PR TITLE
Delete gas used from state

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -145,7 +145,7 @@ class BaseChain(Configurable, metaclass=ABCMeta):
 
     def get_block_by_header(self, block_header):
         vm = self.get_vm(block_header)
-        return vm.get_block_by_header(block_header, self.chaindb)
+        return vm.get_block_class().from_header(block_header, self.chaindb)
 
     @to_tuple
     def get_ancestors(self, limit):
@@ -421,10 +421,6 @@ class Chain(BaseChain):
         validate_word(block_hash, title="Block Hash")
         block_header = self.get_block_header_by_hash(block_hash)
         return self.get_block_by_header(block_header)
-
-    def get_block_by_header(self, block_header):
-        vm = self.get_vm(block_header)
-        return vm.get_block_by_header(block_header, self.chaindb)
 
     #
     # Chain Initialization

--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -484,7 +484,7 @@ class Chain(BaseChain):
         vm = self.get_vm()
         base_block = vm.block
 
-        new_header, receipt, computation = vm.apply_transaction(transaction)
+        new_header, receipt, computation = vm.apply_transaction(base_block.header, transaction)
 
         transactions = base_block.transactions + (transaction, )
         receipts = base_block.get_receipts(self.chaindb) + (receipt, )

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -436,13 +436,6 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         return cls.get_state_class().get_block_class()
 
     @classmethod
-    def get_block_by_header(cls, block_header, db):
-        """
-        Lookup and return the block for the given header.
-        """
-        return cls.get_block_class().from_header(block_header, db)
-
-    @classmethod
     @functools.lru_cache(maxsize=32)
     @to_tuple
     def get_prev_hashes(cls, last_block_hash, db):

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -315,6 +315,13 @@ class BaseVM(Configurable, metaclass=ABCMeta):
         """
         Validate the the given block.
         """
+        if not isinstance(block, self.get_block_class()):
+            raise ValidationError(
+                "This vm ({0!r}) is not equipped to validate a block of type {1!r}".format(
+                    self,
+                    block,
+                )
+            )
         if not block.is_genesis:
             parent_header = get_parent_header(block.header, self.chaindb)
 

--- a/evm/vm/forks/byzantium/__init__.py
+++ b/evm/vm/forks/byzantium/__init__.py
@@ -1,6 +1,3 @@
-from evm.rlp.receipts import (
-    Receipt,
-)
 from evm.vm.forks.spurious_dragon import SpuriousDragonVM
 from evm.vm.forks.frontier import make_frontier_receipt
 
@@ -16,20 +13,15 @@ from .headers import (
 from .state import ByzantiumState
 
 
-def make_byzantium_receipt(transaction, computation, state):
-    old_receipt = make_frontier_receipt(transaction, computation, state)
+def make_byzantium_receipt(base_header, transaction, computation, state):
+    frontier_receipt = make_frontier_receipt(base_header, transaction, computation, state)
 
     if computation.is_error:
-        state_root = EIP658_TRANSACTION_STATUS_CODE_FAILURE
+        status_code = EIP658_TRANSACTION_STATUS_CODE_FAILURE
     else:
-        state_root = EIP658_TRANSACTION_STATUS_CODE_SUCCESS
+        status_code = EIP658_TRANSACTION_STATUS_CODE_SUCCESS
 
-    receipt = Receipt(
-        state_root=state_root,
-        gas_used=old_receipt.gas_used,
-        logs=old_receipt.logs,
-    )
-    return receipt
+    return frontier_receipt.copy(state_root=status_code)
 
 
 ByzantiumVM = SpuriousDragonVM.configure(

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -14,9 +14,10 @@ from .headers import (
     compute_frontier_difficulty,
     configure_frontier_header,
 )
+from .validation import validate_frontier_transaction_against_header
 
 
-def make_frontier_receipt(transaction, computation, state):
+def make_frontier_receipt(base_header, transaction, computation, state):
     # Reusable for other forks
 
     logs = [
@@ -33,7 +34,7 @@ def make_frontier_receipt(transaction, computation, state):
         gas_refund,
         (transaction.gas - gas_remaining) // 2,
     )
-    gas_used = state.gas_used + tx_gas_used
+    gas_used = base_header.gas_used + tx_gas_used
 
     receipt = Receipt(
         state_root=state.state_root,
@@ -55,5 +56,6 @@ FrontierVM = VM.configure(
     create_header_from_parent=staticmethod(create_frontier_header_from_parent),
     compute_difficulty=staticmethod(compute_frontier_difficulty),
     configure_header=configure_frontier_header,
-    make_receipt=staticmethod(make_frontier_receipt)
+    make_receipt=staticmethod(make_frontier_receipt),
+    validate_transaction_against_header=validate_frontier_transaction_against_header,
 )

--- a/evm/vm/forks/frontier/state.py
+++ b/evm/vm/forks/frontier/state.py
@@ -181,7 +181,7 @@ class FrontierState(BaseState, FrontierTransactionExecutor):
     account_db_class = AccountDB  # Type[BaseAccountDB]
 
     def validate_transaction(self, transaction):
-        validate_frontier_transaction(self, transaction)
+        validate_frontier_transaction(self.account_db, transaction)
 
     @staticmethod
     def get_block_reward():

--- a/evm/vm/forks/frontier/validation.py
+++ b/evm/vm/forks/frontier/validation.py
@@ -3,9 +3,9 @@ from evm.exceptions import (
 )
 
 
-def validate_frontier_transaction(state, transaction):
+def validate_frontier_transaction(account_db, transaction):
     gas_cost = transaction.gas * transaction.gas_price
-    sender_balance = state.account_db.get_balance(transaction.sender)
+    sender_balance = account_db.get_balance(transaction.sender)
 
     if sender_balance < gas_cost:
         raise ValidationError(
@@ -17,8 +17,16 @@ def validate_frontier_transaction(state, transaction):
     if sender_balance < total_cost:
         raise ValidationError("Sender account balance cannot afford txn")
 
-    if state.gas_used + transaction.gas > state.gas_limit:
-        raise ValidationError("Transaction exceeds gas limit")
-
-    if state.account_db.get_nonce(transaction.sender) != transaction.nonce:
+    if account_db.get_nonce(transaction.sender) != transaction.nonce:
         raise ValidationError("Invalid transaction nonce")
+
+
+def validate_frontier_transaction_against_header(_vm, base_header, transaction):
+    if base_header.gas_used + transaction.gas > base_header.gas_limit:
+        raise ValidationError(
+            "Transaction exceeds gas limit: using {}, bringing total to {}, but limit is {}".format(
+                transaction.gas,
+                base_header.gas_used + transaction.gas,
+                base_header.gas_limit,
+            )
+        )

--- a/evm/vm/forks/homestead/state.py
+++ b/evm/vm/forks/homestead/state.py
@@ -10,4 +10,4 @@ class HomesteadState(FrontierState):
     computation_class = HomesteadComputation
 
     def validate_transaction(self, transaction):
-        validate_homestead_transaction(self, transaction)
+        validate_homestead_transaction(self.account_db, transaction)

--- a/evm/vm/forks/homestead/validation.py
+++ b/evm/vm/forks/homestead/validation.py
@@ -10,8 +10,8 @@ from evm.vm.forks.frontier.validation import (
 )
 
 
-def validate_homestead_transaction(evm, transaction):
+def validate_homestead_transaction(account_db, transaction):
     if transaction.s > SECPK1_N // 2 or transaction.s == 0:
         raise ValidationError("Invalid signature S value")
 
-    validate_frontier_transaction(evm, transaction)
+    validate_frontier_transaction(account_db, transaction)

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -63,18 +63,16 @@ class BaseState(Configurable, metaclass=ABCMeta):
     _chaindb = None
     execution_context = None
     state_root = None
-    gas_used = None
 
     block_class = None  # type: Type[BaseBlock]
     computation_class = None  # type: Type[BaseComputation]
     transaction_context_class = None  # type: Type[BaseTransactionContext]
     account_db_class = None  # type: Type[BaseAccountDB]
 
-    def __init__(self, db, execution_context, state_root, gas_used):
+    def __init__(self, db, execution_context, state_root):
         self._db = db
         self.execution_context = execution_context
         self.account_db = self.get_account_db_class()(self._db, state_root)
-        self.gas_used = gas_used
 
     #
     # Logging

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -36,16 +36,16 @@ def fill_block(chain, from_, key, gas, data):
     amount = 100
 
     vm = chain.get_vm()
-    assert vm.state.gas_used == 0
+    assert vm.block.header.gas_used == 0
 
     while True:
         tx = new_transaction(chain.get_vm(), from_, recipient, amount, key, gas=gas, data=data)
         try:
             chain.apply_transaction(tx)
         except ValidationError as exc:
-            if "Transaction exceeds gas limit" == str(exc):
+            if str(exc).startswith("Transaction exceeds gas limit"):
                 break
             else:
                 raise exc
 
-    assert chain.get_vm().state.gas_used > 0
+    assert chain.get_vm().block.header.gas_used > 0

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -24,7 +24,7 @@ def test_apply_transaction(
     amount = 100
     from_ = funded_address
     tx = new_transaction(vm, from_, recipient, amount, funded_address_private_key)
-    new_header, _, computation = vm.apply_transaction(tx)
+    new_header, _, computation = vm.apply_transaction(vm.block.header, tx)
 
     assert not computation.is_error
     tx_gas = tx.gas_price * constants.GAS_TX

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -307,7 +307,7 @@ def test_state_fixtures(fixture, fixture_vm_class):
         )
 
     try:
-        header, receipt, computation = vm.apply_transaction(transaction)
+        header, receipt, computation = vm.apply_transaction(vm.block.header, transaction)
         transactions = vm.block.transactions + (transaction, )
         receipts = vm.block.get_receipts(chaindb) + (receipt, )
         block = vm.set_block_transactions(vm.block, header, transactions, receipts)


### PR DESCRIPTION
### What was wrong?

Related to #599 & #507 - there was state mutation inside `VM.apply_transaction()`, to update `gas_used`, and `get_block_by_header` lived in VM (we're generally looking to move block manipulation out of VM, into Chain).

### How was it fixed?

There wasn't really any need for `gas_used` to be in the state, we can verify the transaction against the header in the VM, before even calling `state.apply_transaction`.

- add a new transaction verification, explicitly against the header
- make_receipt new uses the header to generate the cumulative gas used
- apply_transaction now builds on top of a passed-in header (rather than using a local mutation of `self.block.header`)
- `get_block_by_header` really needed to belong in Chain instead of VM.
- use only `account_db` instead of the full state to validate transaction (after separately running the transaction->header validation)

Yay for more use of (immutable) rlp object, and less state mutation.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://data.whicdn.com/images/162058213/large.jpg)