### PR TITLE
Rename LightChain -> LightPeerChain

### DIFF
--- a/docs/guides/evm/building_chains.rst
+++ b/docs/guides/evm/building_chains.rst
@@ -43,10 +43,10 @@ Then to initialize, you can start it up with an in-memory database:
   chain = chain_class.from_genesis_header(MemoryDB(), MAINNET_GENESIS_HEADER)
 
 
-Using the LightChain object
+Using the LightPeerChain object
 ---------------------------
 
-The :class:`~p2p.lightchain.LightChain` is like a Chain but it will also
+The :class:`~p2p.lightchain.LightPeerChain` is like a Chain but it will also
 connect to remote peers and fetch new :class:`~evm.rlp.headers.BlockHeader`
 objects as they are announced on the network. As such, it must first be
 configured with a `vm_configuration` and a `network_id`:
@@ -55,11 +55,11 @@ configured with a `vm_configuration` and a `network_id`:
 
   from evm.chains.mainnet import MAINNET_VM_CONFIGURATION, MAINNET_NETWORK_ID
   from p2p import ecies
-  from p2p.lightchain import LightChain
+  from p2p.lightchain import LightPeerChain
   from p2p.peer import LESPeer, PeerPool
 
-  DemoLightChain = LightChain.configure(
-      __name__='Demo LightChain',
+  DemoLightPeerChain = LightPeerChain.configure(
+      __name__='Demo LightPeerChain',
       vm_configuration=MAINNET_VM_CONFIGURATION,
       network_id=MAINNET_NETWORK_ID,
   )
@@ -82,7 +82,7 @@ its `run()` method:
 
   peer_pool = PeerPool(LESPeer, headerdb, MAINNET_NETWORK_ID, ecies.generate_privkey())
 
-  chain = DemoLightChain.from_genesis_header(base_db, MAINNET_GENESIS_HEADER, peer_pool)
+  chain = DemoLightPeerChain.from_genesis_header(base_db, MAINNET_GENESIS_HEADER, peer_pool)
   loop = asyncio.get_event_loop()
   loop.run_until_complete(chain.run())
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -20,7 +20,7 @@ Sync and interact with the Ropsten chain
 
 Currently we only provide a light client that will sync only block headers,
 although it can fetch block bodies on demand. The easiest way to try it is by
-running the lightchain_shell, which will run the LightChain in the background
+running the lightchain_shell, which will run the LightPeerChain in the background
 and let you use the python interpreter to interact with it:
 
 .. code:: sh
@@ -36,7 +36,7 @@ can use even before it has finished syncing:
   >>> chain.get_canonical_head()
   <BlockHeader #2200794 e3f9c6bb>
 
-Some :class:`~p2p.lightchain.LightChain` methods (e.g. those that need data
+Some :class:`~p2p.lightchain.LightPeerChain` methods (e.g. those that need data
 from block bodies) are coroutines that need to be executed by asyncio's event
 loop, so for those we provide a helper that will schedule their execution and
 wait for the result:

--- a/p2p/les.py
+++ b/p2p/les.py
@@ -214,7 +214,7 @@ class Proofs(Command):
     def decode_payload(self, rlp_data: bytes) -> _DecodedMsgType:
         decoded = super().decode_payload(rlp_data)
         decoded = cast(Dict[str, Any], decoded)
-        # This is just to make Proofs messages compatible with ProofsV2, so that LightChain
+        # This is just to make Proofs messages compatible with ProofsV2, so that LightPeerChain
         # doesn't have to special-case them. Soon we should be able to drop support for LES/1
         # anyway, and then all this code will go away.
         if not decoded['proofs']:

--- a/tests/p2p/test_lightchain.py
+++ b/tests/p2p/test_lightchain.py
@@ -25,7 +25,7 @@ from peer_helpers import (
     get_fresh_mainnet_headerdb,
 )
 
-from trinity.chains.mainnet import MainnetLightChain
+from trinity.chains.mainnet import MainnetLightPeerChain
 
 
 # A full header sync may involve several round trips, so we must be willing to wait a little bit
@@ -214,16 +214,16 @@ async def get_client_and_server_peer_pair(request, event_loop, client_headerdb, 
 
 
 async def get_lightchain_with_peers(request, event_loop, server_peer_headerdb):
-    """Return a MainnetLightChain instance with a client/server peer pair.
+    """Return a MainnetLightPeerChain instance with a client/server peer pair.
 
     The server is a LESPeerServer instance that can be used to send Announce and BlockHeaders
-    messages, and the client will be registered with the LightChain so that a sync
-    request is added to the LightChain's queue every time a new Announce message is received.
+    messages, and the client will be registered with the LightPeerChain so that a sync
+    request is added to the LightPeerChain's queue every time a new Announce message is received.
     """
     headerdb = get_fresh_mainnet_headerdb()
-    light_chain = MainnetLightChain(headerdb, MockPeerPool())
+    light_chain = MainnetLightPeerChain(headerdb, MockPeerPool())
     asyncio.ensure_future(light_chain.run())
-    await asyncio.sleep(0)  # Yield control to give the LightChain a chance to start
+    await asyncio.sleep(0)  # Yield control to give the LightPeerChain a chance to start
 
     def finalizer():
         event_loop.run_until_complete(light_chain.stop())

--- a/tests/p2p/test_lightchain_integration.py
+++ b/tests/p2p/test_lightchain_integration.py
@@ -15,13 +15,13 @@ from evm.db.backends.memory import MemoryDB
 from evm.vm.forks.frontier.blocks import FrontierBlock
 
 from p2p import ecies
-from p2p.lightchain import LightChain
+from p2p.lightchain import LightPeerChain
 from p2p.peer import LESPeer
 
 from integration_test_helpers import FakeAsyncHeaderDB, LocalGethPeerPool
 
 
-class IntegrationTestLightChain(LightChain):
+class IntegrationTestLightPeerChain(LightPeerChain):
     vm_configuration = MAINNET_VM_CONFIGURATION
     network_id = ROPSTEN_NETWORK_ID
     max_consecutive_timeouts = 1
@@ -29,7 +29,7 @@ class IntegrationTestLightChain(LightChain):
 
 @pytest.mark.asyncio
 async def test_lightchain_integration(request, event_loop):
-    """Test LightChain against a local geth instance.
+    """Test LightPeerChain against a local geth instance.
 
     This test assumes a geth/ropsten instance is listening on 127.0.0.1:30303 and serving light
     clients. In order to achieve that, simply run it with the following command line:
@@ -48,11 +48,11 @@ async def test_lightchain_integration(request, event_loop):
     peer_pool = LocalGethPeerPool(
         LESPeer, headerdb, ROPSTEN_NETWORK_ID, ecies.generate_privkey(),
     )
-    chain = IntegrationTestLightChain(base_db, peer_pool)
+    chain = IntegrationTestLightPeerChain(base_db, peer_pool)
 
     asyncio.ensure_future(peer_pool.run())
     asyncio.ensure_future(chain.run())
-    await asyncio.sleep(0)  # Yield control to give the LightChain a chance to start
+    await asyncio.sleep(0)  # Yield control to give the LightPeerChain a chance to start
 
     def finalizer():
         event_loop.run_until_complete(peer_pool.cancel())

--- a/trinity/chains/mainnet.py
+++ b/trinity/chains/mainnet.py
@@ -2,8 +2,8 @@ from evm.chains.mainnet import (
     BaseMainnetChain,
 )
 
-from p2p.lightchain import LightChain
+from p2p.lightchain import LightPeerChain
 
 
-class MainnetLightChain(BaseMainnetChain, LightChain):
+class MainnetLightPeerChain(BaseMainnetChain, LightPeerChain):
     pass

--- a/trinity/chains/ropsten.py
+++ b/trinity/chains/ropsten.py
@@ -2,8 +2,8 @@ from evm.chains.ropsten import (
     BaseRopstenChain,
 )
 
-from p2p.lightchain import LightChain
+from p2p.lightchain import LightPeerChain
 
 
-class RopstenLightChain(BaseRopstenChain, LightChain):
+class RopstenLightPeerChain(BaseRopstenChain, LightPeerChain):
     pass

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -30,10 +30,10 @@ from trinity.chains import (
     serve_chaindb,
 )
 from trinity.chains.mainnet import (
-    MainnetLightChain,
+    MainnetLightPeerChain,
 )
 from trinity.chains.ropsten import (
-    RopstenLightChain,
+    RopstenLightPeerChain,
 )
 from trinity.chains.header import (
     AsyncHeaderChainProxy,
@@ -208,9 +208,9 @@ def run_lightnode_process(chain_config: ChainConfig) -> None:
     headerdb = manager.get_headerdb()  # type: ignore
 
     if chain_config.network_id == MAINNET_NETWORK_ID:
-        chain_class = MainnetLightChain  # type: ignore
+        chain_class = MainnetLightPeerChain  # type: ignore
     elif chain_config.network_id == ROPSTEN_NETWORK_ID:
-        chain_class = RopstenLightChain  # type: ignore
+        chain_class = RopstenLightPeerChain  # type: ignore
     else:
         raise NotImplementedError(
             "Only the mainnet and ropsten chains are currently supported"


### PR DESCRIPTION
### What was wrong?

`LightChain` no longer tries to meet the BaseChain API. It should be renamed to avoid confusion with other Chains. 

### How was it fixed?

Renamed to `LightPeerChain`. `LightPeerSyncer` seemed reasonable too, but there are other classes called synchronizer, and I didn't want to add any more confusion. Open to other ideas for names.

Generated with:
```sh
find {p2p,trinity,docs,tests} -type f -exec sed -i "s/LightChain/LightPeerChain/g" {} \;
```

Extracted from #717 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img.buzzfeed.com/buzzfeed-static/static/2015-06/25/19/campaign_images/webdr04/15-irresistible-photos-of-newborn-animals-that-wi-2-22423-1435274830-0_dblbig.jpg)
