### PR TITLE
WIP - squashing trie data during block import

### DIFF
--- a/evm/db/backends/base.py
+++ b/evm/db/backends/base.py
@@ -2,6 +2,13 @@ from abc import (
     ABCMeta,
     abstractmethod
 )
+from typing import Union
+
+
+class Unset:
+    pass
+
+unset = Unset()
 
 
 class BaseDB(metaclass=ABCMeta):
@@ -12,15 +19,24 @@ class BaseDB(metaclass=ABCMeta):
             "The `init` method must be implemented by subclasses of BaseDB"
         )
 
-    @abstractmethod
-    def get(self, key: bytes) -> bytes:
-        """Return the value for the given key.
-
-        Raises KeyError if key doesn't exist.
+    def get(self, key: bytes, default: Union[bytes, Unset] = unset) -> bytes:
         """
-        raise NotImplementedError(
-            "The `get` method must be implemented by subclasses of BaseDB"
-        )
+        Return the value for the given key.
+
+        If the key doesn't exist, and a default is provided, return the default value.
+        If the key doesn't exist, and a default is not provided, raise a KeyError
+
+        :return: the value with the associated key
+        :raise: KeyError if key is missing
+        """
+        try:
+            return self[key]
+        except KeyError as exc:
+            if default is unset:
+                raise exc
+            else:
+                return default
+
 
     @abstractmethod
     def set(self, key: bytes, value: bytes) -> None:
@@ -44,8 +60,11 @@ class BaseDB(metaclass=ABCMeta):
     #
     # Dictionary API
     #
+    @abstractmethod
     def __getitem__(self, key: bytes) -> bytes:
-        return self.get(key)
+        raise NotImplementedError(
+            "The `__getitem__` method must be implemented by subclasses of BaseDB"
+        )
 
     def __setitem__(self, key: bytes, value: bytes) -> None:
         return self.set(key, value)

--- a/evm/db/backends/level.py
+++ b/evm/db/backends/level.py
@@ -17,7 +17,7 @@ class LevelDB(BaseDB):
         self.db_path = db_path
         self.db = plyvel.DB(db_path, create_if_missing=True, error_if_exists=False)
 
-    def get(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> bytes:
         v = self.db.get(key)
         if v is None:
             raise KeyError(key)

--- a/evm/db/backends/memory.py
+++ b/evm/db/backends/memory.py
@@ -16,7 +16,7 @@ class MemoryDB(BaseDB):
         else:
             self.kv_store = kv_store
 
-    def get(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> bytes:
         return self.kv_store[key]
 
     def set(self, key: bytes, value: bytes) -> None:

--- a/evm/db/batch.py
+++ b/evm/db/batch.py
@@ -55,7 +55,7 @@ class BatchDB(BaseDB):
             return key in self.wrapped_db
 
     # if not key is found, return None
-    def get(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> bytes:
         try:
             value = self.cache[key]
         except KeyError:

--- a/evm/db/hash_trie.py
+++ b/evm/db/hash_trie.py
@@ -26,3 +26,6 @@ class HashTrie(object):
     @root_hash.setter
     def root_hash(self, value):
         self._trie.root_hash = value
+
+    def __getattr__(self, attr):
+        return getattr(self._trie, attr)

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -119,7 +119,7 @@ class Journal(BaseDB):
     #
     # Database API
     #
-    def get(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> bytes:
         """
         For key lookups we need to iterate through the changesets in reverse
         order, returning from the first one in which the key is present.
@@ -170,7 +170,7 @@ class JournalDB(BaseDB):
         self.wrapped_db = wrapped_db
         self.reset()
 
-    def get(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> bytes:
 
         val = self.journal[key]
         if val is DELETED_ENTRY:

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -69,6 +69,12 @@ class BaseState(Configurable, metaclass=ABCMeta):
         self.execution_context = execution_context
         self.account_db = self.get_account_db_class()(self._db, state_root)
 
+    def copy(self, **kwargs):
+        kwargs.setdefault('db', self._db)
+        kwargs.setdefault('execution_context', self.execution_context)
+        kwargs.setdefault('state_root', self.state_root)
+        return type(self)(**kwargs)
+
     #
     # Logging
     #


### PR DESCRIPTION
### What was wrong?

We are storing state roots into the database for every step in the transaction. We only need to store the state roots from the end of the block.

### How was it fixed?

Use the `HexaryTrie`s ability to squash changes, and join all the state changes in a block to one. We don't need to index into state roots from the middle of a block (or the middle of a transaction!), so we can drop them all, except the final one.

It seems natural to do a follow-up where we don't bother calculating the hashes along the way

Also, moved `BaseDB` closer to implementing the `collections.abc.MutableMapping` interface, by adding an optional default parameter. (`HexaryTrie` expects the db to meet that interface)

There are a few hacks in place to make this work without the PR getting a lot bigger. Probably the biggest follow-up todo item is to rethink the trie and account db, and how they fit together, finally getting to #507 

Also, we're technically storing the state root at the end of the last transaction, and then again after the block finalization (eg~ paying the miner), but we'll clean that up later.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://lh6.googleusercontent.com/-DF52JkbS46c/UCP-RwlTWLI/AAAAAAAAA6E/wyYve61ivpw/s640/blogger-image--874794674.jpg)
