### PR TITLE
Move the validate_seal method to the VM class.

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -39,9 +39,6 @@ from evm.db.chain import (
     BaseChainDB,
     ChainDB,
 )
-from evm.consensus.pow import (
-    check_pow,
-)
 from evm.constants import (
     BLANK_ROOT_HASH,
     MAX_UNCLE_DEPTH,
@@ -233,10 +230,6 @@ class BaseChain(Configurable, metaclass=ABCMeta):
 
     @abstractmethod
     def validate_gaslimit(self, header: BlockHeader) -> None:
-        raise NotImplementedError("Chain classes must implement this method")
-
-    @abstractmethod
-    def validate_seal(self, header: BlockHeader) -> None:
         raise NotImplementedError("Chain classes must implement this method")
 
     @abstractmethod
@@ -589,10 +582,7 @@ class Chain(BaseChain):
         Since block validation (specifically the uncle validation must have
         access to the ancestor blocks, this validation must occur at the Chain
         level.
-
-        TODO: move the `seal` validation down into the vm.
         """
-        self.validate_seal(block.header)
         self.validate_uncles(block)
         self.validate_gaslimit(block.header)
 
@@ -610,14 +600,6 @@ class Chain(BaseChain):
             raise ValidationError(
                 "The gas limit on block {0} is too high: {1}. It must be at most {2}".format(
                     encode_hex(header.hash), header.gas_limit, high_bound))
-
-    def validate_seal(self, header: BlockHeader) -> None:
-        """
-        Validate the seal on the given header.
-        """
-        check_pow(
-            header.block_number, header.mining_hash,
-            header.mix_hash, header.nonce, header.difficulty)
 
     def validate_uncles(self, block: BaseBlock) -> None:
         """
@@ -649,8 +631,6 @@ class Chain(BaseChain):
                 raise ValidationError(
                     "Uncle's parent {0} is not an ancestor of {1}".format(
                         encode_hex(uncle.parent_hash), encode_hex(block.hash)))
-
-            self.validate_seal(uncle)
 
 
 # This class is a work in progress; its main purpose is to define the API of an asyncio-compatible

--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -583,6 +583,9 @@ class Chain(BaseChain):
         access to the ancestor blocks, this validation must occur at the Chain
         level.
         """
+        vm = self.get_vm()
+        vm.validate_seal(block.header)
+
         self.validate_uncles(block)
         self.validate_gaslimit(block.header)
 

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -658,8 +658,8 @@ class VM(BaseVM):
             )
 
         for uncle in block.uncles:
-            self.validate_uncle(block, uncle)
             self.validate_seal(uncle)
+            self.validate_uncle(block, uncle)
 
         if not self.chaindb.exists(block.header.state_root):
             raise ValidationError(
@@ -693,8 +693,6 @@ class VM(BaseVM):
         """
         Validate the given uncle in the context of the given block.
         """
-        self.validate_seal(block.header)
-
         if uncle.block_number >= block.number:
             raise ValidationError(
                 "Uncle number ({0}) is higher than block number ({1})".format(

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -22,7 +22,9 @@ from eth_utils import (
 )
 
 from eth_hash.auto import keccak
-
+from evm.consensus.pow import (
+    check_pow,
+)
 from evm.constants import (
     GENESIS_PARENT_HASH,
     MAX_PREV_HEADER_DEPTH,
@@ -257,6 +259,10 @@ class BaseVM(Configurable, metaclass=ABCMeta):
 
         :raises: ValidationError if the transaction is not valid to apply
         """
+        raise NotImplementedError("VM classes must implement this method")
+
+    @abstractmethod
+    def validate_seal(self, header: BlockHeader) -> None:
         raise NotImplementedError("VM classes must implement this method")
 
     @abstractmethod
@@ -653,6 +659,7 @@ class VM(BaseVM):
 
         for uncle in block.uncles:
             self.validate_uncle(block, uncle)
+            self.validate_seal(uncle)
 
         if not self.chaindb.exists(block.header.state_root):
             raise ValidationError(
@@ -674,10 +681,20 @@ class VM(BaseVM):
                 )
             )
 
+    def validate_seal(self, header: BlockHeader) -> None:
+        """
+        Validate the seal on the given header.
+        """
+        check_pow(
+            header.block_number, header.mining_hash,
+            header.mix_hash, header.nonce, header.difficulty)
+
     def validate_uncle(self, block, uncle):
         """
         Validate the given uncle in the context of the given block.
         """
+        self.validate_seal(block.header)
+
         if uncle.block_number >= block.number:
             raise ValidationError(
                 "Uncle number ({0}) is higher than block number ({1})".format(

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -103,10 +103,11 @@ def chain_without_block_validation(base_db, funded_address, funded_address_initi
         'import_block': import_block_without_validation,
         'validate_block': lambda self, block: None,
     }
+    SpuriousDragonVMForTesting = SpuriousDragonVM.configure(validate_seal=lambda self, block: None)
     klass = Chain.configure(
         __name__='TestChainWithoutBlockValidation',
         vm_configuration=(
-            (constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVM),
+            (constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVMForTesting),
         ),
         **overrides,
     )

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -99,13 +99,17 @@ def test_blockchain_fixtures(fixture_data, fixture):
             assert not should_be_good_block
             continue
 
-        try:
+        if should_be_good_block:
             (block, mined_block, block_rlp) = apply_fixture_block_to_chain(block_fixture, chain)
-        except (TypeError, rlp.DecodingError, rlp.DeserializationError, ValidationError) as err:
-            assert not should_be_good_block, "Block should be good: {0}".format(err)
-        else:
             assert_rlp_equal(block, mined_block)
-            assert should_be_good_block, "Block should have caused a validation error"
+        else:
+            try:
+                (block, mined_block, block_rlp) = apply_fixture_block_to_chain(block_fixture, chain)
+            except (TypeError, rlp.DecodingError, rlp.DeserializationError, ValidationError) as err:
+                # failure is expected on this bad block
+                pass
+            else:
+                raise AssertionError("Block should have caused a validation error")
 
     latest_block_hash = chain.get_canonical_block_by_number(chain.get_block().number - 1).hash
     assert latest_block_hash == fixture['lastblockhash']

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -104,7 +104,7 @@ def test_blockchain_fixtures(fixture_data, fixture):
             assert_rlp_equal(block, mined_block)
         else:
             try:
-                (block, mined_block, block_rlp) = apply_fixture_block_to_chain(block_fixture, chain)
+                apply_fixture_block_to_chain(block_fixture, chain)
             except (TypeError, rlp.DecodingError, rlp.DeserializationError, ValidationError) as err:
                 # failure is expected on this bad block
                 pass


### PR DESCRIPTION
### What was wrong?
The `validate_seal` method exists on the `Chain` class, however seal validation can and should be a `VM` level operation.

Issue Reference: https://github.com/ethereum/py-evm/issues/667

### How was it fixed?
Move the `validate_seal` method to the `VM` class. The `VM` class should call out to this within it's `validate_block` method.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRfve8BP3JxRkyewVimdViumIVMm2j_k0UEgF8pI4pczGHQq-P9RA)
