### PR TITLE
p2p: Ensure correct and consistent use of CancelTokens

### DIFF
--- a/p2p/DEVELOPMENT.md
+++ b/p2p/DEVELOPMENT.md
@@ -1,0 +1,14 @@
+# Some guidelines about development in the p2p module
+
+The plan is for this to eventually become a comprehensive guide to aid when developing in the p2p
+package, but for now it's just a collection of random notes/recommendations.
+
+
+## Task cancellation
+
+In order to make sure we stop all pending asyncio tasks upon exit (or when a service terminates),
+we use `CancelToken`s, which are heavily inspired by https://vorpus.org/blog/timeouts-and-cancellation-for-humans/
+
+- A `CancelToken` must be available to all our async APIs. Either as an instance attribute or as an explicit argument.
+- When one of our async APIs `await` for stdlib/third-party coroutines, it must use `wait_with_token()` to ensure the scheduled task is cancelled when the token is triggered.
+- We must never use `wait_with_token()` with coroutines that create other tasks as when the token is triggered and the coroutine passed to `wait_with_token()` is cancelled, the tasks created by it are automatically destroyed by the event loop and we'll get ERROR logs if those tasks were still pending.

--- a/p2p/cancel_token.py
+++ b/p2p/cancel_token.py
@@ -43,6 +43,11 @@ class CancelToken:
             return True
         return any(token.triggered for token in self._chain)
 
+    def raise_if_triggered(self) -> None:
+        if self.triggered:
+            raise OperationCancelled(
+                "Cancellation requested by {} token".format(self.triggered_token))
+
     async def wait(self) -> None:
         if self.triggered_token is not None:
             return

--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -412,6 +412,9 @@ class RegularChainSyncer(ChainSyncer):
 
             block = block_class(header, transactions, uncles)
             t = time.time()
+            # FIXME: Instead of using wait_with_token() here we should pass our cancel_token to
+            # coro_import_block() so that it can cancel the actual import-block task. See
+            # https://github.com/ethereum/py-evm/issues/665 for details.
             await wait_with_token(
                 self.chain.coro_import_block(block, perform_validation=True),
                 token=self.cancel_token)

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -534,6 +534,9 @@ class KademliaProtocol:
         nodes_seen = set()   # type: Set[Node]
 
         async def _find_node(node_id, remote):
+            # Short-circuit in case our token has been triggered to avoid trying to send requests
+            # over a transport that is probably closed already.
+            cancel_token.raise_if_triggered()
             self.wire.send_find_node(remote, node_id)
             candidates = await self.wait_neighbours(remote, cancel_token)
             if not candidates:

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -262,11 +262,6 @@ def _test() -> None:
     import argparse
     import signal
 
-    from eth_keys import keys
-    from eth_utils import (
-        decode_hex,
-    )
-
     from evm.db.backends.memory import MemoryDB
     from evm.chains.ropsten import RopstenChain, ROPSTEN_GENESIS_HEADER
 
@@ -274,13 +269,15 @@ def _test() -> None:
     from p2p import ecies
     from p2p.peer import ETHPeer
 
+    from trinity.utils.chains import load_nodekey
+
     from tests.p2p.integration_test_helpers import FakeAsyncChainDB
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-debug', action="store_true")
-    parser.add_argument('-server-address', type=str, required=True)
-    parser.add_argument('-bootstrap', '--list', type=str)
-    parser.add_argument('-privkey', type=str)
+    parser.add_argument('-address', type=str, required=True)
+    parser.add_argument('-bootnodes', type=str)
+    parser.add_argument('-nodekey', type=str)
 
     args = parser.parse_args()
 
@@ -295,15 +292,15 @@ def _test() -> None:
     chaindb = FakeAsyncChainDB(MemoryDB())
     chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
 
-    if args.privkey:
-        privkey = keys.PrivateKey(decode_hex(args.privkey))
+    if args.nodekey:
+        privkey = load_nodekey(args.nodekey)
     else:
         privkey = ecies.generate_privkey()
 
-    ip, port = args.server_address.split(':')
+    ip, port = args.address.split(':')
     server_address = Address(ip, int(port))
-    if args.list:
-        bootstrap_nodes = args.list.split(',')
+    if args.bootnodes:
+        bootstrap_nodes = args.bootnodes.split(',')
     else:
         bootstrap_nodes = ROPSTEN_BOOTNODES
 


### PR DESCRIPTION
In some places we were not using CancelTokens at the deepest possible level
of the call stack, and as a consequence we were cancelling tasks that had
created sub-tasks and when those sub-tasks were destroyed by the event loop
(because their parents had been cancelled), we were getting ERROR messages
in the logs
(https://docs.python.org/3/library/asyncio-dev.html#pending-task-destroyed)

This makes sure we use CancelTokens correctly and also adds some docs on
how to do so.