### PR TITLE
Piper/implement schema class

### DIFF
--- a/evm/db/schema.py
+++ b/evm/db/schema.py
@@ -1,0 +1,47 @@
+from abc import ABCMeta, abstractmethod
+
+from eth_typing import (
+    BlockNumber,
+    Hash32,
+)
+
+
+class BaseSchema(metaclass=ABCMeta):
+    @staticmethod
+    @abstractmethod
+    def make_canonical_head_hash_lookup_key() -> bytes:
+        raise NotImplementedError('Must be implemented by subclasses')
+
+    @staticmethod
+    @abstractmethod
+    def make_block_number_to_hash_lookup_key(block_number: BlockNumber) -> bytes:
+        raise NotImplementedError('Must be implemented by subclasses')
+
+    @staticmethod
+    @abstractmethod
+    def make_block_hash_to_score_lookup_key(block_hash: Hash32) -> bytes:
+        raise NotImplementedError('Must be implemented by subclasses')
+
+    @staticmethod
+    @abstractmethod
+    def make_transaction_hash_to_block_lookup_key(transaction_hash: Hash32) -> bytes:
+        raise NotImplementedError('Must be implemented by subclasses')
+
+
+class SchemaV1(BaseSchema):
+    @staticmethod
+    def make_canonical_head_hash_lookup_key() -> bytes:
+        return b'v1:canonical_head_hash'
+
+    @staticmethod
+    def make_block_number_to_hash_lookup_key(block_number: BlockNumber) -> bytes:
+        number_to_hash_key = b'block-number-to-hash:%d' % block_number
+        return number_to_hash_key
+
+    @staticmethod
+    def make_block_hash_to_score_lookup_key(block_hash: Hash32) -> bytes:
+        return b'block-hash-to-score:%s' % block_hash
+
+    @staticmethod
+    def make_transaction_hash_to_block_lookup_key(transaction_hash: Hash32) -> bytes:
+        return b'transaction-hash-to-block:%s' % transaction_hash

--- a/evm/utils/db.py
+++ b/evm/utils/db.py
@@ -6,19 +6,6 @@ if TYPE_CHECKING:
     from evm.db.chain import BaseChainDB  # noqa: F401
 
 
-def make_block_number_to_hash_lookup_key(block_number: int) -> bytes:
-    number_to_hash_key = b'block-number-to-hash:%d' % block_number
-    return number_to_hash_key
-
-
-def make_block_hash_to_score_lookup_key(block_hash: bytes) -> bytes:
-    return b'block-hash-to-score:%s' % block_hash
-
-
-def make_transaction_hash_to_block_lookup_key(transaction_hash: bytes) -> bytes:
-    return b'transaction-hash-to-block:%s' % transaction_hash
-
-
 def get_parent_header(block_header: BlockHeader, db: 'BaseChainDB') -> BlockHeader:
     """
     Returns the header for the parent block.


### PR DESCRIPTION
builds on https://github.com/ethereum/py-evm/pull/659

### What was wrong?

The API for generating the keys where various objects were stored in the database was in a `utils/` module, thus making it private.  These functions are needed within the `trinity` codebase.

### How was it fixed?

Added a `Schema` class which is now used to generate database storage keys.

#### Cute Animal Picture

![cute-baby-chickens-wearing-knit-hats6](https://user-images.githubusercontent.com/824194/39728109-ac38f568-5212-11e8-90f1-889edd5e3e57.jpg)
