### PR TITLE
Add more Ropsten peers to HardCodedNodesPeerPool

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -846,6 +846,30 @@ class HardCodedNodesPeerPool(PeerPool):
             ]
         elif self.network_id == RopstenChain.network_id:
             nodes = [
+                Node(keys.PublicKey(decode_hex("0d7f627a9a139c1fbff6731d6e0123561738c5155908e32c3a1eea00a3e0c3b460d97c8aea1935c19bfb4e7013651488b8d328b9c142c0b820e221fde7894253")),  # noqa: E501
+                     Address("58.250.0.61", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("360aeace83f0771dd671f253a023b4757e920aca3598563779d8edb2f4d4ca001b5dc2f900ec1547edcd34cfd5cf858e717647e9b5c1f88cef1934081337678b")),  # noqa: E501
+                     Address("34.212.25.61", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("49f9e25549aaa9d2bbbedb32bc22029833a8ce457ce54310e44ed8097082379ac94ff5319ff57da0afa91584c271d17324bc3ea3a74e01a9684fbe9a392b239d")),  # noqa: E501
+                     Address("34.237.139.163", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("5740300afd843ce51b2ca734e30ec690f1b61b163f67a289888757e8962f8046d46f8b6a8d2663246f0b81a75cbc7604619721567054309f15bc360490c8c4da")),  # noqa: E501
+                     Address("172.104.183.123", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("7f3c9e7472a28904c7b5066bce561ac230801147fb6cffae10967baf058a9fcffe03e386c55e5c1397172aef36d78b9f35b6d4f0dc831707c66530194f4867fb")),  # noqa: E501
+                     Address("114.242.249.161", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("8d24ff3d32b0fc70bf41cf828b98940e2ef18ab82fc37de779c206cbec88d5c11a3e3af9700953b9f5e6582f73cddd76f90fc1688992fbdf3b9216228c80654c")),  # noqa: E501
+                     Address("202.9.6.81", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("bbb3ad8be9684fa1d67ac057d18f7357dd236dc01a806fef6977ac9a259b352c00169d092c50475b80aed9e28eff12d2038e97971e0be3b934b366e86b59a723")),  # noqa: E501
+                     Address("81.169.153.213", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("a147a3adde1daddc0d86f44f1a76404914e44cee018c26d49248142d4dc8a9fb0e7dd14b5153df7e60f23b037922ae1f33b8f318844ef8d2b0453b9ab614d70d")),  # noqa: E501
+                     Address("72.36.89.11", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("bd2867892d879b57734d571b208bb7adc04fa412fbdfe73b89b1a0ec5b7978932cc776609e4ac7bac231049975ecb22c74988da36cbc5111d116b1edf7d44802")),  # noqa: E501
+                     Address("185.68.101.99", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("c2bb011038530b60b40a342705246a84e6d2d22d9f8d8d3df4ae1c7464f302396e7be7673a3971b2de16ebd66574ade262fc292b6de7715983f0f15f9c9922ea")),  # noqa: E501
+                     Address("36.225.32.203", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("d8714127db3c10560a2463c557bbe509c99969078159c69f9ce4f71c2cd1837bcd33db3b9c3c3e88c971b4604bbffa390a0a7f53fc37f122e2e6e0022c059dfd")),  # noqa: E501
+                     Address("51.15.217.106", 30303, 30303)),
+                Node(keys.PublicKey(decode_hex("efc75f109d91cdebc62f33be992ca86fce2637044d49a954a8bdceb439b1239afda32e642456e9dfd759af5b440ef4d8761b9bda887e2200001c5f3ab2614043")),  # noqa: E501
+                     Address("34.228.166.142", 30303, 30303)),
                 Node(keys.PublicKey(decode_hex("c8b9ec645cd7fe570bc73740579064c528771338c31610f44d160d2ae63fd00699caa163f84359ab268d4a0aed8ead66d7295be5e9c08b0ec85b0198273bae1f")),  # noqa: E501
                      Address("178.62.246.6", 30303, 30303)),
                 Node(keys.PublicKey(decode_hex("7a34c02d5ef9de43475580cbb88fb492afb2858cfc45f58cf5c7088ceeded5f58e65be769b79c31c5ae1f012c99b3e9f2ea9ef11764d553544171237a691493b")),  # noqa: E501


### PR DESCRIPTION
Most of the current p2p nodes there haven't been responding lately or already have too many peers, so I digged a few more (via geth's admin.peers console cmd).