### PR TITLE
Trinity log output: reorder, align

### DIFF
--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -20,7 +20,7 @@ def setup_trinity_logging(level: int) -> Tuple[Logger, Queue, handlers.QueueList
     handler = logging.StreamHandler(sys.stdout)
 
     formatter = logging.Formatter(
-        fmt='%(asctime)s %(levelname)8s %(name)s - %(message)s',
+        fmt='%(levelname)8s  %(asctime)s  %(name)s  %(message)s',
         datefmt='%m-%d %H:%M:%S'
     )
     handler.setFormatter(formatter)

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -20,7 +20,8 @@ def setup_trinity_logging(level: int) -> Tuple[Logger, Queue, handlers.QueueList
     handler = logging.StreamHandler(sys.stdout)
 
     formatter = logging.Formatter(
-        '%(asctime)s %(levelname)8s %(name)s - %(message)s'
+        fmt='%(asctime)s %(levelname)8s %(name)s - %(message)s',
+        datefmt='%m-%d %H:%M:%S'
     )
     handler.setFormatter(formatter)
 

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -20,7 +20,7 @@ def setup_trinity_logging(level: int) -> Tuple[Logger, Queue, handlers.QueueList
     handler = logging.StreamHandler(sys.stdout)
 
     formatter = logging.Formatter(
-        '%(levelname)s %(name)s %(asctime)s - %(message)s'
+        '%(asctime)s %(levelname)8s %(name)s - %(message)s'
     )
     handler.setFormatter(formatter)
 

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -19,8 +19,9 @@ def setup_trinity_logging(level: int) -> Tuple[Logger, Queue, handlers.QueueList
 
     handler = logging.StreamHandler(sys.stdout)
 
+    # TODO: allow configuring `detailed` logging
     formatter = logging.Formatter(
-        fmt='%(levelname)8s  %(asctime)s  %(name)s  %(message)s',
+        fmt='%(levelname)8s  %(asctime)s  %(module)9s  %(message)s',
         datefmt='%m-%d %H:%M:%S'
     )
     handler.setFormatter(formatter)


### PR DESCRIPTION
### What was wrong?

Logging output is somewhat hard to read:

```
DEBUG root 2018-05-18 18:29:05,034 - Logging initialized
INFO p2p.server.Server 2018-05-18 18:29:05,067 - Running server...
INFO p2p.server.Server 2018-05-18 18:29:10,073 - No UPNP-enabled devices found
INFO p2p.server.Server 2018-05-18 18:29:10,074 - enode://bdd67f995510d373497248f62f05c5260dc5e5240df95863e3c4963a32090313420ead08c10173bf18039e713cbceaf4c7223a3089a98692fb4814829f169430@0.0.0.0:30303
DEBUG p2p.discovery.DiscoveryProtocol 2018-05-18 18:29:10,122 - boostrapping with [<Node(0x30b7@52.176.7.10)>]
INFO p2p.peer.PeerPool 2018-05-18 18:29:10,125 - Running PeerPool...
DEBUG p2p.peer.PeerPool 2018-05-18 18:29:10,125 - Last node discovery lookup too long ago, triggering another
DEBUG p2p.peer.PeerPool 2018-05-18 18:29:10,128 - Connecting to <Node(0x0250@54.175.255.230)>...
DEBUG p2p.discovery.DiscoveryProtocol 2018-05-18 18:29:10,181 - >>> ping <Node(0x30b7@52.176.7.10)> (token == 0x16bc62851fdc06810c8d7b94b5318e555e5bd5630b42f96702cf141523519fb8)
DEBUG p2p.discovery.KademliaProtocol 2018-05-18 18:29:10,324 - <<< pong from <Node(0x30b7@52.176.7.10)> (token == 0x16bc62851fdc06810c8d7b94b5318e555e5bd5630b42f96702cf141523519fb8)
DEBUG p2p.discovery.KademliaProtocol 2018-05-18 18:29:10,325 - got expected pong with token 0x16bc62851fdc06810c8d7b94b5318e555e5bd5630b42f96702cf141523519fb8
INFO p2p.sync.FullNodeSyncer 2018-05-18 18:29:10,871 - Starting fast-sync; current head: #0
```

### How was it fixed?

The formatting string was changed to have time first, and char-limit the `level` to 8 chars (which matches the char count in `CRITICAL`):

```
2018-05-18 18:30:52,908    DEBUG root - Logging initialized
2018-05-18 18:30:52,941     INFO p2p.server.Server - Running server...
2018-05-18 18:30:57,947     INFO p2p.server.Server - No UPNP-enabled devices found
2018-05-18 18:30:57,949     INFO p2p.server.Server - enode://bdd67f995510d373497248f62f05c5260dc5e5240df95863e3c4963a32090313420ead08c10173bf18039e713cbceaf4c7223a3089a98692fb4814829f169430@0.0.0.0:30303
2018-05-18 18:30:57,992    DEBUG p2p.discovery.DiscoveryProtocol - boostrapping with [<Node(0x30b7@52.176.7.10)>]
2018-05-18 18:30:57,994     INFO p2p.peer.PeerPool - Running PeerPool...
2018-05-18 18:30:57,994    DEBUG p2p.peer.PeerPool - Last node discovery lookup too long ago, triggering another
2018-05-18 18:30:57,996    DEBUG p2p.peer.PeerPool - Connecting to <Node(0x0250@54.175.255.230)>...
2018-05-18 18:30:58,054    DEBUG p2p.discovery.DiscoveryProtocol - >>> ping <Node(0x30b7@52.176.7.10)> (token == 0x41b2d2fd37000511507fe4b7000155628d0922ffba10836529afb7f4a7be7bf3)
2018-05-18 18:30:58,197    DEBUG p2p.discovery.KademliaProtocol - <<< pong from <Node(0x30b7@52.176.7.10)> (token == 0x41b2d2fd37000511507fe4b7000155628d0922ffba10836529afb7f4a7be7bf3)
2018-05-18 18:30:58,198    DEBUG p2p.discovery.KademliaProtocol - got expected pong with token 0x41b2d2fd37000511507fe4b7000155628d0922ffba10836529afb7f4a7be7bf3
2018-05-18 18:30:58,738     INFO p2p.sync.FullNodeSyncer - Starting fast-sync; current head: #0
```

This also makes it easier to remove the timestamp without code modifications (e.g. if running with `systemd`, which already includes a timestamp).

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.surfnetkids.com/images/koala-leaf.jpg)

(Source unknown, found [here](http://carnivoraforum.com/single/?p=8222300&t=9328811))