### PR TITLE
Raise HandshakeFailure instead of ValueError when Ack is wrong size

### DIFF
--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -23,7 +23,7 @@ from p2p.cancel_token import CancelToken, wait_with_token
 from p2p.constants import REPLY_TIMEOUT
 from p2p.exceptions import (
     DecryptionError,
-    HandshakeFailure,
+    BadAckMessage,
 )
 from p2p.utils import (
     sxor,
@@ -179,7 +179,7 @@ class HandshakeInitiator(HandshakeBase):
 
     def decode_auth_ack_message(self, ciphertext: bytes) -> Tuple[datatypes.PublicKey, bytes]:
         if len(ciphertext) < ENCRYPTED_AUTH_ACK_LEN:
-            raise HandshakeFailure("Auth ack msg too short: {}".format(len(ciphertext)))
+            raise BadAckMessage("Auth ack msg too short: {}".format(len(ciphertext)))
         elif len(ciphertext) == ENCRYPTED_AUTH_ACK_LEN:
             eph_pubkey, nonce, _ = decode_ack_plain(ciphertext, self.privkey)
         else:
@@ -239,7 +239,7 @@ def decode_ack_plain(
     """
     message = ecies.decrypt(ciphertext, privkey)
     if len(message) != AUTH_ACK_LEN:
-        raise HandshakeFailure("Unexpected size for ack message: {}".format(len(message)))
+        raise BadAckMessage("Unexpected size for ack message: {}".format(len(message)))
     eph_pubkey = keys.PublicKey(message[:PUBKEY_LEN])
     nonce = message[PUBKEY_LEN: PUBKEY_LEN + HASH_LEN]
     return eph_pubkey, nonce, SUPPORTED_RLPX_VERSION
@@ -265,7 +265,7 @@ def decode_auth_plain(ciphertext: bytes, privkey: datatypes.PrivateKey) -> Tuple
     """Decode legacy pre-EIP-8 auth message format"""
     message = ecies.decrypt(ciphertext, privkey)
     if len(message) != AUTH_MSG_LEN:
-        raise HandshakeFailure("Unexpected size for auth message: {}".format(len(message)))
+        raise BadAckMessage("Unexpected size for auth message: {}".format(len(message)))
     signature = keys.Signature(signature_bytes=message[:SIGNATURE_LEN])
     pubkey_start = SIGNATURE_LEN + HASH_LEN
     pubkey = keys.PublicKey(message[pubkey_start: pubkey_start + PUBKEY_LEN])

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -100,10 +100,18 @@ class EventLoopMismatch(BaseP2PError):
     """
     Raised when two different asyncio event loops are referenced, but must be equal
     """
+    pass
 
 
 class NoEligibleNodes(BaseP2PError):
     """
     Raised when there are no nodes which meet some filter criteria
+    """
+    pass
+
+
+class BadAckMessage(BaseP2PError):
+    """
+    Raised when the ack message during a peer handshake is malformed
     """
     pass

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -746,6 +746,10 @@ class PeerPool(BaseService):
             # TODO: This is kept separate from the `expected_exceptions` to be
             # sure that we aren't silencing an error in our authentication
             # code.
+            self.logger.info('Got bad Ack during peer connection')
+            # We intentionally log this twice, once in INFO to be sure we don't
+            # forget about this and once in DEBUG which includes the stack
+            # trace.
             self.logger.debug('Got bad Ack during peer connection', exc_info=True)
         except expected_exceptions as e:
             self.logger.debug("Could not complete handshake with %s: %s", remote, repr(e))

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -65,6 +65,7 @@ from p2p.discovery import DiscoveryProtocol
 from p2p.kademlia import Address, Node
 from p2p import protocol
 from p2p.exceptions import (
+    BadAckMessage,
     DecryptionError,
     EmptyGetBlockHeadersReply,
     HandshakeFailure,
@@ -741,6 +742,11 @@ class PeerPool(BaseService):
         except OperationCancelled:
             # Pass it on to instruct our main loop to stop.
             raise
+        except BadAckMessage:
+            # TODO: This is kept separate from the `expected_exceptions` to be
+            # sure that we aren't silencing an error in our authentication
+            # code.
+            self.logger.debug('Got bad Ack during peer connection', exc_info=True)
         except expected_exceptions as e:
             self.logger.debug("Could not complete handshake with %s: %s", remote, repr(e))
         except Exception:


### PR DESCRIPTION
Fixes #776 

### What was wrong?

`ValueError` was escaping during `Peer.connect`

### How was it fixed?

Changed `ValueError` exceptions to be `HandshakeFailure` exceptions which are caught and handled in `Peer.connect`.

#### Cute Animal Picture

![d4b7240f2b7ac8965221eb4c2f2ec59a](https://user-images.githubusercontent.com/824194/40576523-4c7a735c-60b5-11e8-8ffa-2e1eca03c0f7.jpg)

