### PR TITLE
Add more info to terminal output for trinity

### DIFF
--- a/p2p/server.py
+++ b/p2p/server.py
@@ -263,6 +263,7 @@ class Server(BaseService):
             external_ip,
             self.port,
         )
+        self.logger.info('network: %s', self.network_id)
         addr = Address(external_ip, self.port, self.port)
         self.discovery = DiscoveryProtocol(self.privkey, addr, bootstrap_nodes=self.bootstrap_nodes)
         await self._start_udp_listener(self.discovery)

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -1,3 +1,8 @@
+import pkg_resources
+
+# TODO: update this to use the `trinity` version once extracted from py-evm
+__version__ = pkg_resources.get_distribution("py-evm").version
+
 from .main import (  # noqa: F401
     main,
 )

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -1,7 +1,7 @@
 import pkg_resources
 
 # TODO: update this to use the `trinity` version once extracted from py-evm
-__version__ = pkg_resources.get_distribution("py-evm").version
+__version__: str = pkg_resources.get_distribution("py-evm").version
 
 from .main import (  # noqa: F401
     main,

--- a/trinity/__version__.py
+++ b/trinity/__version__.py
@@ -1,5 +1,0 @@
-import pkg_resources
-
-
-# TODO: update to trinity package when it gets split out.
-__version__ = pkg_resources.get_distribution("py-evm").version

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -1,4 +1,3 @@
-import logging
 # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
 # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
 from multiprocessing.managers import (  # type: ignore
@@ -162,9 +161,6 @@ def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
 
     manager = DBManager(address=chain_config.database_ipc_path)  # type: ignore
     server = manager.get_server()  # type: ignore
-
-    logger = logging.getLogger('trinity.db')
-    logger.info('database: %s', os.path.abspath(chain_config.database_ipc_path))
 
     server.serve_forever()  # type: ignore
 

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -1,3 +1,4 @@
+import logging
 # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
 # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
 from multiprocessing.managers import (  # type: ignore
@@ -161,6 +162,9 @@ def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
 
     manager = DBManager(address=chain_config.database_ipc_path)  # type: ignore
     server = manager.get_server()  # type: ignore
+
+    logger = logging.getLogger('trinity.db')
+    logger.info('database: %s', os.path.abspath(chain_config.database_ipc_path))
 
     server.serve_forever()  # type: ignore
 

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -7,7 +7,7 @@ from evm.chains.ropsten import (
     ROPSTEN_NETWORK_ID,
 )
 
-from trinity.__version__ import __version__
+from trinity import __version__
 from trinity.constants import (
     SYNC_FULL,
     SYNC_LIGHT,

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -70,9 +70,23 @@ from trinity.utils.logging import (
 from trinity.utils.mp import (
     ctx,
 )
+from trinity.utils.version import (
+    construct_trinity_client_identifier,
+)
 
 
 PRECONFIGURED_NETWORKS = {MAINNET_NETWORK_ID, ROPSTEN_NETWORK_ID}
+
+
+TRINITY_HEADER = (
+    "\n"
+    "  ______     _       _ __       \n"
+    " /_  __/____(_)___  (_) /___  __\n"
+    "  / / / ___/ / __ \/ / __/ / / /\n"
+    " / / / /  / / / / / / /_/ /_/ / \n"
+    "/_/ /_/  /_/_/ /_/_/\__/\__, /  \n"
+    "                       /____/   "
+)
 
 
 def main() -> None:
@@ -179,6 +193,16 @@ def create_dbmanager(ipc_path: str) -> BaseManager:
 
 @with_queued_logging
 def run_lightnode_process(chain_config: ChainConfig) -> None:
+    logger = logging.getLogger('trinity')
+    logger.info(TRINITY_HEADER)
+    logger.info(construct_trinity_client_identifier())
+    logger.info(
+        "enode://%s@%s:%s",
+        chain_config.nodekey.to_hex()[2:],
+        "[:]",
+        chain_config.port,
+    )
+    logger.info('network: %s', chain_config.network_id)
 
     manager = create_dbmanager(chain_config.database_ipc_path)
     headerdb = manager.get_headerdb()  # type: ignore
@@ -219,6 +243,9 @@ def run_lightnode_process(chain_config: ChainConfig) -> None:
 
 @with_queued_logging
 def run_fullnode_process(chain_config: ChainConfig, port: int) -> None:
+    logger = logging.getLogger('trinity')
+    logger.info(TRINITY_HEADER)
+    logger.info(construct_trinity_client_identifier())
 
     manager = create_dbmanager(chain_config.database_ipc_path)
     db = manager.get_db()  # type: ignore

--- a/trinity/rpc/ipc.py
+++ b/trinity/rpc/ipc.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 
 from cytoolz import curry
 
@@ -112,6 +113,8 @@ async def write_error(writer, message):
 
 
 class IPCServer:
+    logger = logging.getLogger('trinity.rpc.ipc.IPCServer')
+
     cancel_token = None
     ipc_path = None
     rpc = None
@@ -129,6 +132,7 @@ class IPCServer:
             loop=loop,
             limit=MAXIMUM_REQUEST_BYTES,
         )
+        self.logger.info('ipc-path: %s', os.path.abspath(self.ipc_path))
         await self.cancel_token.wait()
 
     async def stop(self):

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -107,19 +107,23 @@ def load_nodekey(nodekey_path: str) -> PrivateKey:
 
 
 class ChainConfig:
-    _data_dir = None
-    _nodekey_path = None
+    _data_dir: str = None
+    _nodekey_path: str = None
     _nodekey = None
-    _network_id = None
+    _network_id: int = None
+
+    port: int = None
 
     def __init__(self,
                  network_id: int,
                  data_dir: str=None,
                  nodekey_path: str=None,
                  nodekey: PrivateKey=None,
-                 sync_mode: str=SYNC_FULL) -> None:
+                 sync_mode: str=SYNC_FULL,
+                 port: int=30303) -> None:
         self.network_id = network_id
         self.sync_mode = sync_mode
+        self.port = port
 
         # validation
         if nodekey is not None and nodekey_path is not None:
@@ -232,3 +236,6 @@ def construct_chain_config_params(args):
 
     if args.sync_mode is not None:
         yield 'sync_mode', args.sync_mode
+
+    if args.port is not None:
+        yield 'port', args.port

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -46,7 +46,6 @@ def setup_queue_logging(log_queue: Queue, level: int) -> None:
 def with_queued_logging(fn: Callable) -> Callable:
     @functools.wraps(fn)
     def inner(*args, **kwargs):
-        print(args, kwargs)
         try:
             log_queue = kwargs['log_queue']
         except KeyError:

--- a/trinity/utils/version.py
+++ b/trinity/utils/version.py
@@ -13,5 +13,6 @@ def construct_trinity_client_identifier():
         __version__,
         platform=sys.platform,
         v=sys.version_info,
-        imp=sys.implementation,
+        # mypy Doesn't recognize the `sys` module as having an `implementation` attribute.
+        imp=sys.implementation,  # type: ignore
     )

--- a/trinity/utils/version.py
+++ b/trinity/utils/version.py
@@ -1,0 +1,17 @@
+import sys
+
+from trinity import __version__
+
+
+def construct_trinity_client_identifier():
+    """
+    Constructs the client identifier string
+
+    e.g. 'Trinity/v1.2.3/darwin-amd64/python3.6.5'
+    """
+    return "Trinity/{0}/{platform}/{imp.name}{v.major}.{v.minor}.{v.micro}".format(
+        __version__,
+        platform=sys.platform,
+        v=sys.version_info,
+        imp=sys.implementation,
+    )


### PR DESCRIPTION
Fixes #709 

### What was wrong?

The console output when running the trinity node needed some more information.

### How was it fixed?

- added an ascii header
- added `enode` info for light node
- added path to database IPC socket.
- added network id.

```bash
$ trinity
INFO trinity.db 2018-05-17 12:42:08,787 - database: /Users/piper/.local/share/trinity/mainnet/db.ipc
INFO trinity 2018-05-17 12:42:09,792 -
  ______     _       _ __
 /_  __/____(_)___  (_) /___  __
  / / / ___/ / __ \/ / __/ / / /
 / / / /  / / / / / / /_/ /_/ /
/_/ /_/  /_/_/ /_/_/\__/\__, /
                       /____/
INFO trinity 2018-05-17 12:42:09,792 - Trinity/0.2.0a17/darwin/cpython3.6.3
INFO p2p.server.Server 2018-05-17 12:42:09,822 - Running server...
INFO p2p.server.Server 2018-05-17 12:42:14,827 - No UPNP-enabled devices found
INFO p2p.server.Server 2018-05-17 12:42:14,829 - enode://7b8fb3e32de9aa5d7930fe0dd0e2365361b85c97daa1eb042ac37005f527bb80a450e9ec9012d53d8fcb94d015b115630f4556153fcf4e746993a29b14e13734@0.0.0.0:30303
INFO p2p.server.Server 2018-05-17 12:42:14,829 - network: 1
```


#### Cute Animal Picture

![tumblr_maqmw0fl8u1qzamioo6_1280](https://user-images.githubusercontent.com/824194/40197081-9d443300-59cf-11e8-9392-8af646f9b333.jpg)
