### PR TITLE
Add subscribe context manager API to PeerPoolSubscriber

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -303,7 +303,6 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
             self.logger.info("Waited too long for peers to finish, exiting anyway")
 
     async def _cleanup(self) -> None:
-        self.peer_pool.unsubscribe(self)
         await self.wait_until_finished()
 
     async def _handle_msg(self, peer: ETHPeer, cmd: protocol.Command,

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 import operator
 import random
@@ -14,6 +15,7 @@ from typing import (  # noqa: F401
     Callable,
     Dict,
     Generator,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -626,6 +628,14 @@ class PeerPoolSubscriber(metaclass=ABCMeta):
     @abstractmethod
     def register_peer(self, peer: BasePeer) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
+
+    @contextlib.contextmanager
+    def subscribe(self, peer_pool: 'PeerPool') -> Iterator[None]:
+        peer_pool.subscribe(self)
+        try:
+            yield
+        finally:
+            peer_pool.unsubscribe(self)
 
 
 class PeerPool(BaseService):

--- a/p2p/sharding.py
+++ b/p2p/sharding.py
@@ -179,7 +179,7 @@ class ShardSyncer(BaseService, PeerPoolSubscriber):
                 self.collations_received_event.clear()
 
     async def _cleanup(self) -> None:
-        self.peer_pool.unsubscribe(self)
+        pass
 
     def propose(self) -> Collation:
         """Broadcast a new collation to the network, add it to the local shard, and return it."""


### PR DESCRIPTION
### What was wrong?

The various classes which are `PeerPoolSubscriber` subclasses were not consistently unsubscribing themselves from the peer pool.

### How was it fixed?

Added a new context manager API so that unsubscribe-ing is automatic upon exiting the context. 

#### Cute Animal Picture

![chicks_in_hats7](https://user-images.githubusercontent.com/824194/40283576-ae7f517a-5c3d-11e8-9027-521e04130eec.jpg)
