### PR TITLE
Enable logging to file by default for alpha releases

### DIFF
--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -98,6 +98,9 @@ def initialize_data_dir(chain_config: ChainConfig) -> None:
         with open(chain_config.nodekey_path, 'wb') as nodekey_file:
             nodekey_file.write(nodekey.to_bytes())
 
+    # Logfile
+    os.makedirs(chain_config.logfile_path, exist_ok=True)
+
 
 def initialize_database(chain_config: ChainConfig, chaindb: AsyncChainDB) -> None:
     try:

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -37,6 +37,7 @@ from trinity.utils.chains import (
     get_data_dir_for_network_id,
     get_database_socket_path,
     get_jsonrpc_socket_path,
+    get_logfile_path,
     get_nodekey_path,
     load_nodekey,
 )
@@ -47,6 +48,7 @@ DATABASE_DIR_NAME = 'chain'
 class ChainConfig:
     _data_dir: Path = None
     _nodekey_path: Path = None
+    _logfile_path: Path = None
     _nodekey = None
     _network_id: int = None
 
@@ -59,6 +61,7 @@ class ChainConfig:
                  network_id: int,
                  data_dir: str=None,
                  nodekey_path: str=None,
+                 logfile_path: str=None,
                  nodekey: PrivateKey=None,
                  sync_mode: str=SYNC_FULL,
                  port: int=30303,
@@ -95,6 +98,22 @@ class ChainConfig:
             self.nodekey_path = nodekey_path
         elif nodekey is not None:
             self.nodekey = nodekey
+
+        if logfile_path is not None:
+            self.logfile_path = logfile_path
+        else:
+            self.logfile_path = get_logfile_path(self.data_dir)
+
+    @property
+    def logfile_path(self) -> Path:
+        """
+        The logfile_path is the base directory where all log files are stored.
+        """
+        return self._logfile_path
+
+    @logfile_path.setter
+    def logfile_path(self, value: Path) -> None:
+        self._logfile_path = value
 
     @property
     def data_dir(self) -> Path:

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -84,7 +84,6 @@ def main() -> None:
     args = parser.parse_args()
 
     log_level = getattr(logging, args.log_level.upper())
-    logger, log_queue, listener = setup_trinity_logging(log_level)
 
     if args.network_id not in PRECONFIGURED_NETWORKS:
         raise NotImplementedError(
@@ -93,6 +92,9 @@ def main() -> None:
         )
 
     chain_config = ChainConfig.from_parser_args(args)
+    logger, log_queue, listener_stream, listener_file = (
+        setup_trinity_logging(chain_config, log_level)
+    )
 
     if not is_data_dir_initialized(chain_config):
         # TODO: this will only work as is for chains with known genesis
@@ -107,7 +109,8 @@ def main() -> None:
 
     # start the listener thread to handle logs produced by other processes in
     # the local logger.
-    listener.start()
+    listener_stream.start()
+    listener_file.start()
 
     logging_kwargs = {
         'log_queue': log_queue,

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -51,6 +51,17 @@ def get_data_dir_for_network_id(network_id: int) -> Path:
         raise KeyError("Unknown network id: `{0}`".format(network_id))
 
 
+LOG_DIRNAME = 'logs'
+LOG_FILENAME = 'trinity.log'
+
+
+def get_logfile_path(data_dir: Path) -> Path:
+    """
+    Returns the path to the log files.
+    """
+    return data_dir / LOG_DIRNAME / LOG_FILENAME
+
+
 NODEKEY_FILENAME = 'nodekey'
 
 


### PR DESCRIPTION
### What was wrong?

Users of the alpha releases are very likely going to encounter errors for which we need debug level logging output to diagnose. They however are unlikely to be both logging at the `DEBUG` level and retaining log output.

Issue Reference: https://github.com/ethereum/py-evm/issues/742

### How was it fixed?

Lets enable file based logging in a `$XDG_TRINITY_ROOT/<chain-dir>/logs` at the `DEBUG` level. This way when a user has an issue we can get them to dig out the relevant logfiles for us.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2017/04/cute-dog-shiba-inu-ryuji-japan-18.jpg)
