### PR TITLE
Move bootnode config to `ChainConfig` object

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -42,21 +42,21 @@ REPLY_TIMEOUT = 3
 LES_ANNOUNCE_SIMPLE = 1
 LES_ANNOUNCE_SIGNED = 2
 
-MAINNET_BOOTNODES = [
+MAINNET_BOOTNODES = (
     'enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303',  # noqa: E501
     'enode://aa36fdf33dd030378a0168efe6ed7d5cc587fafa3cdd375854fe735a2e11ea3650ba29644e2db48368c46e1f60e716300ba49396cd63778bf8a818c09bded46f@13.93.211.84:30303',  # noqa: E501
     'enode://78de8a0916848093c73790ead81d1928bec737d565119932b98c6b100d944b7a95e94f847f689fc723399d2e31129d182f7ef3863f2b4c820abbf3ab2722344d@191.235.84.50:30303',  # noqa: E501
     'enode://158f8aab45f6d19c6cbf4a089c2670541a8da11978a2f90dbf6a502a4a3bab80d288afdbeb7ec0ef6d92de563767f3b1ea9e8e334ca711e9f8e2df5a0385e8e6@13.75.154.138:30303',  # noqa: E501
     'enode://1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082@52.74.57.123:30303',   # noqa: E501
-]
-ROPSTEN_BOOTNODES = [
+)
+ROPSTEN_BOOTNODES = (
     'enode://30b7ab30a01c124a6cceca36863ece12c4f5fa68e3ba9b0b51407ccc002eeed3b3102d20a88f1c1d3c3154e2449317b8ef95090e77b312d5cc39354f86d5d606@52.176.7.10:30303',     # noqa: E501
     # FIXME: Re-enable those bootnodes once we've figured out why we can't "bond" with them:
     # https://github.com/ethereum/py-evm/issues/438
     # 'enode://865a63255b3bb68023b6bffd5095118fcc13e79dcf014fe4e47e065c350c7cc72af2e53eff895f11ba1bbb6a2b33271c1116ee870f266618eadfc2e78aa7349c@52.176.100.77:30303',   # noqa: E501
     # 'enode://6332792c4a00e3e4ee0926ed89e0d27ef985424d97b6a45bf0f23e51f0dcb5e66b875777506458aea7af6f9e4ffb69f43f3778ee73c81ed9d34c51c4b16b0b0f@52.232.243.152:30303',  # noqa: E501
     # 'enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@192.81.208.223:30303',  # noqa: E501
-]
+)
 
 # Default configuration
 # Minimum peers number, we'll try to keep open connections to at least this number of peers

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -255,8 +255,16 @@ def run_fullnode_process(chain_config: ChainConfig, port: int) -> None:
 
     peer_pool_class = HardCodedNodesPeerPool
     server = Server(
-        chain_config.nodekey, port, chain, chaindb, headerdb, db, chain_config.network_id,
-        peer_pool_class=peer_pool_class)
+        chain_config.nodekey,
+        port,
+        chain,
+        chaindb,
+        headerdb,
+        db,
+        chain_config.network_id,
+        peer_pool_class=peer_pool_class,
+        bootstrap_nodes=chain_config.bootstrap_nodes,
+    )
 
     loop = asyncio.get_event_loop()
     # Use a ProcessPoolExecutor as the default so that we can offload cpu-intensive tasks from the

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -1,4 +1,8 @@
 import os
+from typing import (
+    Tuple,
+    Union,
+)
 
 from eth_utils import (
     decode_hex,
@@ -15,6 +19,12 @@ from evm.chains.ropsten import (
     ROPSTEN_NETWORK_ID,
 )
 
+from p2p.kademlia import Node
+from p2p.constants import (
+    MAINNET_BOOTNODES,
+    ROPSTEN_BOOTNODES,
+)
+
 from trinity.constants import (
     SYNC_FULL,
     SYNC_LIGHT,
@@ -22,8 +32,6 @@ from trinity.constants import (
 from .xdg import (
     get_xdg_trinity_root,
 )
-
-from typing import Union
 
 
 DEFAULT_DATA_DIRS = {
@@ -114,16 +122,31 @@ class ChainConfig:
 
     port: int = None
 
+    bootstrap_nodes: Tuple[Node, ...] = None
+
     def __init__(self,
                  network_id: int,
                  data_dir: str=None,
                  nodekey_path: str=None,
                  nodekey: PrivateKey=None,
                  sync_mode: str=SYNC_FULL,
-                 port: int=30303) -> None:
+                 port: int=30303,
+                 bootstrap_nodes: Tuple[Node, ...]=None) -> None:
         self.network_id = network_id
         self.sync_mode = sync_mode
         self.port = port
+
+        if bootstrap_nodes is None:
+            if self.network_id == MAINNET_NETWORK_ID:
+                self.bootstrap_nodes = tuple(
+                    Node.from_uri(enode) for enode in MAINNET_BOOTNODES
+                )
+            elif self.network_id == ROPSTEN_NETWORK_ID:
+                self.bootstrap_nodes = tuple(
+                    Node.from_uri(enode) for enode in ROPSTEN_BOOTNODES
+                )
+        else:
+            self.bootstrap_nodes = bootstrap_nodes
 
         # validation
         if nodekey is not None and nodekey_path is not None:


### PR DESCRIPTION
### What was wrong?

Various places where we are juggling a list of bootnodes.

### How was it fixed?

Moved this into the `ChainConfig` as a property which handles the logic for defaulting based on `network_id`

#### Cute Animal Picture

![a3aea23f9f469c47c2517be5751a37f8](https://user-images.githubusercontent.com/824194/40378535-15300d82-5db1-11e8-8c3a-81a1ba2a862f.jpg)

