### PR TITLE
[WIP] Move the validate_seal method to the VM class.

### DIFF
--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -22,7 +22,9 @@ from eth_utils import (
 )
 
 from eth_hash.auto import keccak
-
+from evm.consensus.pow import (
+    check_pow,
+)
 from evm.constants import (
     GENESIS_PARENT_HASH,
     MAX_PREV_HEADER_DEPTH,
@@ -257,6 +259,10 @@ class BaseVM(Configurable, metaclass=ABCMeta):
 
         :raises: ValidationError if the transaction is not valid to apply
         """
+        raise NotImplementedError("VM classes must implement this method")
+
+    @abstractmethod
+    def validate_seal(self, header: BlockHeader) -> None:
         raise NotImplementedError("VM classes must implement this method")
 
     @abstractmethod
@@ -606,6 +612,8 @@ class VM(BaseVM):
         """
         Validate the the given block.
         """
+        self.validate_seal(block.header)
+
         if not isinstance(block, self.get_block_class()):
             raise ValidationError(
                 "This vm ({0!r}) is not equipped to validate a block of type {1!r}".format(
@@ -653,6 +661,7 @@ class VM(BaseVM):
 
         for uncle in block.uncles:
             self.validate_uncle(block, uncle)
+            self.validate_seal(uncle)
 
         if not self.chaindb.exists(block.header.state_root):
             raise ValidationError(
@@ -673,6 +682,14 @@ class VM(BaseVM):
                     block.header.uncle_hash,
                 )
             )
+
+    def validate_seal(self, header: BlockHeader) -> None:
+        """
+        Validate the seal on the given header.
+        """
+        check_pow(
+            header.block_number, header.mining_hash,
+            header.mix_hash, header.nonce, header.difficulty)
 
     def validate_uncle(self, block, uncle):
         """

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -104,10 +104,11 @@ def chain_without_block_validation(chaindb, funded_address, funded_address_initi
         'import_block': import_block_without_validation,
         'validate_block': lambda self, block: None,
     }
+    SpuriousDragonVMForTesting = SpuriousDragonVM.configure(validate_seal=lambda self, block: None)
     klass = Chain.configure(
         __name__='TestChainWithoutBlockValidation',
         vm_configuration=(
-            (constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVM),
+            (constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVMForTesting),
         ),
         **overrides,
     )


### PR DESCRIPTION
### What was wrong?
The `validate_seal` method exists on the `Chain` class, however seal validation can and should be a `VM` level operation.

Issue Reference: https://github.com/ethereum/py-evm/issues/667

### How was it fixed?
Move the `validate_seal` method to the `VM` class. The `VM` class should call out to this within it's `validate_block` method.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRfve8BP3JxRkyewVimdViumIVMm2j_k0UEgF8pI4pczGHQq-P9RA)
