### PR TITLE
Change `Chain` class to expect a `BaseDB` instance for instantiation.

### DIFF
--- a/docs/guides/evm/building_chains.rst
+++ b/docs/guides/evm/building_chains.rst
@@ -35,14 +35,12 @@ Then to initialize, you can start it up with an in-memory database:
 ::
 
   from evm.db.backends.memory import MemoryDB
-  from evm.db.chain import ChainDB
   from evm.chains.mainnet import MAINNET_GENESIS_HEADER
 
   # start a fresh in-memory db
-  chaindb = ChainDB(MemoryDB())
 
   # initialize a fresh chain
-  chain = chain_class.from_genesis_header(chaindb, MAINNET_GENESIS_HEADER)
+  chain = chain_class.from_genesis_header(MemoryDB(), MAINNET_GENESIS_HEADER)
 
 
 Using the LightChain object
@@ -75,15 +73,16 @@ its `run()` method:
 
   import asyncio
   from evm.db.backends.memory import MemoryDB
-  from evm.db.chain import ChainDB
+  from evm.db.header import HeaderDB
   from evm.chains.mainnet import 
 
   # start a fresh in-memory db
-  chaindb = ChainDB(MemoryDB())
+  base_db = MemoryDB()
+  headerdb = HeaderDB(base_db)
 
-  peer_pool = PeerPool(LESPeer, chaindb, MAINNET_NETWORK_ID, ecies.generate_privkey())
+  peer_pool = PeerPool(LESPeer, headerdb, MAINNET_NETWORK_ID, ecies.generate_privkey())
 
-  chain = DemoLightChain.from_genesis_header(chaindb, MAINNET_GENESIS_HEADER, peer_pool)
+  chain = DemoLightChain.from_genesis_header(base_db, MAINNET_GENESIS_HEADER, peer_pool)
   loop = asyncio.get_event_loop()
   loop.run_until_complete(chain.run())
 

--- a/evm/chains/header.py
+++ b/evm/chains/header.py
@@ -19,7 +19,7 @@ from evm.vm.base import BaseVM  # noqa: F401
 
 
 class BaseHeaderChain(Configurable, metaclass=ABCMeta):
-    _basedb = None  # type: BaseDB
+    _base_db = None  # type: BaseDB
 
     _headerdb_class = None  # type: Type[BaseHeaderDB]
     _headerdb = None  # type: BaseHeaderDB
@@ -29,7 +29,7 @@ class BaseHeaderChain(Configurable, metaclass=ABCMeta):
     vm_configuration = None  # type: Tuple[Tuple[int, Type[BaseVM]], ...]
 
     @abstractmethod
-    def __init__(self, basedb: BaseDB, header: BlockHeader=None) -> None:
+    def __init__(self, base_db: BaseDB, header: BlockHeader=None) -> None:
         raise NotImplementedError("Chain classes must implement this method")
 
     #
@@ -38,7 +38,7 @@ class BaseHeaderChain(Configurable, metaclass=ABCMeta):
     @classmethod
     @abstractmethod
     def from_genesis_header(cls,
-                            basedb: BaseDB,
+                            base_db: BaseDB,
                             genesis_header: BlockHeader) -> 'BaseHeaderChain':
         raise NotImplementedError("Chain classes must implement this method")
 
@@ -80,9 +80,9 @@ class BaseHeaderChain(Configurable, metaclass=ABCMeta):
 class HeaderChain(BaseHeaderChain):
     _headerdb_class = HeaderDB  # type: Type[BaseHeaderDB]
 
-    def __init__(self, basedb: BaseDB, header: BlockHeader=None) -> None:
-        self.basedb = basedb
-        self.headerdb = self.get_headerdb_class()(basedb)
+    def __init__(self, base_db: BaseDB, header: BlockHeader=None) -> None:
+        self.base_db = base_db
+        self.headerdb = self.get_headerdb_class()(base_db)
 
         if header is None:
             self.header = self.get_canonical_head()
@@ -94,14 +94,14 @@ class HeaderChain(BaseHeaderChain):
     #
     @classmethod
     def from_genesis_header(cls,
-                            basedb: BaseDB,
+                            base_db: BaseDB,
                             genesis_header: BlockHeader) -> 'BaseHeaderChain':
         """
         Initializes the chain from the genesis header.
         """
-        headerdb = cls.get_headerdb_class()(basedb)
+        headerdb = cls.get_headerdb_class()(base_db)
         headerdb.persist_header(genesis_header)
-        return cls(basedb, genesis_header)
+        return cls(base_db, genesis_header)
 
     #
     # Helpers

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -79,6 +79,10 @@ class TransactionKey(rlp.Serializable):
 class BaseChainDB(metaclass=ABCMeta):
     db = None  # type: BaseDB
 
+    @abstractmethod
+    def __init__(self, db: BaseDB) -> None:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
     #
     # Canonical Chain API
     #

--- a/evm/tools/fixture_tests.py
+++ b/evm/tools/fixture_tests.py
@@ -35,8 +35,7 @@ from evm import MainnetChain
 from evm.constants import (
     CREATE_CONTRACT_ADDRESS,
 )
-from evm.db import get_db_backend
-from evm.db.chain import ChainDB
+from evm.db.backends.memory import MemoryDB
 from evm.utils.state import (
     diff_account_db,
 )
@@ -599,7 +598,7 @@ def genesis_params_from_fixture(fixture):
 
 
 def new_chain_from_fixture(fixture):
-    db = ChainDB(get_db_backend())
+    base_db = MemoryDB()
 
     vm_config = chain_vm_configuration(fixture)
 
@@ -609,7 +608,7 @@ def new_chain_from_fixture(fixture):
     )
 
     return ChainFromFixture.from_genesis(
-        db,
+        base_db,
         genesis_params=genesis_params_from_fixture(fixture),
         genesis_state=fixture['pre'],
     )

--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -485,7 +485,7 @@ def _test() -> None:
     from evm.chains.ropsten import RopstenChain, ROPSTEN_GENESIS_HEADER
     from evm.db.backends.level import LevelDB
     from tests.p2p.integration_test_helpers import (
-        FakeAsyncChainDB, FakeAsyncRopstenChain, LocalGethPeerPool)
+        FakeAsyncChainDB, FakeAsyncRopstenChain, LocalGethPeerPool, FakeAsyncHeaderDB)
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-db', type=str, required=True)
@@ -505,23 +505,35 @@ def _test() -> None:
     # Use a ProcessPoolExecutor as the default because the tasks we want to offload from the main
     # thread are cpu intensive.
     loop.set_default_executor(ProcessPoolExecutor())
-    chaindb = FakeAsyncChainDB(LevelDB(args.db))
+
+    base_db = LevelDB(args.db)
+
+    chaindb = FakeAsyncChainDB(base_db)
     chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
+
+    headerdb = FakeAsyncHeaderDB(base_db)
+
     privkey = ecies.generate_privkey()
     if args.local_geth:
-        peer_pool = LocalGethPeerPool(ETHPeer, chaindb, RopstenChain.network_id, privkey)
+        peer_pool = LocalGethPeerPool(ETHPeer, headerdb, RopstenChain.network_id, privkey)
     else:
         from p2p.peer import HardCodedNodesPeerPool
         discovery = None
         min_peers = 5
         peer_pool = HardCodedNodesPeerPool(
-            ETHPeer, chaindb, RopstenChain.network_id, privkey, discovery, min_peers)
+            peer_class=ETHPeer,
+            headerdb=headerdb,
+            network_id=RopstenChain.network_id,
+            privkey=privkey,
+            discovery=discovery,
+            min_peers=min_peers,
+        )
 
     asyncio.ensure_future(peer_pool.run())
     if args.fast:
         syncer = FastChainSyncer(chaindb, peer_pool)
     else:
-        chain = FakeAsyncRopstenChain(chaindb)
+        chain = FakeAsyncRopstenChain(base_db)
         syncer = RegularChainSyncer(chain, chaindb, peer_pool)
     syncer.min_peers_to_sync = 1
 

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -75,7 +75,7 @@ class Server(BaseService):
                  chain: AsyncChain,
                  chaindb: AsyncChainDB,
                  headerdb: 'BaseAsyncHeaderDB',
-                 db: BaseDB,
+                 base_db: BaseDB,
                  network_id: int,
                  min_peers: int = DEFAULT_MIN_PEERS,
                  peer_class: Type[BasePeer] = ETHPeer,
@@ -106,7 +106,7 @@ class Server(BaseService):
             self.discovery,
             min_peers=min_peers,
         )
-        self.syncer = FullNodeSyncer(chain, chaindb, db, self.peer_pool, self.cancel_token)
+        self.syncer = FullNodeSyncer(chain, chaindb, base_db, self.peer_pool, self.cancel_token)
 
     async def refresh_nat_portmap(self) -> None:
         """Run an infinite loop refreshing our NAT port mapping.

--- a/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
+++ b/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
@@ -49,12 +49,17 @@ class ChainForTesting(Chain):
 
 
 @pytest.fixture()
-def chaindb():
-    return ChainDB(MemoryDB())
+def base_db():
+    return MemoryDB()
 
 
-def test_header_chain_get_vm_class_for_block_number(chaindb, genesis_header):
-    chain = ChainForTesting.from_genesis_header(chaindb, genesis_header)
+@pytest.fixture()
+def chaindb(base_db):
+    return ChainDB(base_db)
+
+
+def test_header_chain_get_vm_class_for_block_number(base_db, genesis_header):
+    chain = ChainForTesting.from_genesis_header(base_db, genesis_header)
 
     assert chain.get_vm_class_for_block_number(0) is VM_A
 
@@ -67,10 +72,10 @@ def test_header_chain_get_vm_class_for_block_number(chaindb, genesis_header):
         assert chain.get_vm_class_for_block_number(num) is VM_B
 
 
-def test_header_chain_invalid_if_no_vm_configuration(genesis_header):
+def test_header_chain_invalid_if_no_vm_configuration(base_db, genesis_header):
     chain_class = Chain.configure('ChainNoEmptyConfiguration', vm_configuration=())
     with pytest.raises(ValueError):
-        chain_class(chaindb, genesis_header)
+        chain_class(base_db, genesis_header)
 
 
 def test_vm_not_found_if_no_matching_block_number(genesis_header):

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -9,8 +9,7 @@ from eth_keys import keys
 
 from evm import Chain
 from evm import constants
-from evm.db import get_db_backend
-from evm.db.chain import ChainDB
+from evm.db.backends.memory import MemoryDB
 # TODO: tests should not be locked into one set of VM rules.  Look at expanding
 # to all mainnet vms.
 from evm.vm.forks.spurious_dragon import SpuriousDragonVM
@@ -38,12 +37,12 @@ def funded_address_initial_balance():
 
 
 @pytest.fixture
-def chaindb():
-    return ChainDB(get_db_backend())
+def base_db():
+    return MemoryDB()
 
 
 @pytest.fixture
-def chain_with_block_validation(chaindb, funded_address, funded_address_initial_balance):
+def chain_with_block_validation(base_db, funded_address, funded_address_initial_balance):
     """
     Return a Chain object containing just the genesis block.
 
@@ -84,12 +83,12 @@ def chain_with_block_validation(chaindb, funded_address, funded_address_initial_
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVM),
         ))
-    chain = klass.from_genesis(chaindb, genesis_params, genesis_state)
+    chain = klass.from_genesis(base_db, genesis_params, genesis_state)
     return chain
 
 
 @pytest.fixture
-def chain_without_block_validation(chaindb, funded_address, funded_address_initial_balance):
+def chain_without_block_validation(base_db, funded_address, funded_address_initial_balance):
     """
     Return a Chain object containing just the genesis block.
 
@@ -130,5 +129,5 @@ def chain_without_block_validation(chaindb, funded_address, funded_address_initi
             'storage': {},
         }
     }
-    chain = klass.from_genesis(chaindb, genesis_params, genesis_state)
+    chain = klass.from_genesis(base_db, genesis_params, genesis_state)
     return chain

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -12,9 +12,7 @@ from eth_hash.auto import keccak
 from evm.constants import (
     BLANK_ROOT_HASH,
 )
-from evm.db import (
-    get_db_backend,
-)
+from evm.db.backends.memory import MemoryDB
 from evm.db.chain import (
     ChainDB,
 )
@@ -50,8 +48,13 @@ def set_empty_root(chaindb, header):
 
 
 @pytest.fixture
-def chaindb(request):
-    return ChainDB(get_db_backend())
+def base_db():
+    return MemoryDB()
+
+
+@pytest.fixture
+def chaindb(base_db):
+    return ChainDB(base_db)
 
 
 @pytest.fixture(params=[0, 10, 999])

--- a/tests/p2p/test_server.py
+++ b/tests/p2p/test_server.py
@@ -44,18 +44,18 @@ INITIATOR_REMOTE = Node(INITIATOR_PUBKEY, INITIATOR_ADDRESS)
 
 
 def get_server(privkey, address, peer_class):
-    db = MemoryDB()
-    headerdb = HeaderDB(db)
-    chaindb = ChainDB(db)
+    base_db = MemoryDB()
+    headerdb = HeaderDB(base_db)
+    chaindb = ChainDB(base_db)
     chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
-    chain = RopstenChain(chaindb)
+    chain = RopstenChain(base_db)
     server = Server(
         privkey,
         address,
         chain,
         chaindb,
         headerdb,
-        db,
+        base_db,
         network_id=1,
         min_peers=1,
         peer_class=peer_class,

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -116,8 +116,8 @@ def initialize_database(chain_config: ChainConfig, chaindb: AsyncChainDB) -> Non
             )
 
 
-def serve_chaindb(chain_config: ChainConfig, db: BaseDB) -> None:
-    chaindb = AsyncChainDB(db)
+def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
+    chaindb = AsyncChainDB(base_db)
 
     if not is_database_initialized(chaindb):
         initialize_database(chain_config, chaindb)
@@ -129,17 +129,17 @@ def serve_chaindb(chain_config: ChainConfig, db: BaseDB) -> None:
         raise NotImplementedError(
             "Only the mainnet and ropsten chains are currently supported"
         )
-    chain = chain_class(chaindb)  # type: ignore
+    chain = chain_class(base_db)  # type: ignore
 
-    headerdb = AsyncHeaderDB(db)
-    header_chain = AsyncHeaderChain(db)
+    headerdb = AsyncHeaderDB(base_db)
+    header_chain = AsyncHeaderChain(base_db)
 
     class DBManager(BaseManager):
         pass
 
     # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
     # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
-    DBManager.register('get_db', callable=lambda: db, proxytype=DBProxy)  # type: ignore
+    DBManager.register('get_db', callable=lambda: base_db, proxytype=DBProxy)  # type: ignore
 
     DBManager.register(  # type: ignore
         'get_chaindb',

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -8,6 +8,7 @@ import signal
 import sys
 from typing import Type
 
+from evm.db.backends.base import BaseDB
 from evm.db.backends.level import LevelDB
 from evm.chains.mainnet import (
     MAINNET_NETWORK_ID,
@@ -154,10 +155,10 @@ def main() -> None:
 
 
 @with_queued_logging
-def run_database_process(chain_config: ChainConfig, db_class: Type[LevelDB]) -> None:
-    db = db_class(db_path=chain_config.database_dir)
+def run_database_process(chain_config: ChainConfig, db_class: Type[BaseDB]) -> None:
+    base_db = db_class(db_path=chain_config.database_dir)
 
-    serve_chaindb(chain_config, db)
+    serve_chaindb(chain_config, base_db)
 
 
 def create_dbmanager(ipc_path: str) -> BaseManager:


### PR DESCRIPTION
### What was wrong?

The `Chain` class expected a `ChainDB` instance to be instantiated.  Changing this to be a `base_db` will make the transition to having the `Chain` use the `HeaderDB` easier.

### How was it fixed?

The `Chain` class now expects a `base_db` and it instantiates its own `ChainDB` instance.

#### Cute Animal Picture

![b7e4dd20353d3ccffd0476d091050fdb](https://user-images.githubusercontent.com/824194/40087099-61c14c22-585e-11e8-9269-3fbaa9beb0c9.jpg)
