### PR TITLE
p2p: Implement a BaseService class and use it everywhere

### DIFF
--- a/p2p/lightchain.py
+++ b/p2p/lightchain.py
@@ -110,7 +110,7 @@ class LightChain(Chain, PeerPoolSubscriber):
 
     async def drop_peer(self, peer: LESPeer) -> None:
         self._last_processed_announcements.pop(peer, None)
-        await peer.stop()
+        await peer.cancel()
 
     async def wait_until_finished(self):
         start_at = time.time()

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -1,0 +1,73 @@
+from abc import ABC, abstractmethod
+import asyncio
+import logging  # noqa: F401
+from typing import Callable, Optional
+
+from p2p.cancel_token import CancelToken
+from p2p.exceptions import OperationCancelled
+
+
+class BaseService(ABC):
+    # Subclasses must define their own logger.
+    logger: logging.Logger = None
+    # Number of seconds cancel() will wait for run() to finish.
+    _wait_until_finished_timeout = 5
+
+    def __init__(self, token: CancelToken) -> None:
+        self.finished = asyncio.Event()
+        self.cancel_token = token
+
+    async def run(
+            self,
+            finished_callback: Optional[Callable[['BaseService'], None]] = None) -> None:
+        """Await for the service's _run() coroutine.
+
+        Once _run() returns, call cleanup(), set the finished event and call
+        finished_callback (if one was passed).
+        """
+        try:
+            await self._run()
+        except OperationCancelled as e:
+            self.logger.info("%s finished: %s", self, e)
+        except Exception:
+            self.logger.exception("Unexpected error in %s, exiting", self)
+        else:
+            self.logger.info("%s finished cleanly", self)
+        finally:
+            await self.cleanup()
+            self.finished.set()
+            if finished_callback is not None:
+                finished_callback(self)
+
+    async def cleanup(self) -> None:
+        """Run the service's _cleanup() coroutine."""
+        await self._cleanup()
+
+    async def cancel(self):
+        """Trigger the CancelToken and wait for the run() coroutine to finish."""
+        self.logger.debug("Cancelling %s", self)
+        self.cancel_token.trigger()
+        try:
+            await asyncio.wait_for(self.finished.wait(), timeout=self._wait_until_finished_timeout)
+        except asyncio.futures.TimeoutError:
+            self.logger.info("Timed out waiting for %s to finish, exiting anyway", self)
+
+    @property
+    def is_finished(self) -> bool:
+        return self.finished.is_set()
+
+    @abstractmethod
+    async def _run(self) -> None:
+        """Run the service's loop.
+
+        Should return or raise OperationCancelled when the CancelToken is triggered.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def _cleanup(self) -> None:
+        """Clean up any resources held by this service.
+
+        Called after the service's _run() method returns.
+        """
+        raise NotImplementedError()

--- a/tests/p2p/peer_helpers.py
+++ b/tests/p2p/peer_helpers.py
@@ -129,8 +129,8 @@ async def get_directly_linked_peers(
 
     def finalizer():
         async def afinalizer():
-            await peer1.stop()
-            await peer2.stop()
+            await peer1.cancel()
+            await peer2.cancel()
         event_loop.run_until_complete(afinalizer())
     request.addfinalizer(finalizer)
 

--- a/tests/p2p/test_lightchain.py
+++ b/tests/p2p/test_lightchain.py
@@ -247,7 +247,7 @@ class MockPeerPool:
     async def run(self):
         pass
 
-    async def stop(self):
+    async def cancel(self):
         pass
 
 

--- a/tests/p2p/test_lightchain_integration.py
+++ b/tests/p2p/test_lightchain_integration.py
@@ -51,7 +51,7 @@ async def test_lightchain_integration(request, event_loop):
     await asyncio.sleep(0)  # Yield control to give the LightChain a chance to start
 
     def finalizer():
-        event_loop.run_until_complete(peer_pool.stop())
+        event_loop.run_until_complete(peer_pool.cancel())
         event_loop.run_until_complete(chain.stop())
 
     request.addfinalizer(finalizer)

--- a/tests/p2p/test_server.py
+++ b/tests/p2p/test_server.py
@@ -111,7 +111,7 @@ async def test_server_authenticates_incoming_connections(monkeypatch, server, ev
     assert initiator_peer.privkey == RECEIVER_PRIVKEY
 
     # Stop our peer to make sure its pending asyncio tasks are cancelled.
-    await initiator_peer.stop()
+    await initiator_peer.cancel()
 
 
 @pytest.mark.asyncio
@@ -128,4 +128,4 @@ async def test_two_servers(event_loop,
 
     # Stop our peer to make sure its pending asyncio tasks are cancelled.
     peer = list(receiver_server_with_dumb_peer.peer_pool.connected_nodes.values())[0]
-    await peer.stop()
+    await peer.cancel()


### PR DESCRIPTION
We had several classes for our different services and they all had
slightly different APIs for running/stopping them. BaseService aims
to provide a standard API for that.

Includes #673 , so better to review that one first