### PR TITLE
Add HeaderDB and HeaderChain abstractions to trinity

### DIFF
--- a/trinity/chains/header.py
+++ b/trinity/chains/header.py
@@ -1,0 +1,67 @@
+from abc import ABCMeta, abstractmethod
+# Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
+# https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
+from multiprocessing.managers import (  # type: ignore
+    BaseProxy,
+)
+from typing import Tuple
+
+from evm.db.backends.base import BaseDB
+from evm.chains.header import (
+    BaseHeaderChain,
+    HeaderChain,
+)
+from evm.rlp.headers import BlockHeader
+
+from trinity.db.header import (
+    AsyncHeaderDB,
+    BaseAsyncHeaderDB,
+)
+from trinity.utils.mp import (
+    async_method,
+    sync_method,
+)
+
+
+class BaseAsyncHeaderChain(metaclass=ABCMeta):
+    @abstractmethod
+    async def coro_get_canonical_head(self):
+        raise NotImplementedError("Chain classes must implement this method")
+
+    @abstractmethod
+    async def coro_import_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("Chain classes must implement this method")
+
+
+class AsyncHeaderChain(HeaderChain, BaseAsyncHeaderChain):
+    _headerdb_class: BaseAsyncHeaderDB = AsyncHeaderDB
+
+    async def coro_get_canonical_head(self):
+        raise NotImplementedError("Chain classes must implement this method")
+
+    async def coro_import_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("Chain classes must implement this method")
+
+
+class AsyncHeaderChainProxy(BaseProxy, BaseAsyncHeaderChain, BaseHeaderChain):
+    @classmethod
+    def from_genesis_header(cls,
+                            basedb: BaseDB,
+                            genesis_header: BlockHeader) -> 'BaseHeaderChain':
+        raise NotImplementedError("Chain classes must implement this method")
+
+    @classmethod
+    def get_headerdb_class(cls):
+        raise NotImplementedError("Chain classes must implement this method")
+
+    coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
+    coro_get_canonical_block_header_by_number = async_method('get_canonical_block_header_by_number')
+    coro_get_canonical_head = async_method('get_canonical_head')
+    coro_import_header = async_method('import_header')
+    coro_header_exists = async_method('header_exists')
+
+    get_block_header_by_hash = sync_method('get_block_header_by_hash')
+    get_canonical_block_header_by_number = sync_method('get_canonical_block_header_by_number')
+    get_canonical_head = sync_method('get_canonical_head')
+    import_header = sync_method('import_header')
+    header_exists = sync_method('header_exists')

--- a/trinity/db/header.py
+++ b/trinity/db/header.py
@@ -1,0 +1,102 @@
+from abc import ABCMeta, abstractmethod
+# Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
+# https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
+from multiprocessing.managers import (  # type: ignore
+    BaseProxy,
+)
+from typing import Tuple
+
+from eth_typing import (
+    Hash32,
+    BlockNumber,
+)
+
+from evm.db.header import (
+    BaseHeaderDB,
+    HeaderDB,
+)
+from evm.rlp.headers import BlockHeader
+
+from trinity.utils.mp import (
+    async_method,
+    sync_method,
+)
+
+
+class BaseAsyncHeaderDB(metaclass=ABCMeta):
+    #
+    # Canonical Chain API
+    #
+    @abstractmethod
+    async def coro_get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeader:  # noqa: E501
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_canonical_head(self) -> BlockHeader:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    #
+    # Header API
+    #
+    @abstractmethod
+    async def coro_get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_score(self, block_hash: Hash32) -> int:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_header_exists(self, block_hash: Hash32) -> bool:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+
+class AsyncHeaderDB(HeaderDB, BaseAsyncHeaderDB):
+    async def coro_get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeader:  # noqa: E501
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_canonical_head(self) -> BlockHeader:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_score(self, block_hash: Hash32) -> int:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_header_exists(self, block_hash: Hash32) -> bool:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+
+class AsyncHeaderDBProxy(BaseProxy, BaseAsyncHeaderDB, BaseHeaderDB):
+    coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
+    coro_get_canonical_block_hash = async_method('get_canonical_block_hash')
+    coro_get_canonical_block_header_by_number = async_method('get_canonical_block_header_by_number')
+    coro_get_canonical_head = async_method('get_canonical_head')
+    coro_get_score = async_method('get_score')
+    coro_header_exists = async_method('header_exists')
+    coro_get_canonical_block_hash = async_method('get_canonical_block_hash')
+    coro_persist_header = async_method('persist_header')
+
+    get_block_header_by_hash = sync_method('get_block_header_by_hash')
+    get_canonical_block_hash = sync_method('get_canonical_block_hash')
+    get_canonical_block_header_by_number = sync_method('get_canonical_block_header_by_number')
+    get_canonical_head = sync_method('get_canonical_head')
+    get_score = sync_method('get_score')
+    header_exists = sync_method('header_exists')
+    get_canonical_block_hash = sync_method('get_canonical_block_hash')
+    persist_header = sync_method('persist_header')

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -35,6 +35,9 @@ from trinity.chains.mainnet import (
 from trinity.chains.ropsten import (
     RopstenLightChain,
 )
+from trinity.chains.header import (
+    AsyncHeaderChainProxy,
+)
 from trinity.console import (
     console,
 )
@@ -43,6 +46,7 @@ from trinity.constants import (
 )
 from trinity.db.chain import ChainDBProxy
 from trinity.db.base import DBProxy
+from trinity.db.header import AsyncHeaderDBProxy
 from trinity.cli_parser import (
     parser,
 )
@@ -164,6 +168,8 @@ def create_dbmanager(ipc_path: str) -> BaseManager:
     DBManager.register('get_db', proxytype=DBProxy)  # type: ignore
     DBManager.register('get_chaindb', proxytype=ChainDBProxy)  # type: ignore
     DBManager.register('get_chain', proxytype=ChainProxy)  # type: ignore
+    DBManager.register('get_headerdb', proxytype=AsyncHeaderDBProxy)  # type: ignore
+    DBManager.register('get_header_chain', proxytype=AsyncHeaderChainProxy)  # type: ignore
 
     manager = DBManager(address=ipc_path)  # type: ignore
     manager.connect()  # type: ignore


### PR DESCRIPTION
### What was wrong?

Trinity needs it's own classes for interacting with the `HeaderChain` and `HeaderDB`.

### How was it fixed?

- `BaseAsyncXXXXXXX` defines the async API
- `AsyncXXXX` provides an instantiatable async version of the class for use with the actual database server.
- `AsyncXXXXProxy` exposes the API over the multiprocessing `Proxy` object.
- updated the database process to serve these objects.

#### Cute Animal Picture

![54e88192d8645a0811fb526e591ff60a](https://user-images.githubusercontent.com/824194/40006585-006292b2-5758-11e8-80de-6c7759f432f0.jpg)

