### PR TITLE
Use proper client version string

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -1,5 +1,3 @@
-CLIENT_VERSION_STRING = "Trinity"
-
 SUPPORTED_RLPX_VERSION = 4
 
 # Overhead added by ECIES encryption

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -11,10 +11,6 @@ from p2p.protocol import (
     _DecodedMsgType,
 )
 
-from .constants import (
-    CLIENT_VERSION_STRING,
-)
-
 
 class Hello(Command):
     _cmd_id = 0
@@ -80,8 +76,10 @@ class P2PProtocol(Protocol):
         super(P2PProtocol, self).__init__(peer, cmd_id_offset=0)
 
     def send_handshake(self):
+        # TODO: move import out once this is in the trinity codebase
+        from trinity.utils.version import construct_trinity_client_identifier
         data = dict(version=self.version,
-                    client_version_string=CLIENT_VERSION_STRING,
+                    client_version_string=construct_trinity_client_identifier(),
                     capabilities=self.peer.capabilities,
                     listen_port=self.peer.listen_port,
                     remote_pubkey=self.peer.privkey.public_key.to_bytes())


### PR DESCRIPTION
### What was wrong?

The client version string that trinity announced was just `Trinity`

### How was it fixed?

Updated to a *proper* version string with 

`ClientName/ClientVersion/Platform/Language+LanguageVersion`


#### Cute Animal Picture

![aaf8c0a358dea06796e77852339cf225--chicken-quotes-chicken-life](https://user-images.githubusercontent.com/824194/40378648-6aefbcc2-5db1-11e8-8f08-a8d70efdb2e8.jpg)

