### PR TITLE
A new DBDiff and DBDiffTracker, to track db changes

### DIFF
--- a/evm/db/batch.py
+++ b/evm/db/batch.py
@@ -57,7 +57,7 @@ class BatchDB(BaseDB):
         try:
             value = self._track_diff[key]
         except DiffMissingError as missing:
-            if missing.is_deleted():
+            if missing.is_deleted:
                 raise KeyError(key)
             else:
                 return self.wrapped_db[key]

--- a/evm/db/diff.py
+++ b/evm/db/diff.py
@@ -1,0 +1,113 @@
+from collections.abc import (
+    Mapping,
+    MutableMapping,
+)
+from typing import (  # noqa: F401
+    Dict,
+    Iterable,
+    Union,
+)
+
+from cytoolz import (
+    merge,
+)
+
+
+class MissingReason:
+    def __init__(self, reason):
+        self.reason = reason
+
+    def __str__(self, reason):
+        return "Key is missing because it was {}".format(self.reason)
+
+
+NEVER_INSERTED = MissingReason("never inserted")
+DELETED = MissingReason("deleted")
+
+
+class DiffMissingError(KeyError):
+    def __init__(self, missing_key: bytes, reason: MissingReason) -> None:
+        self.reason = reason
+        super().__init__(missing_key, reason)
+
+    def is_deleted(self):
+        return self.reason == DELETED
+
+
+class DBDiffTracker(MutableMapping):
+    """
+    Recorded changes to a :class:`~evm.db.BaseDB`
+    """
+    def __init__(self):
+        self._changes = {}  # type: Dict[bytes, Union[bytes, DiffMissingError]]
+
+    def __contains__(self, key):
+        result = self._changes.get(key, NEVER_INSERTED)
+        return result not in (DELETED, NEVER_INSERTED)
+
+    def __getitem__(self, key):
+        result = self._changes.get(key, NEVER_INSERTED)
+        if result in (DELETED, NEVER_INSERTED):
+            raise DiffMissingError(key, result)
+        else:
+            return result
+
+    def __setitem__(self, key, value):
+        self._changes[key] = value
+
+    def __delitem__(self, key):
+        # The diff does not have access to any underlying db,
+        # so it cannot check if the key exists before deleting.
+        self._changes[key] = DELETED
+
+    def __iter__(self):
+        raise NotImplementedError(
+            "Cannot iterate through changes, use diff().apply_to(db) to update a database"
+        )
+
+    def __len__(self):
+        return len(self._changes)
+
+    def diff(self):
+        return DBDiff(self)
+
+
+class DBDiff(Mapping):
+    _changes = None  # type: Dict[bytes, Union[bytes, DiffMissingError]]
+
+    def __init__(self, tracker: DBDiffTracker = None) -> None:
+        if tracker is None:
+            self._changes = {}
+        else:
+            self._changes = tracker._changes
+
+    def __getitem__(self, key):
+        result = self._changes.get(key, NEVER_INSERTED)
+        if result in (DELETED, NEVER_INSERTED):
+            raise DiffMissingError(key, result)
+        else:
+            return result
+
+    def __iter__(self):
+        raise NotImplementedError(
+            "Cannot iterate through changes, use apply_to(db) to update a database"
+        )
+
+    def __len__(self):
+        return len(self._changes)
+
+    def apply_to(self, db, apply_deletes=True):
+        for key, value in self._changes.items():
+            if value is DELETED and apply_deletes:
+                try:
+                    del db[key]
+                except KeyError:
+                    pass
+            else:
+                db[key] = value
+
+    @classmethod
+    def join(cls, diffs: Iterable['DBDiff']) -> 'DBDiff':
+        new_diff = cls()
+        new_diff._changes = merge(diff._changes for diff in diffs)
+        return new_diff

--- a/tests/database/test_batch_db.py
+++ b/tests/database/test_batch_db.py
@@ -24,8 +24,15 @@ def test_batch_db_with_set_and_get(base_db, batch_db):
         assert b'key-1' not in base_db
         assert b'key-2' not in base_db
 
+        diff = batch_db.diff()
+
     assert base_db.get(b'key-1') == b'value-1'
     assert base_db.get(b'key-2') == b'value-2'
+
+    example_db = {b'key-3': b'unrelated'}
+    expected_result = {b'key-1': b'value-1', b'key-2': b'value-2', b'key-3': b'unrelated'}
+    diff.apply_to(example_db)
+    assert example_db == expected_result
 
 
 def test_batch_db_with_set_and_delete(base_db, batch_db):
@@ -42,10 +49,17 @@ def test_batch_db_with_set_and_delete(base_db, batch_db):
         assert b'key-1' in base_db
         assert b'key-1' not in batch_db
 
+        diff = batch_db.diff()
+
     with pytest.raises(KeyError):
         base_db[b'key-1']
     with pytest.raises(KeyError):
         batch_db[b'key-1']
+
+    example_db = {b'key-1': b'origin', b'key-2': b'unrelated'}
+    expected_result = {b'key-2': b'unrelated'}
+    diff.apply_to(example_db)
+    assert example_db == expected_result
 
 
 def test_batch_db_with_exception(base_db, batch_db):

--- a/tests/database/test_db_diff.py
+++ b/tests/database/test_db_diff.py
@@ -1,0 +1,141 @@
+import pytest
+
+from evm.db.diff import (
+    DBDiff,
+    DBDiffTracker,
+    DiffMissingError,
+)
+
+
+@pytest.fixture
+def db():
+    return DBDiffTracker()
+
+
+def test_database_api_get(db):
+    db[b'key-1'] = b'value-1'
+
+    assert db.get(b'key-1') == b'value-1'
+    assert db[b'key-1'] == b'value-1'
+
+
+def test_database_api_set(db):
+    db[b'key-1'] = b'value-1'
+    assert db[b'key-1'] == b'value-1'
+    db[b'key-1'] = b'value-2'
+    assert db[b'key-1'] == b'value-2'
+
+    db[b'key-1'] = b'value-1'
+    assert db[b'key-1'] == b'value-1'
+    db[b'key-1'] = b'value-2'
+    assert db[b'key-1'] == b'value-2'
+
+
+def test_database_api_existence_checking(db):
+    assert b'key-1' not in db
+
+    db[b'key-1'] = b'value-1'
+
+    assert b'key-1' in db
+
+
+def test_database_api_delete(db):
+    db[b'key-1'] = b'value-1'
+    db[b'key-2'] = b'value-2'
+
+    assert b'key-1' in db
+    assert b'key-2' in db
+
+    del db[b'key-1']
+    del db[b'key-2']
+
+    assert b'key-1' not in db
+    assert b'key-2' not in db
+
+
+def test_database_api_missing_key_retrieval(db):
+    assert db.get(b'does-not-exist') is None
+
+    try:
+        val = db[b'does-not-exist']
+    except DiffMissingError as exc:
+        assert not exc.is_deleted()
+    else:
+        assert False, "key should be missing, but was retrieved as {}".format(val)
+
+
+def test_database_api_missing_key_for_deletion(db):
+    # no problem to delete a key that is missing (it may be present in the underlying db)
+    del db[b'does-not-exist']
+
+    try:
+        val = db[b'does-not-exist']
+    except DiffMissingError as exc:
+        assert exc.is_deleted()
+    else:
+        assert False, "key should be missing, but was retrieved as {}".format(val)
+
+
+def test_database_api_deleted_key_for_deletion(db):
+    # create an item, then delete it
+    db[b'used-to-exist'] = b'old-value'
+    del db[b'used-to-exist']
+
+    try:
+        val = db[b'used-to-exist']
+    except DiffMissingError as exc:
+        assert exc.is_deleted()
+    else:
+        assert False, "key should be missing, but was retrieved as {}".format(val)
+
+
+@pytest.mark.parametrize(
+    'db, series_of_diffs, expected',
+    (
+        ({b'0': b'0'}, tuple(), {b'0': b'0'}),
+        ({b'0': b'0'}, ({}, {}), {b'0': b'0'}),
+        (
+            {},
+            (
+                {b'1': b'1'},
+                {b'1': None},
+            ),
+            {},
+        ),
+        (
+            {},
+            (
+                {b'1': b'1'},
+                {b'1': b'2'},
+            ),
+            {b'1': b'2'},
+        ),
+        (
+            {b'1': b'0'},
+            (
+                {b'1': None},
+            ),
+            {},
+        ),
+        (
+            {b'1': b'0'},
+            (
+                {b'2': b'3'},
+            ),
+            {b'1': b'0', b'2': b'3'},
+        ),
+    ),
+)
+def join_diffs(db, series_of_diffs, expected):
+    diffs = []
+    for changes in series_of_diffs:
+        tracker = DBDiffTracker()
+        for key, val in changes.items():
+            if val is None:
+                del tracker[key]
+            else:
+                tracker[key] = val
+        diffs.append(tracker.diff())
+
+    DBDiff.join(diffs).apply_to(db)
+    assert db == expected

--- a/tests/database/test_db_diff.py
+++ b/tests/database/test_db_diff.py
@@ -59,7 +59,7 @@ def test_database_api_missing_key_retrieval(db):
     try:
         val = db[b'does-not-exist']
     except DiffMissingError as exc:
-        assert not exc.is_deleted()
+        assert not exc.is_deleted
     else:
         assert False, "key should be missing, but was retrieved as {}".format(val)
 
@@ -71,7 +71,7 @@ def test_database_api_missing_key_for_deletion(db):
     try:
         val = db[b'does-not-exist']
     except DiffMissingError as exc:
-        assert exc.is_deleted()
+        assert exc.is_deleted
     else:
         assert False, "key should be missing, but was retrieved as {}".format(val)
 
@@ -84,7 +84,7 @@ def test_database_api_deleted_key_for_deletion(db):
     try:
         val = db[b'used-to-exist']
     except DiffMissingError as exc:
-        assert exc.is_deleted()
+        assert exc.is_deleted
     else:
         assert False, "key should be missing, but was retrieved as {}".format(val)
 


### PR DESCRIPTION
### What was wrong?

Many classes share access to a bunch of database state, and different layers all necessarily share the same view of the state. This leads to hard-to-reason-about code.

### How was it fixed?

One step on the way there is to explicitly track changes to a database, and share those changes. Because the changes can include deletes, it's not *quite* as easy as a simple `dict`, but almost. A new `DBDiff` (read-only) and `DBDiffTracker` (read/write) were added to unify any key/value diffs that we pass around between classes.

Instead of modifying a database in place, this enables classes to return diffs that were a result of their actions. The calling method can keep the diff in memory, drop it, or apply it, at the leisure of the caller.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/f4/61/08/f461087da3d949017a98a91e315a8d6e.jpg)
