### PR TITLE
reduce INFO level log output

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -179,7 +179,7 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
             self._downloaded_bodies,
             _body_key,
             'body')
-        self.logger.info("Got block bodies for chain segment")
+        self.logger.debug("Got block bodies for chain segment")
 
         missing_receipts = [header for header in headers if not _is_receipts_empty(header)]
         # Post-Byzantium blocks may have identical receipt roots (e.g. when they have the same
@@ -192,7 +192,7 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
             self._downloaded_receipts,
             _receipts_key,
             'receipt')
-        self.logger.info("Got block receipts for chain segment")
+        self.logger.debug("Got block receipts for chain segment")
 
         # FIXME: Get the bodies returned by self._download_block_parts above and use persit_block
         # here.

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -568,7 +568,7 @@ class KademliaProtocol:
             closest = sort_by_distance(closest, node_id)[:k_bucket_size]
             nodes_to_ask = _exclude_if_asked(closest)
 
-        self.logger.info("lookup finished for %s: %s", node_id, closest)
+        self.logger.debug("lookup finished for %s: %s", node_id, closest)
         return closest
 
     async def lookup_random(self, cancel_token: CancelToken) -> List[Node]:

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -298,7 +298,7 @@ class BasePeer(BaseService):
             try:
                 self.process_msg(cmd, msg)
             except RemoteDisconnected as e:
-                self.logger.info("%s disconnected: %s", self, e)
+                self.logger.debug("%s disconnected: %s", self, e)
                 return
 
     async def read_msg(self) -> Tuple[protocol.Command, protocol._DecodedMsgType]:

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -37,7 +37,7 @@ class BaseService(ABC):
         except Exception:
             self.logger.exception("Unexpected error in %s, exiting", self)
         else:
-            self.logger.info("%s finished cleanly", self)
+            self.logger.debug("%s finished cleanly", self)
         finally:
             await self.cleanup()
             self.finished.set()


### PR DESCRIPTION
### What was wrong?

When you run trinity, the console output looks like this:

```bash
$ trinity
    INFO  05-18 13:43:31       main
  ______     _       _ __
 /_  __/____(_)___  (_) /___  __
  / / / ___/ / __ \/ / __/ / / /
 / / / /  / / / / / / /_/ /_/ /
/_/ /_/  /_/_/ /_/_/\__/\__, /
                       /____/
    INFO  05-18 13:43:31       main  Trinity/0.2.0a18/darwin/cpython3.6.3
    INFO  05-18 13:43:31     server  Running server...
    INFO  05-18 13:43:36     server  enode://7b8fb3e32de9aa5d7930fe0dd0e2365361b85c97daa1eb042ac37005f527bb80a450e9ec9012d53d8fcb94d015b115630f4556153fcf4e746993a29b14e13734@0.0.0.0:30303
    INFO  05-18 13:43:36     server  network: 1
    INFO  05-18 13:43:36       peer  Running PeerPool...
    INFO  05-18 13:43:37       sync  Starting fast-sync; current head: #12287
    INFO  05-18 13:43:47   kademlia  lookup finished for 96090401233785634189406600858114393267280823550807613727467994083749827993146: [<Node(0x25a1@138.197.135.30)>, <Node(0xd075@149.210.194.165)>, <Node(0xf93d@46.229.171.8)>, <Node(0x4742@172.104.130.233)>, <Node(0x33b6@13.72.242.241)>, <Node(0x69b4@104.131.167.208)>, <Node(0xd89b@45.55.179.0)>, <Node(0x1f35@138.197.139.97)>, <Node(0x3d9c@207.154.218.119)>, <Node(0x4b2a@167.114.185.64)>, <Node(0x579f@35.170.162.142)>, <Node(0x13f7@52.47.123.39)>, <Node(0xb49f@88.99.127.25)>, <Node(0x612e@13.57.213.129)>, <Node(0xea57@54.245.170.71)>, <Node(0x312f@45.32.133.9)>]
    INFO  05-18 13:52:18      chain  Starting sync with ETHPeer <Node(0x7869@34.241.136.69)>
    INFO  05-18 13:52:18      chain  Fetching chain segment starting at #12095
    INFO  05-18 13:52:18      chain  Got headers segment starting at #12095
    INFO  05-18 13:52:21      chain  Got block bodies for chain segment
    INFO  05-18 13:52:21      chain  Got block receipts for chain segment
    INFO  05-18 13:52:21      chain  Imported chain segment, new head: #12287
    INFO  05-18 13:52:21      chain  Fetching chain segment starting at #12288
    INFO  05-18 13:52:22      chain  Got headers segment starting at #12288
    INFO  05-18 13:52:23      chain  Got block bodies for chain segment
    INFO  05-18 13:52:23      chain  Got block receipts for chain segment
    INFO  05-18 13:52:23      chain  Imported chain segment, new head: #12479
    INFO  05-18 13:52:23      chain  Fetching chain segment starting at #12480
    INFO  05-18 13:52:24      chain  Got headers segment starting at #12480
    INFO  05-18 13:52:24       peer  ETHPeer <Node(0x7869@34.241.136.69)> disconnected: disconnect_requested
    INFO  05-18 13:52:24    service  ETHPeer <Node(0x7869@34.241.136.69)> finished cleanly
    INFO  05-18 13:52:32       peer  ETHPeer <Node(0x00e6@47.106.65.52)> disconnected: disconnect_requested
    INFO  05-18 13:52:32    service  ETHPeer <Node(0x00e6@47.106.65.52)> finished cleanly
    INFO  05-18 13:52:35       peer  ETHPeer <Node(0xe24b@68.43.210.211)> disconnected: disconnect_requested
    INFO  05-18 13:52:35    service  ETHPeer <Node(0xe24b@68.43.210.211)> finished cleanly
    INFO  05-18 13:52:41       peer  <Node(0xd5b3@54.197.9.131)> stopped responding (PeerConnectionLost("IncompleteReadError('1 bytes read on a total of 32 expected bytes',)",)), disconnecting
    INFO  05-18 13:52:41    service  ETHPeer <Node(0xd5b3@54.197.9.131)> finished cleanly
    INFO  05-18 13:52:42       peer  ETHPeer <Node(0xf857@184.72.111.92)> disconnected: disconnect_requested
    INFO  05-18 13:52:42    service  ETHPeer <Node(0xf857@184.72.111.92)> finished cleanly
    INFO  05-18 13:52:43       peer  ETHPeer <Node(0x4968@196.196.244.21)> disconnected: disconnect_requested
    INFO  05-18 13:52:43    service  ETHPeer <Node(0x4968@196.196.244.21)> finished cleanly
    INFO  05-18 13:52:44       peer  ETHPeer <Node(0x96c0@35.194.240.107)> disconnected: disconnect_requested
    INFO  05-18 13:52:44    service  ETHPeer <Node(0x96c0@35.194.240.107)> finished cleanly
    INFO  05-18 13:52:44       peer  ETHPeer <Node(0xd239@18.233.147.145)> disconnected: disconnect_requested
    INFO  05-18 13:52:44    service  ETHPeer <Node(0xd239@18.233.147.145)> finished cleanly
    INFO  05-18 13:52:45       peer  ETHPeer <Node(0xaec9@95.213.180.67)> disconnected: disconnect_requested
    INFO  05-18 13:52:45    service  ETHPeer <Node(0xaec9@95.213.180.67)> finished cleanly
    INFO  05-18 13:52:46       peer  ETHPeer <Node(0x3428@208.54.240.134)> disconnected: disconnect_requested
    INFO  05-18 13:52:46    service  ETHPeer <Node(0x3428@208.54.240.134)> finished cleanly
    INFO  05-18 13:52:47       peer  ETHPeer <Node(0xee1d@122.235.139.88)> disconnected: disconnect_requested
    INFO  05-18 13:52:47    service  ETHPeer <Node(0xee1d@122.235.139.88)> finished cleanly
    INFO  05-18 13:52:49       peer  ETHPeer <Node(0xff72@95.79.4.133)> disconnected: disconnect_requested
    INFO  05-18 13:52:49    service  ETHPeer <Node(0xff72@95.79.4.133)> finished cleanly
    INFO  05-18 13:52:51       peer  ETHPeer <Node(0xfdb4@202.107.192.12)> disconnected: disconnect_requested
    INFO  05-18 13:52:51    service  ETHPeer <Node(0xfdb4@202.107.192.12)> finished cleanly
    INFO  05-18 13:52:51       peer  ETHPeer <Node(0xb126@176.9.98.36)> disconnected: disconnect_requested
    INFO  05-18 13:52:51    service  ETHPeer <Node(0xb126@176.9.98.36)> finished cleanly
    INFO  05-18 13:53:02       peer  ETHPeer <Node(0x85ba@47.75.9.16)> disconnected: disconnect_requested
```


### How was it fixed?

Adjusted some of the logging to output things at `debug` level.  Result is:

```bash
 /_  __/____(_)___  (_) /___  __
  / / / ___/ / __ \/ / __/ / / /
 / / / /  / / / / / / /_/ /_/ /
/_/ /_/  /_/_/ /_/_/\__/\__, /
                       /____/
    INFO  05-18 14:04:21       main  Trinity/0.2.0a18/darwin/cpython3.6.3
    INFO  05-18 14:04:21     server  Running server...
    INFO  05-18 14:04:26     server  enode://7b8fb3e32de9aa5d7930fe0dd0e2365361b85c97daa1eb042ac37005f527bb80a450e9ec9012d53d8fcb94d015b115630f4556153fcf4e746993a29b14e13734@0.0.0.0:30304
    INFO  05-18 14:04:26     server  network: 1
    INFO  05-18 14:04:26       peer  Running PeerPool...
    INFO  05-18 14:04:28       sync  Starting fast-sync; current head: #12671
    INFO  05-18 14:04:34      chain  Starting sync with ETHPeer <Node(0xa41d@127.0.0.1)>
    INFO  05-18 14:04:34      chain  Fetching chain segment starting at #12479
    INFO  05-18 14:04:34      chain  Got headers segment starting at #12479
    INFO  05-18 14:04:35      chain  Imported chain segment, new head: #12671
    INFO  05-18 14:04:35      chain  Fetching chain segment starting at #12672
    INFO  05-18 14:04:35      chain  Got headers segment starting at #12672
    INFO  05-18 14:04:35      chain  Imported chain segment, new head: #12863
    INFO  05-18 14:04:35      chain  Fetching chain segment starting at #12864
    INFO  05-18 14:04:36      chain  Got headers segment starting at #12864
    INFO  05-18 14:04:36      chain  Imported chain segment, new head: #13055
    INFO  05-18 14:04:36      chain  Fetching chain segment starting at #13056
```

#### Cute Animal Picture

![img_3182](https://user-images.githubusercontent.com/824194/40255468-7de3e386-5aa4-11e8-9d43-b3e7a27aa515.JPG)

