### PR TITLE
Move setup logic for token to Service class

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -42,10 +42,7 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
                  chaindb: AsyncChainDB,
                  peer_pool: PeerPool,
                  token: CancelToken = None) -> None:
-        cancel_token = CancelToken('ChainSyncer')
-        if token is not None:
-            cancel_token = cancel_token.chain(token)
-        super().__init__(cancel_token)
+        super().__init__(token)
         self.chaindb = chaindb
         self.peer_pool = peer_pool
         self._running_peers = set()  # type: Set[ETHPeer]

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -13,9 +13,14 @@ class BaseService(ABC):
     # Number of seconds cancel() will wait for run() to finish.
     _wait_until_finished_timeout = 5
 
-    def __init__(self, token: CancelToken) -> None:
+    def __init__(self, token: CancelToken=None) -> None:
         self.finished = asyncio.Event()
-        self.cancel_token = token
+
+        base_token = CancelToken(type(self).__name__)
+        if token is None:
+            self.cancel_token = base_token
+        else:
+            self.cancel_token = base_token.chain(token)
 
     async def run(
             self,

--- a/p2p/sharding.py
+++ b/p2p/sharding.py
@@ -147,10 +147,7 @@ class ShardingPeer(BasePeer):
 class ShardSyncer(BaseService, PeerPoolSubscriber):
     logger = logging.getLogger("p2p.sharding.ShardSyncer")
 
-    def __init__(self, shard: Shard, peer_pool: PeerPool, token: CancelToken) -> None:
-        cancel_token = CancelToken("ShardSyncer")
-        if token is not None:
-            cancel_token = cancel_token.chain(token)
+    def __init__(self, shard: Shard, peer_pool: PeerPool, token: CancelToken=None) -> None:
         super().__init__(token)
 
         self.shard = shard

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -52,10 +52,7 @@ class StateDownloader(BaseService, PeerPoolSubscriber):
                  root_hash: bytes,
                  peer_pool: PeerPool,
                  token: CancelToken = None) -> None:
-        cancel_token = CancelToken('StateDownloader')
-        if token is not None:
-            cancel_token = cancel_token.chain(token)
-        super().__init__(cancel_token)
+        super().__init__(token)
         self.peer_pool = peer_pool
         self.root_hash = root_hash
         self.scheduler = StateSync(root_hash, account_db)

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -25,10 +25,7 @@ class FullNodeSyncer(BaseService):
                  db: BaseDB,
                  peer_pool: PeerPool,
                  token: CancelToken = None) -> None:
-        cancel_token = CancelToken('FullNodeSyncer')
-        if token is not None:
-            cancel_token = cancel_token.chain(token)
-        super().__init__(cancel_token)
+        super().__init__(token)
         self.chain = chain
         self.chaindb = chaindb
         self.db = db


### PR DESCRIPTION
### What was wrong?

There were multiple subclasses of the `Service` class all implementing the same logic for conditionally chaining it's cancel token with a parent token.

### How was it fixed?

Moved the logic into the constructor for the base `Service` class.

#### Cute Animal Picture

![chicks-in-hats7](https://user-images.githubusercontent.com/824194/40066885-52656f6a-5822-11e8-8741-a9fcde89b97f.jpg)

