### PR TITLE
json-rpc support for full node

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -112,6 +112,10 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
 
     async def handle_msg(self, peer: ETHPeer, cmd: protocol.Command,
                          msg: protocol._DecodedMsgType) -> None:
+        known_exceptions = (
+            BrokenPipeError,
+            ConnectionResetError,
+        )
         try:
             await self._handle_msg(peer, cmd, msg)
         except OperationCancelled:
@@ -119,6 +123,8 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
             # with ensure_future()). Our caller will also get an OperationCancelled anyway, and
             # there it will be handled.
             pass
+        except known_exceptions:
+            self.logger.warn("Halted while handling message from %s", peer)
         except Exception:
             self.logger.exception("Unexpected error when processing msg from %s", peer)
 

--- a/p2p/lightchain.py
+++ b/p2p/lightchain.py
@@ -47,12 +47,13 @@ from p2p.peer import (
 from p2p.service import (
     BaseService,
 )
+from p2p.utils import unclean_close_exceptions
 
 if TYPE_CHECKING:
     from trinity.db.header import BaseAsyncHeaderDB  # noqa: F401
 
 
-class LightPeerChain(BaseService, PeerPoolSubscriber):
+class LightPeerChain(PeerPoolSubscriber, BaseService):
     logger = logging.getLogger("p2p.lightchain.LightPeerChain")
     max_consecutive_timeouts = 5
     headerdb: 'BaseAsyncHeaderDB' = None
@@ -165,8 +166,8 @@ class LightPeerChain(BaseService, PeerPoolSubscriber):
                 except OperationCancelled:
                     self.logger.debug("Asked to stop, breaking out of run() loop")
                     break
-                except (EOFError, ConnectionResetError, BrokenPipeError) as e:
-                    self.logger.debug("I/O error processing announcement. Bailing out: %s" % e)
+                except unclean_close_exceptions:
+                    self.logger.exception("Unclean exit from LightPeerChain")
                     break
                 except LESAnnouncementProcessingError as e:
                     self.logger.warning(repr(e))

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -85,6 +85,7 @@ from p2p.utils import (
     get_devp2p_cmd_id,
     roundup_16,
     sxor,
+    unclean_close_exceptions,
 )
 from p2p import eth
 from p2p import les
@@ -725,8 +726,6 @@ class PeerPool(BaseService):
             self.logger.debug("Skipping %s; already connected to it", remote)
             return None
         expected_exceptions = (
-            BrokenPipeError,
-            EOFError,
             HandshakeFailure,
             PeerConnectionLost,
             TimeoutError,
@@ -743,6 +742,8 @@ class PeerPool(BaseService):
             raise
         except expected_exceptions as e:
             self.logger.debug("Could not complete handshake with %s: %s", remote, repr(e))
+        except unclean_close_exceptions:
+            self.logger.exception("Unclean exit while connecting to %s", remote)
         except Exception:
             self.logger.exception("Unexpected error during auth/p2p handshake with %s", remote)
         return None

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -28,6 +28,7 @@ from p2p.auth import (
     HandshakeResponder,
 )
 from p2p.cancel_token import (
+    CancelToken,
     wait_with_token,
 )
 from p2p.constants import (
@@ -78,8 +79,9 @@ class Server(BaseService):
                  peer_class: Type[BasePeer] = ETHPeer,
                  peer_pool_class: Type[PeerPool] = PeerPool,
                  bootstrap_nodes: Tuple[Node, ...] = None,
+                 token: CancelToken = None,
                  ) -> None:
-        super().__init__()
+        super().__init__(token)
         self.headerdb = headerdb
         self.chaindb = chaindb
         self.chain = chain

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -50,6 +50,10 @@ class BaseService(ABC):
         else:
             self.logger.debug("%s finished cleanly", self)
         finally:
+            # Set self.finished before anything else so that other coroutines started by this
+            # service exit while we wait for cleanup().
+            self.finished.set()
+
             try:
                 await self.cleanup()
             except Exception:
@@ -61,10 +65,6 @@ class BaseService(ABC):
 
     async def cleanup(self) -> None:
         """Run the service's _cleanup() coroutine."""
-        # Set self.finished before anything else so that other coroutines started by this
-        # service exit while we wait for cleanup().
-        self.finished.set()
-
         await self._cleanup()
 
         self.cleaned_up.set()

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -30,3 +30,10 @@ def get_devp2p_cmd_id(msg: bytes) -> int:
     as an integer.
     """
     return rlp.decode(msg[:1], sedes=rlp.sedes.big_endian_int)
+
+
+unclean_close_exceptions = (
+    BrokenPipeError,
+    ConnectionResetError,
+    EOFError,
+)

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -1,12 +1,8 @@
-import asyncio
 import os
-from typing import List
 
 import rlp
 
 from evm.utils.numeric import big_endian_to_int
-
-from p2p.service import BaseService
 
 
 def sxor(s1: bytes, s2: bytes) -> bytes:
@@ -34,16 +30,3 @@ def get_devp2p_cmd_id(msg: bytes) -> int:
     as an integer.
     """
     return rlp.decode(msg[:1], sedes=rlp.sedes.big_endian_int)
-
-
-class RunningServices:
-    def __init__(self, services: List[BaseService]) -> None:
-        self.services = services
-
-    async def __aenter__(self):
-        for service in self.services:
-            asyncio.ensure_future(service.run())
-
-    async def __aexit__(self, exc_type, exc, tb):
-        service_cancellations = [service.cancel() for service in self.services]
-        await asyncio.gather(*service_cancellations, return_exceptions=True)

--- a/tests/p2p/test_lightchain.py
+++ b/tests/p2p/test_lightchain.py
@@ -230,7 +230,7 @@ async def get_lightchain_with_peers(request, event_loop, server_peer_headerdb):
     await asyncio.sleep(0)  # Yield control to give the LightPeerChain a chance to start
 
     def finalizer():
-        event_loop.run_until_complete(light_chain.stop())
+        event_loop.run_until_complete(light_chain.cancel())
 
     request.addfinalizer(finalizer)
 

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -21,14 +21,12 @@ from evm.exceptions import CanonicalHeadNotFound
 
 from p2p import ecies
 
+from trinity.config import ChainConfig
 from trinity.db.base import DBProxy
 from trinity.db.chain import ChainDBProxy
 from trinity.db.header import (
     AsyncHeaderDB,
     AsyncHeaderDBProxy,
-)
-from trinity.config import (
-    ChainConfig,
 )
 from trinity.utils.mp import (
     async_method,

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -137,9 +137,6 @@ def run_database_process(chain_config: ChainConfig, db_class: Type[BaseDB]) -> N
 
 async def exit_on_signal(service_to_exit: BaseService) -> None:
     loop = asyncio.get_event_loop()
-    # TODO Use a ProcessPoolExecutor explicitly when we need to offload cpu-intensive tasks from the
-    # main thread. See: https://groups.google.com/d/msg/python-tulip/91NCCqV4SFs/9McZnfea_VcJ
-    # GvR: "Setting the default executor to a ProcessPoolExecutor feels like a bad idea"
     sigint_received = asyncio.Event()
     for sig in [signal.SIGINT, signal.SIGTERM]:
         # TODO also support Windows

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -1,20 +1,37 @@
 from abc import abstractmethod
 import asyncio
 from pathlib import Path
+from multiprocessing.managers import (
+    BaseManager,
+)
 from threading import Thread
 from typing import Type
 
+from eth_keys.datatypes import PrivateKey
 from evm.chains.base import BaseChain
 from evm.db.header import BaseHeaderDB
+from p2p.peer import PeerPool
 from p2p.service import (
     BaseService,
     EmptyService,
 )
+from trinity.chains import (
+    ChainProxy,
+)
+from trinity.chains.header import (
+    AsyncHeaderChainProxy,
+)
+from trinity.db.chain import ChainDBProxy
+from trinity.db.base import DBProxy
+from trinity.db.header import AsyncHeaderDBProxy
 from trinity.rpc.main import (
     RPCServer,
 )
 from trinity.rpc.ipc import (
     IPCServer,
+)
+from trinity.utils.chains import (
+    ChainConfig,
 )
 
 
@@ -27,20 +44,31 @@ class Node(BaseService):
     chain_class: Type[BaseChain] = None
     peer_chain_class: Type[BaseService] = None
 
-    def __init__(
-            self,
-            headerdb: BaseHeaderDB,
-            peer_pool,
-            jsonrpc_ipc_path: Path = None):
+    def __init__(self, chain_config: ChainConfig) -> None:
         super().__init__()
-        self._headerdb = headerdb
-        self._jsonrpc_ipc_path = jsonrpc_ipc_path
-        self._peer_pool = peer_pool
-        self._peer_chain = self.peer_chain_class(headerdb, peer_pool)
+
+        self._db_manager = create_db_manager(chain_config.database_ipc_path)
+        self._headerdb = self._db_manager.get_headerdb()  # type: ignore
+
+        self._jsonrpc_ipc_path: Path = chain_config.jsonrpc_ipc_path
+        self._peer_pool = self.create_peer_pool(chain_config.network_id, chain_config.nodekey)
+        self._peer_chain = self.peer_chain_class(self._headerdb, self._peer_pool)
 
     @abstractmethod
     def get_chain(self) -> BaseChain:
         raise NotImplementedError("Node classes must implement this method")
+
+    @abstractmethod
+    def create_peer_pool(self, network_id: int, node_key: PrivateKey) -> PeerPool:
+        raise NotImplementedError("Node classes must implement this method")
+
+    @property
+    def db_manager(self) -> BaseManager:
+        return self._db_manager
+
+    @property
+    def headerdb(self) -> BaseHeaderDB:
+        return self._headerdb
 
     def make_ipc_server(self) -> IPCServer:
         if self._jsonrpc_ipc_path:
@@ -82,3 +110,24 @@ class Node(BaseService):
         thread.start()
 
         return new_loop
+
+
+def create_db_manager(ipc_path: str) -> BaseManager:
+    """
+    We're still using 'str' here on param ipc_path because an issue with
+    multi-processing not being able to interpret 'Path' objects correctly
+    """
+    class DBManager(BaseManager):
+        pass
+
+    # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
+    # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
+    DBManager.register('get_db', proxytype=DBProxy)  # type: ignore
+    DBManager.register('get_chaindb', proxytype=ChainDBProxy)  # type: ignore
+    DBManager.register('get_chain', proxytype=ChainProxy)  # type: ignore
+    DBManager.register('get_headerdb', proxytype=AsyncHeaderDBProxy)  # type: ignore
+    DBManager.register('get_header_chain', proxytype=AsyncHeaderChainProxy)  # type: ignore
+
+    manager = DBManager(address=ipc_path)  # type: ignore
+    manager.connect()  # type: ignore
+    return manager

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -116,7 +116,7 @@ class Node(BaseService):
         return new_loop
 
 
-def create_db_manager(ipc_path: str) -> BaseManager:
+def create_db_manager(ipc_path: Path) -> BaseManager:
     """
     We're still using 'str' here on param ipc_path because an issue with
     multi-processing not being able to interpret 'Path' objects correctly
@@ -132,5 +132,5 @@ def create_db_manager(ipc_path: str) -> BaseManager:
     DBManager.register('get_headerdb', proxytype=AsyncHeaderDBProxy)  # type: ignore
     DBManager.register('get_header_chain', proxytype=AsyncHeaderChainProxy)  # type: ignore
 
-    manager = DBManager(address=ipc_path)  # type: ignore
+    manager = DBManager(address=str(ipc_path))  # type: ignore
     return manager

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -1,0 +1,46 @@
+from evm.chains.base import BaseChain
+from p2p.peer import (
+    PreferredNodePeerPool,
+)
+from p2p.server import Server
+from p2p.service import BaseService
+
+from trinity.nodes.base import Node
+from trinity.config import (
+    ChainConfig,
+)
+
+
+class FullNode(Node):
+    _chain: BaseChain = None
+    _p2p_server: BaseService = None
+
+    def __init__(self, chain_config: ChainConfig) -> None:
+        super().__init__(chain_config)
+
+        self._bootstrap_nodes = chain_config.bootstrap_nodes
+        self._network_id = chain_config.network_id
+        self._node_key = chain_config.nodekey
+        self._node_port = chain_config.port
+
+    def get_chain(self):
+        if self._chain is None:
+            self._chain = self.chain_class(self.db_manager.get_db())
+
+        return self._chain
+
+    def get_p2p_server(self) -> BaseService:
+        if self._p2p_server is None:
+            manager = self.db_manager
+            self._p2p_server = Server(
+                self._node_key,
+                self._node_port,
+                manager.get_chain(),
+                manager.get_chaindb(),
+                self.headerdb,
+                manager.get_db(),
+                self._network_id,
+                peer_pool_class=PreferredNodePeerPool,
+                bootstrap_nodes=self._bootstrap_nodes,
+            )
+        return self._p2p_server

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -42,5 +42,6 @@ class FullNode(Node):
                 self._network_id,
                 peer_pool_class=PreferredNodePeerPool,
                 bootstrap_nodes=self._bootstrap_nodes,
+                token=self.cancel_token,
             )
         return self._p2p_server

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -1,6 +1,6 @@
+import asyncio
 from typing import Type
 
-from eth_keys.datatypes import PrivateKey
 from p2p.discovery import DiscoveryProtocol
 from p2p.kademlia import Address
 from p2p.lightchain import LightPeerChain
@@ -17,7 +17,7 @@ from trinity.chains.light import (
     LightDispatchChain,
 )
 from trinity.nodes.base import Node
-from trinity.utils.chains import (
+from trinity.config import (
     ChainConfig,
 )
 
@@ -26,37 +26,51 @@ class LightNode(Node):
     chain_class: Type[LightDispatchChain] = None
 
     _chain: LightDispatchChain = None
+    _p2p_server: BaseService = None
 
     def __init__(self, chain_config: ChainConfig) -> None:
         super().__init__(chain_config)
 
+        self._port = chain_config.port
+        self._discovery = DiscoveryProtocol(
+            chain_config.nodekey,
+            Address('0.0.0.0', chain_config.port, chain_config.port),
+            bootstrap_nodes=chain_config.bootstrap_nodes,
+        )
         self._peer_pool = self._create_peer_pool(chain_config)
         self.add_service(self._peer_pool)
+
+    async def _run(self):
+        # TODO add a datagram endpoint service that can be added with self.add_service
+        transport, _ = await asyncio.get_event_loop().create_datagram_endpoint(
+            lambda: self._discovery,
+            local_addr=('0.0.0.0', self._port)
+        )
+        await self._discovery.bootstrap()
+        try:
+            await super()._run()
+        finally:
+            await self._discovery.stop()
 
     def get_chain(self) -> LightDispatchChain:
         if self._chain is None:
             if self.chain_class is None:
                 raise AttributeError("LightNode subclass must set chain_class")
-            self._chain = self.chain_class(self._headerdb, peer_chain=self.get_peer_service())
+            self._chain = self.chain_class(self._headerdb, peer_chain=self.get_p2p_server())
 
         return self._chain
 
-    def get_peer_service(self) -> BaseService:
-        if self._peer_service is None:
-            self._peer_service = LightPeerChain(self.headerdb, self._peer_pool)
-        return self._peer_service
+    def get_p2p_server(self) -> BaseService:
+        if self._p2p_server is None:
+            self._p2p_server = LightPeerChain(self.headerdb, self._peer_pool)
+        return self._p2p_server
 
     def _create_peer_pool(self, chain_config: ChainConfig) -> PeerPool:
-        discovery = DiscoveryProtocol(
-            chain_config.nodekey,
-            Address('0.0.0.0', chain_config.port, chain_config.port),
-            bootstrap_nodes=chain_config.bootstrap_nodes,
-        )
         return PreferredNodePeerPool(
             LESPeer,
             self.headerdb,
             chain_config.network_id,
             chain_config.nodekey,
-            discovery,
+            self._discovery,
             preferred_nodes=chain_config.preferred_nodes,
         )

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -1,6 +1,14 @@
 from typing import Type
 
+from eth_keys.datatypes import PrivateKey
+from p2p.discovery import DiscoveryProtocol
+from p2p.kademlia import Address
 from p2p.lightchain import LightPeerChain
+from p2p.peer import (
+    LESPeer,
+    PeerPool,
+    PreferredNodePeerPool,
+)
 
 from trinity.chains.light import (
     LightDispatchChain,
@@ -23,3 +31,18 @@ class LightNode(Node):
             self._chain = self.chain_class(self._headerdb, peer_chain=peer_chain)
 
         return self._chain
+
+    def create_peer_pool(self, network_id: int, node_key: PrivateKey) -> PeerPool:
+        discovery = DiscoveryProtocol(
+            chain_config.nodekey,
+            Address('0.0.0.0', chain_config.port, chain_config.port),
+            bootstrap_nodes=chain_config.bootstrap_nodes,
+        )
+        return PreferredNodePeerPool(
+            LESPeer,
+            self.headerdb,
+            network_id,
+            node_key,
+            discovery,
+            preferred_nodes=chain_config.preferred_nodes,
+        )

--- a/trinity/nodes/mainnet.py
+++ b/trinity/nodes/mainnet.py
@@ -1,5 +1,16 @@
-from trinity.chains.mainnet import MainnetLightDispatchChain
+from evm.chains.mainnet import (
+    MainnetChain,
+)
+
+from trinity.chains.mainnet import (
+    MainnetLightDispatchChain,
+)
 from trinity.nodes.light import LightNode
+from trinity.nodes.full import FullNode
+
+
+class MainnetFullNode(FullNode):
+    chain_class = MainnetChain
 
 
 class MainnetLightNode(LightNode):

--- a/trinity/nodes/ropsten.py
+++ b/trinity/nodes/ropsten.py
@@ -1,5 +1,16 @@
-from trinity.chains.ropsten import RopstenLightDispatchChain
+from evm.chains.ropsten import (
+    RopstenChain,
+)
+
+from trinity.chains.ropsten import (
+    RopstenLightDispatchChain,
+)
 from trinity.nodes.light import LightNode
+from trinity.nodes.full import FullNode
+
+
+class RopstenFullNode(FullNode):
+    chain_class = RopstenChain
 
 
 class RopstenLightNode(LightNode):


### PR DESCRIPTION
### What was wrong?

light and full nodes had some duplicate implementations, and the full node did not support requests over RPC

### How was it fixed?

Not done, but:

- unify the light and full node launch code some more
- launch the RPC server with the full node (reusing the same logic from the base node implementation)

Some open issues:

- shutdown is still ugly on the full node
- had to stop using process pool as the default executor, because I couldn't get it to respect the signal handler (also GvR said it was probably a bad idea)
- Directly initialized the Chain for use with the RPC server. Is that a bad idea? The `ChainProxy` didn't really support anything I needed.
- probably linting and testing, I was only testing at the shell

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.fsnc1-1.fna.fbcdn.net/v/t1.0-9/22046491_1377809865668721_4139365722380619941_n.jpg?_nc_cat=0&oh=51f64138f8b9e24778559d3e431594c0&oe=5B79146A)
