### PR TITLE
Add PreferredNodePeerPool

### DIFF
--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -100,4 +100,10 @@ class EventLoopMismatch(BaseP2PError):
     """
     Raised when two different asyncio event loops are referenced, but must be equal
     """
+
+
+class NoEligibleNodes(BaseP2PError):
+    """
+    Raised when there are no nodes which meet some filter criteria
+    """
     pass

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -912,7 +912,7 @@ class PreferredNodePeerPool(PeerPool):
     @to_tuple
     def _get_eligible_preferred_nodes(self) -> Generator[Node, None, None]:
         """
-        Returns nodes from the preferred_nodes which have not been used within
+        Return nodes from the preferred_nodes which have not been used within
         the last preferred_node_recycle_time
         """
         for node in self.preferred_nodes:
@@ -922,7 +922,7 @@ class PreferredNodePeerPool(PeerPool):
 
     def _get_random_preferred_node(self) -> Node:
         """
-        Returns a random node from the preferred list.
+        Return a random node from the preferred list.
         """
         eligible_nodes = self._get_eligible_preferred_nodes()
         if not eligible_nodes:
@@ -932,7 +932,7 @@ class PreferredNodePeerPool(PeerPool):
 
     def _get_random_bootnode(self) -> Generator[Node, None, None]:
         """
-        Returns a single node to bootstrap, preferring nodes from the preferred list.
+        Return a single node to bootstrap, preferring nodes from the preferred list.
         """
         try:
             node = self._get_random_preferred_node()
@@ -943,7 +943,7 @@ class PreferredNodePeerPool(PeerPool):
 
     def get_nodes_to_connect(self) -> Generator[Node, None, None]:
         """
-        Returns up to `min_peers` nodes, preferring nodes from the preferred list.
+        Return up to `min_peers` nodes, preferring nodes from the preferred list.
         """
         preferred_nodes = self._get_eligible_preferred_nodes()[:self.min_peers]
         for node in preferred_nodes:

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -7,11 +7,26 @@ from evm.chains.ropsten import (
     ROPSTEN_NETWORK_ID,
 )
 
+from p2p.kademlia import Node
+
 from trinity import __version__
 from trinity.constants import (
     SYNC_FULL,
     SYNC_LIGHT,
 )
+
+
+class ValidateAndStoreEnodes(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if values is None:
+            return
+
+        enode = Node.from_uri(values)
+
+        if getattr(namespace, self.dest) is None:
+            setattr(namespace, self.dest, [])
+        enode_list = getattr(namespace, self.dest)
+        enode_list.append(enode)
 
 
 DEFAULT_LOG_LEVEL = 'info'
@@ -89,6 +104,16 @@ networkid_parser.add_argument(
     help=(
         "Ropsten network: pre configured proof-of-work test network.  Shortcut "
         "for `--networkid=3`"
+    ),
+)
+
+network_parser.add_argument(
+    '--preferred-node',
+    action=ValidateAndStoreEnodes,
+    dest="preferred_nodes",
+    help=(
+        "An enode address which will be 'preferred' above nodes found using the "
+        "discovery protocol"
     ),
 )
 

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -1,10 +1,9 @@
 import os
+from pathlib import PurePath
 from typing import (
     Tuple,
     Union,
 )
-
-from pathlib import PurePath
 
 from eth_utils import (
     decode_hex,
@@ -129,6 +128,7 @@ class ChainConfig:
     _network_id: int = None
 
     port: int = None
+    preferred_nodes: Tuple[Node, ...] = None
 
     bootstrap_nodes: Tuple[Node, ...] = None
 
@@ -139,10 +139,12 @@ class ChainConfig:
                  nodekey: PrivateKey=None,
                  sync_mode: str=SYNC_FULL,
                  port: int=30303,
+                 preferred_nodes: Tuple[Node, ...]=None,
                  bootstrap_nodes: Tuple[Node, ...]=None) -> None:
         self.network_id = network_id
         self.sync_mode = sync_mode
         self.port = port
+        self.preferred_nodes = preferred_nodes
 
         if bootstrap_nodes is None:
             if self.network_id == MAINNET_NETWORK_ID:
@@ -270,3 +272,8 @@ def construct_chain_config_params(args):
 
     if args.port is not None:
         yield 'port', args.port
+
+    if args.preferred_nodes is None:
+        yield 'preferred_nodes', args.preferred_nodes
+    else:
+        yield 'preferred_nodes', tuple(args.preferred_nodes)


### PR DESCRIPTION
link: https://github.com/ethereum/py-evm/issues/741

### What was wrong?

- Running `trinity --light` with a niave peer pool and discovery will rarely find an LES peer to connect to.
- Using `HardCodedNodesPeerPool` eliminates discovery, but also locks Trinity into only being able to connect to a few nodes.
- We will be implementing APIs for Trinity to support reserving slots for certain nodes and trusted nodes.

### How was it fixed?

Implement a new `PeerPool` class which implements list of *preferred* nodes.  

- Anytime the peer pool is looking for a new node to connect to it will try to use one of the preferred nodes.  
- Each preferred node may only be used once every 300 seconds.
- If there are no preferred nodes which have not been used recently then it falls back to use the discovery protocol

#### Cute Animal Picture

![86037878e80b3023632ab6b9907a750b](https://user-images.githubusercontent.com/824194/40387450-08a7bd44-5dca-11e8-941d-906f994c9fd5.jpg)

