### PR TITLE
Piper/update headerdb api

### DIFF
--- a/evm/chains/header.py
+++ b/evm/chains/header.py
@@ -78,7 +78,7 @@ class BaseHeaderChain(Configurable, metaclass=ABCMeta):
 
 
 class HeaderChain(BaseHeaderChain):
-    _headerdb_class = HeaderDB
+    _headerdb_class = HeaderDB  # type: Type[BaseHeaderDB]
 
     def __init__(self, basedb: BaseDB, header: BlockHeader=None) -> None:
         self.basedb = basedb

--- a/evm/chains/header.py
+++ b/evm/chains/header.py
@@ -69,6 +69,10 @@ class BaseHeaderChain(Configurable, metaclass=ABCMeta):
         raise NotImplementedError("Chain classes must implement this method")
 
     @abstractmethod
+    def header_exists(self, block_hash: Hash32) -> bool:
+        raise NotImplementedError("Chain classes must implement this method")
+
+    @abstractmethod
     def import_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
         raise NotImplementedError("Chain classes must implement this method")
 
@@ -140,6 +144,12 @@ class HeaderChain(BaseHeaderChain):
         Direct passthrough to `headerdb`
         """
         return self.headerdb.get_block_header_by_hash(block_hash)
+
+    def header_exists(self, block_hash: Hash32) -> bool:
+        """
+        Direct passthrough to `headerdb`
+        """
+        return self.headerdb.header_exists(block_hash)
 
     def import_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
         """

--- a/evm/chains/header.py
+++ b/evm/chains/header.py
@@ -29,7 +29,7 @@ class BaseHeaderChain(Configurable, metaclass=ABCMeta):
     vm_configuration = None  # type: Tuple[Tuple[int, Type[BaseVM]], ...]
 
     @abstractmethod
-    def __init__(self, basedb: BaseDB, header: BlockHeader) -> None:
+    def __init__(self, basedb: BaseDB, header: BlockHeader=None) -> None:
         raise NotImplementedError("Chain classes must implement this method")
 
     #
@@ -51,7 +51,7 @@ class BaseHeaderChain(Configurable, metaclass=ABCMeta):
         raise NotImplementedError("Chain classes must implement this method")
 
     #
-    # Header API
+    # Canonical Chain API
     #
     @abstractmethod
     def get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeader:
@@ -61,6 +61,9 @@ class BaseHeaderChain(Configurable, metaclass=ABCMeta):
     def get_canonical_head(self) -> BlockHeader:
         raise NotImplementedError("Chain classes must implement this method")
 
+    #
+    # Header API
+    #
     @abstractmethod
     def get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
         raise NotImplementedError("Chain classes must implement this method")
@@ -73,10 +76,14 @@ class BaseHeaderChain(Configurable, metaclass=ABCMeta):
 class HeaderChain(BaseHeaderChain):
     _headerdb_class = HeaderDB
 
-    def __init__(self, basedb: BaseDB, header: BlockHeader) -> None:
+    def __init__(self, basedb: BaseDB, header: BlockHeader=None) -> None:
         self.basedb = basedb
         self.headerdb = self.get_headerdb_class()(basedb)
-        self.header = header
+
+        if header is None:
+            self.header = self.get_canonical_head()
+        else:
+            self.header = header
 
     #
     # Chain Initialization API

--- a/evm/db/header.py
+++ b/evm/db/header.py
@@ -63,6 +63,10 @@ class BaseHeaderDB(metaclass=ABCMeta):
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
+    def header_exists(self, block_hash: Hash32) -> bool:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
     def persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
         raise NotImplementedError("ChainDB classes must implement this method")
 
@@ -132,6 +136,10 @@ class HeaderDB(BaseHeaderDB):
             self.db[SchemaV1.make_block_hash_to_score_lookup_key(block_hash)],
             sedes=rlp.sedes.big_endian_int,
         )
+
+    def header_exists(self, block_hash: Hash32) -> bool:
+        validate_word(block_hash, title="Block Hash")
+        return block_hash in self.db
 
     def persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
         """

--- a/p2p/lightchain.py
+++ b/p2p/lightchain.py
@@ -10,30 +10,11 @@ from typing import (  # noqa: F401
     Set,
     Tuple,
     Type,
+    TYPE_CHECKING,
 )
 
-from async_lru import alru_cache
-
-from eth_utils import (
-    encode_hex,
-)
-
-from eth_typing import (
-    Address,
-    BlockNumber,
-    Hash32,
-)
-
-from evm.chains import Chain
 from evm.constants import GENESIS_BLOCK_NUMBER
-from evm.db.chain import AsyncChainDB
-from evm.exceptions import (
-    HeaderNotFound,
-)
-from evm.rlp.accounts import Account
-from evm.rlp.blocks import BaseBlock
 from evm.rlp.headers import BlockHeader
-from evm.rlp.receipts import Receipt
 
 from p2p.exceptions import (
     EmptyGetBlockHeadersReply,
@@ -54,24 +35,22 @@ from p2p.peer import (
     PeerPoolSubscriber,
 )
 
+if TYPE_CHECKING:
+    from trinity.db.header import BaseAsyncHeaderDB  # noqa: F401
 
-class LightChain(Chain, PeerPoolSubscriber):
+
+class LightChain(PeerPoolSubscriber):
     logger = logging.getLogger("p2p.lightchain.LightChain")
     max_consecutive_timeouts = 5
-    chaindb = None  # type: AsyncChainDB
+    headerdb: 'BaseAsyncHeaderDB' = None
 
-    def __init__(self, chaindb: AsyncChainDB, peer_pool: PeerPool) -> None:
-        super(LightChain, self).__init__(chaindb)
+    def __init__(self, headerdb: 'BaseAsyncHeaderDB', peer_pool: PeerPool) -> None:
+        self.headerdb = headerdb
         self.peer_pool = peer_pool
         self._announcement_queue = asyncio.Queue()  # type: asyncio.Queue[Tuple[LESPeer, les.HeadInfo]]  # noqa: E501
         self._last_processed_announcements = {}  # type: Dict[LESPeer, les.HeadInfo]
         self.cancel_token = CancelToken('LightChain')
         self._running_peers = set()  # type: Set[LESPeer]
-
-    @classmethod
-    def from_genesis_header(cls, chaindb, genesis_header, peer_pool):
-        chaindb.persist_header(genesis_header)
-        return cls(chaindb, peer_pool)
 
     def register_peer(self, peer: BasePeer) -> None:
         asyncio.ensure_future(self.handle_peer(cast(LESPeer, peer)))
@@ -194,7 +173,7 @@ class LightChain(Chain, PeerPoolSubscriber):
         raise TooManyTimeouts()
 
     async def get_sync_start_block(self, peer: LESPeer, head_info: les.HeadInfo) -> int:
-        chain_head = await self.chaindb.coro_get_canonical_head()
+        chain_head = await self.headerdb.coro_get_canonical_head()
         last_peer_announcement = self._last_processed_announcements.get(peer)
         if chain_head.block_number == GENESIS_BLOCK_NUMBER:
             start_block = GENESIS_BLOCK_NUMBER
@@ -216,7 +195,7 @@ class LightChain(Chain, PeerPoolSubscriber):
                 raise LESAnnouncementProcessingError(
                     "Too many timeouts when fetching headers from {}".format(peer))
             for header in headers:
-                await self.chaindb.coro_persist_header(header)
+                await self.headerdb.coro_persist_header(header)
             start_block = chain_head.block_number
         else:
             start_block = last_peer_announcement.block_number - head_info.reorg_depth
@@ -225,7 +204,7 @@ class LightChain(Chain, PeerPoolSubscriber):
     # TODO: Distribute requests among our peers, ensuring the selected peer has the info we want
     # and respecting the flow control rules.
     async def process_announcement(self, peer: LESPeer, head_info: les.HeadInfo) -> None:
-        if await self.chaindb.coro_header_exists(head_info.block_hash):
+        if await self.headerdb.coro_header_exists(head_info.block_hash):
             self.logger.debug(
                 "Skipping processing of %s from %s as head has already been fetched",
                 head_info, peer)
@@ -241,7 +220,7 @@ class LightChain(Chain, PeerPoolSubscriber):
                 raise LESAnnouncementProcessingError(
                     "Too many timeouts when fetching headers from {}".format(peer))
             for header in batch:
-                await self.chaindb.coro_persist_header(header)
+                await self.headerdb.coro_persist_header(header)
                 start_block = header.block_number
             self.logger.info("synced headers up to #%s", start_block)
 
@@ -251,55 +230,3 @@ class LightChain(Chain, PeerPoolSubscriber):
         self.logger.debug("Waiting for all pending tasks to finish...")
         await self.wait_until_finished()
         self.logger.debug("LightChain finished")
-
-    # we have to ignore type hinting in this function since it's parent classes
-    # don't use `async def`
-    async def get_canonical_block_by_number(self, block_number: BlockNumber) -> BaseBlock:  # type: ignore  # noqa: E501
-        """Return the block with the given number from the canonical chain.
-
-        Raises HeaderNotFound if it is not found.
-        """
-        try:
-            block_hash = await self.chaindb.coro_get_canonical_block_hash(block_number)
-        except KeyError:
-            raise HeaderNotFound(
-                "No block with number {} found on local chain".format(block_number))
-        return await self.get_block_by_hash(block_hash)
-
-    @alru_cache(maxsize=1024, cache_exceptions=False)
-    async def get_block_by_hash(self, block_hash: Hash32) -> BaseBlock:
-        peer = await self.get_best_peer()
-        try:
-            header = await self.chaindb.coro_get_block_header_by_hash(block_hash)
-        except HeaderNotFound:
-            self.logger.debug("Fetching header %s from %s", encode_hex(block_hash), peer)
-            header = await peer.get_block_header_by_hash(block_hash, self.cancel_token)
-
-        self.logger.debug("Fetching block %s from %s", encode_hex(block_hash), peer)
-        body = await peer.get_block_by_hash(block_hash, self.cancel_token)
-        block_class = self.get_vm_class_for_block_number(header.block_number).get_block_class()
-        transactions = [
-            block_class.transaction_class.from_base_transaction(tx)
-            for tx in body.transactions
-        ]
-        return block_class(
-            header=header,
-            transactions=transactions,
-            uncles=body.uncles,
-        )
-
-    @alru_cache(maxsize=1024, cache_exceptions=False)
-    async def get_receipts(self, block_hash: Hash32) -> List[Receipt]:
-        peer = await self.get_best_peer()
-        self.logger.debug("Fetching %s receipts from %s", encode_hex(block_hash), peer)
-        return await peer.get_receipts(block_hash, self.cancel_token)
-
-    @alru_cache(maxsize=1024, cache_exceptions=False)
-    async def get_account(self, block_hash: Hash32, address: Address) -> Account:
-        peer = await self.get_best_peer()
-        return await peer.get_account(block_hash, address, self.cancel_token)
-
-    @alru_cache(maxsize=1024, cache_exceptions=False)
-    async def get_contract_code(self, block_hash: Hash32, key: bytes) -> bytes:
-        peer = await self.get_best_peer()
-        return await peer.get_contract_code(block_hash, key, self.cancel_token)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -9,7 +9,18 @@ from abc import (
     abstractmethod
 )
 
-from typing import (Any, cast, Callable, Dict, Generator, List, Optional, Tuple, Type)  # noqa: F401
+from typing import (  # noqa: F401
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TYPE_CHECKING,
+    cast,
+)
 
 import sha3
 
@@ -87,13 +98,14 @@ from .constants import (
     REPLY_TIMEOUT,
 )
 
-from trinity.db.header import BaseAsyncHeaderDB
+if TYPE_CHECKING:
+    from trinity.db.header import BaseAsyncHeaderDB  # noqa: F401
 
 
 async def handshake(remote: Node,
                     privkey: datatypes.PrivateKey,
                     peer_class: 'Type[BasePeer]',
-                    headerdb: BaseAsyncHeaderDB,
+                    headerdb: 'BaseAsyncHeaderDB',
                     network_id: int,
                     token: CancelToken,
                     ) -> 'BasePeer':
@@ -147,7 +159,7 @@ class BasePeer(BaseService):
                  mac_secret: bytes,
                  egress_mac: sha3.keccak_256,
                  ingress_mac: sha3.keccak_256,
-                 headerdb: BaseAsyncHeaderDB,
+                 headerdb: 'BaseAsyncHeaderDB',
                  network_id: int,
                  ) -> None:
         super().__init__(CancelToken('Peer'))
@@ -626,7 +638,7 @@ class PeerPool(BaseService):
 
     def __init__(self,
                  peer_class: Type[BasePeer],
-                 headerdb: BaseAsyncHeaderDB,
+                 headerdb: 'BaseAsyncHeaderDB',
                  network_id: int,
                  privkey: datatypes.PrivateKey,
                  discovery: DiscoveryProtocol,
@@ -784,7 +796,7 @@ class HardCodedNodesPeerPool(PeerPool):
 
     def __init__(self,
                  peer_class: Type[BasePeer],
-                 headerdb: BaseAsyncHeaderDB,
+                 headerdb: 'BaseAsyncHeaderDB',
                  network_id: int,
                  privkey: datatypes.PrivateKey,
                  min_peers: int = 2,

--- a/tests/core/chain-object/test_header_chain.py
+++ b/tests/core/chain-object/test_header_chain.py
@@ -174,3 +174,43 @@ def test_header_chain_get_block_header_by_hash_passthrough(headerdb, header_chai
     for header in chain_b:
         actual = header_chain.get_block_header_by_hash(header.hash)
         assert actual == header
+
+
+def test_header_chain_header_exists(header_chain, genesis_header):
+    assert header_chain.header_exists(genesis_header.hash) is True
+
+    chain_a = mk_header_chain(genesis_header, 3)
+    chain_b = mk_header_chain(genesis_header, 5)
+
+    assert not any(header_chain.header_exists(h.hash) for h in chain_a)
+    assert not any(header_chain.header_exists(h.hash) for h in chain_b)
+
+    for idx, header in enumerate(chain_a):
+        assert all(header_chain.header_exists(h.hash) for h in chain_a[:idx])
+        assert not any(header_chain.header_exists(h.hash) for h in chain_a[idx:])
+
+        # sanity pre-check
+        assert not header_chain.header_exists(header.hash)
+        header_chain.import_header(header)
+        assert header_chain.header_exists(header.hash)
+
+    # `chain_a` should now all exist
+    assert all(header_chain.header_exists(h.hash) for h in chain_a)
+    # `chain_b` should not be in the database.
+    assert not any(header_chain.header_exists(h.hash) for h in chain_b)
+
+    for idx, header in enumerate(chain_b):
+        # `chain_a` should remain accessible
+        assert all(header_chain.header_exists(h.hash) for h in chain_a)
+
+        assert all(header_chain.header_exists(h.hash) for h in chain_b[:idx])
+        assert not any(header_chain.header_exists(h.hash) for h in chain_b[idx:])
+
+        # sanity pre-check
+        assert not header_chain.header_exists(header.hash)
+        header_chain.import_header(header)
+        assert header_chain.header_exists(header.hash)
+
+    # both `chain_a` & `chain_b` should now all exist
+    assert all(header_chain.header_exists(h.hash) for h in chain_a)
+    assert all(header_chain.header_exists(h.hash) for h in chain_b)

--- a/tests/core/chain-object/test_header_chain.py
+++ b/tests/core/chain-object/test_header_chain.py
@@ -86,38 +86,16 @@ def test_header_chain_initialization_header_already_persisted(base_db, genesis_h
     assert_headers_eq(head, genesis_header)
 
 
-def test_header_chain_get_canonical_block_hash_passthrough(headerdb, header_chain):
-    headers = mk_header_chain(headerdb.get_canonical_head(), 10)
-
-    # push headers directly into database
-    for header in headers:
-        headerdb.persist_header(header)
-
-    for header in headers:
-        canonical_hash = header_chain.get_canonical_block_hash(header.block_number)
-        assert canonical_hash == header.hash
+def test_header_chain_get_canonical_block_hash_passthrough(header_chain, genesis_header):
+    assert header_chain.get_canonical_block_hash(0) == genesis_header.hash
 
 
-def test_header_chain_get_canonical_block_header_by_number_passthrough(headerdb, header_chain):
-    headers = mk_header_chain(headerdb.get_canonical_head(), 10)
-
-    # push headers directly into database
-    for header in headers:
-        headerdb.persist_header(header)
-
-    for header in headers:
-        canonical_header = header_chain.get_canonical_block_header_by_number(header.block_number)
-        assert_headers_eq(canonical_header, header)
+def test_header_chain_get_canonical_block_header_by_number_passthrough(header_chain, genesis_header):
+    assert header_chain.get_canonical_block_header_by_number(0) == genesis_header
 
 
-def test_header_chain_get_canonical_head_passthrough(headerdb, header_chain, genesis_header):
-    headers = mk_header_chain(genesis_header, 10)
-
-    # push headers directly into database
-    for header in headers:
-        headerdb.persist_header(header)
-        head = header_chain.get_canonical_head()
-        assert_headers_eq(head, header)
+def test_header_chain_get_canonical_head_passthrough(header_chain):
+    assert header_chain.get_canonical_head() == header_chain.header
 
 
 def test_header_chain_import_block(header_chain, genesis_header):
@@ -157,60 +135,10 @@ def test_header_chain_import_block(header_chain, genesis_header):
     assert_headers_eq(header_chain.header, chain_c[-1])
 
 
-def test_header_chain_get_block_header_by_hash_passthrough(headerdb, header_chain):
-    chain_a = mk_header_chain(headerdb.get_canonical_head(), 5)
-    chain_b = mk_header_chain(headerdb.get_canonical_head(), 7)
-
-    # push both chains of headers into the database
-    for header in chain_a:
-        headerdb.persist_header(header)
-    for header in chain_b:
-        headerdb.persist_header(header)
-
-    # verify we can retrieve both `chain_a` and `chain_b` headers
-    for header in chain_a:
-        actual = header_chain.get_block_header_by_hash(header.hash)
-        assert actual == header
-    for header in chain_b:
-        actual = header_chain.get_block_header_by_hash(header.hash)
-        assert actual == header
+def test_header_chain_get_block_header_by_hash_passthrough(header_chain, genesis_header):
+    assert header_chain.get_block_header_by_hash(genesis_header.hash) == genesis_header
 
 
 def test_header_chain_header_exists(header_chain, genesis_header):
     assert header_chain.header_exists(genesis_header.hash) is True
-
-    chain_a = mk_header_chain(genesis_header, 3)
-    chain_b = mk_header_chain(genesis_header, 5)
-
-    assert not any(header_chain.header_exists(h.hash) for h in chain_a)
-    assert not any(header_chain.header_exists(h.hash) for h in chain_b)
-
-    for idx, header in enumerate(chain_a):
-        assert all(header_chain.header_exists(h.hash) for h in chain_a[:idx])
-        assert not any(header_chain.header_exists(h.hash) for h in chain_a[idx:])
-
-        # sanity pre-check
-        assert not header_chain.header_exists(header.hash)
-        header_chain.import_header(header)
-        assert header_chain.header_exists(header.hash)
-
-    # `chain_a` should now all exist
-    assert all(header_chain.header_exists(h.hash) for h in chain_a)
-    # `chain_b` should not be in the database.
-    assert not any(header_chain.header_exists(h.hash) for h in chain_b)
-
-    for idx, header in enumerate(chain_b):
-        # `chain_a` should remain accessible
-        assert all(header_chain.header_exists(h.hash) for h in chain_a)
-
-        assert all(header_chain.header_exists(h.hash) for h in chain_b[:idx])
-        assert not any(header_chain.header_exists(h.hash) for h in chain_b[idx:])
-
-        # sanity pre-check
-        assert not header_chain.header_exists(header.hash)
-        header_chain.import_header(header)
-        assert header_chain.header_exists(header.hash)
-
-    # both `chain_a` & `chain_b` should now all exist
-    assert all(header_chain.header_exists(h.hash) for h in chain_a)
-    assert all(header_chain.header_exists(h.hash) for h in chain_b)
+    assert header_chain.header_exists(b'\x0f' * 32) is False

--- a/tests/core/chain-object/test_header_chain.py
+++ b/tests/core/chain-object/test_header_chain.py
@@ -90,7 +90,9 @@ def test_header_chain_get_canonical_block_hash_passthrough(header_chain, genesis
     assert header_chain.get_canonical_block_hash(0) == genesis_header.hash
 
 
-def test_header_chain_get_canonical_block_header_by_number_passthrough(header_chain, genesis_header):
+def test_header_chain_get_canonical_block_header_by_number_passthrough(
+        header_chain,
+        genesis_header):
     assert header_chain.get_canonical_block_header_by_number(0) == genesis_header
 
 

--- a/tests/p2p/integration_test_helpers.py
+++ b/tests/p2p/integration_test_helpers.py
@@ -10,6 +10,17 @@ from evm.db.chain import AsyncChainDB
 from p2p import kademlia
 from p2p.peer import BasePeer, HardCodedNodesPeerPool
 
+from trinity.db.header import AsyncHeaderDB
+
+
+def async_passthrough(base_name):
+    coro_name = 'coro_{0}'.format(base_name)
+
+    async def passthrough_method(self, *args, **kwargs):
+        return getattr(self, base_name)(*args, **kwargs)
+    passthrough_method.__name__ = coro_name
+    return passthrough_method
+
 
 class LocalGethPeerPool(HardCodedNodesPeerPool):
 
@@ -31,29 +42,14 @@ class LocalGethPeerPool(HardCodedNodesPeerPool):
 
 
 class FakeAsyncChainDB(AsyncChainDB):
-    async def coro_get_score(self, *args, **kwargs):
-        return self.get_score(*args, **kwargs)
-
-    async def coro_get_block_header_by_hash(self, *args, **kwargs):
-        return self.get_block_header_by_hash(*args, **kwargs)
-
-    async def coro_get_canonical_head(self, *args, **kwargs):
-        return self.get_canonical_head(*args, **kwargs)
-
-    async def coro_header_exists(self, *args, **kwargs):
-        return self.header_exists(*args, **kwargs)
-
-    async def coro_get_canonical_block_hash(self, *args, **kwargs):
-        return self.get_canonical_block_hash(*args, **kwargs)
-
-    async def coro_persist_header(self, *args, **kwargs):
-        return self.persist_header(*args, **kwargs)
-
-    async def coro_persist_uncles(self, *args, **kwargs):
-        return self.persist_uncles(*args, **kwargs)
-
-    async def coro_persist_trie_data_dict(self, *args, **kwargs):
-        return self.persist_trie_data_dict(*args, **kwargs)
+    coro_get_score = async_passthrough('get_score')
+    coro_get_block_header_by_hash = async_passthrough('get_block_header_by_hash')
+    coro_get_canonical_head = async_passthrough('get_canonical_head')
+    coro_header_exists = async_passthrough('header_exists')
+    coro_get_canonical_block_hash = async_passthrough('get_canonical_block_hash')
+    coro_persist_header = async_passthrough('persist_header')
+    coro_persist_uncles = async_passthrough('persist_uncles')
+    coro_persist_trie_data_dict = async_passthrough('persist_trie_data_dict')
 
 
 async def coro_import_block(chain, block, perform_validation=True):
@@ -69,3 +65,13 @@ class FakeAsyncRopstenChain(RopstenChain):
 
 class FakeAsyncMainnetChain(MainnetChain):
     coro_import_block = coro_import_block
+
+
+class FakeAsyncHeaderDB(AsyncHeaderDB):
+    coro_get_canonical_block_hash = async_passthrough('get_canonical_block_hash')
+    coro_get_canonical_block_header_by_number = async_passthrough('get_canonical_block_header_by_number')  # noqa: E501
+    coro_get_canonical_head = async_passthrough('get_canonical_head')
+    coro_get_block_header_by_hash = async_passthrough('get_block_header_by_hash')
+    coro_get_score = async_passthrough('get_score')
+    coro_header_exists = async_passthrough('header_exists')
+    coro_persist_header = async_passthrough('persist_header')

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -121,13 +121,13 @@ async def test_handshake():
     initiator_peer = DummyPeer(
         remote=initiator.remote, privkey=initiator.privkey, reader=initiator_reader,
         writer=initiator_writer, aes_secret=initiator_aes_secret, mac_secret=initiator_mac_secret,
-        egress_mac=initiator_egress_mac, ingress_mac=initiator_ingress_mac, chaindb=None,
+        egress_mac=initiator_egress_mac, ingress_mac=initiator_ingress_mac, headerdb=None,
         network_id=1)
     initiator_peer.base_protocol.send_handshake()
     responder_peer = DummyPeer(
         remote=responder.remote, privkey=responder.privkey, reader=responder_reader,
         writer=responder_writer, aes_secret=aes_secret, mac_secret=mac_secret,
-        egress_mac=egress_mac, ingress_mac=ingress_mac, chaindb=None, network_id=1)
+        egress_mac=egress_mac, ingress_mac=ingress_mac, headerdb=None, network_id=1)
     responder_peer.base_protocol.send_handshake()
 
     # The handshake msgs sent by each peer (above) are going to be fed directly into their remote's

--- a/tests/p2p/test_server.py
+++ b/tests/p2p/test_server.py
@@ -4,7 +4,7 @@ import socket
 
 from eth_keys import keys
 
-from evm.db.chain import ChainDB
+from evm.db.header import HeaderDB
 from evm.db.backends.memory import MemoryDB
 
 from p2p.peer import (
@@ -43,11 +43,11 @@ INITIATOR_REMOTE = Node(INITIATOR_PUBKEY, INITIATOR_ADDRESS)
 
 def get_server(privkey, address, peer_class):
     bootstrap_nodes = []
-    chaindb = ChainDB(MemoryDB())
+    headerdb = HeaderDB(MemoryDB())
     server = Server(
         privkey,
         address,
-        chaindb,
+        headerdb,
         bootstrap_nodes,
         network_id=1,
         min_peers=1,

--- a/tests/p2p/test_sharding.py
+++ b/tests/p2p/test_sharding.py
@@ -175,7 +175,7 @@ async def test_shard_syncer(n_peers, connections):
         server = Server(
             privkey=private_key,
             server_address=address,
-            chaindb=None,
+            headerdb=None,
             bootstrap_nodes=[],
             network_id=9324090483,
             min_peers=0,

--- a/trinity/chains/header.py
+++ b/trinity/chains/header.py
@@ -1,10 +1,10 @@
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
 # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
 from multiprocessing.managers import (  # type: ignore
     BaseProxy,
 )
-from typing import Tuple
+from typing import Tuple, Type
 
 from evm.db.backends.base import BaseDB
 from evm.chains.header import (
@@ -23,7 +23,7 @@ from trinity.utils.mp import (
 )
 
 
-class BaseAsyncHeaderChain(metaclass=ABCMeta):
+class BaseAsyncHeaderChain(BaseHeaderChain):
     @abstractmethod
     async def coro_get_canonical_head(self):
         raise NotImplementedError("Chain classes must implement this method")
@@ -34,7 +34,7 @@ class BaseAsyncHeaderChain(metaclass=ABCMeta):
 
 
 class AsyncHeaderChain(HeaderChain, BaseAsyncHeaderChain):
-    _headerdb_class: BaseAsyncHeaderDB = AsyncHeaderDB
+    _headerdb_class: Type[BaseAsyncHeaderDB] = AsyncHeaderDB
 
     async def coro_get_canonical_head(self):
         raise NotImplementedError("Chain classes must implement this method")

--- a/trinity/chains/header.py
+++ b/trinity/chains/header.py
@@ -1,0 +1,67 @@
+from abc import ABCMeta, abstractmethod
+# Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
+# https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
+from multiprocessing.managers import (  # type: ignore
+    BaseProxy,
+)
+from typing import Tuple
+
+from evm.db.backends.base import BaseDB
+from evm.chains.header import (
+    BaseHeaderChain,
+    HeaderChain,
+)
+from evm.rlp.headers import BlockHeader
+
+from trinity.db.header import (
+    AsyncHeaderDB,
+    BaseAsyncHeaderDB,
+)
+from trinity.utils.mp import (
+    async_method,
+    sync_method,
+)
+
+
+class BaseAsyncHeaderChain(metaclass=ABCMeta):
+    @abstractmethod
+    async def coro_get_canonical_head(self):
+        raise NotImplementedError("Chain classes must implement this method")
+
+    @abstractmethod
+    async def coro_import_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("Chain classes must implement this method")
+
+
+class AsyncHeaderChain(HeaderChain, BaseAsyncHeaderChain):
+    _headerdb_class: BaseAsyncHeaderDB = AsyncHeaderDB
+
+    async def coro_get_canonical_head(self):
+        raise NotImplementedError("Chain classes must implement this method")
+
+    async def coro_import_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("Chain classes must implement this method")
+
+
+class AsyncHeaderChainProxy(BaseProxy, BaseAsyncHeaderChain, BaseHeaderChain):
+    @classmethod
+    def from_genesis_header(cls,
+                            basedb: BaseDB,
+                            genesis_header: BlockHeader) -> 'BaseHeaderChain':
+        raise NotImplementedError("Chain classes must implement this method")
+
+    @classmethod
+    def get_headerdb_class(cls):
+        raise NotImplementedError("Chain classes must implement this method")
+
+    coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
+    coro_get_canonical_block_header_by_number = async_method('get_canonical_block_header_by_number')
+    coro_get_canonical_head = async_method('get_canonical_head')
+    coro_import_header = async_method('import_header')
+    coro_header_exists = async_method('header_exists')
+
+    get_block_header_by_hash = sync_method('get_block_header_by_hash')
+    get_canonical_block_header_by_number = sync_method('get_canonical_block_header_by_number')
+    get_canonical_head = sync_method('get_canonical_head')
+    import_header = sync_method('import_header')
+    header_exists = sync_method('header_exists')

--- a/trinity/db/header.py
+++ b/trinity/db/header.py
@@ -1,0 +1,102 @@
+from abc import ABCMeta, abstractmethod
+# Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
+# https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
+from multiprocessing.managers import (  # type: ignore
+    BaseProxy,
+)
+from typing import Tuple
+
+from eth_typing import (
+    Hash32,
+    BlockNumber,
+)
+
+from evm.db.header import (
+    BaseHeaderDB,
+    HeaderDB,
+)
+from evm.rlp.headers import BlockHeader
+
+from trinity.utils.mp import (
+    async_method,
+    sync_method,
+)
+
+
+class BaseAsyncHeaderDB(metaclass=ABCMeta):
+    #
+    # Canonical Chain API
+    #
+    @abstractmethod
+    async def coro_get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeader:  # noqa: E501
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_canonical_head(self) -> BlockHeader:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    #
+    # Header API
+    #
+    @abstractmethod
+    async def coro_get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_score(self, block_hash: Hash32) -> int:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_header_exists(self, block_hash: Hash32) -> bool:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+
+class AsyncHeaderDB(HeaderDB, BaseAsyncHeaderDB):
+    async def coro_get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeader:  # noqa: E501
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_canonical_head(self) -> BlockHeader:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_score(self, block_hash: Hash32) -> int:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_header_exists(self, block_hash: Hash32) -> bool:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+
+class AsyncHeaderDBProxy(BaseProxy, BaseAsyncHeaderDB, BaseHeaderDB):
+    coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
+    coro_get_canonical_block_hash = async_method('get_canonical_block_hash')
+    coro_get_canonical_block_header_by_number = async_method('get_canonical_block_header_by_number')
+    coro_get_canonical_head = async_method('get_canonical_head')
+    coro_get_score = async_method('get_score')
+    coro_header_exists = async_method('header_exists')
+    coro_get_canonical_block_hash = async_method('get_canonical_block_hash')
+    coro_persist_header = async_method('persist_header')
+
+    get_block_header_by_hash = sync_method('get_block_header_by_hash')
+    get_canonical_block_hash = sync_method('get_canonical_block_hash')
+    get_canonical_block_header_by_number = sync_method('get_canonical_block_header_by_number')
+    get_canonical_head = sync_method('get_canonical_head')
+    get_score = sync_method('get_score')
+    header_exists = sync_method('header_exists')
+    get_canonical_block_hash = sync_method('get_canonical_block_hash')
+    persist_header = sync_method('persist_header')

--- a/trinity/db/header.py
+++ b/trinity/db/header.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
 # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
 from multiprocessing.managers import (  # type: ignore
@@ -23,7 +23,7 @@ from trinity.utils.mp import (
 )
 
 
-class BaseAsyncHeaderDB(metaclass=ABCMeta):
+class BaseAsyncHeaderDB(BaseHeaderDB):
     #
     # Canonical Chain API
     #

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -182,7 +182,7 @@ def run_lightnode_process(
         pool_class: Type[HardCodedNodesPeerPool]) -> None:
 
     manager = create_dbmanager(chain_config.database_ipc_path)
-    chaindb = manager.get_chaindb()  # type: ignore
+    headerdb = manager.get_headerdb()  # type: ignore
 
     if chain_config.network_id == MAINNET_NETWORK_ID:
         chain_class = MainnetLightChain  # type: ignore
@@ -192,8 +192,8 @@ def run_lightnode_process(
         raise NotImplementedError(
             "Only the mainnet and ropsten chains are currently supported"
         )
-    peer_pool = pool_class(LESPeer, chaindb, chain_config.network_id, chain_config.nodekey)
-    chain = chain_class(chaindb, peer_pool)
+    peer_pool = pool_class(LESPeer, headerdb, chain_config.network_id, chain_config.nodekey)
+    chain = chain_class(headerdb, peer_pool)
 
     loop = asyncio.get_event_loop()
     for sig in [signal.SIGINT, signal.SIGTERM]:

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -35,6 +35,9 @@ from trinity.chains.mainnet import (
 from trinity.chains.ropsten import (
     RopstenLightChain,
 )
+from trinity.chains.header import (
+    AsyncHeaderChainProxy,
+)
 from trinity.console import (
     console,
 )
@@ -43,6 +46,7 @@ from trinity.constants import (
 )
 from trinity.db.chain import ChainDBProxy
 from trinity.db.base import DBProxy
+from trinity.db.header import AsyncHeaderDBProxy
 from trinity.cli_parser import (
     parser,
 )
@@ -164,6 +168,8 @@ def create_dbmanager(ipc_path: str) -> BaseManager:
     DBManager.register('get_db', proxytype=DBProxy)  # type: ignore
     DBManager.register('get_chaindb', proxytype=ChainDBProxy)  # type: ignore
     DBManager.register('get_chain', proxytype=ChainProxy)  # type: ignore
+    DBManager.register('get_headerdb', proxytype=AsyncHeaderDBProxy)  # type: ignore
+    DBManager.register('get_header_chain', proxytype=AsyncHeaderChainProxy)  # type: ignore
 
     manager = DBManager(address=ipc_path)  # type: ignore
     manager.connect()  # type: ignore


### PR DESCRIPTION
### What was wrong?

Some updates to the API for working with the `HeaderChain` and `HeaderDB`.

### How was it fixed?

- The test suite for the `HeaderChain` class has been slimmed down to reduce duplication in what we're testing.  Now the passthrough methods simply do a sanity check that the API isn't fundamentally broken.
- Added `header_exists` to both `HeaderChain` and `HeaderDB`.  This is needed for upcoming conversion of other parts of py-evm and trinity to use these APIs
- Now the `header` argument is optional when creating a `HeaderChain` instance.  When not provided, it's looked up from the database.


#### Cute Animal Picture

![cute-baby-chickens-wearing-knit-hats5](https://user-images.githubusercontent.com/824194/40006178-f14b11ec-5756-11e8-9503-129db8168b39.jpg)

