### PR TITLE
Enable ipc queries to light chain

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -42,6 +42,9 @@ from evm.db.chain import (
     BaseChainDB,
     ChainDB,
 )
+from evm.db.header import (
+    HeaderDB,
+)
 from evm.constants import (
     BLANK_ROOT_HASH,
     MAX_UNCLE_DEPTH,
@@ -176,6 +179,10 @@ class BaseChain(Configurable, metaclass=ABCMeta):
     def get_canonical_head(self):
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
+    def get_score(self, block_hash):
+        raise NotImplementedError("Chain classes must implement this method")
+
     #
     # Block API
     #
@@ -275,6 +282,7 @@ class Chain(BaseChain):
             validate_vm_configuration(self.vm_configuration)
 
         self.chaindb = self.get_chaindb_class()(base_db)
+        self.headerdb = HeaderDB(base_db)
         self.header = header
         if self.header is None:
             self.header = self.create_header_from_parent(self.get_canonical_head())
@@ -400,6 +408,14 @@ class Chain(BaseChain):
         Raises CanonicalHeadNotFound if there's no head defined for the canonical chain.
         """
         return self.chaindb.get_canonical_head()
+
+    def get_score(self, block_hash):
+        """
+        Returns the difficulty score of the block with the given hash.
+
+        Raises HeaderNotFound if there is no matching black hash.
+        """
+        return self.headerdb.get_score(block_hash)
 
     #
     # Block API

--- a/evm/db/header.py
+++ b/evm/db/header.py
@@ -132,10 +132,12 @@ class HeaderDB(BaseHeaderDB):
         return rlp.decode(header_rlp, BlockHeader)
 
     def get_score(self, block_hash: Hash32) -> int:
-        return rlp.decode(
-            self.db[SchemaV1.make_block_hash_to_score_lookup_key(block_hash)],
-            sedes=rlp.sedes.big_endian_int,
-        )
+        try:
+            score = self.db[SchemaV1.make_block_hash_to_score_lookup_key(block_hash)]
+        except KeyError:
+            raise HeaderNotFound("No header with hash {0} found".format(
+                encode_hex(block_hash)))
+        return rlp.decode(score, sedes=rlp.sedes.big_endian_int)
 
     def header_exists(self, block_hash: Hash32) -> bool:
         validate_word(block_hash, title="Block Hash")

--- a/evm/db/header.py
+++ b/evm/db/header.py
@@ -133,11 +133,11 @@ class HeaderDB(BaseHeaderDB):
 
     def get_score(self, block_hash: Hash32) -> int:
         try:
-            score = self.db[SchemaV1.make_block_hash_to_score_lookup_key(block_hash)]
+            encoded_score = self.db[SchemaV1.make_block_hash_to_score_lookup_key(block_hash)]
         except KeyError:
             raise HeaderNotFound("No header with hash {0} found".format(
                 encode_hex(block_hash)))
-        return rlp.decode(score, sedes=rlp.sedes.big_endian_int)
+        return rlp.decode(encoded_score, sedes=rlp.sedes.big_endian_int)
 
     def header_exists(self, block_hash: Hash32) -> bool:
         validate_word(block_hash, title="Block Hash")

--- a/p2p/cancel_token.py
+++ b/p2p/cancel_token.py
@@ -6,10 +6,11 @@ from p2p.exceptions import OperationCancelled
 
 class CancelToken:
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, loop: asyncio.AbstractEventLoop = None) -> None:
         self.name = name
         self._chain = []  # type: List['CancelToken']
-        self._triggered = asyncio.Event()
+        self._triggered = asyncio.Event(loop=loop)
+        self._loop = loop
 
     def chain(self, token: 'CancelToken') -> 'CancelToken':
         """Return a new CancelToken chaining this and the given token.
@@ -19,7 +20,7 @@ class CancelToken:
         has no effect on either of the chained tokens.
         """
         chain_name = ":".join([self.name, token.name])
-        chain = CancelToken(chain_name)
+        chain = CancelToken(chain_name, loop=self._loop)
         chain._chain.extend([self, token])
         return chain
 
@@ -52,16 +53,16 @@ class CancelToken:
         if self.triggered_token is not None:
             return
 
-        futures = [asyncio.ensure_future(self._triggered.wait())]
+        futures = [asyncio.ensure_future(self._triggered.wait(), loop=self._loop)]
         for token in self._chain:
-            futures.append(asyncio.ensure_future(token.wait()))
+            futures.append(asyncio.ensure_future(token.wait(), loop=self._loop))
 
         def cancel_pending(f):
             for future in futures:
                 if not future.done():
                     future.cancel()
 
-        fut = asyncio.ensure_future(_wait_for_first(futures))
+        fut = asyncio.ensure_future(_wait_for_first(futures), loop=self._loop)
         fut.add_done_callback(cancel_pending)
         await fut
 

--- a/p2p/cancel_token.py
+++ b/p2p/cancel_token.py
@@ -1,7 +1,10 @@
 import asyncio
 from typing import Any, Awaitable, cast, List
 
-from p2p.exceptions import OperationCancelled
+from p2p.exceptions import (
+    EventLoopMismatch,
+    OperationCancelled,
+)
 
 
 class CancelToken:
@@ -19,6 +22,8 @@ class CancelToken:
         called on either of the chained tokens, but calling trigger() on the new token
         has no effect on either of the chained tokens.
         """
+        if self._loop != token._loop:
+            raise EventLoopMismatch("Chained CancelToken objects must be on the same event loop")
         chain_name = ":".join([self.name, token.name])
         chain = CancelToken(chain_name, loop=self._loop)
         chain._chain.extend([self, token])

--- a/p2p/cancel_token.py
+++ b/p2p/cancel_token.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Awaitable, cast, List  # noqa: F401
+from typing import Any, Awaitable, cast, List
 
 from p2p.exceptions import OperationCancelled
 
@@ -8,7 +8,7 @@ class CancelToken:
 
     def __init__(self, name: str, loop: asyncio.AbstractEventLoop = None) -> None:
         self.name = name
-        self._chain = []  # type: List['CancelToken']
+        self._chain: List['CancelToken'] = []
         self._triggered = asyncio.Event(loop=loop)
         self._loop = loop
 

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -94,3 +94,10 @@ class NoConnectedPeers(BaseP2PError):
     Raised when an operation requires a peer connection but we have none.
     """
     pass
+
+
+class EventLoopMismatch(BaseP2PError):
+    """
+    Raised when two different asyncio event loops are referenced, but must be equal
+    """
+    pass

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -10,14 +10,13 @@ from abc import (
     abstractmethod
 )
 
-from typing import (  # noqa: F401
+from typing import (
     Any,
     Callable,
     Dict,
     Generator,
     Iterator,
     List,
-    Optional,
     Tuple,
     Type,
     TYPE_CHECKING,
@@ -38,7 +37,7 @@ from eth_utils import (
     encode_hex,
 )
 
-from eth_typing import BlockNumber, Hash32  # noqa: F401
+from eth_typing import BlockNumber, Hash32
 
 from eth_keys import (
     datatypes,
@@ -146,11 +145,11 @@ class BasePeer(BaseService):
     reply_timeout = REPLY_TIMEOUT
     # Must be defined in subclasses. All items here must be Protocol classes representing
     # different versions of the same P2P sub-protocol (e.g. ETH, LES, etc).
-    _supported_sub_protocols = []  # type: List[Type[protocol.Protocol]]
+    _supported_sub_protocols: List[Type[protocol.Protocol]] = []
     # FIXME: Must be configurable.
     listen_port = 30303
     # Will be set upon the successful completion of a P2P handshake.
-    sub_proto = None  # type: protocol.Protocol
+    sub_proto: protocol.Protocol = None
 
     def __init__(self,
                  remote: Node,
@@ -172,7 +171,7 @@ class BasePeer(BaseService):
         self.base_protocol = P2PProtocol(self)
         self.headerdb = headerdb
         self.network_id = network_id
-        self.sub_proto_msg_queue = asyncio.Queue()  # type: asyncio.Queue[Tuple[protocol.Command, protocol._DecodedMsgType]]  # noqa: E501
+        self.sub_proto_msg_queue: asyncio.Queue[Tuple[protocol.Command, protocol._DecodedMsgType]] = asyncio.Queue()  # noqa: E501
 
         self.egress_mac = egress_mac
         self.ingress_mac = ingress_mac
@@ -462,12 +461,12 @@ class BasePeer(BaseService):
 class LESPeer(BasePeer):
     max_headers_fetch = les.MAX_HEADERS_FETCH
     _supported_sub_protocols = [les.LESProtocol, les.LESProtocolV2]
-    sub_proto = None  # type: les.LESProtocol
-    head_info = None  # type: les.HeadInfo
+    sub_proto: les.LESProtocol = None
+    head_info: les.HeadInfo = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._pending_replies = {}  # type: Dict[int, Callable[[protocol._DecodedMsgType], None]]
+        self._pending_replies: Dict[int, Callable[[protocol._DecodedMsgType], None]] = {}
 
     async def send_sub_proto_handshake(self):
         self.sub_proto.send_handshake(await self._local_chain_info)
@@ -594,9 +593,9 @@ class LESPeer(BasePeer):
 
 class ETHPeer(BasePeer):
     _supported_sub_protocols = [eth.ETHProtocol]
-    sub_proto = None  # type: eth.ETHProtocol
-    head_td = None  # type: int
-    head_hash = None  # type: Hash32
+    sub_proto: eth.ETHProtocol = None
+    head_td: int = None
+    head_hash: Hash32 = None
 
     async def send_sub_proto_handshake(self):
         self.sub_proto.send_handshake(await self._local_chain_info)
@@ -642,8 +641,8 @@ class PeerPool(BaseService):
     """PeerPool attempts to keep connections to at least min_peers on the given network."""
     logger = logging.getLogger("p2p.peer.PeerPool")
     _connect_loop_sleep = 2
-    _last_lookup = 0  # type: float
-    _lookup_interval = 20  # type: int
+    _last_lookup: float = 0
+    _lookup_interval: int = 20
 
     def __init__(self,
                  peer_class: Type[BasePeer],
@@ -660,8 +659,8 @@ class PeerPool(BaseService):
         self.privkey = privkey
         self.discovery = discovery
         self.min_peers = min_peers
-        self.connected_nodes = {}  # type: Dict[Node, BasePeer]
-        self._subscribers = []  # type: List[PeerPoolSubscriber]
+        self.connected_nodes: Dict[Node, BasePeer] = {}
+        self._subscribers: List[PeerPoolSubscriber] = []
 
     def get_nodes_to_connect(self) -> Generator[Node, None, None]:
         return self.discovery.get_random_nodes(self.min_peers)
@@ -711,12 +710,12 @@ class PeerPool(BaseService):
             self.logger.debug("Skipping %s; already connected to it", remote)
             return None
         expected_exceptions = (
-            UnreachablePeer,
-            TimeoutError,
-            PeerConnectionLost,
-            HandshakeFailure,
-            EOFError,
             BrokenPipeError,
+            EOFError,
+            HandshakeFailure,
+            PeerConnectionLost,
+            TimeoutError,
+            UnreachablePeer,
         )
         try:
             self.logger.debug("Connecting to %s...", remote)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -710,7 +710,14 @@ class PeerPool(BaseService):
         if remote in self.connected_nodes:
             self.logger.debug("Skipping %s; already connected to it", remote)
             return None
-        expected_exceptions = (UnreachablePeer, TimeoutError, PeerConnectionLost, HandshakeFailure)
+        expected_exceptions = (
+            UnreachablePeer,
+            TimeoutError,
+            PeerConnectionLost,
+            HandshakeFailure,
+            EOFError,
+            BrokenPipeError,
+        )
         try:
             self.logger.debug("Connecting to %s...", remote)
             peer = await handshake(

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -8,12 +8,14 @@ from p2p.exceptions import OperationCancelled
 
 
 class BaseService(ABC):
-    # Subclasses must define their own logger.
     logger: logging.Logger = None
     # Number of seconds cancel() will wait for run() to finish.
     _wait_until_finished_timeout = 5
 
     def __init__(self, token: CancelToken=None) -> None:
+        if self.logger is None:
+            self.logger = logging.getLogger(self.__module__ + '.' + self.__class__.__name__)
+
         self.finished = asyncio.Event()
 
         base_token = CancelToken(type(self).__name__)
@@ -76,3 +78,11 @@ class BaseService(ABC):
         Called after the service's _run() method returns.
         """
         raise NotImplementedError()
+
+
+class EmptyService(BaseService):
+    async def _run(self) -> None:
+        pass
+
+    async def _cleanup(self) -> None:
+        pass

--- a/tests/p2p/test_cancel_token.py
+++ b/tests/p2p/test_cancel_token.py
@@ -4,7 +4,10 @@ import functools
 import pytest
 
 from p2p.cancel_token import CancelToken, wait_with_token
-from p2p.exceptions import OperationCancelled
+from p2p.exceptions import (
+    EventLoopMismatch,
+    OperationCancelled,
+)
 
 
 def test_token_single():
@@ -13,6 +16,13 @@ def test_token_single():
     token.trigger()
     assert token.triggered
     assert token.triggered_token == token
+
+
+def test_token_chain_event_loop_mismatch():
+    token = CancelToken('token')
+    token2 = CancelToken('token2', loop=asyncio.new_event_loop())
+    with pytest.raises(EventLoopMismatch):
+        token.chain(token2)
 
 
 def test_token_chain_trigger_chain():

--- a/tests/p2p/test_lightchain.py
+++ b/tests/p2p/test_lightchain.py
@@ -248,6 +248,9 @@ class MockPeerPool:
     def subscribe(self, subscriber):
         pass
 
+    def unsubscribe(self, subscriber):
+        pass
+
     async def run(self):
         pass
 

--- a/tests/p2p/test_lightchain.py
+++ b/tests/p2p/test_lightchain.py
@@ -6,9 +6,11 @@ import pytest
 import rlp
 from rlp import sedes
 
+from evm.chains.mainnet import BaseMainnetChain
 from evm.db.backends.memory import MemoryDB
 from evm.rlp.headers import BlockHeader
 
+from p2p.lightchain import LightPeerChain
 from p2p.les import (
     LESProtocol,
     Announce,
@@ -25,7 +27,9 @@ from peer_helpers import (
     get_fresh_mainnet_headerdb,
 )
 
-from trinity.chains.mainnet import MainnetLightPeerChain
+
+class MainnetLightPeerChain(BaseMainnetChain, LightPeerChain):
+    pass
 
 
 # A full header sync may involve several round trips, so we must be willing to wait a little bit

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -1,0 +1,208 @@
+import asyncio
+import inspect
+from typing import (  # noqa: F401
+    Any,
+    Optional,
+    Callable,
+    cast,
+    Dict,
+    Generator,
+    Iterator,
+    Tuple,
+    Type,
+    TYPE_CHECKING,
+    Union,
+)
+
+from eth_typing import (
+    BlockNumber,
+    Hash32,
+)
+
+from evm.chains.base import (
+    AccountState,
+    BaseChain,
+)
+from evm.db.backends.base import BaseDB
+from evm.db.chain import (
+    BaseChainDB,
+)
+from evm.db.header import (
+    BaseHeaderDB,
+)
+from evm.rlp.blocks import (
+    BaseBlock,
+)
+from evm.rlp.headers import (
+    BlockHeader,
+    HeaderParams,
+)
+from evm.rlp.transactions import (
+    BaseTransaction,
+    BaseUnsignedTransaction,
+)
+
+from p2p.lightchain import (
+    LightPeerChain,
+)
+
+if TYPE_CHECKING:
+    from evm.vm.base import BaseVM  # noqa: F401
+
+
+class LightDispatchChain(BaseChain):
+    """
+    Provide the :class:`BaseChain` API, even though only a
+    :class:`LightPeerChain` is syncing. Store results locally so that not
+    all requests hit the light peer network.
+    """
+
+    ASYNC_TIMEOUT_SECONDS = 10
+    _loop = None
+
+    def __init__(self, headerdb: BaseHeaderDB, peer_chain: LightPeerChain) -> None:
+        self._headerdb = headerdb
+        self._peer_chain = peer_chain
+        self._peer_chain_loop = asyncio.get_event_loop()
+
+    #
+    # Helpers
+    #
+    @classmethod
+    def get_chaindb_class(cls) -> Type[BaseChainDB]:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    #
+    # Chain API
+    #
+    @classmethod
+    def from_genesis(cls,
+                     base_db: BaseDB,
+                     genesis_params: Dict[str, HeaderParams],
+                     genesis_state: AccountState=None) -> 'BaseChain':
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    @classmethod
+    def from_genesis_header(cls,
+                            base_db: BaseDB,
+                            genesis_header: BlockHeader) -> 'BaseChain':
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def get_chain_at_block_parent(self, block: BaseBlock) -> 'BaseChain':
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    #
+    # VM API
+    #
+    def get_vm(self, header: BlockHeader=None) -> 'BaseVM':
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    #
+    # Header API
+    #
+    def create_header_from_parent(self,
+                                  parent_header: BlockHeader,
+                                  **header_params: HeaderParams) -> BlockHeader:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
+        return self._headerdb.get_block_header_by_hash(block_hash)
+
+    def get_canonical_head(self):
+        return self._headerdb.get_canonical_head()
+
+    def get_score(self, block_hash: Hash32) -> int:
+        return self._headerdb.get_score(block_hash)
+
+    #
+    # Block API
+    #
+    def get_ancestors(self, limit: int) -> Iterator[BaseBlock]:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def get_block(self) -> BaseBlock:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def get_block_by_hash(self, block_hash: Hash32) -> BaseBlock:
+        header = self._headerdb.get_block_header_by_hash(block_hash)
+        return self.get_block_by_header(header)
+
+    def get_block_by_header(self, header: BlockHeader) -> BaseBlock:
+        # TODO check local cache, before hitting peer
+        block_body = self._run_async(
+            self._peer_chain.get_block_body_by_hash(header.hash)
+        )
+
+        block_class = self.get_vm_class_for_block_number(header.block_number).get_block_class()
+        transactions = [
+            block_class.transaction_class.from_base_transaction(tx)
+            for tx in block_body.transactions
+        ]
+        return block_class(
+            header=header,
+            transactions=transactions,
+            uncles=block_body.uncles,
+        )
+
+    def get_canonical_block_by_number(self, block_number: BlockNumber) -> BaseBlock:
+        """
+        Return the block with the given number from the canonical chain.
+        Raises HeaderNotFound if it is not found.
+        """
+        header = self._headerdb.get_canonical_block_header_by_number(block_number)
+        return self.get_block_by_header(header)
+
+    def get_canonical_block_hash(self, block_number):
+        return self._headerdb.get_canonical_block_hash(block_number)
+
+    #
+    # Transaction API
+    #
+    def create_transaction(self, *args: Any, **kwargs: Any) -> BaseTransaction:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def create_unsigned_transaction(self,
+                                    *args: Any,
+                                    **kwargs: Any) -> BaseUnsignedTransaction:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def get_canonical_transaction(self, transaction_hash: Hash32) -> BaseTransaction:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    #
+    # Execution API
+    #
+    def apply_transaction(self, transaction):
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def estimate_gas(self, transaction: BaseTransaction, at_header: BlockHeader=None) -> int:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def import_block(self, block: BaseBlock, perform_validation: bool=True) -> BaseBlock:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def mine_block(self, *args: Any, **kwargs: Any) -> BaseBlock:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    #
+    # Validation API
+    #
+    def validate_block(self, block: BaseBlock) -> None:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def validate_gaslimit(self, header: BlockHeader) -> None:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def validate_seal(self, header: BlockHeader) -> None:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    def validate_uncles(self, block: BaseBlock) -> None:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    #
+    # Async utils
+    #
+
+    def _run_async(self, async_method):
+        future = asyncio.run_coroutine_threadsafe(async_method, loop=self._peer_chain_loop)
+        return future.result(self.ASYNC_TIMEOUT_SECONDS)

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -117,7 +117,7 @@ class LightDispatchChain(BaseChain):
     #
     # Block API
     #
-    def get_ancestors(self, limit: int) -> Iterator[BaseBlock]:
+    def get_ancestors(self, limit: int, header: BlockHeader=None) -> Iterator[BaseBlock]:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
     def get_block(self) -> BaseBlock:

--- a/trinity/chains/mainnet.py
+++ b/trinity/chains/mainnet.py
@@ -2,8 +2,8 @@ from evm.chains.mainnet import (
     BaseMainnetChain,
 )
 
-from p2p.lightchain import LightPeerChain
+from trinity.chains.light import LightDispatchChain
 
 
-class MainnetLightPeerChain(BaseMainnetChain, LightPeerChain):
+class MainnetLightDispatchChain(BaseMainnetChain, LightDispatchChain):
     pass

--- a/trinity/chains/ropsten.py
+++ b/trinity/chains/ropsten.py
@@ -2,8 +2,8 @@ from evm.chains.ropsten import (
     BaseRopstenChain,
 )
 
-from p2p.lightchain import LightPeerChain
+from trinity.chains.light import LightDispatchChain
 
 
-class RopstenLightPeerChain(BaseRopstenChain, LightPeerChain):
+class RopstenLightDispatchChain(BaseRopstenChain, LightDispatchChain):
     pass

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -62,7 +62,7 @@ class Node(BaseService):
 
         try:
             asyncio.ensure_future(self._peer_pool.run())
-            asyncio.run_coroutine_threadsafe(ipc_server.run(), loop=ipc_loop)
+            asyncio.run_coroutine_threadsafe(ipc_server.run(loop=ipc_loop), loop=ipc_loop)
             await self._peer_chain.run()
         finally:
             await ipc_server.stop()

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -1,0 +1,84 @@
+from abc import abstractmethod
+import asyncio
+from pathlib import PurePath
+from threading import Thread
+from typing import Type
+
+from evm.chains.base import BaseChain
+from evm.db.header import BaseHeaderDB
+from p2p.service import (
+    BaseService,
+    EmptyService,
+)
+from trinity.rpc.main import (
+    RPCServer,
+)
+from trinity.rpc.ipc import (
+    IPCServer,
+)
+
+
+class Node(BaseService):
+    """
+    Create usable nodes by adding subclasses that define the following
+    unset attributes...
+    """
+
+    chain_class: Type[BaseChain] = None
+    peer_chain_class: Type[BaseService] = None
+
+    def __init__(
+            self,
+            headerdb: BaseHeaderDB,
+            peer_pool,
+            jsonrpc_ipc_path: PurePath = None):
+        super().__init__()
+        self._headerdb = headerdb
+        self._jsonrpc_ipc_path = jsonrpc_ipc_path
+        self._peer_pool = peer_pool
+        self._peer_chain = self.peer_chain_class(headerdb, peer_pool)
+
+    @abstractmethod
+    def get_chain(self) -> BaseChain:
+        raise NotImplementedError("Node classes must implement this method")
+
+    def make_ipc_server(self) -> IPCServer:
+        if self._jsonrpc_ipc_path:
+            rpc = RPCServer(self.get_chain())
+            return IPCServer(rpc, self._jsonrpc_ipc_path)
+        else:
+            return EmptyService()
+
+    async def _run(self):
+        ipc_server = self.make_ipc_server()
+
+        # The RPC server needs its own thread, because it provides a synchcronous
+        # API which might call into p2p async methods. These sync->async calls
+        # deadlock if they are run in the same Thread and loop.
+        ipc_loop = self._make_new_loop_thread()
+
+        # keep a copy on self, for debugging
+        self._ipc_server, self._ipc_loop = ipc_server, ipc_loop
+
+        try:
+            asyncio.ensure_future(self._peer_pool.run())
+            asyncio.run_coroutine_threadsafe(ipc_server.run(), loop=ipc_loop)
+            await self._peer_chain.run()
+        finally:
+            await ipc_server.stop()
+            await self._peer_pool.cancel()
+
+    async def _cleanup(self):
+        await self._peer_chain.stop()
+
+    def _make_new_loop_thread(self):
+        new_loop = asyncio.new_event_loop()
+
+        def start_loop(loop):
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+
+        thread = Thread(target=start_loop, args=(new_loop, ))
+        thread.start()
+
+        return new_loop

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -1,0 +1,25 @@
+from typing import Type
+
+from p2p.lightchain import LightPeerChain
+
+from trinity.chains.light import (
+    LightDispatchChain,
+)
+
+from trinity.nodes.base import Node
+
+
+class LightNode(Node):
+    peer_chain_class = LightPeerChain
+    chain_class: Type[LightDispatchChain] = None
+
+    _chain: LightDispatchChain = None
+
+    def get_chain(self) -> LightDispatchChain:
+        if self._chain is None:
+            if self.chain_class is None:
+                raise AttributeError("LightNode subclass must set chain_class")
+            peer_chain = self._peer_chain
+            self._chain = self.chain_class(self._headerdb, peer_chain=peer_chain)
+
+        return self._chain

--- a/trinity/nodes/mainnet.py
+++ b/trinity/nodes/mainnet.py
@@ -1,0 +1,6 @@
+from trinity.chains.mainnet import MainnetLightDispatchChain
+from trinity.nodes.light import LightNode
+
+
+class MainnetLightNode(LightNode):
+    chain_class = MainnetLightDispatchChain

--- a/trinity/nodes/ropsten.py
+++ b/trinity/nodes/ropsten.py
@@ -1,0 +1,6 @@
+from trinity.chains.ropsten import RopstenLightDispatchChain
+from trinity.nodes.light import LightNode
+
+
+class RopstenLightNode(LightNode):
+    chain_class = RopstenLightDispatchChain

--- a/trinity/rpc/format.py
+++ b/trinity/rpc/format.py
@@ -58,7 +58,7 @@ def block_to_dict(block, chain, include_transactions):
 
     block_dict = dict(
         header_dict,
-        totalDifficulty=hex(chain.chaindb.get_score(block.hash)),
+        totalDifficulty=hex(chain.get_score(block.hash)),
         uncles=[encode_hex(uncle.hash) for uncle in block.uncles],
         size=hex(len(rlp.encode(block))),
     )

--- a/trinity/rpc/ipc.py
+++ b/trinity/rpc/ipc.py
@@ -132,7 +132,7 @@ class IPCServer:
             loop=loop,
             limit=MAXIMUM_REQUEST_BYTES,
         )
-        self.logger.info('ipc-path: %s', os.path.abspath(self.ipc_path))
+        self.logger.info('IPC started at: %s', os.path.abspath(self.ipc_path))
         await self.cancel_token.wait()
 
     async def stop(self):

--- a/trinity/rpc/ipc.py
+++ b/trinity/rpc/ipc.py
@@ -123,9 +123,9 @@ class IPCServer:
     def __init__(self, rpc, ipc_path):
         self.rpc = rpc
         self.ipc_path = ipc_path
-        self.cancel_token = CancelToken('IPCServer')
 
     async def run(self, loop=None):
+        self.cancel_token = CancelToken('IPCServer', loop=loop)
         self.server = await asyncio.start_unix_server(
             connection_handler(self.rpc.execute, self.cancel_token),
             self.ipc_path,
@@ -136,6 +136,7 @@ class IPCServer:
         await self.cancel_token.wait()
 
     async def stop(self):
-        self.cancel_token.trigger()
+        if self.cancel_token is not None:
+            self.cancel_token.trigger()
         self.server.close()
         await self.server.wait_closed()


### PR DESCRIPTION
### What was wrong?

Want to use IPC to query the light chain, starting from trinity command line.

### How was it fixed?

Still very much in progress, but this shows the number of the latest downloaded header:

```sh
$ trinity --ropsten --light --data-dir /tmp/trinity-light-ropsten/
... <logs> ...
```
```py
from web3 import Web3
w3t = Web3(Web3.IPCProvider('/tmp/trinity-light-ropsten/jsonrpc.ipc'))
w3t.eth.blockNumber
```
I've been hacking away to get `w3t.eth.getBlock('latest')` working, then I'll pinch this PR off.

Some outstanding questions:
- What is the best way to interface with `LightPeerChain` (formerly `p2p.lightchain.LightChain`) from a synchronous interface. I tried to avoid asyncio spreading virally through the code base. But still getting errors about futures on different threads, etc, and I'm new enough to asyncio that a *good* solution isn't obvious to me.
- Which things should be running in their own threads?
- Some modules are split by network (mainnet/ropsten/etc), others split by node type (full/light/sharding?/stateless?). Which makes more sense? (all the ropsten variants in one file, or all the full nodes in one file?)
- Surely a lot more.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/u6HR0om_TL4/maxresdefault.jpg)
