### PR TITLE
p2p: RegularChainSyncer now serves peer requests as well

### DIFF
--- a/p2p/eth.py
+++ b/p2p/eth.py
@@ -1,7 +1,6 @@
 import logging
 from typing import List, Union
 
-import rlp
 from rlp import sedes
 
 from evm.rlp.headers import BlockHeader
@@ -125,6 +124,11 @@ class ETHProtocol(Protocol):
         header, body = cmd.encode(node_hashes)
         self.send(header, body)
 
+    def send_node_data(self, nodes: List[bytes]) -> None:
+        cmd = NodeData(self.cmd_id_offset)
+        header, body = cmd.encode(nodes)
+        self.send(header, body)
+
     def send_get_block_headers(self, block_number_or_hash: Union[int, bytes],
                                max_headers: int, reverse: bool = True
                                ) -> None:
@@ -151,7 +155,7 @@ class ETHProtocol(Protocol):
 
     def send_block_headers(self, headers: List[BlockHeader]) -> None:
         cmd = BlockHeaders(self.cmd_id_offset)
-        header, body = cmd.encode([rlp.encode(header) for header in headers])
+        header, body = cmd.encode(headers)
         self.send(header, body)
 
     def send_get_block_bodies(self, block_hashes: List[bytes]) -> None:
@@ -161,10 +165,15 @@ class ETHProtocol(Protocol):
 
     def send_block_bodies(self, blocks: List[BlockBody]) -> None:
         cmd = BlockBodies(self.cmd_id_offset)
-        header, body = cmd.encode([rlp.encode(block) for block in blocks])
+        header, body = cmd.encode(blocks)
         self.send(header, body)
 
     def send_get_receipts(self, block_hashes: List[bytes]) -> None:
         cmd = GetReceipts(self.cmd_id_offset)
         header, body = cmd.encode(block_hashes)
+        self.send(header, body)
+
+    def send_receipts(self, receipts: List[Receipt]) -> None:
+        cmd = Receipts(self.cmd_id_offset)
+        header, body = cmd.encode(receipts)
         self.send(header, body)

--- a/p2p/lightchain.py
+++ b/p2p/lightchain.py
@@ -73,6 +73,8 @@ class LightPeerChain(PeerPoolSubscriber):
         """
         self._running_peers.add(peer)
         try:
+            # FIXME: Once we're a BaseService subclass, fix this to look like
+            # ChainSyncer.handle_peer()
             await self._handle_peer(peer)
         finally:
             self._running_peers.remove(peer)

--- a/tests/p2p/integration_test_helpers.py
+++ b/tests/p2p/integration_test_helpers.py
@@ -5,6 +5,7 @@ from eth_utils import decode_hex
 from eth_keys import datatypes, keys
 
 from evm import MainnetChain, RopstenChain
+from evm.chains.base import Chain
 from evm.db.chain import AsyncChainDB
 
 from p2p import kademlia
@@ -67,6 +68,10 @@ class FakeAsyncRopstenChain(RopstenChain):
 
 class FakeAsyncMainnetChain(MainnetChain):
     chaindb_class = FakeAsyncChainDB
+    coro_import_block = coro_import_block
+
+
+class FakeAsyncChain(Chain):
     coro_import_block = coro_import_block
 
 

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -1,0 +1,143 @@
+import asyncio
+
+import pytest
+
+from eth_keys import keys
+from eth_utils import decode_hex
+
+from evm import constants
+from evm.db.backends.memory import MemoryDB
+from evm.vm.forks.frontier import FrontierVM, _PoWMiningVM
+
+from p2p.peer import ETHPeer
+from p2p.chain import FastChainSyncer, RegularChainSyncer
+from p2p.state import StateDownloader
+
+from integration_test_helpers import FakeAsyncChain, FakeAsyncChainDB, FakeAsyncHeaderDB
+from peer_helpers import get_directly_linked_peers, MockPeerPoolWithConnectedPeers
+from test_lightchain import wait_for_head
+
+
+@pytest.mark.asyncio
+async def test_fast_syncer(request, event_loop, chaindb_fresh, chaindb_20):
+    client_peer, server_peer = await get_directly_linked_peers(
+        request, event_loop,
+        ETHPeer, FakeAsyncHeaderDB(chaindb_fresh.db),
+        ETHPeer, FakeAsyncHeaderDB(chaindb_20.db))
+    client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer])
+    client = FastChainSyncer(chaindb_fresh, client_peer_pool)
+    server = RegularChainSyncer(
+        FrontierTestChain(chaindb_20.db),
+        chaindb_20,
+        MockPeerPoolWithConnectedPeers([server_peer]))
+    asyncio.ensure_future(server.run())
+
+    def finalizer():
+        event_loop.run_until_complete(server.cancel())
+        # Yield control so that server.run() returns, otherwise asyncio will complain.
+        event_loop.run_until_complete(asyncio.sleep(0.1))
+    request.addfinalizer(finalizer)
+
+    # FastChainSyncer.run() will return as soon as it's caught up with the peer.
+    await asyncio.wait_for(client.run(), timeout=2)
+
+    head = chaindb_fresh.get_canonical_head()
+    assert head == chaindb_20.get_canonical_head()
+
+    # Now download the state for the chain's head.
+    state_downloader = StateDownloader(chaindb_fresh.db, head.state_root, client_peer_pool)
+    await asyncio.wait_for(state_downloader.run(), timeout=2)
+
+    assert head.state_root in chaindb_fresh.db
+
+
+@pytest.mark.asyncio
+async def test_regular_syncer(request, event_loop, chaindb_fresh, chaindb_20):
+    client_peer, server_peer = await get_directly_linked_peers(
+        request, event_loop,
+        ETHPeer, FakeAsyncHeaderDB(chaindb_fresh.db),
+        ETHPeer, FakeAsyncHeaderDB(chaindb_20.db))
+    client = RegularChainSyncer(
+        FrontierTestChain(chaindb_fresh.db),
+        chaindb_fresh,
+        MockPeerPoolWithConnectedPeers([client_peer]))
+    server = RegularChainSyncer(
+        FrontierTestChain(chaindb_20.db),
+        chaindb_20,
+        MockPeerPoolWithConnectedPeers([server_peer]))
+    asyncio.ensure_future(server.run())
+
+    def finalizer():
+        event_loop.run_until_complete(asyncio.gather(client.cancel(), server.cancel()))
+        # Yield control so that client/server.run() returns, otherwise asyncio will complain.
+        event_loop.run_until_complete(asyncio.sleep(0.1))
+    request.addfinalizer(finalizer)
+
+    asyncio.ensure_future(client.run())
+
+    await wait_for_head(client.chaindb, server.chaindb.get_canonical_head())
+    head = client.chaindb.get_canonical_head()
+    assert head.state_root in client.chaindb.db
+
+
+@pytest.fixture
+def chaindb_20():
+    chain = PoWMiningChain.from_genesis(MemoryDB(), GENESIS_PARAMS, GENESIS_STATE)
+    for i in range(20):
+        tx = chain.create_unsigned_transaction(
+            nonce=i,
+            gas_price=1234,
+            gas=1234000,
+            to=RECEIVER.public_key.to_canonical_address(),
+            value=i,
+            data=b'',
+        )
+        chain.apply_transaction(tx.as_signed_transaction(SENDER))
+        chain.mine_block()
+    return chain.chaindb
+
+
+@pytest.fixture
+def chaindb_fresh():
+    chain = PoWMiningChain.from_genesis(MemoryDB(), GENESIS_PARAMS, GENESIS_STATE)
+    assert chain.chaindb.get_canonical_head().block_number == 0
+    return chain.chaindb
+
+
+SENDER = keys.PrivateKey(
+    decode_hex("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee"))
+RECEIVER = keys.PrivateKey(
+    decode_hex("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"))
+GENESIS_PARAMS = {
+    'parent_hash': constants.GENESIS_PARENT_HASH,
+    'uncles_hash': constants.EMPTY_UNCLE_HASH,
+    'coinbase': constants.ZERO_ADDRESS,
+    'transaction_root': constants.BLANK_ROOT_HASH,
+    'receipt_root': constants.BLANK_ROOT_HASH,
+    'bloom': 0,
+    'difficulty': 5,
+    'block_number': constants.GENESIS_BLOCK_NUMBER,
+    'gas_limit': constants.GENESIS_GAS_LIMIT,
+    'gas_used': 0,
+    'timestamp': 1514764800,
+    'extra_data': constants.GENESIS_EXTRA_DATA,
+    'nonce': constants.GENESIS_NONCE
+}
+GENESIS_STATE = {
+    SENDER.public_key.to_canonical_address(): {
+        "balance": 100000000000000000,
+        "code": b"",
+        "nonce": 0,
+        "storage": {}
+    }
+}
+
+
+class FrontierTestChain(FakeAsyncChain):
+    vm_configuration = ((0, FrontierVM),)
+    chaindb_class = FakeAsyncChainDB
+    network_id = 999
+
+
+class PoWMiningChain(FrontierTestChain):
+    vm_configuration = ((0, _PoWMiningVM),)


### PR DESCRIPTION
Up until now we'd only fetch chain/state data, ignoring any peer requests for data


We now handle chain/state data requests from other peers.

Also adds tests for chain syncing and state downloading