### PR TITLE
Move ChainConfig to trinity.config, add node_class

### DIFF
--- a/tests/trinity/core/chain-management/test_initialize_data_dir.py
+++ b/tests/trinity/core/chain-management/test_initialize_data_dir.py
@@ -3,11 +3,9 @@ import pytest
 import os
 
 from trinity.chains import (
+    ChainConfig,
     is_data_dir_initialized,
     initialize_data_dir,
-)
-from trinity.utils.chains import (
-    ChainConfig,
 )
 
 

--- a/tests/trinity/core/chain-management/test_initialize_data_dir.py
+++ b/tests/trinity/core/chain-management/test_initialize_data_dir.py
@@ -3,9 +3,11 @@ import pytest
 import os
 
 from trinity.chains import (
-    ChainConfig,
     is_data_dir_initialized,
     initialize_data_dir,
+)
+from trinity.config import (
+    ChainConfig,
 )
 
 

--- a/tests/trinity/core/chain-management/test_initialize_database.py
+++ b/tests/trinity/core/chain-management/test_initialize_database.py
@@ -5,12 +5,10 @@ from evm.db.backends.level import LevelDB
 from evm.db.chain import ChainDB
 
 from trinity.chains import (
+    ChainConfig,
     initialize_data_dir,
     initialize_database,
     is_database_initialized,
-)
-from trinity.utils.chains import (
-    ChainConfig,
 )
 
 

--- a/tests/trinity/core/chain-management/test_initialize_database.py
+++ b/tests/trinity/core/chain-management/test_initialize_database.py
@@ -5,10 +5,12 @@ from evm.db.backends.level import LevelDB
 from evm.db.chain import ChainDB
 
 from trinity.chains import (
-    ChainConfig,
     initialize_data_dir,
     initialize_database,
     is_database_initialized,
+)
+from trinity.config import (
+    ChainConfig,
 )
 
 

--- a/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
@@ -4,8 +4,10 @@ import pytest
 from eth_utils import decode_hex
 
 from trinity.chains import (
-    ChainConfig,
     is_data_dir_initialized,
+)
+from trinity.config import (
+    ChainConfig,
 )
 
 

--- a/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
@@ -4,10 +4,8 @@ import pytest
 from eth_utils import decode_hex
 
 from trinity.chains import (
-    is_data_dir_initialized,
-)
-from trinity.utils.chains import (
     ChainConfig,
+    is_data_dir_initialized,
 )
 
 

--- a/tests/trinity/core/chain-management/test_is_database_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_database_initialized.py
@@ -6,9 +6,11 @@ from evm.db.backends.level import LevelDB
 from evm.db.chain import ChainDB
 
 from trinity.chains import (
-    ChainConfig,
     initialize_data_dir,
     is_database_initialized,
+)
+from trinity.config import (
+    ChainConfig,
 )
 
 

--- a/tests/trinity/core/chain-management/test_is_database_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_database_initialized.py
@@ -6,11 +6,9 @@ from evm.db.backends.level import LevelDB
 from evm.db.chain import ChainDB
 
 from trinity.chains import (
+    ChainConfig,
     initialize_data_dir,
     is_database_initialized,
-)
-from trinity.utils.chains import (
-    ChainConfig,
 )
 
 

--- a/tests/trinity/core/chains-utils/test_chain_config_object.py
+++ b/tests/trinity/core/chains-utils/test_chain_config_object.py
@@ -11,6 +11,8 @@ from eth_keys import keys
 from trinity.utils.chains import (
     get_local_data_dir,
     get_nodekey_path,
+)
+from trinity.config import (
     ChainConfig,
     DATABASE_DIR_NAME,
 )

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -12,13 +12,11 @@ from evm.db.chain import (
 )
 
 from trinity.chains import (
+    ChainConfig,
     serve_chaindb,
 )
 from trinity.db.chain import ChainDBProxy
 from trinity.db.base import DBProxy
-from trinity.utils.chains import (
-    ChainConfig,
-)
 from trinity.utils.db import (
     MemoryDB,
 )

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -12,8 +12,10 @@ from evm.db.chain import (
 )
 
 from trinity.chains import (
-    ChainConfig,
     serve_chaindb,
+)
+from trinity.config import (
+    ChainConfig,
 )
 from trinity.db.chain import ChainDBProxy
 from trinity.db.base import DBProxy

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -27,7 +27,7 @@ from trinity.db.header import (
     AsyncHeaderDB,
     AsyncHeaderDBProxy,
 )
-from trinity.utils.chains import (
+from trinity.config import (
     ChainConfig,
 )
 from trinity.utils.mp import (

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -1,0 +1,194 @@
+import os
+from pathlib import PurePath
+from typing import (
+    Tuple,
+    Type,
+    Union,
+)
+
+from eth_keys import keys
+from eth_keys.datatypes import PrivateKey
+from evm.chains.mainnet import (
+    MAINNET_NETWORK_ID,
+)
+from evm.chains.ropsten import (
+    ROPSTEN_NETWORK_ID,
+)
+from p2p.kademlia import Node as KademliaNode
+from p2p.constants import (
+    MAINNET_BOOTNODES,
+    ROPSTEN_BOOTNODES,
+)
+
+from trinity.constants import (
+    SYNC_FULL,
+    SYNC_LIGHT,
+)
+from trinity.nodes.base import (
+    Node,
+)
+from trinity.nodes.mainnet import (
+    MainnetLightNode,
+)
+from trinity.nodes.ropsten import (
+    RopstenLightNode,
+)
+from trinity.utils.chains import (
+    construct_chain_config_params,
+    get_data_dir_for_network_id,
+    get_database_socket_path,
+    get_jsonrpc_socket_path,
+    get_nodekey_path,
+    load_nodekey,
+)
+
+DATABASE_DIR_NAME = 'chain'
+
+
+class ChainConfig:
+    _data_dir: PurePath = None
+    _nodekey_path: PurePath = None
+    _nodekey = None
+    _network_id: int = None
+
+    port: int = None
+    preferred_nodes: Tuple[KademliaNode, ...] = None
+
+    bootstrap_nodes: Tuple[KademliaNode, ...] = None
+
+    def __init__(self,
+                 network_id: int,
+                 data_dir: str=None,
+                 nodekey_path: str=None,
+                 nodekey: PrivateKey=None,
+                 sync_mode: str=SYNC_FULL,
+                 port: int=30303,
+                 preferred_nodes: Tuple[KademliaNode, ...]=None,
+                 bootstrap_nodes: Tuple[KademliaNode, ...]=None) -> None:
+        self.network_id = network_id
+        self.sync_mode = sync_mode
+        self.port = port
+        self.preferred_nodes = preferred_nodes
+
+        if bootstrap_nodes is None:
+            if self.network_id == MAINNET_NETWORK_ID:
+                self.bootstrap_nodes = tuple(
+                    KademliaNode.from_uri(enode) for enode in MAINNET_BOOTNODES
+                )
+            elif self.network_id == ROPSTEN_NETWORK_ID:
+                self.bootstrap_nodes = tuple(
+                    KademliaNode.from_uri(enode) for enode in ROPSTEN_BOOTNODES
+                )
+        else:
+            self.bootstrap_nodes = bootstrap_nodes
+
+        # validation
+        if nodekey is not None and nodekey_path is not None:
+            raise ValueError("It is invalid to provide both a `nodekey` and a `nodekey_path`")
+
+        # set values
+        if data_dir is not None:
+            self.data_dir = data_dir
+        else:
+            self.data_dir = get_data_dir_for_network_id(self.network_id)
+
+        if nodekey_path is not None:
+            self.nodekey_path = nodekey_path
+        elif nodekey is not None:
+            self.nodekey = nodekey
+
+    @property
+    def data_dir(self) -> PurePath:
+        """
+        The data_dir is the base directory that all chain specific information
+        for a given chain is stored.  All other chain directories are by
+        default relative to this directory.
+        """
+        return self._data_dir
+
+    @data_dir.setter
+    def data_dir(self, value: str) -> None:
+        self._data_dir = PurePath(os.path.abspath(value))
+
+    @property
+    def database_dir(self) -> str:
+        if self.sync_mode == SYNC_FULL:
+            return str(self.data_dir / DATABASE_DIR_NAME / "full")
+        elif self.sync_mode == SYNC_LIGHT:
+            return str(self.data_dir / DATABASE_DIR_NAME / "light")
+        else:
+            raise ValueError("Unknown sync mode: {}}".format(self.sync_mode))
+
+    @property
+    def database_ipc_path(self) -> str:
+        return get_database_socket_path(self.data_dir)
+
+    @property
+    def jsonrpc_ipc_path(self) -> str:
+        return get_jsonrpc_socket_path(self.data_dir)
+
+    @property
+    def nodekey_path(self) -> PurePath:
+        if self._nodekey_path is None:
+            if self._nodekey is not None:
+                return None
+            else:
+                return get_nodekey_path(self.data_dir)
+        else:
+            return self._nodekey_path
+
+    @nodekey_path.setter
+    def nodekey_path(self, value: str) -> None:
+        self._nodekey_path = PurePath(os.path.abspath(value))
+
+    @property
+    def nodekey(self) -> PrivateKey:
+        if self._nodekey is None:
+            try:
+                return load_nodekey(self.nodekey_path)
+            except FileNotFoundError:
+                # no file at the nodekey_path so we have a null nodekey
+                return None
+        else:
+            if isinstance(self._nodekey, bytes):
+                return keys.PrivateKey(self._nodekey)
+            elif isinstance(self._nodekey, PrivateKey):
+                return self._nodekey
+            return self._nodekey
+
+    @nodekey.setter
+    def nodekey(self, value: Union[bytes, PrivateKey]) -> None:
+        if isinstance(value, bytes):
+            self._nodekey = keys.PrivateKey(value)
+        elif isinstance(value, PrivateKey):
+            self._nodekey = value
+        else:
+            raise TypeError(
+                "Nodekey must either be a raw byte-string or an eth_keys "
+                "`PrivateKey` instance"
+            )
+
+    @classmethod
+    def from_parser_args(cls, parser_args):
+        constructor_kwargs = construct_chain_config_params(parser_args)
+        return cls(**constructor_kwargs)
+
+    @property
+    def node_class(self) -> Type[Node]:
+        if self.sync_mode == SYNC_LIGHT:
+            if self.network_id == MAINNET_NETWORK_ID:
+                return MainnetLightNode
+            elif self.network_id == ROPSTEN_NETWORK_ID:
+                return RopstenLightNode
+            else:
+                raise NotImplementedError(
+                    "Only the mainnet and ropsten chains are currently supported"
+                )
+        elif self.sync_mode == SYNC_FULL:
+            raise NotImplementedError(
+                "Full sync mode from ChainConfig is not yet supported"
+            )
+        else:
+            raise NotImplementedError(
+                "Only full and light sync modes are supported"
+            )

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -47,7 +47,7 @@ from trinity.db.header import AsyncHeaderDBProxy
 from trinity.cli_parser import (
     parser,
 )
-from trinity.chains import (
+from trinity.config import (
     ChainConfig,
 )
 from trinity.utils.ipc import (

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -8,14 +8,14 @@ import signal
 import sys
 from typing import Type
 
-from evm.db.backends.base import BaseDB
-from evm.db.backends.level import LevelDB
 from evm.chains.mainnet import (
     MAINNET_NETWORK_ID,
 )
 from evm.chains.ropsten import (
     ROPSTEN_NETWORK_ID,
 )
+from evm.db.backends.base import BaseDB
+from evm.db.backends.level import LevelDB
 
 from p2p.discovery import DiscoveryProtocol
 from p2p.kademlia import Address
@@ -32,12 +32,6 @@ from trinity.chains import (
     is_data_dir_initialized,
     serve_chaindb,
 )
-from trinity.nodes.mainnet import (
-    MainnetLightNode,
-)
-from trinity.nodes.ropsten import (
-    RopstenLightNode,
-)
 from trinity.chains.header import (
     AsyncHeaderChainProxy,
 )
@@ -53,7 +47,7 @@ from trinity.db.header import AsyncHeaderDBProxy
 from trinity.cli_parser import (
     parser,
 )
-from trinity.utils.chains import (
+from trinity.chains import (
     ChainConfig,
 )
 from trinity.utils.ipc import (
@@ -222,14 +216,7 @@ def run_lightnode_process(chain_config: ChainConfig) -> None:
     manager = create_dbmanager(chain_config.database_ipc_path)
     headerdb = manager.get_headerdb()  # type: ignore
 
-    if chain_config.network_id == MAINNET_NETWORK_ID:
-        node_class = MainnetLightNode
-    elif chain_config.network_id == ROPSTEN_NETWORK_ID:
-        node_class = RopstenLightNode
-    else:
-        raise NotImplementedError(
-            "Only the mainnet and ropsten chains are currently supported"
-        )
+    NodeClass = chain_config.node_class
     discovery = DiscoveryProtocol(
         chain_config.nodekey,
         Address('0.0.0.0', chain_config.port, chain_config.port),
@@ -243,7 +230,7 @@ def run_lightnode_process(chain_config: ChainConfig) -> None:
         discovery,
         preferred_nodes=chain_config.preferred_nodes,
     )
-    node = node_class(headerdb, peer_pool, chain_config.jsonrpc_ipc_path)
+    node = NodeClass(headerdb, peer_pool, chain_config.jsonrpc_ipc_path)
 
     loop = asyncio.get_event_loop()
     asyncio.ensure_future(loop.create_datagram_endpoint(

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -1,9 +1,5 @@
 import os
 from pathlib import PurePath
-from typing import (
-    Tuple,
-    Union,
-)
 
 from eth_utils import (
     decode_hex,
@@ -20,16 +16,6 @@ from evm.chains.ropsten import (
     ROPSTEN_NETWORK_ID,
 )
 
-from p2p.kademlia import Node
-from p2p.constants import (
-    MAINNET_BOOTNODES,
-    ROPSTEN_BOOTNODES,
-)
-
-from trinity.constants import (
-    SYNC_FULL,
-    SYNC_LIGHT,
-)
 from .xdg import (
     get_xdg_trinity_root,
 )
@@ -39,7 +25,6 @@ DEFAULT_DATA_DIRS = {
     ROPSTEN_NETWORK_ID: 'ropsten',
     MAINNET_NETWORK_ID: 'mainnet',
 }
-DATABASE_DIR_NAME = 'chain'
 
 
 #
@@ -119,135 +104,6 @@ def load_nodekey(nodekey_path: PurePath) -> PrivateKey:
         nodekey_raw = nodekey_file.read()
     nodekey = keys.PrivateKey(nodekey_raw)
     return nodekey
-
-
-class ChainConfig:
-    _data_dir: PurePath = None
-    _nodekey_path: PurePath = None
-    _nodekey = None
-    _network_id: int = None
-
-    port: int = None
-    preferred_nodes: Tuple[Node, ...] = None
-
-    bootstrap_nodes: Tuple[Node, ...] = None
-
-    def __init__(self,
-                 network_id: int,
-                 data_dir: str=None,
-                 nodekey_path: str=None,
-                 nodekey: PrivateKey=None,
-                 sync_mode: str=SYNC_FULL,
-                 port: int=30303,
-                 preferred_nodes: Tuple[Node, ...]=None,
-                 bootstrap_nodes: Tuple[Node, ...]=None) -> None:
-        self.network_id = network_id
-        self.sync_mode = sync_mode
-        self.port = port
-        self.preferred_nodes = preferred_nodes
-
-        if bootstrap_nodes is None:
-            if self.network_id == MAINNET_NETWORK_ID:
-                self.bootstrap_nodes = tuple(
-                    Node.from_uri(enode) for enode in MAINNET_BOOTNODES
-                )
-            elif self.network_id == ROPSTEN_NETWORK_ID:
-                self.bootstrap_nodes = tuple(
-                    Node.from_uri(enode) for enode in ROPSTEN_BOOTNODES
-                )
-        else:
-            self.bootstrap_nodes = bootstrap_nodes
-
-        # validation
-        if nodekey is not None and nodekey_path is not None:
-            raise ValueError("It is invalid to provide both a `nodekey` and a `nodekey_path`")
-
-        # set values
-        if data_dir is not None:
-            self.data_dir = data_dir
-        else:
-            self.data_dir = get_data_dir_for_network_id(self.network_id)
-
-        if nodekey_path is not None:
-            self.nodekey_path = nodekey_path
-        elif nodekey is not None:
-            self.nodekey = nodekey
-
-    @property
-    def data_dir(self) -> PurePath:
-        """
-        The data_dir is the base directory that all chain specific information
-        for a given chain is stored.  All other chain directories are by
-        default relative to this directory.
-        """
-        return self._data_dir
-
-    @data_dir.setter
-    def data_dir(self, value: str) -> None:
-        self._data_dir = PurePath(os.path.abspath(value))
-
-    @property
-    def database_dir(self) -> str:
-        if self.sync_mode == SYNC_FULL:
-            return str(self.data_dir / DATABASE_DIR_NAME / "full")
-        elif self.sync_mode == SYNC_LIGHT:
-            return str(self.data_dir / DATABASE_DIR_NAME / "light")
-        else:
-            raise ValueError("Unknown sync mode: {}}".format(self.sync_mode))
-
-    @property
-    def database_ipc_path(self) -> str:
-        return get_database_socket_path(self.data_dir)
-
-    @property
-    def jsonrpc_ipc_path(self) -> str:
-        return get_jsonrpc_socket_path(self.data_dir)
-
-    @property
-    def nodekey_path(self) -> PurePath:
-        if self._nodekey_path is None:
-            if self._nodekey is not None:
-                return None
-            else:
-                return get_nodekey_path(self.data_dir)
-        else:
-            return self._nodekey_path
-
-    @nodekey_path.setter
-    def nodekey_path(self, value: str) -> None:
-        self._nodekey_path = PurePath(os.path.abspath(value))
-
-    @property
-    def nodekey(self) -> PrivateKey:
-        if self._nodekey is None:
-            try:
-                return load_nodekey(self.nodekey_path)
-            except FileNotFoundError:
-                # no file at the nodekey_path so we have a null nodekey
-                return None
-        else:
-            if isinstance(self._nodekey, bytes):
-                return keys.PrivateKey(self._nodekey)
-            elif isinstance(self._nodekey, PrivateKey):
-                return self._nodekey
-            return self._nodekey
-
-    @nodekey.setter
-    def nodekey(self, value: Union[bytes, PrivateKey]) -> None:
-        if isinstance(value, bytes):
-            self._nodekey = keys.PrivateKey(value)
-        elif isinstance(value, PrivateKey):
-            self._nodekey = value
-        else:
-            raise TypeError(
-                "Nodekey must either be a raw byte-string or an eth_keys "
-                "`PrivateKey` instance"
-            )
-
-    @classmethod
-    def from_parser_args(cls, parser_args):
-        constructor_kwargs = construct_chain_config_params(parser_args)
-        return cls(**constructor_kwargs)
 
 
 @to_dict


### PR DESCRIPTION
### What was wrong?

ChainConfig usage is expanding, and it's getting smarter. It shouldn't live in the sandboxed `utils` package anymore.

### How was it fixed?

- Moved ChainConfig to `trinity/config.py`
- Added a `node_class` implementation to automatically look up the right node class based on the configuration.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.fsnc1-1.fna.fbcdn.net/v/t1.0-9/22089618_1377809879002053_6688926054002632333_n.jpg?_nc_cat=0&oh=e37fc6adbfa3d2d14ce9d32a2c2f721f&oe=5B98B103)
