### PR TITLE
Sharding protocol with collation requests

### DIFF
--- a/evm/constants.py
+++ b/evm/constants.py
@@ -175,7 +175,7 @@ MAX_PREV_HEADER_DEPTH = 256
 #
 CHUNK_SIZE = 32
 CHUNK_DATA_SIZE = CHUNK_SIZE - 1  # size of chunk excluding the indicator byte
-COLLATION_SIZE = 2**20
+COLLATION_SIZE = 2**17
 assert COLLATION_SIZE % CHUNK_SIZE == 0
 # size of a blob filling a full collation
 MAX_BLOB_SIZE = COLLATION_SIZE // CHUNK_SIZE * CHUNK_DATA_SIZE

--- a/p2p/sharding_peer.py
+++ b/p2p/sharding_peer.py
@@ -1,0 +1,105 @@
+import asyncio
+from typing import (
+    cast,
+    Dict,
+    List,
+    Set,
+    Tuple,
+)
+
+from eth_typing import (
+    Hash32,
+)
+
+from evm.rlp.collations import Collation
+
+from p2p.cancel_token import (
+    CancelToken,
+    wait_with_token,
+)
+from p2p import protocol
+from p2p.protocol import (
+    Command,
+)
+from p2p.peer import (
+    BasePeer,
+)
+from p2p.p2p_proto import (
+    DisconnectReason,
+)
+
+from p2p.sharding_protocol import (
+    ShardingProtocol,
+    Collations,
+    Status,
+)
+
+from p2p.utils import (
+    gen_request_id,
+)
+from p2p.exceptions import (
+    HandshakeFailure,
+    UnexpectedMessage,
+)
+
+
+class ShardingPeer(BasePeer):
+    _supported_sub_protocols = [ShardingProtocol]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.known_collation_hashes: Set[Hash32] = set()
+        self._pending_replies: Dict[
+            int,
+            asyncio.Future[Tuple[Command, protocol._DecodedMsgType]]
+        ] = {}
+
+    #
+    # Handshake
+    #
+    async def send_sub_proto_handshake(self) -> None:
+        cast(ShardingProtocol, self.sub_proto).send_handshake()
+
+    async def process_sub_proto_handshake(self,
+                                          cmd: Command,
+                                          msg: protocol._DecodedMsgType) -> None:
+        if not isinstance(cmd, Status):
+            self.disconnect(DisconnectReason.other)
+            raise HandshakeFailure("Expected status msg, got {}, disconnecting".format(cmd))
+
+    #
+    # Message handling
+    #
+    def handle_sub_proto_msg(self, cmd: Command, msg: protocol._DecodedMsgType) -> None:
+        if isinstance(msg, dict):
+            request_id = msg.get("request_id")
+            if request_id is not None and request_id in self._pending_replies:
+                # This is a reply we're waiting for, so we consume it by resolving the registered
+                # future
+                future = self._pending_replies.pop(request_id)
+                future.set_result((cmd, msg))
+                return
+        super().handle_sub_proto_msg(cmd, msg)
+
+    #
+    # Requests
+    #
+    async def get_collations(self,
+                             collation_hashes: List[Hash32],
+                             cancel_token: CancelToken) -> Set[Collation]:
+        # Don't send empty request
+        if len(collation_hashes) == 0:
+            return set()
+
+        request_id = gen_request_id()
+        pending_reply: asyncio.Future[Tuple[Command, protocol._DecodedMsgType]] = asyncio.Future()
+        self._pending_replies[request_id] = pending_reply
+        cast(ShardingProtocol, self.sub_proto).send_get_collations(request_id, collation_hashes)
+        cmd, msg = await wait_with_token(pending_reply, token=cancel_token)
+
+        if not isinstance(cmd, Collations):
+            raise UnexpectedMessage(
+                "Expected Collations as response to GetCollations, but got %s",
+                cmd.__class__.__name__
+            )
+        return set(msg["collations"])

--- a/p2p/sharding_protocol.py
+++ b/p2p/sharding_protocol.py
@@ -1,0 +1,105 @@
+import logging
+from typing import (
+    List,
+    Tuple,
+)
+
+from eth_typing import (
+    Hash32,
+)
+
+from rlp import sedes
+
+from evm.rlp.collations import Collation
+from evm.rlp.sedes import (
+    hash32,
+)
+
+from p2p.protocol import (
+    Command,
+    Protocol,
+)
+
+
+class Status(Command):
+    _cmd_id = 0
+
+
+class Collations(Command):
+    _cmd_id = 1
+
+    structure = [
+        ("request_id", sedes.big_endian_int),
+        ("collations", sedes.CountableList(Collation)),
+    ]
+
+
+class GetCollations(Command):
+    _cmd_id = 2
+
+    structure = [
+        ("request_id", sedes.big_endian_int),
+        ("collation_hashes", sedes.CountableList(hash32)),
+    ]
+
+
+class NewCollationHashes(Command):
+    _cmd_id = 3
+
+    structure = [
+        (
+            "collation_hashes_and_periods", sedes.CountableList(
+                sedes.List([hash32, sedes.big_endian_int])
+            )
+        ),
+    ]
+
+
+class ShardingProtocol(Protocol):
+    name = "sha"
+    version = 0
+    _commands = [Status, Collations, GetCollations, NewCollationHashes]
+    cmd_length = 4
+
+    logger = logging.getLogger("p2p.sharding.ShardingProtocol")
+
+    def send_handshake(self) -> None:
+        cmd = Status(self.cmd_id_offset)
+        self.logger.debug("Sending status msg")
+        self.send(*cmd.encode([]))
+
+    def send_collations(self, request_id: int, collations: List[Collation]) -> None:
+        cmd = Collations(self.cmd_id_offset)
+        self.logger.debug("Sending %d collations (request id %d)", len(collations), request_id)
+        data = {
+            "request_id": request_id,
+            "collations": collations,
+        }
+        self.send(*cmd.encode(data))
+
+    def send_get_collations(self, request_id: int, collation_hashes: List[Hash32]) -> None:
+        cmd = GetCollations(self.cmd_id_offset)
+        self.logger.debug(
+            "Requesting %d collations (request id %d)",
+            len(collation_hashes),
+            request_id,
+        )
+        data = {
+            "request_id": request_id,
+            "collation_hashes": collation_hashes,
+        }
+        self.send(*cmd.encode(data))
+
+    def send_new_collation_hashes(self,
+                                  collation_hashes_and_periods: List[Tuple[Hash32, int]]) -> None:
+        cmd = NewCollationHashes(self.cmd_id_offset)
+        self.logger.debug(
+            "Announcing %d new collations (period %d to %d)",
+            len(collation_hashes_and_periods),
+            min(period for _, period in collation_hashes_and_periods),
+            max(period for _, period in collation_hashes_and_periods)
+        )
+        data = {
+            "collation_hashes_and_periods": collation_hashes_and_periods
+        }
+        self.send(*cmd.encode(data))

--- a/tests/p2p/test_sharding.py
+++ b/tests/p2p/test_sharding.py
@@ -1,4 +1,5 @@
 import asyncio
+import itertools
 
 import pytest
 
@@ -14,7 +15,8 @@ from evm.utils.padding import (
 )
 
 from p2p.sharding import (
-    Collations,
+    GetCollations,
+    NewCollationHashes,
     ShardingPeer,
     ShardingProtocol,
     ShardSyncer,
@@ -39,6 +41,43 @@ from tests.p2p.peer_helpers import (
     get_directly_linked_peers_without_handshake,
     MockPeerPoolWithConnectedPeers,
 )
+
+from cytoolz import (
+    merge,
+)
+
+
+def generate_collations():
+    explicit_params = {}
+    for period in itertools.count():
+        default_params = {
+            "shard_id": 0,
+            "period": period,
+            "body": zpad_right(b"body%d" % period, COLLATION_SIZE),
+            "proposer_address": zpad_right(b"proposer%d" % period, 20),
+        }
+        # only calculate chunk root if it wouldn't be replaced anyway
+        if "chunk_root" not in explicit_params:
+            default_params["chunk_root"] = calc_chunk_root(default_params["body"])
+
+        params = merge(default_params, explicit_params)
+        header = CollationHeader(
+            shard_id=params["shard_id"],
+            chunk_root=params["chunk_root"],
+            period=params["period"],
+            proposer_address=params["proposer_address"],
+        )
+        collation = Collation(header, params["body"])
+        explicit_params = (yield collation) or {}
+
+
+collations = generate_collations()
+next(collations)  # yield once so that we can send values to the generator
+
+
+async def get_directly_linked_sharding_peers(request, event_loop):
+    return await get_directly_linked_peers(
+        request, event_loop, ShardingPeer, None, ShardingPeer, None,)
 
 
 @pytest.mark.asyncio
@@ -69,8 +108,7 @@ async def test_invalid_handshake():
     class InvalidShardingPeer(ShardingPeer):
 
         async def send_sub_proto_handshake(self):
-            cmd = Collations(self.sub_proto.cmd_id_offset)
-            self.send(*cmd.encode([]))
+            self.sub_proto.send_collations(0, [])
 
     peer1, peer2 = await get_directly_linked_peers_without_handshake(
         ShardingPeer,
@@ -93,14 +131,7 @@ async def test_invalid_handshake():
 @pytest.mark.asyncio
 async def test_collation_requests(request, event_loop):
     # setup two peers
-    sender, receiver = await get_directly_linked_peers(
-        request,
-        event_loop,
-        ShardingPeer,
-        None,
-        ShardingPeer,
-        None,
-    )
+    sender, receiver = await get_directly_linked_sharding_peers(request, event_loop)
     receiver_peer_pool = MockPeerPoolWithConnectedPeers([receiver])
 
     # setup shard db for request receiving node
@@ -164,46 +195,104 @@ async def test_collation_requests(request, event_loop):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("connections", [
-    ([(0, 1)]),  # two peers connected directly with each other
-    ([(0, 1), (0, 2), (1, 2)]),  # three fully connected peers
-    ([(0, 1), (1, 2)]),  # three peers in a row
-    # 10 nodes randomly connected to ~4 peers each
-    # TODO: do something against time out because of long chunk root calculation time
-    # (10, set(tuple(sorted(random.sample(range(10), 2))) for _ in range(10 * 4))),
-])
-async def test_shard_syncer(connections, request, event_loop):
-    peers_by_server = {}
-    for server_id1, server_id2 in connections:
-        peer1, peer2 = await get_directly_linked_sharding_peers(request, event_loop)
-        peers_by_server.setdefault(server_id1, []).append(peer1)
-        peers_by_server.setdefault(server_id2, []).append(peer2)
+async def test_new_collations_notification(request, event_loop):
+    # setup a-b-c topology
+    peer_a_b, peer_b_a = await get_directly_linked_sharding_peers(request, event_loop)
+    peer_b_c, peer_c_b = await get_directly_linked_sharding_peers(request, event_loop)
+    peer_pool_b = MockPeerPoolWithConnectedPeers([peer_b_a, peer_b_c])
 
-    syncers = []
-    for _, peers in sorted(peers_by_server.items()):
-        peer_pool = MockPeerPoolWithConnectedPeers(peers)
-        shard_db = ShardDB(MemoryDB())
-        syncer = ShardSyncer(Shard(shard_db, 0), peer_pool)
-        syncers.append(syncer)
-        asyncio.ensure_future(syncer.run())
+    # setup shard dbs at b
+    shard_db = ShardDB(MemoryDB())
+    shard = Shard(shard_db, 0)
+
+    # start shard syncer
+    syncer = ShardSyncer(shard, peer_pool_b)
+    asyncio.ensure_future(syncer.run())
 
     def finalizer():
-        event_loop.run_until_complete(
-            asyncio.gather(*[syncer.cancel() for syncer in syncers]))
+        event_loop.run_until_complete(syncer.cancel())
     request.addfinalizer(finalizer)
 
-    # let each node propose and check that collation appears at all other nodes
-    for proposer in syncers:
-        collation = proposer.propose()
-        await asyncio.wait_for(asyncio.gather(*[
-            syncer.collations_received_event.wait()
-            for syncer in syncers
-            if syncer != proposer
-        ]), timeout=2)
-        for syncer in syncers:
-            assert syncer.shard.get_collation_by_hash(collation.hash) == collation
+    # send collation from a to b and check that c gets notified
+    c1 = next(collations)
+    peer_a_b.sub_proto.send_collations(0, [c1])
+    cmd, msg = await asyncio.wait_for(
+        peer_c_b.sub_proto_msg_queue.get(),
+        timeout=1,
+    )
+    assert isinstance(cmd, NewCollationHashes)
+    assert msg["collation_hashes_and_periods"] == ((c1.hash, c1.period),)
+
+    # check that a has not been notified
+    assert peer_b_a.sub_proto_msg_queue.empty()
+
+    # check that c won't be notified about c1 again
+    c2 = next(collations)
+    peer_a_b.sub_proto.send_collations(0, [c1, c2])
+    cmd, msg = await asyncio.wait_for(
+        peer_c_b.sub_proto_msg_queue.get(),
+        timeout=1,
+    )
+    assert isinstance(cmd, NewCollationHashes)
+    assert msg["collation_hashes_and_periods"] == ((c2.hash, c2.period),)
 
 
-async def get_directly_linked_sharding_peers(request, event_loop):
-    return await get_directly_linked_peers(
-        request, event_loop, ShardingPeer, None, ShardingPeer, None,)
+@pytest.mark.asyncio
+async def test_syncer_requests_new_collations(request, event_loop):
+    # setup a-b topology
+    peer_a_b, peer_b_a = await get_directly_linked_sharding_peers(request, event_loop)
+    peer_pool_b = MockPeerPoolWithConnectedPeers([peer_b_a])
+
+    # setup shard dbs at b
+    shard_db = ShardDB(MemoryDB())
+    shard = Shard(shard_db, 0)
+
+    # start shard syncer
+    syncer = ShardSyncer(shard, peer_pool_b)
+    asyncio.ensure_future(syncer.run())
+
+    def finalizer():
+        event_loop.run_until_complete(syncer.cancel())
+    request.addfinalizer(finalizer)
+
+    # notify b about new hashes at a and check that it requests them
+    hashes_and_periods = ((b"\xaa" * 32, 0),)
+    peer_a_b.sub_proto.send_new_collation_hashes(hashes_and_periods)
+    cmd, msg = await asyncio.wait_for(
+        peer_a_b.sub_proto_msg_queue.get(),
+        timeout=1,
+    )
+    assert isinstance(cmd, GetCollations)
+    assert msg["collation_hashes"] == (hashes_and_periods[0][0],)
+
+
+@pytest.mark.asyncio
+async def test_syncer_proposing(request, event_loop):
+    # setup a-b topology
+    peer_a_b, peer_b_a = await get_directly_linked_sharding_peers(request, event_loop)
+    peer_pool_b = MockPeerPoolWithConnectedPeers([peer_b_a])
+
+    # setup shard dbs at b
+    shard_db = ShardDB(MemoryDB())
+    shard = Shard(shard_db, 0)
+
+    # start shard syncer
+    syncer = ShardSyncer(shard, peer_pool_b)
+    asyncio.ensure_future(syncer.run())
+
+    def finalizer():
+        event_loop.run_until_complete(syncer.cancel())
+    request.addfinalizer(finalizer)
+
+    # propose at b and check that it announces its proposal
+    syncer.propose()
+    cmd, msg = await asyncio.wait_for(
+        peer_a_b.sub_proto_msg_queue.get(),
+        timeout=1,
+    )
+    assert isinstance(cmd, NewCollationHashes)
+    assert len(msg["collation_hashes_and_periods"]) == 1
+    proposed_hash = msg["collation_hashes_and_periods"][0][0]
+
+    # test that the collation has been added to the shard
+    shard.get_collation_by_hash(proposed_hash)

--- a/tests/p2p/test_sharding.py
+++ b/tests/p2p/test_sharding.py
@@ -14,11 +14,15 @@ from evm.utils.padding import (
     zpad_right,
 )
 
-from p2p.sharding import (
+from p2p.sharding_protocol import (
+    ShardingProtocol,
     GetCollations,
     NewCollationHashes,
+)
+from p2p.sharding_peer import (
     ShardingPeer,
-    ShardingProtocol,
+)
+from p2p.shard_syncer import (
     ShardSyncer,
 )
 from p2p.cancel_token import (


### PR DESCRIPTION
### What was wrong?

The previous version of the minimal^2 sharding protocol only allows for broadcasting collations meaning that syncing an existing chain is not possible

### How was it fixed?

To the existing `Collations` message type (for collation transmission) add types `GetCollations` (for collation requests) and `NewCollationHashes` (for announcement of new collations).

Basic logic of the `ShardSyncer` that handles all these messages:

- whenever it proposes, send `NewCollationHashes` with the proposed collation hash and period
- whenever it receives `NewCollationHashes` reply with `GetCollations` containing the new hashes
- whenever it receives `GetCollations` reply with `Collations` containing the requested collations (provided it knows about them of course)
- whenever it receives `Collations` add the contained collations to the DB and send `NewCollationHashes` to its peers

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/40437239-1a8a56c0-5eb5-11e8-8d7e-daad1a2f251a.jpg)

