### PR TITLE
Piper/handle empty peer list in preferred peer pool

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -24,6 +24,11 @@ from eth_utils import (
     to_list,
 )
 
+from eth_utils import (
+    int_to_big_endian,
+    big_endian_to_int,
+)
+
 from eth_keys import keys
 from eth_keys import datatypes
 
@@ -31,10 +36,6 @@ from eth_hash.auto import keccak
 
 from p2p.cancel_token import CancelToken
 from p2p import kademlia
-from evm.utils.numeric import (
-    big_endian_to_int,
-    int_to_big_endian,
-)
 
 # UDP packet constants.
 MAC_SIZE = 256 // 8  # 32

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -237,6 +237,8 @@ class RoutingTable:
         # to nodes.
         while len(seen) < count:
             bucket = random.choice(self.buckets)
+            if not bucket.nodes:
+                continue
             node = random.choice(bucket.nodes)
             if node not in seen:
                 yield node


### PR DESCRIPTION
Fixes #760

### What was wrong?

Unhandle exception case in Kademlia `RoutingTable`

### How was it fixed?

Do a pre-condition check before trying to get a node from the bucket.

#### Cute Animal Picture

![proxy duckduckgo com](https://user-images.githubusercontent.com/824194/40454162-dab56d9c-5ea4-11e8-89b3-80d5158fefe7.jpg)

