### PR TITLE
light client launch fixup

### DIFF
--- a/trinity/main.py
+++ b/trinity/main.py
@@ -124,7 +124,7 @@ def main() -> None:
     if args.sync_mode == SYNC_LIGHT:
         networking_process = ctx.Process(
             target=run_lightnode_process,
-            args=(chain_config),
+            args=(chain_config, ),
             kwargs=logging_kwargs,
         )
     else:


### PR DESCRIPTION
### What was wrong?

`trinity --light` was failing with roughly "args is not iterable"

### How was it fixed?

Add a comma to make a real tuple when creating the lightnode process.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRK2bgOct-iy_FRhcgcngUo3pWbCzwvkGkkmcWnzgd4k0fbtlAQTQ)