### PR TITLE
Pin mypy to versions before 0.600

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ deps = {
     ],
     'lint': [
         "flake8==3.5.0",
-        "mypy>=0.590",
+        "mypy<0.600",
     ],
     'doc': [
         "py-evm>=0.2.0-alpha.14",


### PR DESCRIPTION
That release seems to be doing a lot more checks by default, and we're not ready for that yet. More info at http://mypy-lang.blogspot.pt/2018/05/mypy-0600-released.html