### PR TITLE
Make DB compatible with MutableMapping

### DIFF
--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -288,7 +288,7 @@ class AccountDB(BaseAccountDB):
     # Internal
     #
     def _get_account(self, address):
-        cache_key = (self._unwrapped_db, self.state_root, address)
+        cache_key = (id(self._unwrapped_db), self.state_root, address)
         if cache_key not in account_cache:
             account_cache[cache_key] = self._trie[address]
 
@@ -302,7 +302,7 @@ class AccountDB(BaseAccountDB):
     def _set_account(self, address, account):
         rlp_account = rlp.encode(account, sedes=Account)
         self._trie[address] = rlp_account
-        cache_key = (self._unwrapped_db, self.state_root, address)
+        cache_key = (id(self._unwrapped_db), self.state_root, address)
         account_cache[cache_key] = rlp_account
 
     #

--- a/evm/db/backends/level.py
+++ b/evm/db/backends/level.py
@@ -17,17 +17,17 @@ class LevelDB(BaseDB):
         self.db_path = db_path
         self.db = plyvel.DB(db_path, create_if_missing=True, error_if_exists=False)
 
-    def get(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> bytes:
         v = self.db.get(key)
         if v is None:
             raise KeyError(key)
         return v
 
-    def set(self, key: bytes, value: bytes) -> None:
+    def __setitem__(self, key: bytes, value: bytes) -> None:
         self.db.put(key, value)
 
-    def exists(self, key: bytes) -> bool:
+    def _exists(self, key: bytes) -> bool:
         return self.db.get(key) is not None
 
-    def delete(self, key: bytes) -> None:
+    def __delitem__(self, key: bytes) -> None:
         self.db.delete(key)

--- a/evm/db/backends/memory.py
+++ b/evm/db/backends/memory.py
@@ -16,14 +16,14 @@ class MemoryDB(BaseDB):
         else:
             self.kv_store = kv_store
 
-    def get(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> bytes:
         return self.kv_store[key]
 
-    def set(self, key: bytes, value: bytes) -> None:
+    def __setitem__(self, key: bytes, value: bytes) -> None:
         self.kv_store[key] = value
 
-    def exists(self, key: bytes) -> bool:
+    def _exists(self, key: bytes) -> bool:
         return key in self.kv_store
 
-    def delete(self, key: bytes) -> None:
+    def __delitem__(self, key: bytes) -> None:
         del self.kv_store[key]

--- a/evm/db/batch.py
+++ b/evm/db/batch.py
@@ -48,14 +48,13 @@ class BatchDB(BaseDB):
 
         self.clear()
 
-    def exists(self, key: bytes) -> bool:
+    def _exists(self, key: bytes) -> bool:
         try:
             return self.cache[key] is not None
         except KeyError:
             return key in self.wrapped_db
 
-    # if not key is found, return None
-    def get(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> bytes:
         try:
             value = self.cache[key]
         except KeyError:
@@ -65,10 +64,10 @@ class BatchDB(BaseDB):
                 raise KeyError(key)
             return value
 
-    def set(self, key: bytes, value: bytes) -> None:
+    def __setitem__(self, key: bytes, value: bytes) -> None:
         self.cache[key] = value
 
-    def delete(self, key: bytes) -> None:
+    def __delitem__(self, key: bytes) -> None:
         if key not in self:
             raise KeyError(key)
         self.cache[key] = None

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -240,7 +240,7 @@ class ChainDB(BaseChainDB):
         """
         validate_word(block_hash, title="Block Hash")
         try:
-            header_rlp = self.db.get(block_hash)
+            header_rlp = self.db[block_hash]
         except KeyError:
             raise BlockNotFound("No block with hash {0} found".format(
                 encode_hex(block_hash)))
@@ -376,7 +376,7 @@ class ChainDB(BaseChainDB):
         validate_uint256(block_number, title="Block Number")
         number_to_hash_key = make_block_number_to_hash_lookup_key(block_number)
         return rlp.decode(
-            self.db.get(number_to_hash_key),
+            self.db[number_to_hash_key],
             sedes=rlp.sedes.binary,
         )
 
@@ -472,7 +472,7 @@ class ChainDB(BaseChainDB):
 
     def get_transaction_index(self, transaction_hash: bytes) -> Tuple[int, int]:
         try:
-            encoded_key = self.db.get(make_transaction_hash_to_block_lookup_key(transaction_hash))
+            encoded_key = self.db[make_transaction_hash_to_block_lookup_key(transaction_hash)]
         except KeyError:
             raise TransactionNotFound(
                 "Transaction {} not found in canonical chain".format(encode_hex(transaction_hash)))

--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -119,7 +119,7 @@ class Journal(BaseDB):
     #
     # Database API
     #
-    def get(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> bytes:
         """
         For key lookups we need to iterate through the changesets in reverse
         order, returning from the first one in which the key is present.
@@ -133,14 +133,14 @@ class Journal(BaseDB):
 
         return None
 
-    def set(self, key: bytes, value: bytes) -> None:
+    def __setitem__(self, key: bytes, value: bytes) -> None:
         self.latest[key] = value
 
-    def exists(self, key: bytes) -> bool:
+    def _exists(self, key: bytes) -> bool:
         val = self.get(key)
         return val is not None and val is not DELETED_ENTRY
 
-    def delete(self, key: bytes) -> None:
+    def __delitem__(self, key: bytes) -> None:
         self.latest[key] = DELETED_ENTRY
 
 
@@ -170,7 +170,7 @@ class JournalDB(BaseDB):
         self.wrapped_db = wrapped_db
         self.reset()
 
-    def get(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> bytes:
 
         val = self.journal[key]
         if val is DELETED_ENTRY:
@@ -180,17 +180,17 @@ class JournalDB(BaseDB):
         else:
             return val
 
-    def set(self, key: bytes, value: bytes) -> None:
+    def __setitem__(self, key: bytes, value: bytes) -> None:
         """
         - replacing an existing value
         - setting a value that does not exist
         """
         self.journal[key] = value
 
-    def exists(self, key: bytes) -> bool:
+    def _exists(self, key: bytes) -> bool:
         return key in self.journal or key in self.wrapped_db
 
-    def delete(self, key: bytes) -> None:
+    def __delitem__(self, key: bytes) -> None:
         if key not in self.journal and key not in self.wrapped_db:
             raise KeyError(key)
         del self.journal[key]

--- a/evm/db/shard.py
+++ b/evm/db/shard.py
@@ -52,14 +52,14 @@ class ShardDB:
     #
     def get_header_by_hash(self, collation_hash: Hash32) -> CollationHeader:
         try:
-            header = self.db.get(collation_hash)
+            header = self.db[collation_hash]
         except KeyError:
             raise CollationHeaderNotFound("No header with hash {} found".format(collation_hash))
         return rlp.decode(header, sedes=CollationHeader)
 
     def get_body_by_chunk_root(self, chunk_root: Hash32) -> bytes:
         try:
-            body = self.db.get(chunk_root)
+            body = self.db[chunk_root]
         except KeyError:
             raise CollationBodyNotFound("No body with chunk root {} found".format(chunk_root))
         return body
@@ -85,7 +85,7 @@ class ShardDB:
     def get_canonical_collation_hash(self, shard_id: int, period: int) -> Hash32:
         key = make_canonical_hash_lookup_key(shard_id, period)
         try:
-            canonical_hash = self.db.get(key)
+            canonical_hash = self.db[key]
         except KeyError:
             raise CanonicalCollationNotFound(
                 "No collation set as canonical for shard {} and period {}".format(
@@ -139,7 +139,7 @@ class ShardDB:
     def get_availability(self, chunk_root: Hash32) -> Availability:
         key = make_collation_availability_lookup_key(chunk_root)
         try:
-            availability_entry = self.db.get(key)
+            availability_entry = self.db[key]
         except KeyError:
             return Availability.UNKNOWN
         else:

--- a/tests/database/test_base_db_api.py
+++ b/tests/database/test_base_db_api.py
@@ -65,16 +65,14 @@ def test_database_api_delete(db):
 
 
 def test_database_api_missing_key_retrieval(db):
-    with pytest.raises(KeyError):
-        db.get(b'does-not-exist')
+    assert db.get(b'does-not-exist') is None
 
     with pytest.raises(KeyError):
         db[b'does-not-exist']
 
 
 def test_database_api_missing_key_for_deletion(db):
-    with pytest.raises(KeyError):
-        db.delete(b'does-not-exist')
+    db.delete(b'does-not-exist')
 
     with pytest.raises(KeyError):
         del db[b'does-not-exist']

--- a/tests/database/test_batch_db.py
+++ b/tests/database/test_batch_db.py
@@ -36,16 +36,16 @@ def test_batch_db_with_set_and_delete(base_db, batch_db):
 
         assert b'key-1' not in batch_db
         with pytest.raises(KeyError):
-            assert batch_db.get(b'key-1')
+            assert batch_db[b'key-1']
 
         # key should still be in base batch_db
         assert b'key-1' in base_db
         assert b'key-1' not in batch_db
 
     with pytest.raises(KeyError):
-        base_db.get(b'key-1')
+        base_db[b'key-1']
     with pytest.raises(KeyError):
-        batch_db.get(b'key-1')
+        batch_db[b'key-1']
 
 
 def test_batch_db_with_exception(base_db, batch_db):


### PR DESCRIPTION
### What was wrong?

The BaseDB was almost, but not quite, compatible with `collections.abc.MutableMapping`. That seemed to add an unnecessary burden on readers to understand/remember the differences.

### How was it fixed?

The main differences were:
- `get(key, default=None)` now acts just like it does on other mappings (returning `None` by default, rather than raise an exception) -- required fixes in various places of the code
- Add `collections.abc.MutableMapping` as a superclass of `BaseDB`
- some renamings of internal implementations, to align with how `MutableMapping` works
- added an optional `_exists` method that can be strictly typed (since `__contains__` cannot be).

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/c1/4d/71/c14d71a60808a30eccf07ecfc800c720.jpg)
