### PR TITLE
Journal before trie

### DIFF
--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -5,7 +5,7 @@ from abc import (
 from uuid import UUID
 import logging
 from lru import LRU
-from typing import Tuple
+from typing import Set, Tuple  # noqa: F401
 
 import rlp
 
@@ -354,8 +354,10 @@ class AccountDB(BaseAccountDB):
     def persist(self) -> None:
         self._journaldb.persist()
         self.logger.debug("Persisting account values...")
-        accounts_displayed = set()
-        for checkpoint, accounts in reversed(self._journaltrie.journal.journal_data.items()):
+        accounts_displayed = set()  # type: Set[bytes]
+        queued_changes = self._journaltrie.journal.journal_data.items()
+        # mypy bug for ordered dict reversibility: https://github.com/python/typeshed/issues/2078
+        for checkpoint, accounts in reversed(queued_changes):  # type: ignore
             for address in accounts:
                 if address in accounts_displayed:
                     continue

--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -352,8 +352,11 @@ class AccountDB(BaseAccountDB):
         self._journaltrie.commit(trie_changeset)
 
     def persist(self) -> None:
+        self.logger.debug("Persisting AccountDB...")
         self._journaldb.persist()
-        self.logger.debug("Persisting account values...")
+        self._journaltrie.persist()
+
+    def _log_pending_accounts(self) -> None:
         accounts_displayed = set()  # type: Set[bytes]
         queued_changes = self._journaltrie.journal.journal_data.items()
         # mypy bug for ordered dict reversibility: https://github.com/python/typeshed/issues/2078
@@ -365,12 +368,10 @@ class AccountDB(BaseAccountDB):
                     accounts_displayed.add(address)
                     account = self._get_account(address)
                     self.logger.debug(
-                        "Saving Account %s: balance %d, nonce %d, storage root %s, code hash %s",
+                        "Account %s: balance %d, nonce %d, storage root %s, code hash %s",
                         encode_hex(address),
                         account.balance,
                         account.nonce,
                         encode_hex(account.storage_root),
                         encode_hex(account.code_hash),
                     )
-
-        self._journaltrie.persist()

--- a/evm/db/cache.py
+++ b/evm/db/cache.py
@@ -26,5 +26,6 @@ class CacheDB(BaseDB):
         self._db[key] = value
 
     def __delitem__(self, key):
-        del self._cached_values[key]
+        if key in self._cached_values:
+            del self._cached_values[key]
         del self._db[key]

--- a/evm/db/cache.py
+++ b/evm/db/cache.py
@@ -1,0 +1,30 @@
+from lru import LRU
+
+from evm.db.backends.base import BaseDB
+
+
+class CacheDB(BaseDB):
+    """
+    Set and get decoded RLP objects, where the underlying db stores
+    encoded objects.
+    """
+    def __init__(self, db, cache_size=2048):
+        self._db = db
+        self._cache_size = cache_size
+        self.reset_cache()
+
+    def reset_cache(self):
+        self._cached_values = LRU(self._cache_size)
+
+    def __getitem__(self, key):
+        if key not in self._cached_values:
+            self._cached_values[key] = self._db[key]
+        return self._cached_values[key]
+
+    def __setitem__(self, key, value):
+        self._cached_values[key] = value
+        self._db[key] = value
+
+    def __delitem__(self, key):
+        del self._cached_values[key]
+        del self._db[key]


### PR DESCRIPTION
### What was wrong?

Right now, when an account changes multiple times within a transaction, then we:
- waste time calculating keccak on intermediate state
- waste time doing trie manipulation on intermediate state
- store unnecessary data for intermediate account values

### How was it fixed?

- Journal the raw account values, before entering them into the trie. 
- Replaced values get dropped in the journal, in between calling `persist`, so they never hit the trie

Right now, this will save state at every `persist` call. We can do even better, saving it only at the end of every block, but this PR was getting full.

Side note: The account cache started returning stale results, because the state_root is no longer updated at every change. I tried to fix it in place, with a sprinkling of cache invalidations, but it was taking too long to hunt down all the bugs, so I wrote a simpler `CacheDB` instead. It works, but I'm not sure of the performance impact yet.

Plus a little unrelated VM refactor for creating state more succinctly.

~_Edit: probably need some more persists in there somewhere... Will come back to it after some reviews_~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img00.deviantart.net/faec/i/2014/114/5/f/lizard_bunny_by_crownvic4life-d7fuzmx.jpg)
