### PR TITLE
Convert path types to use `PurePath`

### DIFF
--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -79,7 +79,7 @@ def is_database_initialized(chaindb: AsyncChainDB) -> bool:
 
 
 def initialize_data_dir(chain_config: ChainConfig) -> None:
-    if is_under_xdg_trinity_root(chain_config.data_dir):
+    if is_under_xdg_trinity_root(str(chain_config.data_dir)):
         os.makedirs(chain_config.data_dir, exist_ok=True)
     elif not os.path.exists(chain_config.data_dir):
         # we don't lazily create the base dir for non-default base directories.

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -175,6 +175,10 @@ def run_database_process(chain_config: ChainConfig, db_class: Type[BaseDB]) -> N
 
 
 def create_dbmanager(ipc_path: str) -> BaseManager:
+    """
+    We're still using 'str' here on param ipc_path because an issue with
+    multi-processing not being able to interpret 'PurePath' objects correctly
+    """
     class DBManager(BaseManager):
         pass
 


### PR DESCRIPTION
### What was wrong?

In the `trinity` module we have a number of path objects that are typed as `str`.

The `pathlib` standard library module has a [PurePath](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath) class which is more appropriate.

Issue Reference: https://github.com/ethereum/py-evm/issues/725, https://github.com/ethereum/py-evm/pull/716#discussion_r189361151

### How was it fixed?

Update the `trinity` module to use the `PurePath` type for all filesystem paths. If it seems appropriate, lets also update the code to actually use and return `PurePath` objects.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2017/04/cute-dog-shiba-inu-ryuji-japan-68.jpg)
