### PR TITLE
trinity: Use p2p.Server instead of running FullNodeSyncer directly

### DIFF
--- a/p2p/DEVELOPMENT.md
+++ b/p2p/DEVELOPMENT.md
@@ -12,3 +12,10 @@ we use `CancelToken`s, which are heavily inspired by https://vorpus.org/blog/tim
 - A `CancelToken` must be available to all our async APIs. Either as an instance attribute or as an explicit argument.
 - When one of our async APIs `await` for stdlib/third-party coroutines, it must use `wait_with_token()` to ensure the scheduled task is cancelled when the token is triggered.
 - We must never use `wait_with_token()` with coroutines that create other tasks as when the token is triggered and the coroutine passed to `wait_with_token()` is cancelled, the tasks created by it are automatically destroyed by the event loop and we'll get ERROR logs if those tasks were still pending.
+
+
+## BaseService
+
+- If your service runs coroutines in the background (e.g. via `asyncio.ensure_future`), you must
+  ensure they exit when `is_finished` is True or when the cancel token is triggered
+- If your service runs other services in the background, you should ensure your `_cleanup()` method stops them.

--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -515,9 +515,10 @@ def _test() -> None:
         peer_pool = LocalGethPeerPool(ETHPeer, chaindb, RopstenChain.network_id, privkey)
     else:
         from p2p.peer import HardCodedNodesPeerPool
+        discovery = None
         min_peers = 5
         peer_pool = HardCodedNodesPeerPool(
-            ETHPeer, chaindb, RopstenChain.network_id, privkey, min_peers)
+            ETHPeer, chaindb, RopstenChain.network_id, privkey, discovery, min_peers)
 
     asyncio.ensure_future(peer_pool.run())
     if args.fast:

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -794,16 +794,6 @@ class HardCodedNodesPeerPool(PeerPool):
     nodes that seem to have a good uptime.
     """
 
-    def __init__(self,
-                 peer_class: Type[BasePeer],
-                 headerdb: 'BaseAsyncHeaderDB',
-                 network_id: int,
-                 privkey: datatypes.PrivateKey,
-                 min_peers: int = 2,
-                 ) -> None:
-        discovery = None
-        super().__init__(peer_class, headerdb, network_id, privkey, discovery, min_peers)
-
     def _get_random_bootnode(self) -> Generator[Node, None, None]:
         # We don't have a DiscoveryProtocol with bootnodes, so just return one of our regular
         # hardcoded nodes.
@@ -828,7 +818,11 @@ class HardCodedNodesPeerPool(PeerPool):
                      Address("13.93.211.84", 30303, 30303)),
             ]
         elif self.network_id == RopstenChain.network_id:
+            # FIXME: Many of those nodes are no longer responsive and should be removed from this
+            # list.
             nodes = [
+                Node(keys.PublicKey(decode_hex("60ce95dc5b6873e1c53897815496c28132fa50a1227935c58fbffc30a25bf9df68594f7bdc63b1d33c2911c96013b5b058dcfc9184a78082e9af5ace05fe5486")),  # noqa: E501
+                     Address("79.98.29.93", 30303, 30303)),
                 Node(keys.PublicKey(decode_hex("0d7f627a9a139c1fbff6731d6e0123561738c5155908e32c3a1eea00a3e0c3b460d97c8aea1935c19bfb4e7013651488b8d328b9c142c0b820e221fde7894253")),  # noqa: E501
                      Address("58.250.0.61", 30303, 30303)),
                 Node(keys.PublicKey(decode_hex("360aeace83f0771dd671f253a023b4757e920aca3598563779d8edb2f4d4ca001b5dc2f900ec1547edcd34cfd5cf858e717647e9b5c1f88cef1934081337678b")),  # noqa: E501

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -267,8 +267,9 @@ def _test():
 
     db = LevelDB(args.db)
     chaindb = FakeAsyncChainDB(db)
+    discovery = None
     peer_pool = HardCodedNodesPeerPool(
-        ETHPeer, chaindb, RopstenChain.network_id, ecies.generate_privkey(), min_peers=5)
+        ETHPeer, chaindb, RopstenChain.network_id, ecies.generate_privkey(), discovery, min_peers=5)
     asyncio.ensure_future(peer_pool.run())
 
     head = chaindb.get_canonical_head()

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -23,8 +23,12 @@ class FullNodeSyncer(BaseService):
                  chain: AsyncChain,
                  chaindb: AsyncChainDB,
                  db: BaseDB,
-                 peer_pool: PeerPool) -> None:
-        super().__init__(CancelToken('FullNodeSyncer'))
+                 peer_pool: PeerPool,
+                 token: CancelToken = None) -> None:
+        cancel_token = CancelToken('FullNodeSyncer')
+        if token is not None:
+            cancel_token = cancel_token.chain(token)
+        super().__init__(cancel_token)
         self.chain = chain
         self.chaindb = chaindb
         self.db = db
@@ -80,8 +84,9 @@ def _test():
 
     chaindb = FakeAsyncChainDB(LevelDB(args.db))
     chain = FakeAsyncRopstenChain(chaindb)
+    discovery = None
     peer_pool = HardCodedNodesPeerPool(
-        ETHPeer, chaindb, RopstenChain.network_id, ecies.generate_privkey(), min_peers=5)
+        ETHPeer, chaindb, RopstenChain.network_id, ecies.generate_privkey(), discovery, min_peers=5)
     asyncio.ensure_future(peer_pool.run())
 
     loop = asyncio.get_event_loop()

--- a/tests/p2p/integration_test_helpers.py
+++ b/tests/p2p/integration_test_helpers.py
@@ -31,7 +31,8 @@ class LocalGethPeerPool(HardCodedNodesPeerPool):
                  privkey: datatypes.PrivateKey,
                  ) -> None:
         min_peers = 1
-        super().__init__(peer_class, chaindb, network_id, privkey, min_peers)
+        discovery = None
+        super().__init__(peer_class, chaindb, network_id, privkey, discovery, min_peers)
 
     def get_nodes_to_connect(self):
         nodekey = keys.PrivateKey(decode_hex(

--- a/tests/p2p/test_server.py
+++ b/tests/p2p/test_server.py
@@ -4,6 +4,8 @@ import socket
 
 from eth_keys import keys
 
+from evm.chains.ropsten import RopstenChain, ROPSTEN_GENESIS_HEADER
+from evm.db.chain import ChainDB
 from evm.db.header import HeaderDB
 from evm.db.backends.memory import MemoryDB
 
@@ -42,13 +44,18 @@ INITIATOR_REMOTE = Node(INITIATOR_PUBKEY, INITIATOR_ADDRESS)
 
 
 def get_server(privkey, address, peer_class):
-    bootstrap_nodes = []
-    headerdb = HeaderDB(MemoryDB())
+    db = MemoryDB()
+    headerdb = HeaderDB(db)
+    chaindb = ChainDB(db)
+    chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
+    chain = RopstenChain(chaindb)
     server = Server(
         privkey,
         address,
+        chain,
+        chaindb,
         headerdb,
-        bootstrap_nodes,
+        db,
         network_id=1,
         min_peers=1,
         peer_class=peer_class,

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -49,6 +49,15 @@ trinity_parser.add_argument(
         "information.  Default: $XDG_DATA_HOME/.local/share/trinity"
     ),
 )
+# TODO: Get rid of this once https://github.com/ethereum/py-evm/issues/683 is fixed
+trinity_parser.add_argument(
+    '--listen-on',
+    type=str,
+    required=True,
+    help=(
+        "IP address on which trinity should listen for incoming peer connections"
+    ),
+)
 
 
 #


### PR DESCRIPTION
With this, when we run trinity we'll also be listening for incoming peer
connections

Part of #651