### PR TITLE
python 3.6 typing

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -74,7 +74,7 @@ CMD_ID_MAP = dict((cmd.id, cmd) for cmd in [CMD_PING, CMD_PONG, CMD_FIND_NODE, C
 class DiscoveryProtocol(asyncio.DatagramProtocol):
     """A Kademlia-like protocol to discover RLPx nodes."""
     logger = logging.getLogger("p2p.discovery.DiscoveryProtocol")
-    transport = None  # type: asyncio.DatagramTransport
+    transport: asyncio.DatagramTransport = None
     _max_neighbours_per_packet_cache = None
 
     def __init__(self, privkey: datatypes.PrivateKey, address: kademlia.Address,

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -8,10 +8,8 @@ import struct
 import time
 from urllib import parse as urlparse
 from functools import total_ordering
-from typing import (  # noqa: F401
-    Any,
+from typing import (
     Callable,
-    cast,
     Dict,
     Generator,
     List,
@@ -141,8 +139,8 @@ class KBucket(Sized):
     def __init__(self, start: int, end: int) -> None:
         self.start = start
         self.end = end
-        self.nodes = []  # type: List[Node]
-        self.replacement_cache = []  # type: List[Node]
+        self.nodes: List[Node] = []
+        self.replacement_cache: List[Node] = []
         self.last_updated = time.time()
 
     @property
@@ -232,7 +230,7 @@ class RoutingTable:
             self.logger.warn(
                 "Cannot get %d nodes as RoutingTable contains only %d nodes", count, len(self))
             count = len(self)
-        seen = []  # type: List[Node]
+        seen: List[Node] = []
         # This is a rather inneficient way of randomizing nodes from all buckets, but even if we
         # iterate over all nodes in the routing table, the time it takes would still be
         # insignificant compared to the time it takes for the network roundtrips when connecting
@@ -329,9 +327,9 @@ class KademliaProtocol:
         self.this_node = node
         self.wire = wire
         self.routing = RoutingTable(node)
-        self.pong_callbacks = {}  # type: Dict[bytes, Callable[[], None]]
-        self.ping_callbacks = {}  # type: Dict[Node, Callable[[], None]]
-        self.neighbours_callbacks = {}  # type: Dict[Node, Callable[[List[Node]], None]]
+        self.pong_callbacks: Dict[bytes, Callable[[], None]] = {}
+        self.ping_callbacks: Dict[Node, Callable[[], None]] = {}
+        self.neighbours_callbacks: Dict[Node, Callable[[List[Node]], None]] = {}
 
     def recv_neighbours(self, remote: Node, neighbours: List[Node]) -> None:
         """Process a neighbours response.
@@ -461,7 +459,7 @@ class KademliaProtocol:
                 "There's another coroutine waiting for a neighbours packet from {}".format(remote))
 
         event = asyncio.Event()
-        neighbours = []  # type: List[Node]
+        neighbours: List[Node] = []
 
         def process(response):
             neighbours.extend(response)
@@ -530,8 +528,8 @@ class KademliaProtocol:
         It approaches the target by querying nodes that are closer to it on each iteration.  The
         given target does not need to be an actual node identifier.
         """
-        nodes_asked = set()  # type: Set[Node]
-        nodes_seen = set()   # type: Set[Node]
+        nodes_asked: Set[Node] = set()
+        nodes_seen: Set[Node] = set()
 
         async def _find_node(node_id, remote):
             # Short-circuit in case our token has been triggered to avoid trying to send requests

--- a/p2p/lightchain.py
+++ b/p2p/lightchain.py
@@ -1,15 +1,12 @@
 import asyncio
 import logging
 import time
-from typing import (  # noqa: F401
-    Any,
+from typing import (
     cast,
     Dict,
     List,
-    Optional,
     Set,
     Tuple,
-    Type,
     TYPE_CHECKING,
 )
 
@@ -47,10 +44,10 @@ class LightPeerChain(PeerPoolSubscriber):
     def __init__(self, headerdb: 'BaseAsyncHeaderDB', peer_pool: PeerPool) -> None:
         self.headerdb = headerdb
         self.peer_pool = peer_pool
-        self._announcement_queue = asyncio.Queue()  # type: asyncio.Queue[Tuple[LESPeer, les.HeadInfo]]  # noqa: E501
-        self._last_processed_announcements = {}  # type: Dict[LESPeer, les.HeadInfo]
+        self._announcement_queue: asyncio.Queue[Tuple[LESPeer, les.HeadInfo]] = asyncio.Queue()
+        self._last_processed_announcements: Dict[LESPeer, les.HeadInfo] = {}
         self.cancel_token = CancelToken('LightPeerChain')
-        self._running_peers = set()  # type: Set[LESPeer]
+        self._running_peers: Set[LESPeer] = set()
 
     def register_peer(self, peer: BasePeer) -> None:
         asyncio.ensure_future(self.handle_peer(cast(LESPeer, peer)))

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -1,6 +1,6 @@
 import logging
 import struct
-from typing import (  # noqa: F401
+from typing import (
     Any,
     Dict,
     List,
@@ -32,9 +32,9 @@ _DecodedMsgType = Union[
 
 
 class Command:
-    _cmd_id = None  # type: int
+    _cmd_id: int = None
     decode_strict = True
-    structure = []  # type: List[Tuple[str, Any]]
+    structure: List[Tuple[str, Any]] = []
 
     def __init__(self, cmd_id_offset: int) -> None:
         self.cmd_id_offset = cmd_id_offset
@@ -101,11 +101,11 @@ class Command:
 
 class Protocol:
     logger = logging.getLogger("p2p.protocol.Protocol")
-    name = None  # type: str
-    version = None  # type: int
-    cmd_length = None  # type: int
+    name: str = None
+    version: int = None
+    cmd_length: int = None
     # List of Command classes that this protocol supports.
-    _commands = []  # type: List[Type[Command]]
+    _commands: List[Type[Command]] = []
 
     def __init__(self, peer: 'BasePeer', cmd_id_offset: int) -> None:
         self.peer = peer

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import asyncio
-import logging  # noqa: F401
+import logging
 from typing import Callable, Optional
 
 from p2p.cancel_token import CancelToken

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import secrets
 import time
-from typing import (  # noqa: F401
+from typing import (
     Any,
     cast,
     Dict,
@@ -40,11 +40,11 @@ from p2p.service import BaseService
 
 class StateDownloader(BaseService, PeerPoolSubscriber):
     logger = logging.getLogger("p2p.state.StateDownloader")
-    _pending_nodes = {}  # type: Dict[Any, float]
+    _pending_nodes: Dict[Any, float] = {}
     _total_processed_nodes = 0
     _report_interval = 10  # Number of seconds between progress reports.
     _reply_timeout = 20  # seconds
-    _start_time = None  # type: float
+    _start_time: float = None
     _total_timeouts = 0
 
     def __init__(self,
@@ -56,8 +56,8 @@ class StateDownloader(BaseService, PeerPoolSubscriber):
         self.peer_pool = peer_pool
         self.root_hash = root_hash
         self.scheduler = StateSync(root_hash, account_db)
-        self._running_peers = set()  # type: Set[ETHPeer]
-        self._peers_with_pending_requests = {}  # type: Dict[ETHPeer, float]
+        self._running_peers: Set[ETHPeer] = set()
+        self._peers_with_pending_requests: Dict[ETHPeer, float] = {}
 
     def register_peer(self, peer: BasePeer) -> None:
         asyncio.ensure_future(self.handle_peer(cast(ETHPeer, peer)))

--- a/trinity/console.py
+++ b/trinity/console.py
@@ -23,16 +23,14 @@ DEFAULT_BANNER = (
 def ipython_shell(namespace, banner):
     """Try to run IPython shell."""
     try:
-        import IPython  # noqa: F401
+        import IPython
     except ImportError:
         raise ImportError(
             "The IPython library is not available.  Make sure IPython is "
             "installed or re-run with --vanilla-shell"
         )
 
-    from IPython.terminal.embed import InteractiveShellEmbed
-
-    return InteractiveShellEmbed(user_ns=namespace, banner1=banner)
+    return IPython.terminal.embed.InteractiveShellEmbed(user_ns=namespace, banner1=banner)
 
 
 def python_shell(namespace, banner):

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -1,12 +1,12 @@
 import json
 import logging
-from typing import Dict  # noqa: F401
+from typing import Dict
 
 from evm.exceptions import (
     ValidationError,
 )
 
-from trinity.rpc.modules import (  # noqa: F401
+from trinity.rpc.modules import (
     Eth,
     EVM,
     RPCModule,
@@ -58,7 +58,7 @@ class RPCServer:
     )
 
     def __init__(self, chain):
-        self.modules = {}  # type: Dict[str, RPCModule]
+        self.modules: Dict[str, RPCModule] = {}
         self.chain = chain
         for M in self.module_classes:
             self.modules[M.__name__.lower()] = M(chain)


### PR DESCRIPTION
I intentionally skipped a few because of a conflict with
PR #717 on ipc-light-client

### What was wrong?

Still using a bunch of old py35-style typing in p2p and trinity. Inspired by https://github.com/ethereum/py-evm/pull/717#discussion_r189720999

### How was it fixed?

Switched to py36-style typing. Once I wrote the macro, how could I *not* do it everywhere?

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.fsnc1-1.fna.fbcdn.net/v/t1.0-9/22089462_1377809919002049_5462839965115167143_n.jpg?_nc_cat=0&oh=7194e5ec15da5b8703b6a81df4c9a1cd&oe=5B8C6801)
