### PR TITLE
Implement a limited version of PoW mining

### DIFF
--- a/evm/consensus/pow.py
+++ b/evm/consensus/pow.py
@@ -65,3 +65,18 @@ def check_pow(block_number: int,
             encode_hex(mining_output[b'mix digest']), encode_hex(mix_hash)))
     result = big_endian_to_int(mining_output[b'result'])
     validate_lte(result, 2**256 // difficulty, title="POW Difficulty")
+
+
+MAX_TEST_MINE_ATTEMPTS = 1000
+
+
+def test_mine_pow_nonce(block_number, mining_hash, difficulty):
+    cache = get_cache(block_number)
+    for nonce in range(MAX_TEST_MINE_ATTEMPTS):
+        mining_output = hashimoto_light(block_number, cache, mining_hash, nonce)
+        result = big_endian_to_int(mining_output[b'result'])
+        result_cap = 2**256 // difficulty
+        if result <= result_cap:
+            return nonce.to_bytes(8, 'big'), mining_output[b'mix digest']
+
+    raise Exception("Too many attempts at POW mining, giving up")

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -212,7 +212,7 @@ class BaseVM(Configurable, metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def get_prev_hashes(cls, last_block_hash, db):
+    def get_prev_hashes(cls, last_block_hash, chaindb):
         raise NotImplementedError("VM classes must implement this method")
 
     @staticmethod
@@ -565,16 +565,16 @@ class VM(BaseVM):
     @classmethod
     @functools.lru_cache(maxsize=32)
     @to_tuple
-    def get_prev_hashes(cls, last_block_hash, db):
+    def get_prev_hashes(cls, last_block_hash, chaindb):
         if last_block_hash == GENESIS_PARENT_HASH:
             return
 
-        block_header = get_block_header_by_hash(last_block_hash, db)
+        block_header = get_block_header_by_hash(last_block_hash, chaindb)
 
         for _ in range(MAX_PREV_HEADER_DEPTH):
             yield block_header.hash
             try:
-                block_header = get_parent_header(block_header, db)
+                block_header = get_parent_header(block_header, chaindb)
             except (IndexError, HeaderNotFound):
                 break
 

--- a/evm/vm/forks/frontier/__init__.py
+++ b/evm/vm/forks/frontier/__init__.py
@@ -81,3 +81,15 @@ class FrontierVM(VM):
     @classmethod
     def get_nephew_reward(cls):
         return cls.get_block_reward() // 32
+
+
+# A VM that does POW mining as well. Should be used only in tests, when we need to programatically
+# populate a ChainDB.
+class _PoWMiningVM(FrontierVM):
+
+    def finalize_block(self, block):
+        from evm.consensus import pow
+        block = super().finalize_block(block)
+        nonce, mix_hash = pow.test_mine_pow_nonce(
+            block.number, block.header.mining_hash, block.header.difficulty)
+        return block.copy(header=block.header.copy(nonce=nonce, mix_hash=mix_hash))

--- a/tests/core/chain-object/test_mining.py
+++ b/tests/core/chain-object/test_mining.py
@@ -1,0 +1,56 @@
+from eth_keys import keys
+from eth_utils import decode_hex
+
+from evm import constants
+from evm.chains.base import Chain
+from evm.db.backends.memory import MemoryDB
+from evm.vm.forks.frontier import _PoWMiningVM
+
+
+class PowMiningChain(Chain):
+    vm_configuration = ((0, _PoWMiningVM),)
+    network_id = 999
+
+
+def test_pow_mining():
+    sender = keys.PrivateKey(
+        decode_hex("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee"))
+    receiver = keys.PrivateKey(
+        decode_hex("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"))
+    genesis_params = {
+        'parent_hash': constants.GENESIS_PARENT_HASH,
+        'uncles_hash': constants.EMPTY_UNCLE_HASH,
+        'coinbase': constants.ZERO_ADDRESS,
+        'transaction_root': constants.BLANK_ROOT_HASH,
+        'receipt_root': constants.BLANK_ROOT_HASH,
+        'bloom': 0,
+        'difficulty': 5,
+        'block_number': constants.GENESIS_BLOCK_NUMBER,
+        'gas_limit': constants.GENESIS_GAS_LIMIT,
+        'gas_used': 0,
+        'timestamp': 1514764800,
+        'extra_data': constants.GENESIS_EXTRA_DATA,
+        'nonce': constants.GENESIS_NONCE
+    }
+    state = {
+        sender.public_key.to_canonical_address(): {
+            "balance": 100000000000000000,
+            "code": b"",
+            "nonce": 0,
+            "storage": {}
+        }
+    }
+    chain = PowMiningChain.from_genesis(MemoryDB(), genesis_params, state)
+    for i in range(10):
+        tx = chain.create_unsigned_transaction(
+            nonce=i,
+            gas_price=1234,
+            gas=1234000,
+            to=receiver.public_key.to_canonical_address(),
+            value=i,
+            data=b'',
+        )
+        chain.apply_transaction(tx.as_signed_transaction(sender))
+        block = chain.mine_block()
+        assert block.number == i + 1
+        assert chain.header.block_number == i + 2


### PR DESCRIPTION
So, I'm trying to generate a full blockchain DB programatically, from scratch,
by creating arbitrary transactions and then mining the blocks. I intend to use
that to test the chain syncers

However, I first realized we currently cannot do that as BaseVM.mine_block() doesn't
set the block's mix_hash, so I changed it to do that, but now I get a validation
error on the POW difficulty check, and I've no idea why, so it'd be great if you
guys could have a look at this and maybe shed some light.

Also, is the change to BaseVM.finalise_block() something we'd want to merge?

Finally, can you guys think of a better way to programmatically generate a
blockchain DB with a dozen or so blocks? Or is this approach ok?

The failing test: https://circleci.com/gh/ethereum/py-evm/11905?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link