### PR TITLE
Adding more log to debug the case when "ciphertext" length is less than required

### DIFF
--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -153,6 +153,7 @@ class HandshakeBase:
 
 
 class HandshakeInitiator(HandshakeBase):
+    logger = logging.getLogger("p2p.peer.HandshakeInitiator")
     _is_initiator = True
 
     def encrypt_auth_message(self, auth_message: bytes) -> bytes:
@@ -176,6 +177,7 @@ class HandshakeInitiator(HandshakeBase):
 
     def decode_auth_ack_message(self, ciphertext: bytes) -> Tuple[datatypes.PublicKey, bytes]:
         if len(ciphertext) < ENCRYPTED_AUTH_ACK_LEN:
+            self.logger.debug("Ciphertext %s, with length: %s", ciphertext, len(ciphertext))
             raise ValueError("Auth ack msg too short: {}".format(len(ciphertext)))
         elif len(ciphertext) == ENCRYPTED_AUTH_ACK_LEN:
             eph_pubkey, nonce, _ = decode_ack_plain(ciphertext, self.privkey)


### PR DESCRIPTION
### What was wrong?

```
   ERROR  05-24 15:52:55        peer  Unexpected error during auth/p2p handshake with <Node(0x4382@104.149.231.208)>
Traceback (most recent call last):
  File "/Users/piper/sites/py-evm/p2p/peer.py", line 739, in connect
    self.cancel_token)
  File "/Users/piper/sites/py-evm/p2p/peer.py", line 136, in handshake
    ) = await auth.handshake(remote, privkey, token)
  File "/Users/piper/sites/py-evm/p2p/auth.py", line 55, in handshake
    initiator, reader, writer, token)
  File "/Users/piper/sites/py-evm/p2p/auth.py", line 77, in _handshake
    ephemeral_pubkey, responder_nonce = initiator.decode_auth_ack_message(auth_ack)
  File "/Users/piper/sites/py-evm/p2p/auth.py", line 179, in decode_auth_ack_message
    raise ValueError("Auth ack msg too short: {}".format(len(ciphertext)))
ValueError: Auth ack msg too short: 0
```

This error occurs semi regularly during fast sync (and in general during running the trinity node.)

Issue Reference: https://github.com/ethereum/py-evm/issues/776

### How was it fixed?

I'm adding more logging to understand the root cause.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://puppytoob.com/wp-content/uploads/2018/02/Boo-Dog-1-750x500.jpg)
