### PR TITLE
p2p: PeerPool no longer restarts itself on unexpected exceptions

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -667,18 +667,10 @@ class PeerPool(BaseService):
     async def _run(self) -> None:
         self.logger.info("Running PeerPool...")
         while not self.cancel_token.triggered:
-            try:
-                await self.maybe_connect_to_more_peers()
-                # Wait self._connect_loop_sleep seconds, unless we're asked to stop.
-                await wait_with_token(
-                    asyncio.sleep(self._connect_loop_sleep), token=self.cancel_token)
-            except OperationCancelled as e:
-                self.logger.debug("PeerPool finished: %s", e)
-                break
-            except:  # noqa: E722
-                # Most unexpected errors should be transient, so we log and restart from scratch.
-                self.logger.exception("Unexpected error, restarting")
-                await self.stop_all_peers()
+            await self.maybe_connect_to_more_peers()
+            # Wait self._connect_loop_sleep seconds, unless we're asked to stop.
+            await wait_with_token(
+                asyncio.sleep(self._connect_loop_sleep), token=self.cancel_token)
 
     async def stop_all_peers(self) -> None:
         self.logger.info("Stopping all peers ...")


### PR DESCRIPTION
PeerPool's main loop used to catch any exceptions, log them, restart all
peers and continue in the loop. This was useful because our services
generally run the PeerPool in the background (with `asyncio.ensure_future`),
but it turns out this is problematic because sometimes when exiting the
main process the PeerPool's main loop may get an exception
(a RuntimeError, because the event loop has been closed) before the
parent service has had a chance to tell the PeerPool to shut down, so we
end up in an infinite loop with the PeerPool catching those
RuntimeErrors and trying to restart all peers.