### PR TITLE
Squash all trie changes, persisting minimally

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -517,6 +517,9 @@ class Chain(BaseChain):
 
         new_header, receipt, computation = vm.apply_transaction(base_block.header, transaction)
 
+        # since we are building the block locally, we have to persist all the incremental state
+        vm.state.account_db.persist()
+
         transactions = base_block.transactions + (transaction, )
         receipts = base_block.get_receipts(self.chaindb) + (receipt, )
 

--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -71,7 +71,7 @@ class BaseAccountDB(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclasses")
 
     @abstractmethod
-    def has_root(self):
+    def has_root(self, state_root: bytes) -> bool:
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
@@ -218,7 +218,7 @@ class AccountDB(BaseAccountDB):
         self._trie_cache.reset_cache()
         self._trie.root_hash = value
 
-    def has_root(self, state_root):
+    def has_root(self, state_root: bytes) -> bool:
         return state_root in self._batchtrie
 
     #

--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -7,6 +7,8 @@ import logging
 from lru import LRU
 from typing import Set, Tuple  # noqa: F401
 
+from eth_typing import Hash32
+
 import rlp
 
 from trie import (
@@ -134,6 +136,23 @@ class BaseAccountDB(metaclass=ABCMeta):
     def commit(self, changeset: Tuple[UUID, UUID]) -> None:
         raise NotImplementedError("Must be implemented by subclass")
 
+    @abstractmethod
+    def make_state_root(self) -> Hash32:
+        """
+        Generate the state root with all the current changes in AccountDB
+
+        :return: the new state root
+        """
+        raise NotImplementedError("Must be implemented by subclass")
+
+    @abstractmethod
+    def persist(self) -> None:
+        """
+        Send changes to underlying database, including the trie state
+        so that it will forever be possible to read the trie from this checkpoint.
+        """
+        raise NotImplementedError("Must be implemented by subclass")
+
 
 class AccountDB(BaseAccountDB):
 
@@ -146,13 +165,19 @@ class AccountDB(BaseAccountDB):
 
         .. code::
 
-                                                                   -> hash-trie -> storage lookups
+                                                                    -> hash-trie -> storage lookups
                                                                   /
-            db -------------------------------------> _journaldb ----------------> code lookups
+            db > _batchdb ---------------------------> _journaldb ----------------> code lookups
              \
-              > _batchtrie -> _trie -> _trie_cache -> _journaltrie --------------> account lookups
+              -> _batchtrie -> _trie -> _trie_cache -> _journaltrie --------------> account lookups
 
         Journaling sequesters writes at the _journal* attrs ^, until persist is called.
+
+        _batchtrie enables us to prune all trie changes while building
+        state,  without deleting old trie roots.
+
+        _batchdb and _batchtrie together enable us to make the state root,
+        without saving everything to the database.
 
         _journaldb is a journaling of the keys and values used to store
         code and account storage.
@@ -173,8 +198,9 @@ class AccountDB(BaseAccountDB):
         AccountDB synchronizes the snapshot/revert/persist of both of the
         journals.
         """
-        self._journaldb = JournalDB(db)
+        self._batchdb = BatchDB(db)
         self._batchtrie = BatchDB(db)
+        self._journaldb = JournalDB(self._batchdb)
         self._trie = HashTrie(HexaryTrie(self._batchtrie, state_root, prune=True))
         self._trie_cache = CacheDB(self._trie)
         self._journaltrie = JournalDB(self._trie_cache)
@@ -355,11 +381,16 @@ class AccountDB(BaseAccountDB):
         self._journaldb.commit(db_changeset)
         self._journaltrie.commit(trie_changeset)
 
-    def persist(self) -> None:
-        self.logger.debug("Persisting AccountDB...")
+    def make_state_root(self) -> Hash32:
+        self.logger.debug("Generating AccountDB trie")
         self._journaldb.persist()
         self._journaltrie.persist()
+        return self.state_root
+
+    def persist(self) -> None:
+        self.make_state_root()
         self._batchtrie.commit(apply_deletes=False)
+        self._batchdb.commit(apply_deletes=True)
 
     def _log_pending_accounts(self) -> None:
         accounts_displayed = set()  # type: Set[bytes]

--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -70,6 +70,10 @@ class BaseAccountDB(metaclass=ABCMeta):
     def state_root(self):
         raise NotImplementedError("Must be implemented by subclasses")
 
+    @abstractmethod
+    def has_root(self):
+        raise NotImplementedError("Must be implemented by subclasses")
+
     #
     # Storage
     #
@@ -213,6 +217,9 @@ class AccountDB(BaseAccountDB):
     def state_root(self, value):
         self._trie_cache.reset_cache()
         self._trie.root_hash = value
+
+    def has_root(self, state_root):
+        return state_root in self._batchtrie
 
     #
     # Storage

--- a/evm/db/backends/base.py
+++ b/evm/db/backends/base.py
@@ -17,7 +17,7 @@ class BaseDB(MutableMapping, metaclass=ABCMeta):
     (Unless a subclass explicitly enables it).
 
     All subclasses must implement these methods:
-    __getitem__, __setitem__, __delitem__
+    __init__, __getitem__, __setitem__, __delitem__
 
     Subclasses may optionally implement an _exists method
     that is type-checked for key and value.

--- a/evm/db/batch.py
+++ b/evm/db/batch.py
@@ -41,8 +41,8 @@ class BatchDB(BaseDB):
     def clear(self):
         self._track_diff = DBDiffTracker()
 
-    def commit(self):
-        self.diff().apply_to(self.wrapped_db)
+    def commit(self, apply_deletes: bool = True) -> None:
+        self.diff().apply_to(self.wrapped_db, apply_deletes)
         self.clear()
 
     def _exists(self, key: bytes) -> bool:

--- a/evm/db/diff.py
+++ b/evm/db/diff.py
@@ -127,10 +127,13 @@ class DBDiff(Mapping):
             applied to the database
         """
         for key, value in self._changes.items():
-            if value is DELETED and apply_deletes:
-                try:
-                    del db[key]
-                except KeyError:
+            if value is DELETED:
+                if apply_deletes:
+                    try:
+                        del db[key]
+                    except KeyError:
+                        pass
+                else:
                     pass
             else:
                 db[key] = value

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -425,12 +425,17 @@ class VM(BaseVM):
         """
         Mine the current block. Proxies to self.pack_block method.
         """
-        block = self.pack_block(self.block, *args, **kwargs)
+        packed_block = self.pack_block(self.block, *args, **kwargs)
 
-        if block.number == 0:
-            return block
+        if packed_block.number == 0:
+            final_block = packed_block
         else:
-            return self.finalize_block(block)
+            final_block = self.finalize_block(packed_block)
+
+        # Perform validation
+        self.validate_block(final_block)
+
+        return final_block
 
     def set_block_transactions(self, base_block, new_header, transactions, receipts):
 
@@ -517,9 +522,6 @@ class VM(BaseVM):
 
         header = block.header.copy(**kwargs)
         packed_block = block.copy(uncles=uncles, header=header)
-
-        # Perform validation
-        self.validate_block(packed_block)
 
         return packed_block
 

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -44,9 +44,8 @@ def make_frontier_receipt(base_header, transaction, computation, state):
     )
     gas_used = base_header.gas_used + tx_gas_used
 
-    state_root = state.account_db.make_state_root()
     receipt = Receipt(
-        state_root=state_root,
+        state_root=state.state_root,
         gas_used=gas_used,
         logs=logs,
     )

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -44,8 +44,9 @@ def make_frontier_receipt(base_header, transaction, computation, state):
     )
     gas_used = base_header.gas_used + tx_gas_used
 
+    state_root = state.account_db.make_state_root()
     receipt = Receipt(
-        state_root=state.state_root,
+        state_root=state_root,
         gas_used=gas_used,
         logs=logs,
     )

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -218,8 +218,8 @@ class BaseState(Configurable, metaclass=ABCMeta):
         if self.state_root != BLANK_ROOT_HASH and self.state_root not in self._db:
             raise StateRootNotFound(self.state_root)
         computation = self.execute_transaction(transaction)
-        self.account_db.persist()
-        return self.account_db.state_root, computation
+        state_root = self.account_db.make_state_root()
+        return state_root, computation
 
     def get_transaction_executor(self):
         return self.transaction_executor(self)

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -215,7 +215,7 @@ class BaseState(Configurable, metaclass=ABCMeta):
         :param transaction: the transaction to apply
         :return: the new state root, and the computation
         """
-        if self.state_root != BLANK_ROOT_HASH and self.state_root not in self._db:
+        if self.state_root != BLANK_ROOT_HASH and not self.account_db.has_root(self.state_root):
             raise StateRootNotFound(self.state_root)
         computation = self.execute_transaction(transaction)
         state_root = self.account_db.make_state_root()


### PR DESCRIPTION
### What was wrong?

We are storing state roots into the database for every step in the transaction. We only need to store the trie at the end of the block.

### How was it fixed?

Added an extra batch db in AccountDB, so that we can calculate the state root without persisting, and only persist the new state root when absolutely necessary.

Bonus bugfix: `BatchDB` had a bug when it tried to skip deletes.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQN8roo9oYPSSs11ibuaNnp5E5zEoytE522LOmpKxOJZRQlzddf)
