### PR TITLE
Use Python 3.6 to generate docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 # https://docs.readthedocs.io/en/latest/yaml-config.html
 build:
-    image: latest
+  image: latest
 python:
   version: 3.6
   pip_install: True

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,8 @@
 # https://docs.readthedocs.io/en/latest/yaml-config.html
+build:
+    image: latest
 python:
-  version: 3.5
+  version: 3.6
   pip_install: True
   extra_requirements:
     - doc


### PR DESCRIPTION
### What was wrong?

Our live doc site is currently broken not showing any of the API docs as seen here.

![image](https://user-images.githubusercontent.com/521109/39571860-39501de4-4ecd-11e8-9a88-bc666f978fed.png)

This PR fixes it as seen on the following screenshot (notice the URL. This is live on a special `doctest` branch that I pushed into this repo but will delete again now)

![image](https://user-images.githubusercontent.com/521109/39571912-6c85d7c6-4ecd-11e8-8293-20544ea65965.png)

### How was it fixed?

Apparently readthedocs had issues building our API docs with Python 3.5 (which should work in general, trio uses Python 3.5 for rtd as well and has no issues with the autodoc feature). Instructing readthedocs to build with Python 3.6 instead fixes the issue.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media1.giphy.com/media/og9xs41IID5vy/giphy.gif)
