### PR TITLE
Move all AsyncChain and AsyncChainDB into trinity

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -375,7 +375,7 @@ class Chain(BaseChain):
             ))
 
         init_header = self.create_header_from_parent(parent_header)
-        return type(self)(self.chaindb.db, init_header)
+        return type(self)(self.base_db, init_header)
 
     #
     # VM API
@@ -421,7 +421,7 @@ class Chain(BaseChain):
         Raises BlockNotFound if there's no block header with the given hash in the db.
         """
         validate_word(block_hash, title="Block Hash")
-        return self.chaindb.get_block_header_by_hash(block_hash)
+        return self.headerdb.get_block_header_by_hash(block_hash)
 
     def get_canonical_head(self):
         """
@@ -429,7 +429,7 @@ class Chain(BaseChain):
 
         Raises CanonicalHeadNotFound if there's no head defined for the canonical chain.
         """
-        return self.chaindb.get_canonical_head()
+        return self.headerdb.get_canonical_head()
 
     #
     # Block API
@@ -472,7 +472,7 @@ class Chain(BaseChain):
         canonical chain.
         """
         validate_uint256(block_number, title="Block Number")
-        return self.get_block_by_hash(self.chaindb.get_canonical_block_hash(block_number))
+        return self.get_block_by_hash(self.headerdb.get_canonical_block_hash(block_number))
 
     def get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
         """
@@ -481,7 +481,7 @@ class Chain(BaseChain):
         Raises BlockNotFound if there's no block with the given number in the
         canonical chain.
         """
-        return self.chaindb.get_canonical_block_hash(block_number)
+        return self.headerdb.get_canonical_block_hash(block_number)
 
     #
     # Transaction API
@@ -600,6 +600,8 @@ class Chain(BaseChain):
 
         self.validate_block(mined_block)
 
+        # first persist the header
+        self.headerdb.persist_header(mined_block.header)
         self.chaindb.persist_block(mined_block)
         self.header = self.create_header_from_parent(self.get_canonical_head())
         return mined_block

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -6,7 +6,6 @@ from abc import (
     abstractmethod
 )
 from typing import (
-    cast,
     Dict,
     Iterable,
     List,
@@ -33,13 +32,8 @@ from eth_utils import (
 
 from eth_hash.auto import keccak
 
-from evm.constants import (
-    GENESIS_PARENT_HASH,
-)
 from evm.exceptions import (
-    CanonicalHeadNotFound,
     HeaderNotFound,
-    ParentNotFound,
     TransactionNotFound,
 )
 from evm.db.backends.base import (
@@ -56,7 +50,6 @@ from evm.utils.hexadecimal import (
     encode_hex,
 )
 from evm.validation import (
-    validate_uint256,
     validate_word,
 )
 
@@ -84,41 +77,10 @@ class BaseChainDB(metaclass=ABCMeta):
         raise NotImplementedError("ChainDB classes must implement this method")
 
     #
-    # Canonical Chain API
+    # Uncles API
     #
-    @abstractmethod
-    def get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeader:
-        raise NotImplementedError("ChainDB classes must implement this method")
-
-    @abstractmethod
-    def get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
-        raise NotImplementedError("ChainDB classes must implement this method")
-
-    @abstractmethod
-    def get_canonical_head(self) -> BlockHeader:
-        raise NotImplementedError("ChainDB classes must implement this method")
-
-    #
-    # Header API
-    #
-    @abstractmethod
-    def header_exists(self, block_hash: Hash32) -> bool:
-        raise NotImplementedError("ChainDB classes must implement this method")
-
-    @abstractmethod
-    def get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
-        raise NotImplementedError("ChainDB classes must implement this method")
-
     @abstractmethod
     def get_block_uncles(self, uncles_hash: Hash32) -> List[BlockHeader]:
-        raise NotImplementedError("ChainDB classes must implement this method")
-
-    @abstractmethod
-    def get_score(self, block_hash: Hash32) -> int:
-        raise NotImplementedError("ChainDB classes must implement this method")
-
-    @abstractmethod
-    def persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
         raise NotImplementedError("ChainDB classes must implement this method")
 
     #
@@ -189,226 +151,25 @@ class BaseChainDB(metaclass=ABCMeta):
 
 
 class ChainDB(BaseChainDB):
-    def __init__(self, db: BaseDB) -> None:
-        self.db = db
+    def __init__(self, base_db: BaseDB) -> None:
+        self.base_db = base_db
 
     #
-    # Canonical Chain API
+    # Uncles API
     #
-    def get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
-        """
-        Return the block hash for the given block number.
-        """
-        validate_uint256(block_number, title="Block Number")
-        number_to_hash_key = SchemaV1.make_block_number_to_hash_lookup_key(block_number)
-        try:
-            return rlp.decode(
-                self.db[number_to_hash_key],
-                sedes=rlp.sedes.binary,
-            )
-        except KeyError:
-            raise HeaderNotFound(
-                "No header found on the canonical chain with number {0}".format(block_number)
-            )
-
-    def get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeader:
-        """
-        Returns the block header with the given number in the canonical chain.
-
-        Raises HeaderNotFound if there's no block header with the given number in the
-        canonical chain.
-        """
-        validate_uint256(block_number, title="Block Number")
-        return self.get_block_header_by_hash(self.get_canonical_block_hash(block_number))
-
-    def get_canonical_head(self) -> BlockHeader:
-        """
-        Returns the current block header at the head of the chain.
-
-        Raises CanonicalHeadNotFound if no canonical head has been set.
-        """
-        try:
-            canonical_head_hash = self.db[SchemaV1.make_canonical_head_hash_lookup_key()]
-        except KeyError:
-            raise CanonicalHeadNotFound("No canonical head set for this chain")
-        return self.get_block_header_by_hash(
-            cast(Hash32, canonical_head_hash),
-        )
-
-    #
-    # Header API
-    #
-    def header_exists(self, block_hash: Hash32) -> bool:
-        """
-        Returns True if the header with the given hash is in our DB.
-        """
-        return self.db.exists(block_hash)
-
-    def get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
-        """
-        Returns the requested block header as specified by block hash.
-
-        Raises HeaderNotFound if it is not present in the db.
-        """
-        validate_word(block_hash, title="Block Hash")
-        try:
-            header_rlp = self.db[block_hash]
-        except KeyError:
-            raise HeaderNotFound(
-                "No header with hash {0} found".format(encode_hex(block_hash))
-            )
-        return _decode_block_header(header_rlp)
-
     def get_block_uncles(self, uncles_hash: Hash32) -> List[BlockHeader]:
         """
         Returns an iterable of uncle headers specified by the given uncles_hash
         """
         validate_word(uncles_hash, title="Uncles Hash")
         try:
-            encoded_uncles = self.db[uncles_hash]
+            encoded_uncles = self.base_db[uncles_hash]
         except KeyError:
             raise HeaderNotFound(
                 "No uncles found for hash {0}".format(uncles_hash)
             )
         else:
             return rlp.decode(encoded_uncles, sedes=rlp.sedes.CountableList(BlockHeader))
-
-    def get_score(self, block_hash: Hash32) -> int:
-        """
-        Returns the score for the header with the given hash.
-
-        Raises HeaderNotFound if no header with the given has is found in the database.
-        """
-        try:
-            encoded_score = self.db[SchemaV1.make_block_hash_to_score_lookup_key(block_hash)]
-        except KeyError:
-            raise HeaderNotFound(
-                "No header with hash {0} found".format(encode_hex(block_hash))
-            )
-        else:
-            return rlp.decode(
-                encoded_score,
-                sedes=rlp.sedes.big_endian_int,
-            )
-
-    # TODO: This method should take a chain of headers as that's the most common use case
-    # and it'd be much faster than inserting each header individually.
-    def persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
-        """
-        Returns iterable of headers newly on the canonical chain
-        """
-        is_genesis = header.parent_hash == GENESIS_PARENT_HASH
-        if not is_genesis and not self.header_exists(header.parent_hash):
-            raise ParentNotFound(
-                "Cannot persist block header ({}) with unknown parent ({})".format(
-                    encode_hex(header.hash), encode_hex(header.parent_hash)))
-
-        self.db.set(
-            header.hash,
-            rlp.encode(header),
-        )
-
-        if is_genesis:
-            score = header.difficulty
-        else:
-            score = self.get_score(header.parent_hash) + header.difficulty
-
-        self.db.set(
-            SchemaV1.make_block_hash_to_score_lookup_key(header.hash),
-            rlp.encode(score, sedes=rlp.sedes.big_endian_int),
-        )
-
-        try:
-            head_score = self.get_score(self.get_canonical_head().hash)
-        except CanonicalHeadNotFound:
-            new_headers = self._set_as_canonical_chain_head(header)
-        else:
-            if score > head_score:
-                new_headers = self._set_as_canonical_chain_head(header)
-            else:
-                new_headers = tuple()
-
-        return new_headers
-
-    # TODO: update this to take a `hash` rather than a full header object.
-    def _set_as_canonical_chain_head(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
-        """
-        Returns iterable of headers newly on the canonical head
-        """
-        try:
-            self.get_block_header_by_hash(header.hash)
-        except HeaderNotFound:
-            raise ValueError("Cannot use unknown block hash as canonical head: {}".format(
-                header.hash))
-
-        new_canonical_headers = tuple(reversed(self._find_new_ancestors(header)))
-
-        # remove transaction lookups for blocks that are no longer canonical
-        for h in new_canonical_headers:
-            try:
-                old_hash = self.get_canonical_block_hash(h.block_number)
-            except HeaderNotFound:
-                # no old block, and no more possible
-                break
-            else:
-                old_header = self.get_block_header_by_hash(old_hash)
-                for transaction_hash in self.get_block_transaction_hashes(old_header):
-                    self._remove_transaction_from_canonical_chain(transaction_hash)
-                    # TODO re-add txn to internal pending pool (only if local sender)
-                    pass
-
-        for h in new_canonical_headers:
-            self._add_block_number_to_hash_lookup(h)
-
-        self.db.set(SchemaV1.make_canonical_head_hash_lookup_key(), header.hash)
-
-        return new_canonical_headers
-
-    @to_tuple
-    def _find_new_ancestors(self, header: BlockHeader) -> Iterable[BlockHeader]:
-        """
-        Returns the chain leading up from the given header until (but not including)
-        the first ancestor it has in common with our canonical chain.
-
-        If D is the canonical head in the following chain, and F is the new header,
-        then this function returns (F, E).
-
-        A - B - C - D
-               \
-                E - F
-        """
-        h = header
-        while True:
-            try:
-                orig = self.get_canonical_block_header_by_number(h.block_number)
-            except HeaderNotFound:
-                # This just means the block is not on the canonical chain.
-                pass
-            else:
-                if orig.hash == h.hash:
-                    # Found the common ancestor, stop.
-                    break
-
-            # Found a new ancestor
-            yield h
-
-            if h.parent_hash == GENESIS_PARENT_HASH:
-                break
-            else:
-                h = self.get_block_header_by_hash(h.parent_hash)
-
-    def _add_block_number_to_hash_lookup(self, header: BlockHeader) -> None:
-        """
-        Sets a record in the database to allow looking up this header by its
-        block number.
-        """
-        block_number_to_hash_key = SchemaV1.make_block_number_to_hash_lookup_key(
-            header.block_number
-        )
-        self.db.set(
-            block_number_to_hash_key,
-            rlp.encode(header.hash, sedes=rlp.sedes.binary),
-        )
 
     #
     # Block API
@@ -436,7 +197,7 @@ class ChainDB(BaseChainDB):
         Returns the uncles hash.
         """
         uncles_hash = keccak(rlp.encode(uncles))
-        self.db.set(
+        self.base_db.set(
             uncles_hash,
             rlp.encode(uncles, sedes=rlp.sedes.CountableList(BlockHeader)))
         return uncles_hash
@@ -450,7 +211,7 @@ class ChainDB(BaseChainDB):
 
         Returns the updated `receipts_root` for updated block header.
         """
-        receipt_db = HexaryTrie(db=self.db, root_hash=block_header.receipt_root)
+        receipt_db = HexaryTrie(db=self.base_db, root_hash=block_header.receipt_root)
         receipt_db[index_key] = rlp.encode(receipt)
         return receipt_db.root_hash
 
@@ -463,7 +224,7 @@ class ChainDB(BaseChainDB):
 
         Returns the updated `transactions_root` for updated block header.
         """
-        transaction_db = HexaryTrie(self.db, root_hash=block_header.transaction_root)
+        transaction_db = HexaryTrie(self.base_db, root_hash=block_header.transaction_root)
         transaction_db[index_key] = rlp.encode(transaction)
         return transaction_db.root_hash
 
@@ -497,7 +258,7 @@ class ChainDB(BaseChainDB):
         Returns an iterable of receipts for the block specified by the given
         block header.
         """
-        receipt_db = HexaryTrie(db=self.db, root_hash=header.receipt_root)
+        receipt_db = HexaryTrie(db=self.base_db, root_hash=header.receipt_root)
         for receipt_idx in itertools.count():
             receipt_key = rlp.encode(receipt_idx)
             if receipt_key in receipt_db:
@@ -521,7 +282,7 @@ class ChainDB(BaseChainDB):
             block_header = self.get_canonical_block_header_by_number(block_number)
         except HeaderNotFound:
             raise TransactionNotFound("Block {} is not in the canonical chain".format(block_number))
-        transaction_db = HexaryTrie(self.db, root_hash=block_header.transaction_root)
+        transaction_db = HexaryTrie(self.base_db, root_hash=block_header.transaction_root)
         encoded_index = rlp.encode(transaction_index)
         if encoded_index in transaction_db:
             encoded_transaction = transaction_db[encoded_index]
@@ -541,7 +302,7 @@ class ChainDB(BaseChainDB):
         """
         key = SchemaV1.make_transaction_hash_to_block_lookup_key(transaction_hash)
         try:
-            encoded_key = self.db[key]
+            encoded_key = self.base_db[key]
         except KeyError:
             raise TransactionNotFound(
                 "Transaction {} not found in canonical chain".format(encode_hex(transaction_hash)))
@@ -553,7 +314,7 @@ class ChainDB(BaseChainDB):
         '''
         Returns iterable of the encoded transactions for the given block header
         '''
-        transaction_db = HexaryTrie(self.db, root_hash=transaction_root)
+        transaction_db = HexaryTrie(self.base_db, root_hash=transaction_root)
         for transaction_idx in itertools.count():
             transaction_key = rlp.encode(transaction_idx)
             if transaction_key in transaction_db:
@@ -578,7 +339,7 @@ class ChainDB(BaseChainDB):
         Removes the transaction specified by the given hash from the canonical
         chain.
         """
-        self.db.delete(SchemaV1.make_transaction_hash_to_block_lookup_key(transaction_hash))
+        self.base_db.delete(SchemaV1.make_transaction_hash_to_block_lookup_key(transaction_hash))
 
     def _add_transaction_to_canonical_chain(self,
                                             transaction_hash: Hash32,
@@ -592,7 +353,7 @@ class ChainDB(BaseChainDB):
         - remove transaction hash to body lookup in the pending pool
         """
         transaction_key = TransactionKey(block_header.block_number, index)
-        self.db.set(
+        self.base_db.set(
             SchemaV1.make_transaction_hash_to_block_lookup_key(transaction_hash),
             rlp.encode(transaction_key),
         )
@@ -604,14 +365,14 @@ class ChainDB(BaseChainDB):
         """
         Returns True if the given key exists in the database.
         """
-        return self.db.exists(key)
+        return self.base_db.exists(key)
 
     def persist_trie_data_dict(self, trie_data_dict: Dict[bytes, bytes]) -> None:
         """
         Store raw trie data to db from a dict
         """
         for key, value in trie_data_dict.items():
-            self.db[key] = value
+            self.base_db[key] = value
 
 
 # When performing a chain sync (either fast or regular modes), we'll very often need to look
@@ -621,29 +382,3 @@ class ChainDB(BaseChainDB):
 @functools.lru_cache(128)
 def _decode_block_header(header_rlp: bytes) -> BlockHeader:
     return rlp.decode(header_rlp, sedes=BlockHeader)
-
-
-class AsyncChainDB(ChainDB):
-    async def coro_get_score(self, block_hash: Hash32) -> int:
-        raise NotImplementedError()
-
-    async def coro_get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
-        raise NotImplementedError()
-
-    async def coro_get_canonical_head(self) -> BlockHeader:
-        raise NotImplementedError()
-
-    async def coro_header_exists(self, block_hash: Hash32) -> bool:
-        raise NotImplementedError()
-
-    async def coro_get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
-        raise NotImplementedError()
-
-    async def coro_persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
-        raise NotImplementedError()
-
-    async def coro_persist_uncles(self, uncles: Tuple[BlockHeader]) -> Hash32:
-        raise NotImplementedError()
-
-    async def coro_persist_trie_data_dict(self, trie_data_dict: Dict[bytes, bytes]) -> None:
-        raise NotImplementedError()

--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -4,13 +4,23 @@ import math
 import operator
 import time
 from typing import (  # noqa: F401
-    Any, Awaitable, Callable, cast, Dict, Generator, List, Set, Tuple, Union)
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Set,
+    TYPE_CHECKING,
+    Tuple,
+    Union,
+    cast,
+)
 
 from cytoolz.itertoolz import partition_all, unique
 
 from evm.constants import BLANK_ROOT_HASH, EMPTY_UNCLE_HASH
 from evm.chains import AsyncChain
-from evm.db.chain import AsyncChainDB
 from evm.db.trie import make_trie_root_and_nodes
 from evm.exceptions import HeaderNotFound
 from evm.rlp.headers import BlockHeader
@@ -22,6 +32,9 @@ from p2p.cancel_token import CancelToken, wait_with_token
 from p2p.exceptions import OperationCancelled
 from p2p.peer import BasePeer, ETHPeer, PeerPool, PeerPoolSubscriber
 from p2p.service import BaseService
+
+if TYPE_CHECKING:
+    from trinity.db.chain import BaseAsyncChainDB  # noqa: F401
 
 
 class FastChainSyncer(BaseService, PeerPoolSubscriber):
@@ -39,7 +52,7 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
     _reply_timeout = 60
 
     def __init__(self,
-                 chaindb: AsyncChainDB,
+                 chaindb: 'BaseAsyncChainDB',
                  peer_pool: PeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token)
@@ -374,7 +387,7 @@ class RegularChainSyncer(FastChainSyncer):
 
     def __init__(self,
                  chain: AsyncChain,
-                 chaindb: AsyncChainDB,
+                 chaindb: 'BaseAsyncChainDB',
                  peer_pool: PeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(chaindb, peer_pool, token)

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -23,7 +23,6 @@ from evm.chains.ropsten import (
     ROPSTEN_NETWORK_ID,
 )
 from evm.db.backends.base import BaseDB
-from evm.db.chain import AsyncChainDB
 
 from p2p.auth import (
     decode_authentication,
@@ -61,6 +60,7 @@ from p2p.service import BaseService
 from p2p.sync import FullNodeSyncer
 
 if TYPE_CHECKING:
+    from trinity.db.chain import BaseAsyncChainDB  # noqa: F401
     from trinity.db.header import BaseAsyncHeaderDB  # noqa: F401
 
 
@@ -73,7 +73,7 @@ class Server(BaseService):
                  privkey: datatypes.PrivateKey,
                  address: Address,
                  chain: AsyncChain,
-                 chaindb: AsyncChainDB,
+                 chaindb: 'BaseAsyncChainDB',
                  headerdb: 'BaseAsyncHeaderDB',
                  base_db: BaseDB,
                  network_id: int,

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -1,16 +1,21 @@
 import logging
 import time
+from typing import (
+    TYPE_CHECKING,
+)
 
 from evm.chains import AsyncChain
 from evm.constants import BLANK_ROOT_HASH
 from evm.db.backends.base import BaseDB
-from evm.db.chain import AsyncChainDB
 
 from p2p.cancel_token import CancelToken
 from p2p.peer import PeerPool
 from p2p.chain import FastChainSyncer, RegularChainSyncer
 from p2p.service import BaseService
 from p2p.state import StateDownloader
+
+if TYPE_CHECKING:
+    from trinity.db.chain import BaseAsyncChainDB  # noqa: F401
 
 
 # How old (in seconds) must our local head be to cause us to start with a fast-sync before we
@@ -19,16 +24,16 @@ FAST_SYNC_CUTOFF = 60 * 60 * 24
 
 
 class FullNodeSyncer(BaseService):
-    logger = logging.getLogger("p2p.sync.FullNodeSyncer")
+    logger: logging.BaseLogger = logging.getLogger("p2p.sync.FullNodeSyncer")
 
     chain: AsyncChain = None
-    chaindb: AsyncChainDB = None
+    chaindb: 'BaseAsyncChainDB' = None
     base_db: BaseDB = None
     peer_pool: PeerPool = None
 
     def __init__(self,
                  chain: AsyncChain,
-                 chaindb: AsyncChainDB,
+                 chaindb: 'BaseAsyncChainDB',
                  base_db: BaseDB,
                  peer_pool: PeerPool,
                  token: CancelToken = None) -> None:

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -24,7 +24,7 @@ FAST_SYNC_CUTOFF = 60 * 60 * 24
 
 
 class FullNodeSyncer(BaseService):
-    logger: logging.BaseLogger = logging.getLogger("p2p.sync.FullNodeSyncer")
+    logger: logging.Logger = logging.getLogger("p2p.sync.FullNodeSyncer")
 
     chain: AsyncChain = None
     chaindb: 'BaseAsyncChainDB' = None

--- a/tests/trinity/core/chain-management/test_initialize_database.py
+++ b/tests/trinity/core/chain-management/test_initialize_database.py
@@ -1,13 +1,14 @@
 import pytest
 
-# TODO: use a custom chain class only for testing.
 from evm.db.backends.level import LevelDB
-from evm.db.chain import ChainDB
 
 from trinity.chains import (
     initialize_data_dir,
     initialize_database,
     is_database_initialized,
+)
+from trinity.db.header import (
+    AsyncHeaderDB,
 )
 from trinity.utils.chains import (
     ChainConfig,
@@ -22,11 +23,11 @@ def chain_config():
 
 
 @pytest.fixture
-def chaindb(chain_config):
-    return ChainDB(LevelDB(db_path=chain_config.database_dir))
+def headerdb(chain_config):
+    return AsyncHeaderDB(LevelDB(db_path=chain_config.database_dir))
 
 
-def test_initialize_database(chain_config, chaindb):
-    assert not is_database_initialized(chaindb)
-    initialize_database(chain_config, chaindb)
-    assert is_database_initialized(chaindb)
+def test_initialize_database(chain_config, headerdb):
+    assert not is_database_initialized(headerdb)
+    initialize_database(chain_config, headerdb)
+    assert is_database_initialized(headerdb)

--- a/tests/trinity/core/chain-management/test_is_database_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_database_initialized.py
@@ -3,11 +3,13 @@ import pytest
 # TODO: use a custom chain class only for testing.
 from evm.chains.ropsten import ROPSTEN_GENESIS_HEADER
 from evm.db.backends.level import LevelDB
-from evm.db.chain import ChainDB
 
 from trinity.chains import (
     initialize_data_dir,
     is_database_initialized,
+)
+from trinity.db.header import (
+    AsyncHeaderDB,
 )
 from trinity.utils.chains import (
     ChainConfig,
@@ -22,15 +24,15 @@ def chain_config():
 
 
 @pytest.fixture
-def chaindb(chain_config):
-    return ChainDB(LevelDB(db_path=chain_config.database_dir))
+def headerdb(chain_config):
+    return AsyncHeaderDB(LevelDB(db_path=chain_config.database_dir))
 
 
-def test_database_dir_not_initialized_without_canonical_head_block(chaindb):
-    assert not is_database_initialized(chaindb)
+def test_database_dir_not_initialized_without_canonical_head_block(headerdb):
+    assert not is_database_initialized(headerdb)
 
 
-def test_fully_initialized_database_dir(chaindb):
-    assert not is_database_initialized(chaindb)
-    chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
-    assert is_database_initialized(chaindb)
+def test_fully_initialized_database_dir(headerdb):
+    assert not is_database_initialized(headerdb)
+    headerdb.persist_header(ROPSTEN_GENESIS_HEADER)
+    assert is_database_initialized(headerdb)

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -16,13 +16,16 @@ from evm.chains.ropsten import (
     ROPSTEN_NETWORK_ID,
 )
 from evm.db.backends.base import BaseDB
-from evm.db.chain import AsyncChainDB
 from evm.exceptions import CanonicalHeadNotFound
 
 from p2p import ecies
 
 from trinity.db.base import DBProxy
-from trinity.db.chain import ChainDBProxy
+from trinity.db.chain import (
+    BaseAsyncChainDB,
+    AsyncChainDB,
+    AsyncChainDBProxy,
+)
 from trinity.db.header import (
     AsyncHeaderDB,
     AsyncHeaderDBProxy,
@@ -68,7 +71,7 @@ def is_data_dir_initialized(chain_config: ChainConfig) -> bool:
     return True
 
 
-def is_database_initialized(chaindb: AsyncChainDB) -> bool:
+def is_database_initialized(chaindb: BaseAsyncChainDB) -> bool:
     try:
         chaindb.get_canonical_head()
     except CanonicalHeadNotFound:
@@ -99,7 +102,7 @@ def initialize_data_dir(chain_config: ChainConfig) -> None:
             nodekey_file.write(nodekey.to_bytes())
 
 
-def initialize_database(chain_config: ChainConfig, chaindb: AsyncChainDB) -> None:
+def initialize_database(chain_config: ChainConfig, chaindb: BaseAsyncChainDB) -> None:
     try:
         chaindb.get_canonical_head()
     except CanonicalHeadNotFound:
@@ -144,7 +147,7 @@ def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
     DBManager.register(  # type: ignore
         'get_chaindb',
         callable=lambda: chaindb,
-        proxytype=ChainDBProxy,
+        proxytype=AsyncChainDBProxy,
     )
     DBManager.register('get_chain', callable=lambda: chain, proxytype=ChainProxy)  # type: ignore
 

--- a/trinity/chains/chain.py
+++ b/trinity/chains/chain.py
@@ -1,0 +1,104 @@
+from abc import abstractmethod
+# Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
+# https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
+from multiprocessing.managers import (  # type: ignore
+    BaseProxy,
+)
+from typing import (
+    Dict,
+    Type,
+)
+
+from evm.chains.base import (
+    AccountState,
+    BaseChain,
+    Chain,
+)
+from evm.db.backends.base import BaseDB
+from evm.db.chain import (
+    BaseChainDB,
+)
+from evm.db.header import (
+    BaseHeaderDB,
+)
+from evm.rlp.headers import (
+    BlockHeader,
+    HeaderParams,
+)
+from evm.rlp.blocks import BaseBlock
+
+from trinity.utils.mp import (
+    async_method,
+    sync_method,
+)
+
+
+class BaseAsyncChain(BaseChain):
+    @abstractmethod
+    async def coro_import_block(self, block: BaseBlock) -> BaseBlock:
+        raise NotImplementedError("Chain classes must implement this method")
+
+
+class AsyncChain(Chain, BaseAsyncChain):
+    async def coro_import_block(self, block: BaseBlock) -> BaseBlock:
+        raise NotImplementedError("Chain classes must implement this method")
+
+
+class AsyncChainProxy(BaseProxy, BaseAsyncChain):
+    #
+    # Async Proxy Methods
+    #
+    coro_import_block = async_method('import_block')
+
+    #
+    # APIS not available on the proxy class
+    #
+    def get_chaindb_class(cls) -> Type[BaseChainDB]:
+        raise NotImplementedError("Chain classes must implement this method")
+
+    @classmethod
+    def get_headerdb_class(cls) -> Type[BaseHeaderDB]:
+        raise NotImplementedError("Chain classes must implement this method")
+
+    @classmethod
+    def from_genesis(cls,
+                     base_db: BaseDB,
+                     genesis_params: Dict[str, HeaderParams],
+                     genesis_state: AccountState=None) -> 'BaseChain':
+        raise NotImplementedError("Chain classes must implement this method")
+
+    @classmethod
+    def from_genesis_header(cls,
+                            base_db: BaseDB,
+                            genesis_header: BlockHeader) -> 'BaseChain':
+        raise NotImplementedError("Chain classes must implement this method")
+
+    @abstractmethod
+    def get_chain_at_block_parent(self, block: BaseBlock) -> 'BaseChain':
+        raise NotImplementedError("Chain classes must implement this method")
+
+    #
+    # Sync Proxy Methods
+    #
+    get_vm = sync_method('get_vm')
+    get_vm_class_for_block_number = sync_method('get_vm_class_for_block_number')
+    create_header_from_parent = sync_method('create_header_from_parent')
+    get_block_header_by_hash = sync_method('get_block_header_by_hash')
+    get_canonical_head = sync_method('get_canonical_head')
+    get_ancestors = sync_method('get_ancestors')
+    get_block = sync_method('get_block')
+    get_block_by_hash = sync_method('get_block_by_hash')
+    get_block_by_header = sync_method('get_block_by_header')
+    get_canonical_block_by_number = sync_method('get_canonical_block_by_number')
+    get_canonical_block_hash = sync_method('get_canonical_block_hash')
+    create_transaction = sync_method('create_transaction')
+    create_unsigned_transaction = sync_method('create_unsigned_transaction')
+    get_canonical_transaction = sync_method('get_canonical_transaction')
+    apply_transaction = sync_method('apply_transaction')
+    estimate_gas = sync_method('estimate_gas')
+    import_block = sync_method('import_block')
+    mine_block = sync_method('mine_block')
+    validate_block = sync_method('validate_block')
+    validate_gaslimit = sync_method('validate_gaslimit')
+    validate_seal = sync_method('validate_seal')
+    validate_uncles = sync_method('validate_uncles')

--- a/trinity/chains/header.py
+++ b/trinity/chains/header.py
@@ -43,7 +43,7 @@ class AsyncHeaderChain(HeaderChain, BaseAsyncHeaderChain):
         raise NotImplementedError("Chain classes must implement this method")
 
 
-class AsyncHeaderChainProxy(BaseProxy, BaseAsyncHeaderChain, BaseHeaderChain):
+class AsyncHeaderChainProxy(BaseProxy, BaseAsyncHeaderChain):
     @classmethod
     def from_genesis_header(cls,
                             basedb: BaseDB,

--- a/trinity/db/chain.py
+++ b/trinity/db/chain.py
@@ -1,30 +1,206 @@
+from abc import abstractmethod
 # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
 # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
 from multiprocessing.managers import (  # type: ignore
     BaseProxy,
 )
+from typing import (
+    Dict,
+    Iterable,
+    List,
+    Tuple,
+    Type,
+    TYPE_CHECKING,
+)
+
+from eth_typing import (
+    BlockNumber,
+    Hash32,
+)
+
+from evm.db.chain import (
+    BaseChainDB,
+    ChainDB,
+)
+from evm.rlp.headers import BlockHeader
+from evm.rlp.receipts import Receipt
 
 from trinity.utils.mp import (
     async_method,
     sync_method,
 )
 
+if TYPE_CHECKING:
+    from evm.rlp.blocks import (  # noqa: F401
+        BaseBlock
+    )
+    from evm.rlp.transactions import (  # noqa: F401
+        BaseTransaction
+    )
 
-class ChainDBProxy(BaseProxy):
-    coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
-    coro_get_canonical_head = async_method('get_canonical_head')
-    coro_get_score = async_method('get_score')
-    coro_header_exists = async_method('header_exists')
-    coro_get_canonical_block_hash = async_method('get_canonical_block_hash')
-    coro_persist_header = async_method('persist_header')
+
+class BaseAsyncChainDB(BaseChainDB):
+    #
+    # Uncles API
+    #
+    @abstractmethod
+    async def coro_get_block_uncles(self, uncles_hash: Hash32) -> List[BlockHeader]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    #
+    # Block API
+    #
+    @abstractmethod
+    async def coro_persist_block(self, block: 'BaseBlock') -> None:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_persist_uncles(self, uncles: Tuple[BlockHeader]) -> Hash32:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    #
+    # Transaction API
+    #
+    @abstractmethod
+    async def coro_add_receipt(self,
+                               block_header: BlockHeader,
+                               index_key: int, receipt: Receipt) -> Hash32:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_add_transaction(self,
+                                   block_header: BlockHeader,
+                                   index_key: int, transaction: 'BaseTransaction') -> Hash32:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_block_transactions(
+            self,
+            block_header: BlockHeader,
+            transaction_class: Type['BaseTransaction']) -> Iterable['BaseTransaction']:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_block_transaction_hashes(self, block_header: BlockHeader) -> Iterable[Hash32]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_receipts(self,
+                                header: BlockHeader,
+                                receipt_class: Type[Receipt]) -> Iterable[Receipt]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_transaction_by_index(
+            self,
+            block_number: BlockNumber,
+            transaction_index: int,
+            transaction_class: Type['BaseTransaction']) -> 'BaseTransaction':
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_get_transaction_index(self,
+                                         transaction_hash: Hash32) -> Tuple[BlockNumber, int]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    #
+    # Raw Database API
+    #
+    @abstractmethod
+    async def coro_exists(self, key: bytes) -> bool:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
+    async def coro_persist_trie_data_dict(self, trie_data_dict: Dict[bytes, bytes]) -> None:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+
+class AsyncChainDB(ChainDB, BaseAsyncChainDB):
+    #
+    # Uncles API
+    #
+    async def coro_get_block_uncles(self, uncles_hash: Hash32) -> List[BlockHeader]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    #
+    # Block API
+    #
+    async def coro_persist_block(self, block: 'BaseBlock') -> None:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_persist_uncles(self, uncles: Tuple[BlockHeader]) -> Hash32:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    #
+    # Transaction API
+    #
+    async def coro_add_receipt(self,
+                               block_header: BlockHeader,
+                               index_key: int, receipt: Receipt) -> Hash32:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_add_transaction(self,
+                                   block_header: BlockHeader,
+                                   index_key: int, transaction: 'BaseTransaction') -> Hash32:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_block_transactions(
+            self,
+            block_header: BlockHeader,
+            transaction_class: Type['BaseTransaction']) -> Iterable['BaseTransaction']:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_block_transaction_hashes(self, block_header: BlockHeader) -> Iterable[Hash32]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_receipts(self,
+                                header: BlockHeader,
+                                receipt_class: Type[Receipt]) -> Iterable[Receipt]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_transaction_by_index(
+            self,
+            block_number: BlockNumber,
+            transaction_index: int,
+            transaction_class: Type['BaseTransaction']) -> 'BaseTransaction':
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_get_transaction_index(self, transaction_hash: Hash32) -> Tuple[BlockNumber, int]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    #
+    # Raw Database API
+    #
+    async def coro_exists(self, key: bytes) -> bool:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    async def coro_persist_trie_data_dict(self, trie_data_dict: Dict[bytes, bytes]) -> None:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+
+class AsyncChainDBProxy(BaseProxy, BaseAsyncChainDB):
+    coro_get_block_uncles = async_method('get_block_uncles')
+    coro_persist_block = async_method('persist_block')
     coro_persist_uncles = async_method('persist_uncles')
+    coro_add_receipt = async_method('add_receipt')
+    coro_add_transaction = async_method('add_transaction')
+    coro_get_block_transactions = async_method('get_block_transactions')
+    coro_get_block_transaction_hashes = async_method('get_block_transaction_hashes')
+    coro_get_receipts = async_method('get_receipts')
+    coro_get_transaction_by_index = async_method('get_transaction_by_index')
+    coro_get_transaction_index = async_method('get_transaction_index')
+    coro_exists = async_method('exists')
     coro_persist_trie_data_dict = async_method('persist_trie_data_dict')
 
-    get_block_header_by_hash = sync_method('get_block_header_by_hash')
-    get_canonical_head = sync_method('get_canonical_head')
-    get_score = sync_method('get_score')
-    header_exists = sync_method('header_exists')
-    get_canonical_block_hash = sync_method('get_canonical_block_hash')
-    persist_header = sync_method('persist_header')
+    get_block_uncles = sync_method('get_block_uncles')
+    persist_block = sync_method('persist_block')
     persist_uncles = sync_method('persist_uncles')
+    add_receipt = sync_method('add_receipt')
+    add_transaction = sync_method('add_transaction')
+    get_block_transactions = sync_method('get_block_transactions')
+    get_block_transaction_hashes = sync_method('get_block_transaction_hashes')
+    get_receipts = sync_method('get_receipts')
+    get_transaction_by_index = sync_method('get_transaction_by_index')
+    get_transaction_index = sync_method('get_transaction_index')
+    exists = sync_method('exists')
     persist_trie_data_dict = sync_method('persist_trie_data_dict')

--- a/trinity/db/header.py
+++ b/trinity/db/header.py
@@ -82,7 +82,7 @@ class AsyncHeaderDB(HeaderDB, BaseAsyncHeaderDB):
         raise NotImplementedError("ChainDB classes must implement this method")
 
 
-class AsyncHeaderDBProxy(BaseProxy, BaseAsyncHeaderDB, BaseHeaderDB):
+class AsyncHeaderDBProxy(BaseProxy, BaseAsyncHeaderDB):
     coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
     coro_get_canonical_block_hash = async_method('get_canonical_block_hash')
     coro_get_canonical_block_header_by_number = async_method('get_canonical_block_header_by_number')

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -25,10 +25,12 @@ from p2p.peer import (
 from p2p.server import Server
 
 from trinity.chains import (
-    ChainProxy,
     initialize_data_dir,
     is_data_dir_initialized,
     serve_chaindb,
+)
+from trinity.chains.chain import (
+    AsyncChainProxy,
 )
 from trinity.chains.mainnet import (
     MainnetLightChain,
@@ -45,7 +47,7 @@ from trinity.console import (
 from trinity.constants import (
     SYNC_LIGHT,
 )
-from trinity.db.chain import ChainDBProxy
+from trinity.db.chain import AsyncChainDBProxy
 from trinity.db.base import DBProxy
 from trinity.db.header import AsyncHeaderDBProxy
 from trinity.cli_parser import (
@@ -168,8 +170,8 @@ def create_dbmanager(ipc_path: str) -> BaseManager:
     # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
     # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
     DBManager.register('get_db', proxytype=DBProxy)  # type: ignore
-    DBManager.register('get_chaindb', proxytype=ChainDBProxy)  # type: ignore
-    DBManager.register('get_chain', proxytype=ChainProxy)  # type: ignore
+    DBManager.register('get_chaindb', proxytype=AsyncChainDBProxy)  # type: ignore
+    DBManager.register('get_chain', proxytype=AsyncChainProxy)  # type: ignore
     DBManager.register('get_headerdb', proxytype=AsyncHeaderDBProxy)  # type: ignore
     DBManager.register('get_header_chain', proxytype=AsyncHeaderChainProxy)  # type: ignore
 


### PR DESCRIPTION
### What was wrong?

The `AsyncChain` lived in the EVM codebase (which felt wrong), and the general structure of the `AsyncChain` and `ChainProxy` weren't conforming to the *correct* inheritance structure.

### How was it fixed?

WIP

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
