### PR TITLE
trinity: Add support for full node syncing and run that by default

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -354,8 +354,12 @@ class ChainSyncer(PeerPoolSubscriber):
 
 class RegularChainSyncer(ChainSyncer):
 
-    def __init__(self, chain: AsyncChain, peer_pool: PeerPool, token: CancelToken = None) -> None:
-        super().__init__(chain.chaindb, peer_pool, token)
+    def __init__(self,
+                 chain: AsyncChain,
+                 chaindb: AsyncChainDB,
+                 peer_pool: PeerPool,
+                 token: CancelToken = None) -> None:
+        super().__init__(chaindb, peer_pool, token)
         self.chain = chain
 
     async def _handle_msg(self, peer: ETHPeer, cmd: protocol.Command,
@@ -395,6 +399,7 @@ class RegularChainSyncer(ChainSyncer):
         for header in headers:
             vm_class = self.chain.get_vm_class_for_block_number(header.block_number)
             block_class = vm_class.get_block_class()
+
             if _is_body_empty(header):
                 transactions = []  # type: List[BaseTransaction]
                 uncles = []  # type: List[BlockHeader]
@@ -491,7 +496,7 @@ def _test() -> None:
 
     asyncio.ensure_future(peer_pool.run())
     chain = FakeAsyncRopstenChain(chaindb)
-    downloader = RegularChainSyncer(chain, peer_pool)
+    downloader = RegularChainSyncer(chain, chaindb, peer_pool)
     downloader.min_peers_to_sync = 1
 
     async def run():

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -1,6 +1,8 @@
 import logging
 
 from evm.chains import AsyncChain
+from evm.db.backends.base import BaseDB
+from evm.db.chain import AsyncChainDB
 from p2p.cancel_token import CancelToken
 from p2p.exceptions import OperationCancelled
 from p2p.peer import PeerPool
@@ -11,26 +13,31 @@ from p2p.state import StateDownloader
 class FullNodeSyncer:
     logger = logging.getLogger("p2p.sync.FullNodeSyncer")
 
-    def __init__(self, chain: AsyncChain, peer_pool: PeerPool) -> None:
+    def __init__(self,
+                 chain: AsyncChain,
+                 chaindb: AsyncChainDB,
+                 db: BaseDB,
+                 peer_pool: PeerPool) -> None:
         self.chain = chain
+        self.chaindb = chaindb
+        self.db = db
         self.peer_pool = peer_pool
         self.cancel_token = CancelToken('FullNodeSyncer')
 
     async def run(self) -> None:
-        chaindb = self.chain.chaindb
         # Fast-sync chain data.
-        head = await chaindb.coro_get_canonical_head()
+        head = await self.chaindb.coro_get_canonical_head()
         self.logger.info("Starting fast-sync; current head: #%d", head.block_number)
-        chain_syncer = ChainSyncer(chaindb, self.peer_pool, self.cancel_token)
+        chain_syncer = ChainSyncer(self.chaindb, self.peer_pool, self.cancel_token)
         try:
             await chain_syncer.run()
         finally:
             await chain_syncer.stop()
 
         # Download state for our current head.
-        head = await chaindb.coro_get_canonical_head()
+        head = await self.chaindb.coro_get_canonical_head()
         downloader = StateDownloader(
-            chaindb.db, head.state_root, self.peer_pool, self.cancel_token)
+            self.db, head.state_root, self.peer_pool, self.cancel_token)
         try:
             await downloader.run()
         finally:
@@ -38,7 +45,8 @@ class FullNodeSyncer:
 
         # Now, loop forever, fetching missing blocks and applying them.
         self.logger.info("Starting normal sync; current head: #%d", head.block_number)
-        chain_syncer = RegularChainSyncer(self.chain, self.peer_pool, self.cancel_token)
+        chain_syncer = RegularChainSyncer(
+            self.chain, self.chaindb, self.peer_pool, self.cancel_token)
         try:
             await chain_syncer.run()
         finally:
@@ -73,7 +81,7 @@ def _test():
     loop = asyncio.get_event_loop()
     loop.set_default_executor(ProcessPoolExecutor())
 
-    syncer = FullNodeSyncer(chain, peer_pool)
+    syncer = FullNodeSyncer(chain, chaindb, chaindb.db, peer_pool)
 
     for sig in [signal.SIGINT, signal.SIGTERM]:
         loop.add_signal_handler(sig, syncer.cancel_token.trigger)

--- a/tests/p2p/integration_test_helpers.py
+++ b/tests/p2p/integration_test_helpers.py
@@ -4,7 +4,7 @@ from typing import Type
 from eth_utils import decode_hex
 from eth_keys import datatypes, keys
 
-from evm import RopstenChain
+from evm import MainnetChain, RopstenChain
 from evm.db.chain import AsyncChainDB
 
 from p2p import kademlia
@@ -56,10 +56,16 @@ class FakeAsyncChainDB(AsyncChainDB):
         return self.persist_trie_data_dict(*args, **kwargs)
 
 
-class FakeAsyncRopstenChain(RopstenChain):
+async def coro_import_block(chain, block, perform_validation=True):
+    # Be nice and yield control to give other coroutines a chance to run before us as
+    # importing a block is a very expensive operation.
+    await asyncio.sleep(0)
+    return chain.import_block(block, perform_validation=perform_validation)
 
-    async def coro_import_block(self, block, perform_validation=True):
-        # Be nice and yield control to give other coroutines a chance to run before us as
-        # importing a block is a very expensive operation.
-        await asyncio.sleep(0)
-        return self.import_block(block, perform_validation=perform_validation)
+
+class FakeAsyncRopstenChain(RopstenChain):
+    coro_import_block = coro_import_block
+
+
+class FakeAsyncMainnetChain(MainnetChain):
+    coro_import_block = coro_import_block

--- a/tests/trinity/core/chains-utils/test_chain_config_object.py
+++ b/tests/trinity/core/chains-utils/test_chain_config_object.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from eth_utils import (
@@ -8,9 +10,9 @@ from eth_keys import keys
 
 from trinity.utils.chains import (
     get_local_data_dir,
-    get_database_dir,
     get_nodekey_path,
     ChainConfig,
+    DATABASE_DIR_NAME,
 )
 from trinity.utils.filesystem import (
     is_same_path,
@@ -23,7 +25,7 @@ def test_chain_config_computed_properties():
 
     assert chain_config.network_id == 1234
     assert chain_config.data_dir == data_dir
-    assert chain_config.database_dir == get_database_dir(data_dir)
+    assert chain_config.database_dir == os.path.join(data_dir, DATABASE_DIR_NAME, "full")
     assert chain_config.nodekey_path == get_nodekey_path(data_dir)
 
 

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -91,7 +91,7 @@ mode_parser = syncing_parser.add_mutually_exclusive_group()
 mode_parser.add_argument(
     '--sync-mode',
     choices={SYNC_LIGHT, SYNC_FULL},
-    default=SYNC_LIGHT,
+    default=SYNC_FULL,
 )
 mode_parser.add_argument(
     '--light',  # TODO: consider --sync-mode like geth.

--- a/trinity/db/chain.py
+++ b/trinity/db/chain.py
@@ -1,33 +1,13 @@
-import asyncio
-import functools
-
-from typing import Callable, Any
-
-
 # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
 # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
 from multiprocessing.managers import (  # type: ignore
     BaseProxy,
 )
 
-
-def async_method(method_name: str) -> Callable[..., Any]:
-    async def method(self, *args, **kwargs):
-        loop = asyncio.get_event_loop()
-
-        return await loop.run_in_executor(
-            None,
-            functools.partial(self._callmethod, kwds=kwargs),
-            method_name,
-            args,
-        )
-    return method
-
-
-def sync_method(method_name: str) -> Callable[..., Any]:
-    def method(self, *args, **kwargs):
-        return self._callmethod(method_name, args, kwargs)
-    return method
+from trinity.utils.mp import (
+    async_method,
+    sync_method,
+)
 
 
 class ChainDBProxy(BaseProxy):

--- a/trinity/utils/mp.py
+++ b/trinity/utils/mp.py
@@ -1,5 +1,8 @@
+import asyncio
+import functools
 import multiprocessing
 import os
+from typing import Callable, Any
 
 
 MP_CONTEXT = os.environ.get('TRINITY_MP_CONTEXT', 'spawn')
@@ -7,3 +10,22 @@ MP_CONTEXT = os.environ.get('TRINITY_MP_CONTEXT', 'spawn')
 
 # sets the type of process that multiprocessing will create.
 ctx = multiprocessing.get_context(MP_CONTEXT)
+
+
+def async_method(method_name: str) -> Callable[..., Any]:
+    async def method(self, *args, **kwargs):
+        loop = asyncio.get_event_loop()
+
+        return await loop.run_in_executor(
+            None,
+            functools.partial(self._callmethod, kwds=kwargs),
+            method_name,
+            args,
+        )
+    return method
+
+
+def sync_method(method_name: str) -> Callable[..., Any]:
+    def method(self, *args, **kwargs):
+        return self._callmethod(method_name, args, kwargs)
+    return method


### PR DESCRIPTION
Trinity used to support only light sync; now it supports both light and full sync

Also:
* Changed the default from light to full sync, as light is very unreliable since we can't find peers
* Includes fixes for #580 and #632 