### PR TITLE
Block class to vm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	tox -elint-py36
+	tox -elint-py3{6,5}
 
 test:
 	py.test --tb native tests

--- a/evm/vm/forks/byzantium/__init__.py
+++ b/evm/vm/forks/byzantium/__init__.py
@@ -1,6 +1,9 @@
+from evm.rlp.blocks import BaseBlock  # noqa: F401
 from evm.vm.forks.spurious_dragon import SpuriousDragonVM
 from evm.vm.forks.frontier import make_frontier_receipt
+from evm.vm.state import BaseState  # noqa: F401
 
+from .blocks import ByzantiumBlock
 from .constants import (
     EIP658_TRANSACTION_STATUS_CODE_FAILURE,
     EIP658_TRANSACTION_STATUS_CODE_SUCCESS,
@@ -29,7 +32,8 @@ class ByzantiumVM(SpuriousDragonVM):
     fork = 'byzantium'
 
     # classes
-    _state_class = ByzantiumState
+    block_class = ByzantiumBlock  # type: Type[BaseBlock]
+    _state_class = ByzantiumState  # type: Type[BaseState]
 
     # Methods
     create_header_from_parent = staticmethod(create_byzantium_header_from_parent)

--- a/evm/vm/forks/byzantium/__init__.py
+++ b/evm/vm/forks/byzantium/__init__.py
@@ -1,10 +1,21 @@
+from typing import (  # noqa: F401
+    Type,
+)
+
+from evm.constants import (
+    MAX_UNCLE_DEPTH,
+)
 from evm.rlp.blocks import BaseBlock  # noqa: F401
+from evm.validation import (
+    validate_lte,
+)
 from evm.vm.forks.spurious_dragon import SpuriousDragonVM
 from evm.vm.forks.frontier import make_frontier_receipt
 from evm.vm.state import BaseState  # noqa: F401
 
 from .blocks import ByzantiumBlock
 from .constants import (
+    EIP649_BLOCK_REWARD,
     EIP658_TRANSACTION_STATUS_CODE_FAILURE,
     EIP658_TRANSACTION_STATUS_CODE_SUCCESS,
 )
@@ -40,3 +51,13 @@ class ByzantiumVM(SpuriousDragonVM):
     compute_difficulty = staticmethod(compute_byzantium_difficulty)
     configure_header = configure_byzantium_header
     make_receipt = staticmethod(make_byzantium_receipt)
+
+    @staticmethod
+    def get_block_reward():
+        return EIP649_BLOCK_REWARD
+
+    @staticmethod
+    def get_uncle_reward(block_number, uncle):
+        block_number_delta = block_number - uncle.block_number
+        validate_lte(block_number_delta, MAX_UNCLE_DEPTH)
+        return (8 - block_number_delta) * EIP649_BLOCK_REWARD // 8

--- a/evm/vm/forks/byzantium/state.py
+++ b/evm/vm/forks/byzantium/state.py
@@ -1,26 +1,7 @@
-from evm.constants import (
-    MAX_UNCLE_DEPTH,
-)
-from evm.validation import (
-    validate_lte,
-)
 from evm.vm.forks.spurious_dragon.state import SpuriousDragonState
 
 from .computation import ByzantiumComputation
-from .constants import (
-    EIP649_BLOCK_REWARD,
-)
 
 
 class ByzantiumState(SpuriousDragonState):
     computation_class = ByzantiumComputation
-
-    @staticmethod
-    def get_block_reward():
-        return EIP649_BLOCK_REWARD
-
-    @staticmethod
-    def get_uncle_reward(block_number, uncle):
-        block_number_delta = block_number - uncle.block_number
-        validate_lte(block_number_delta, MAX_UNCLE_DEPTH)
-        return (8 - block_number_delta) * EIP649_BLOCK_REWARD // 8

--- a/evm/vm/forks/byzantium/state.py
+++ b/evm/vm/forks/byzantium/state.py
@@ -6,7 +6,6 @@ from evm.validation import (
 )
 from evm.vm.forks.spurious_dragon.state import SpuriousDragonState
 
-from .blocks import ByzantiumBlock
 from .computation import ByzantiumComputation
 from .constants import (
     EIP649_BLOCK_REWARD,
@@ -14,7 +13,6 @@ from .constants import (
 
 
 class ByzantiumState(SpuriousDragonState):
-    block_class = ByzantiumBlock
     computation_class = ByzantiumComputation
 
     @staticmethod

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -1,4 +1,5 @@
 from typing import Type  # noqa: F401
+from evm.rlp.blocks import BaseBlock  # noqa: F401
 from evm.vm.state import BaseState  # noqa: F401
 
 
@@ -10,6 +11,7 @@ from evm.rlp.logs import (
     Log,
 )
 
+from .blocks import FrontierBlock
 from .state import FrontierState
 from .headers import (
     create_frontier_header_from_parent,
@@ -52,6 +54,7 @@ class FrontierVM(VM):
     fork = 'frontier'  # type: str
 
     # classes
+    block_class = FrontierBlock  # type: Type[BaseBlock]
     _state_class = FrontierState  # type: Type[BaseState]
 
     # methods

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -3,6 +3,10 @@ from evm.rlp.blocks import BaseBlock  # noqa: F401
 from evm.vm.state import BaseState  # noqa: F401
 
 
+from evm.constants import (
+    BLOCK_REWARD,
+    UNCLE_DEPTH_PENALTY_FACTOR,
+)
 from evm.vm import VM
 from evm.rlp.receipts import (
     Receipt,
@@ -63,3 +67,17 @@ class FrontierVM(VM):
     configure_header = configure_frontier_header
     make_receipt = staticmethod(make_frontier_receipt)
     validate_transaction_against_header = validate_frontier_transaction_against_header
+
+    @staticmethod
+    def get_block_reward():
+        return BLOCK_REWARD
+
+    @staticmethod
+    def get_uncle_reward(block_number, uncle):
+        return BLOCK_REWARD * (
+            UNCLE_DEPTH_PENALTY_FACTOR + uncle.block_number - block_number
+        ) // UNCLE_DEPTH_PENALTY_FACTOR
+
+    @classmethod
+    def get_nephew_reward(cls):
+        return cls.get_block_reward() // 32

--- a/evm/vm/forks/frontier/state.py
+++ b/evm/vm/forks/frontier/state.py
@@ -4,10 +4,6 @@ from typing import Type  # noqa: F401
 from eth_hash.auto import keccak
 
 from evm import constants
-from evm.constants import (
-    BLOCK_REWARD,
-    UNCLE_DEPTH_PENALTY_FACTOR,
-)
 from evm.db.account import (
     AccountDB,
 )
@@ -180,17 +176,3 @@ class FrontierState(BaseState, FrontierTransactionExecutor):
 
     def validate_transaction(self, transaction):
         validate_frontier_transaction(self.account_db, transaction)
-
-    @staticmethod
-    def get_block_reward():
-        return BLOCK_REWARD
-
-    @staticmethod
-    def get_uncle_reward(block_number, uncle):
-        return BLOCK_REWARD * (
-            UNCLE_DEPTH_PENALTY_FACTOR + uncle.block_number - block_number
-        ) // UNCLE_DEPTH_PENALTY_FACTOR
-
-    @classmethod
-    def get_nephew_reward(cls):
-        return cls.get_block_reward() // 32

--- a/evm/vm/forks/frontier/state.py
+++ b/evm/vm/forks/frontier/state.py
@@ -29,7 +29,6 @@ from evm.utils.hexadecimal import (
     encode_hex,
 )
 
-from .blocks import FrontierBlock
 from .computation import FrontierComputation
 from .constants import REFUND_SELFDESTRUCT
 from .transaction_context import (  # noqa: F401
@@ -175,7 +174,6 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
 
 
 class FrontierState(BaseState, FrontierTransactionExecutor):
-    block_class = FrontierBlock
     computation_class = FrontierComputation
     transaction_context_class = FrontierTransactionContext  # type: Type[BaseTransactionContext]
     account_db_class = AccountDB  # Type[BaseAccountDB]

--- a/evm/vm/forks/homestead/__init__.py
+++ b/evm/vm/forks/homestead/__init__.py
@@ -1,4 +1,5 @@
 from typing import Type  # noqa: F401
+from evm.rlp.blocks import BaseBlock  # noqa: F401
 from evm.vm.state import BaseState  # noqa: F401
 
 from evm.chains.mainnet.constants import (
@@ -6,6 +7,7 @@ from evm.chains.mainnet.constants import (
 )
 from evm.vm.forks.frontier import FrontierVM
 
+from .blocks import HomesteadBlock
 from .headers import (
     create_homestead_header_from_parent,
     compute_homestead_difficulty,
@@ -24,6 +26,7 @@ class HomesteadVM(MetaHomesteadVM):
     fork = 'homestead'  # type: str
 
     # classes
+    block_class = HomesteadBlock  # type: Type[BaseBlock]
     _state_class = HomesteadState  # type: Type[BaseState]
 
     # method overrides

--- a/evm/vm/forks/homestead/state.py
+++ b/evm/vm/forks/homestead/state.py
@@ -1,12 +1,10 @@
 from evm.vm.forks.frontier.state import FrontierState
 
-from .blocks import HomesteadBlock
 from .computation import HomesteadComputation
 from .validation import validate_homestead_transaction
 
 
 class HomesteadState(FrontierState):
-    block_class = HomesteadBlock
     computation_class = HomesteadComputation
 
     def validate_transaction(self, transaction):

--- a/evm/vm/forks/spurious_dragon/__init__.py
+++ b/evm/vm/forks/spurious_dragon/__init__.py
@@ -1,8 +1,10 @@
 from typing import Type  # noqa: F401
+from evm.rlp.blocks import BaseBlock  # noqa: F401
 from evm.vm.state import BaseState  # noqa: F401
 
 from ..tangerine_whistle import TangerineWhistleVM
 
+from .blocks import SpuriousDragonBlock
 from .state import SpuriousDragonState
 
 
@@ -11,4 +13,5 @@ class SpuriousDragonVM(TangerineWhistleVM):
     fork = 'spurious-dragon'  # type: str
 
     # classes
+    block_class = SpuriousDragonBlock  # type: Type[BaseBlock]
     _state_class = SpuriousDragonState  # type: Type[BaseState]

--- a/evm/vm/forks/spurious_dragon/state.py
+++ b/evm/vm/forks/spurious_dragon/state.py
@@ -6,13 +6,11 @@ from evm.vm.forks.homestead.state import (
     HomesteadState,
 )
 
-from .blocks import SpuriousDragonBlock
 from .computation import SpuriousDragonComputation
 from .utils import collect_touched_accounts
 
 
 class SpuriousDragonState(HomesteadState):
-    block_class = SpuriousDragonBlock
     computation_class = SpuriousDragonComputation
 
     def run_post_computation(self, transaction, computation):

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -29,9 +29,6 @@ from evm.utils.datatypes import (
 )
 
 if TYPE_CHECKING:
-    from evm.rlp.blocks import (  # noqa: F401
-        BaseBlock,
-    )
     from evm.computation import (  # noqa: F401
         BaseComputation,
     )
@@ -51,7 +48,6 @@ class BaseState(Configurable, metaclass=ABCMeta):
 
         Each :class:`~evm.vm.state.BaseState` class must be configured with:
 
-        - ``block_class``: The :class:`~evm.rlp.blocks.Block` class for blocks in this VM ruleset.
         - ``computation_class``: The :class:`~evm.vm.computation.BaseComputation` class for
           vm execution.
         - ``transaction_context_class``: The :class:`~evm.vm.transaction_context.TransactionContext`
@@ -64,7 +60,6 @@ class BaseState(Configurable, metaclass=ABCMeta):
     execution_context = None
     state_root = None
 
-    block_class = None  # type: Type[BaseBlock]
     computation_class = None  # type: Type[BaseComputation]
     transaction_context_class = None  # type: Type[BaseTransactionContext]
     account_db_class = None  # type: Type[BaseAccountDB]
@@ -216,20 +211,6 @@ class BaseState(Configurable, metaclass=ABCMeta):
         if cls.transaction_context_class is None:
             raise AttributeError("No `transaction_context_class` has been set for this State")
         return cls.transaction_context_class
-
-    #
-    # Block class
-    #
-    @classmethod
-    def get_block_class(cls) -> Type['BaseBlock']:
-        """
-        Return the class used for Blocks
-
-        TODO: this should move up to the VM
-        """
-        if cls.block_class is None:
-            raise AttributeError("No `block_class_class` has been set for this VMState")
-        return cls.block_class
 
     #
     # Execution


### PR DESCRIPTION
### What was wrong?

Related to #599 & #507 
- state shouldn't care about `block_class` at all
- variable mutation internal to method that applies transactions sequentially

### How was it fixed?

- moved `block_class` to VM
- this concept of applying a series of data one on top of the other seems oft-repeated in blockchains, so made a reusable `pipe_accumulator` to handle this case, and hopefully others.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i2-prod.mirror.co.uk/incoming/article5989957.ece/ALTERNATES/s615/PAY-owlpussycat.jpg)
