### PR TITLE
Convert PurePath to Path. Cleaning up consistency of Path utilizations.

### DIFF
--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -79,7 +79,7 @@ def is_database_initialized(chaindb: AsyncChainDB) -> bool:
 
 
 def initialize_data_dir(chain_config: ChainConfig) -> None:
-    if is_under_xdg_trinity_root(str(chain_config.data_dir)):
+    if is_under_xdg_trinity_root(chain_config.data_dir):
         os.makedirs(chain_config.data_dir, exist_ok=True)
     elif not os.path.exists(chain_config.data_dir):
         # we don't lazily create the base dir for non-default base directories.

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -1,5 +1,4 @@
-import os
-from pathlib import PurePath
+from pathlib import Path
 from typing import (
     Tuple,
     Type,
@@ -46,8 +45,8 @@ DATABASE_DIR_NAME = 'chain'
 
 
 class ChainConfig:
-    _data_dir: PurePath = None
-    _nodekey_path: PurePath = None
+    _data_dir: Path = None
+    _nodekey_path: Path = None
     _nodekey = None
     _network_id: int = None
 
@@ -98,7 +97,7 @@ class ChainConfig:
             self.nodekey = nodekey
 
     @property
-    def data_dir(self) -> PurePath:
+    def data_dir(self) -> Path:
         """
         The data_dir is the base directory that all chain specific information
         for a given chain is stored.  All other chain directories are by
@@ -108,7 +107,7 @@ class ChainConfig:
 
     @data_dir.setter
     def data_dir(self, value: str) -> None:
-        self._data_dir = PurePath(os.path.abspath(value))
+        self._data_dir = Path(value).resolve()
 
     @property
     def database_dir(self) -> str:
@@ -128,7 +127,7 @@ class ChainConfig:
         return get_jsonrpc_socket_path(self.data_dir)
 
     @property
-    def nodekey_path(self) -> PurePath:
+    def nodekey_path(self) -> Path:
         if self._nodekey_path is None:
             if self._nodekey is not None:
                 return None
@@ -139,7 +138,7 @@ class ChainConfig:
 
     @nodekey_path.setter
     def nodekey_path(self, value: str) -> None:
-        self._nodekey_path = PurePath(os.path.abspath(value))
+        self._nodekey_path = Path(value).resolve()
 
     @property
     def nodekey(self) -> PrivateKey:

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -168,7 +168,7 @@ def run_database_process(chain_config: ChainConfig, db_class: Type[BaseDB]) -> N
 def create_dbmanager(ipc_path: str) -> BaseManager:
     """
     We're still using 'str' here on param ipc_path because an issue with
-    multi-processing not being able to interpret 'PurePath' objects correctly
+    multi-processing not being able to interpret 'Path' objects correctly
     """
     class DBManager(BaseManager):
         pass

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 import asyncio
-from pathlib import PurePath
+from pathlib import Path
 from threading import Thread
 from typing import Type
 
@@ -31,7 +31,7 @@ class Node(BaseService):
             self,
             headerdb: BaseHeaderDB,
             peer_pool,
-            jsonrpc_ipc_path: PurePath = None):
+            jsonrpc_ipc_path: Path = None):
         super().__init__()
         self._headerdb = headerdb
         self._jsonrpc_ipc_path = jsonrpc_ipc_path

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -1,5 +1,5 @@
 import os
-from pathlib import PurePath
+from pathlib import Path
 
 from eth_utils import (
     decode_hex,
@@ -30,17 +30,17 @@ DEFAULT_DATA_DIRS = {
 #
 # Filesystem path utils
 #
-def get_local_data_dir(chain_name: str) -> PurePath:
+def get_local_data_dir(chain_name: str) -> Path:
     """
     Returns the base directory path where data for a given chain will be stored.
     """
-    return PurePath(os.environ.get(
+    return Path(os.environ.get(
         'TRINITY_DATA_DIR',
         os.path.join(get_xdg_trinity_root(), chain_name),
     ))
 
 
-def get_data_dir_for_network_id(network_id: int) -> PurePath:
+def get_data_dir_for_network_id(network_id: int) -> Path:
     """
     Returns the data directory for the chain associated with the given network
     id.  If the network id is unknown, raises a KeyError.
@@ -54,11 +54,11 @@ def get_data_dir_for_network_id(network_id: int) -> PurePath:
 NODEKEY_FILENAME = 'nodekey'
 
 
-def get_nodekey_path(data_dir: PurePath) -> PurePath:
+def get_nodekey_path(data_dir: Path) -> Path:
     """
     Returns the path to the private key used for devp2p connections.
     """
-    return PurePath(os.environ.get(
+    return Path(os.environ.get(
         'TRINITY_NODEKEY',
         str(data_dir / NODEKEY_FILENAME),
     ))
@@ -67,40 +67,40 @@ def get_nodekey_path(data_dir: PurePath) -> PurePath:
 DATABASE_SOCKET_FILENAME = 'db.ipc'
 
 
-def get_database_socket_path(data_dir: PurePath) -> str:
+def get_database_socket_path(data_dir: Path) -> str:
     """
     Returns the path to the private key used for devp2p connections.
 
     We're still returning 'str' here on ipc-related path because an issue with
-    multi-processing not being able to interpret 'PurePath' objects correctly.
+    multi-processing not being able to interpret 'Path' objects correctly.
     """
     return os.environ.get(
         'TRINITY_DATABASE_IPC',
-        os.path.join(str(data_dir), DATABASE_SOCKET_FILENAME),
+        str(data_dir / DATABASE_SOCKET_FILENAME),
     )
 
 
 JSONRPC_SOCKET_FILENAME = 'jsonrpc.ipc'
 
 
-def get_jsonrpc_socket_path(data_dir: PurePath) -> str:
+def get_jsonrpc_socket_path(data_dir: Path) -> str:
     """
     Returns the path to the ipc socket for the JSON-RPC server.
 
     We're still returning 'str' here on ipc-related path because an issue with
-    multi-processing not being able to interpret 'PurePath' objects correctly.
+    multi-processing not being able to interpret 'Path' objects correctly.
     """
     return os.environ.get(
         'TRINITY_JSONRPC_IPC',
-        os.path.join(str(data_dir), JSONRPC_SOCKET_FILENAME),
+        str(data_dir / JSONRPC_SOCKET_FILENAME),
     )
 
 
 #
 # Nodekey loading
 #
-def load_nodekey(nodekey_path: PurePath) -> PrivateKey:
-    with open(str(nodekey_path), 'rb') as nodekey_file:
+def load_nodekey(nodekey_path: Path) -> PrivateKey:
+    with nodekey_path.open('rb') as nodekey_file:
         nodekey_raw = nodekey_file.read()
     nodekey = keys.PrivateKey(nodekey_raw)
     return nodekey

--- a/trinity/utils/xdg.py
+++ b/trinity/utils/xdg.py
@@ -1,5 +1,7 @@
 import os
 
+from pathlib import Path
+
 from .filesystem import (
     is_under_path,
 )
@@ -31,8 +33,8 @@ def get_xdg_trinity_root() -> str:
     )
 
 
-def is_under_xdg_trinity_root(path: str) -> bool:
+def is_under_xdg_trinity_root(path: Path) -> bool:
     return is_under_path(
         get_xdg_trinity_root(),
-        path,
+        str(path),
     )


### PR DESCRIPTION
### What was wrong?
Convert `PurePath` to `Path`. Cleaning up consistency of `Path` utilizations.

Issue Reference: https://github.com/ethereum/py-evm/pull/734

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.pbh2.com/wordpress/wp-content/uploads/2013/11/shiba-inu-puppy.jpg)
