### PR TITLE
Handle AlreadyWaiting condition during discovery node lookup

### DIFF
--- a/tests/p2p/test_kademlia.py
+++ b/tests/p2p/test_kademlia.py
@@ -112,7 +112,7 @@ async def test_wait_neighbours(cancel_token):
 
     # Schedule a call to proto.recv_neighbours() simulating a neighbours response from the node we
     # expect.
-    neighbours = [random_node(), random_node(), random_node()]
+    neighbours = (random_node(), random_node(), random_node())
     recv_neighbours_coroutine = asyncio.coroutine(lambda: proto.recv_neighbours(node, neighbours))
     asyncio.ensure_future(recv_neighbours_coroutine())
 
@@ -125,7 +125,7 @@ async def test_wait_neighbours(cancel_token):
     # If wait_neighbours() times out, we get an empty list of neighbours.
     received_neighbours = await proto.wait_neighbours(node, cancel_token)
 
-    assert received_neighbours == []
+    assert received_neighbours == tuple()
     assert node not in proto.neighbours_callbacks
 
 


### PR DESCRIPTION
fixes #762 

### What was wrong?

Unhandled exception case during discovery node lookup.

### How was it fixed?

Do a pre-filter on the list of nodes to remove any for which we're already waiting for a response.

Also moved the removal of the callback into a `finally` block to be sure it doesn't get skipped.

#### Cute Animal Picture

![donkey2](https://user-images.githubusercontent.com/824194/40454594-97853b5e-5ea6-11e8-9b52-9bf0ef43b44d.png)

