### PR TITLE
Return early in Kademlia.recv_ping if remote is this_node

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -427,7 +427,7 @@ class KademliaProtocol:
         """
         self.logger.debug('<<< ping from %s', remote)
         if remote == self.this_node:
-            self.logger.debug('Received ping from this_node: %s', remote)
+            self.logger.info('Invariant: received ping from this_node: %s', remote)
             return
         else:
             self.update_routing_table(remote)

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -426,7 +426,11 @@ class KademliaProtocol:
         reply with a pong, whereas in the latter we'll also fire a callback from ping_callbacks.
         """
         self.logger.debug('<<< ping from %s', remote)
-        self.update_routing_table(remote)
+        if remote == self.this_node:
+            self.logger.debug('Received ping from this_node: %s', remote)
+            return
+        else:
+            self.update_routing_table(remote)
         self.wire.send_pong(remote, hash_)
         # Sometimes a ping will be sent to us as part of the bonding
         # performed the first time we see a node, and it is in those cases that


### PR DESCRIPTION
### What was wrong?

Occasionally receiving a `ping` from `this_node`.

### How was it fixed?

Avoid trying to add `remote` to routing table if it is `this_node` and return early from `recv_ping` when `remote == this_node`.

#### Cute Animal Picture

![163e48dbb409544f5332da5060194d52](https://user-images.githubusercontent.com/824194/40564288-5b8bee92-6025-11e8-83f5-8306578dbc3c.jpg)

