### PR TITLE
Keymap db

### DIFF
--- a/evm/db/hash_trie.py
+++ b/evm/db/hash_trie.py
@@ -1,28 +1,10 @@
+from functools import partial
+
 from eth_hash.auto import keccak
 
+from evm.db.keymap import (
+    KeyMapDB,
+)
 
-class HashTrie(object):
-    _trie = None
 
-    def __init__(self, trie):
-        self._trie = trie
-
-    def __setitem__(self, key, value):
-        self._trie[keccak(key)] = value
-
-    def __getitem__(self, key):
-        return self._trie[keccak(key)]
-
-    def __delitem__(self, key):
-        del self._trie[keccak(key)]
-
-    def __contains__(self, key):
-        return keccak(key) in self._trie
-
-    @property
-    def root_hash(self):
-        return self._trie.root_hash
-
-    @root_hash.setter
-    def root_hash(self, value):
-        self._trie.root_hash = value
+HashTrie = partial(KeyMapDB, keccak)

--- a/evm/db/hash_trie.py
+++ b/evm/db/hash_trie.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 from eth_hash.auto import keccak
 
 from evm.db.keymap import (
@@ -7,4 +5,5 @@ from evm.db.keymap import (
 )
 
 
-HashTrie = partial(KeyMapDB, keccak)
+class HashTrie(KeyMapDB):
+    keymap = keccak

--- a/evm/db/keymap.py
+++ b/evm/db/keymap.py
@@ -1,0 +1,36 @@
+from evm.db.backends.base import BaseDB
+
+
+class KeyMapDB(BaseDB):
+    """
+    Modify keys when accessing the database, accourding to the
+    keymap function set at initialization.
+    """
+    def __init__(self, keymap, db):
+        self._keymap = keymap
+        self._db = db
+
+    def __getitem__(self, key):
+        mapped_key = self._keymap(key)
+        return self._db[mapped_key]
+
+    def __setitem__(self, key, val):
+        mapped_key = self._keymap(key)
+        self._db[mapped_key] = val
+
+    def __delitem__(self, key):
+        mapped_key = self._keymap(key)
+        del self._db[mapped_key]
+
+    def __contains__(self, key):
+        mapped_key = self._keymap(key)
+        return mapped_key in self._db
+
+    def __getattr__(self, attr):
+        return getattr(self._db, attr)
+
+    def __setattr__(self, attr, val):
+        if attr in ('_db', '_keymap'):
+            super().__setattr__(attr, val)
+        else:
+            setattr(self._db, attr, val)

--- a/evm/db/keymap.py
+++ b/evm/db/keymap.py
@@ -1,36 +1,44 @@
+from abc import (
+    abstractmethod,
+)
+
 from evm.db.backends.base import BaseDB
 
 
 class KeyMapDB(BaseDB):
     """
-    Modify keys when accessing the database, accourding to the
-    keymap function set at initialization.
+    Modify keys when accessing the database, according to the
+    abstract keymap function set in the subclass.
     """
-    def __init__(self, keymap, db):
-        self._keymap = keymap
+    def __init__(self, db):
         self._db = db
 
+    @staticmethod
+    @abstractmethod
+    def keymap(key: bytes) -> bytes:
+        raise NotImplementedError
+
     def __getitem__(self, key):
-        mapped_key = self._keymap(key)
+        mapped_key = self.keymap(key)
         return self._db[mapped_key]
 
     def __setitem__(self, key, val):
-        mapped_key = self._keymap(key)
+        mapped_key = self.keymap(key)
         self._db[mapped_key] = val
 
     def __delitem__(self, key):
-        mapped_key = self._keymap(key)
+        mapped_key = self.keymap(key)
         del self._db[mapped_key]
 
     def __contains__(self, key):
-        mapped_key = self._keymap(key)
+        mapped_key = self.keymap(key)
         return mapped_key in self._db
 
     def __getattr__(self, attr):
         return getattr(self._db, attr)
 
     def __setattr__(self, attr, val):
-        if attr in ('_db', '_keymap'):
+        if attr in ('_db', 'keymap'):
             super().__setattr__(attr, val)
         else:
             setattr(self._db, attr, val)

--- a/tests/database/test_hash_trie.py
+++ b/tests/database/test_hash_trie.py
@@ -1,0 +1,62 @@
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+from eth_hash.auto import keccak
+from trie import HexaryTrie
+
+from evm.db.hash_trie import (
+    HashTrie,
+)
+
+
+class ExplicitHashTrie(object):
+    _trie = None
+
+    def __init__(self, trie):
+        self._trie = trie
+
+    def __setitem__(self, key, value):
+        self._trie[keccak(key)] = value
+
+    def __getitem__(self, key):
+        return self._trie[keccak(key)]
+
+    def __delitem__(self, key):
+        del self._trie[keccak(key)]
+
+    def __contains__(self, key):
+        return keccak(key) in self._trie
+
+    @property
+    def root_hash(self):
+        return self._trie.root_hash
+
+    @root_hash.setter
+    def root_hash(self, value):
+        self._trie.root_hash = value
+
+
+@given(st.binary(), st.binary())
+def test_keymap_equivalence(key, val):
+    explicit_db = {}
+    composed_db = {}
+
+    explicit_trie = HexaryTrie(explicit_db)
+    composed_trie = HexaryTrie(composed_db)
+
+    explicit = ExplicitHashTrie(explicit_trie)
+    composed = HashTrie(composed_trie)
+
+    explicit[key] = val
+    composed[key] = val
+
+    assert explicit[key] == composed[key]
+    assert explicit_db == composed_db
+    assert explicit.root_hash == composed.root_hash
+
+    explicit.root_hash = b'\0' * 32
+    composed.root_hash = b'\0' * 32
+
+    assert explicit_trie.root_hash == composed_trie.root_hash


### PR DESCRIPTION
### What was wrong?

A few other places use a key mapping DB (like Storage). Don't want to rewrite a new one like `HashTrie` each time.

### How was it fixed?

Added a generic `KeyMapDB`, plus a `HashTrie` alias that uses `keccak` as the key mapper.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/qI3KPsti-Sg/maxresdefault.jpg)
