### PR TITLE
Piper/remove validate block number

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -52,7 +52,6 @@ from evm.exceptions import (
     VMNotFound,
 )
 from evm.validation import (
-    validate_block_number,
     validate_uint256,
     validate_word,
     validate_vm_configuration,
@@ -410,7 +409,7 @@ class Chain(BaseChain):
         """
         Returns the VM class for the given block number.
         """
-        validate_block_number(block_number)
+        validate_uint256(block_number)
         for start_block, vm_class in reversed(cls.vm_configuration):
             if block_number >= start_block:
                 return vm_class

--- a/evm/validation.py
+++ b/evm/validation.py
@@ -197,16 +197,11 @@ def validate_unique(values, title="Value"):
         )
 
 
-def validate_block_number(block_number, title="Block Number"):
-    validate_is_integer(block_number, title="Block Number")
-    validate_gte(block_number, 0, title="Block Number")
-
-
 def validate_vm_block_numbers(vm_block_numbers):
     validate_unique(vm_block_numbers, title="Block Number set")
 
     for block_number in vm_block_numbers:
-        validate_block_number(block_number)
+        validate_uint256(block_number)
 
 
 def validate_vm_configuration(vm_configuration):

--- a/tests/core/validation/test_validation.py
+++ b/tests/core/validation/test_validation.py
@@ -9,7 +9,6 @@ from evm.constants import (
     SECPK1_N,
 )
 from evm.validation import (
-    validate_block_number,
     validate_canonical_address,
     validate_gt,
     validate_gte,
@@ -355,28 +354,6 @@ def test_validate_lt_secpk1n2(value, is_valid):
     else:
         with pytest.raises(ValidationError):
             validate_lt_secpk1n2(value)
-
-
-@pytest.mark.parametrize(
-    "block_number,is_valid",
-    (
-        (tuple(), False),
-        ([], False),
-        ({}, False),
-        (set(), False),
-        ('abc', False),
-        (1234, True),
-        (-1, False),
-        (0, True),
-        (100, True),
-    ),
-)
-def test_validate_block_number(block_number, is_valid):
-    if is_valid:
-        validate_block_number(block_number)
-    else:
-        with pytest.raises(ValidationError):
-            validate_block_number(block_number)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Builds on https://github.com/ethereum/py-evm/pull/660

### What was wrong?

The `validate_block_number` function doesn't actually do all of the proper validation for block numbers.

### How was it fixed?

Changed all usage of `validate_block_number` to instead use `validate_uint256`

#### Cute Animal Picture

![il_570xn 511004122_hw7n](https://user-images.githubusercontent.com/824194/39728422-28b93de0-5214-11e8-94ae-000e4e33a640.jpg)

