### PR TITLE
Documentation: fix typos in "Guides" section

### DIFF
--- a/docs/guides/evm/architecture.rst
+++ b/docs/guides/evm/architecture.rst
@@ -101,4 +101,4 @@ The term **Opcode** is used to encapsulate:
 
 - A single instruction within the VM such as the ``ADD`` or ``MUL`` opcodes.
 
-Opcodes are imple
+Opcodes are implemented as TODO

--- a/docs/guides/evm/architecture.rst
+++ b/docs/guides/evm/architecture.rst
@@ -39,9 +39,9 @@ Most of the ``Chain`` APIs merely serving as a passthrough to the appropriate
 A chain has one or more underlying **Virtual Machines** or VMs.  The chain
 contains a mapping which defines which VM should be active for which blocks.
 
-The chain for the public mainnet Ethereum blockchain would have a VM defined
-for each fork rulese (e.g. **Frontier**, **Homestead**, **Tangerine Whistle**,
-**Byzantium**).
+The chain for the public mainnet Ethereum blockchain would have a separate VM defined
+for each fork ruleset (e.g. **Frontier**, **Homestead**, **Tangerine Whistle**,
+**Spurious Dragon**, **Byzantium**).
 
 
 The VM

--- a/docs/guides/evm/architecture.rst
+++ b/docs/guides/evm/architecture.rst
@@ -22,7 +22,7 @@ Py-EVM based blockchain.
 The Chain
 ---------
 
-The term **Chain** is used to encapuslate:
+The term **Chain** is used to encapsulate:
 
 - The state transition function (e.g. VM opcodes and execution logic)
 - Protocol rules (e.g. block rewards, header rewards, difficulty calculations, transaction execution)
@@ -47,7 +47,7 @@ for each fork ruleset (e.g. **Frontier**, **Homestead**, **Tangerine Whistle**,
 The VM
 ------
 
-The term **VM** is used to encapulate:
+The term **VM** is used to encapsulate:
 
 - The state transition function for a single fork ruleset.
 - Orchestration logic for transaction execution.
@@ -67,7 +67,7 @@ The term **VMState** is used to encapsulate:
 
 - Execution context for the VM (e.g. ``coinbase`` or ``gas_limit``)
 - The state root defining the current VM state.
-- Some block valaidation
+- Some block validation
 
 
 The Message

--- a/docs/guides/evm/building_chains.rst
+++ b/docs/guides/evm/building_chains.rst
@@ -49,9 +49,9 @@ Using the LightChain object
 ---------------------------
 
 The :class:`~p2p.lightchain.LightChain` is like a Chain but it will also
-connect to remote peers and fetch new :class:`~evm.rlp.headers.BlockHeader` s
-as they are announced on the network. As such, it must first be configured
-with a vm_configuration, but it also requires a network_id and privkey:
+connect to remote peers and fetch new :class:`~evm.rlp.headers.BlockHeader`
+objects as they are announced on the network. As such, it must first be
+configured with a `vm_configuration` and a `network_id`:
 
 ::
 
@@ -67,8 +67,9 @@ with a vm_configuration, but it also requires a network_id and privkey:
   )
 
 
-And in order for it to connect to other peers in the network and fetch new
-headers, you should tell asyncio to execute its run() method:
+In order for it to connect to other peers in the network and fetch new
+headers, you should give it a `privkey` and tell `asyncio` to execute
+its `run()` method:
 
 ::
 

--- a/docs/guides/evm/creating_opcodes.rst
+++ b/docs/guides/evm/creating_opcodes.rst
@@ -30,7 +30,7 @@ While these examples are demonstrative of *simple* logic, opcodes will
 traditionally have an intrinsic gas cost associated with them.  Py-EVM offers
 an abstraction which allows for decoupling of gas consumption from opcode logic
 which can be convenient for cases where an opcode's gas cost changes between
-different VM rules but it's logic remains constant.
+different VM rules but its logic remains constant.
 
 .. py:function:: evm.vm.opcode.as_opcode(logic_fn, mnemonic, gas_cost)
 
@@ -44,7 +44,7 @@ different VM rules but it's logic remains constant.
     execution of the ``logic_fn``.
 
 
-Usage of the `~evm.vm.opcode.as_opcode` helper:
+Usage of the :func:`~evm.vm.opcode.as_opcode` helper:
 
 
 .. code-block:: python
@@ -63,9 +63,9 @@ Opcodes as classes
 
 Sometimes it may be helpful to share common logic between similar opcodes, or
 the same opcode across multiple fork rules.  In these cases, implementing
-opcodes as classes *may* be the right choices.  This is as simple as
+opcodes as classes *may* be the right choice.  This is as simple as
 implementing a ``__call__`` method on your class which conforms to the opcode
-API, taking a single `~evm.vm.computation.Computation` instance as the sole
+API, taking a single :class:`~evm.vm.computation.Computation` instance as the sole
 argument.
 
 .. code-block:: python

--- a/docs/guides/evm/creating_opcodes.rst
+++ b/docs/guides/evm/creating_opcodes.rst
@@ -27,7 +27,7 @@ The :func:`~evm.vm.opcode.as_opcode` helper
 
 
 While these examples are demonstrative of *simple* logic, opcodes will
-traditionally have an intrensic gas cost associated with them.  Py-EVM offers
+traditionally have an intrinsic gas cost associated with them.  Py-EVM offers
 an abstraction which allows for decoupling of gas consumption from opcode logic
 which can be convenient for cases where an opcode's gas cost changes between
 different VM rules but it's logic remains constant.


### PR DESCRIPTION
### What was wrong?

Typos and misformatting in docs' guides section.

### How was it fixed?

`aspell` and reading. :)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://fortbragglibrary.org/wp-content/uploads/2014/06/hedgehog-reading.jpg)

Source: [Fort Bragg Library](http://fortbragglibrary.org/paws-to-read/hedgehog-reading/).