### PR TITLE
Try separating trinity and evm packages

### DIFF
--- a/README-trinity.md
+++ b/README-trinity.md
@@ -1,0 +1,8 @@
+# Trinity
+
+[Documentation hosted by ReadTheDocs](http://py-evm.readthedocs.io/en/latest/)
+
+
+## Introducing Py-EVM
+
+Trinity is a client for the Ethereum blockchain written in Python.

--- a/README-trinity.md
+++ b/README-trinity.md
@@ -1,8 +1,0 @@
-# Trinity
-
-[Documentation hosted by ReadTheDocs](http://py-evm.readthedocs.io/en/latest/)
-
-
-## Introducing Py-EVM
-
-Trinity is a client for the Ethereum blockchain written in Python.

--- a/setup_trinity.py
+++ b/setup_trinity.py
@@ -9,7 +9,7 @@ setup(
     # NOT CURRENTLY APPLICABLE. VERSION BUMPS MANUAL FOR NOW
     version='0.1.0-alpha.2',
     description='The Trinity Ethereum Client',
-    author='Piper Merriam',
+    author='Ethereum Foundation',
     author_email='piper@pipermerriam.com',
     url='https://github.com/ethereum/py-evm',
     include_package_data=True,

--- a/setup_trinity.py
+++ b/setup_trinity.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from setuptools import setup
+
+
+setup(
+    name='trinity',
+    # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
+    # NOT CURRENTLY APPLICABLE. VERSION BUMPS MANUAL FOR NOW
+    version='0.1.0-alpha.2',
+    description='The Trinity Ethereum Client',
+    author='Piper Merriam',
+    author_email='piper@pipermerriam.com',
+    url='https://github.com/ethereum/py-evm',
+    include_package_data=True,
+    py_modules=[],
+    install_requires=[
+        'py-evm[trinity,p2p]==0.2.0a18',
+    ],
+    license='MIT',
+    zip_safe=False,
+    keywords='ethereum blockchain evm trinity',
+    packages=[],
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3.6',
+    ],
+    # trinity
+    entry_points={
+        'console_scripts': ['trinity=trinity:main'],
+    },
+)

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -4,7 +4,8 @@ import pkg_resources
 try:
     __version__: str = pkg_resources.get_distribution("trinity").version
 except pkg_resources.DistributionNotFound:
-    __version__: str = pkg_resources.get_distribution("py-evm").version
+    # mypy doesn't like that `__version__` is defined twice
+    __version__: str = pkg_resources.get_distribution("py-evm").version  # type: ignore
 
 from .main import (  # noqa: F401
     main,

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -1,7 +1,10 @@
 import pkg_resources
 
 # TODO: update this to use the `trinity` version once extracted from py-evm
-__version__: str = pkg_resources.get_distribution("py-evm").version
+try:
+    __version__: str = pkg_resources.get_distribution("trinity").version
+except pkg_resources.DistributionNotFound:
+    __version__: str = pkg_resources.get_distribution("py-evm").version
 
 from .main import (  # noqa: F401
     main,


### PR DESCRIPTION
Fixes: https://github.com/ethereum/py-evm/issues/728

### What was wrong?

Trinity and Py-EVM are not the same python package but they live in the same repo.

### How was it fixed?

Added a `setup_trinity.py` file which can be used to release **only** the trinity code (maybe)

#### Cute Animal Picture

![376740 xcitefun-baby-donkey-7](https://user-images.githubusercontent.com/824194/40391641-405f6cc6-5dd6-11e8-94ca-c7d68e0135d1.jpg)

