### PR TITLE
p2p: Explicitly use a ProcessPoolExecutor where needed

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -1,7 +1,9 @@
 import asyncio
+from concurrent.futures import ProcessPoolExecutor
 import logging
 import math
 import operator
+import os
 import time
 from typing import (
     Any,
@@ -74,6 +76,14 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
         # bodies/receipts for a given chain segment.
         self._downloaded_receipts: asyncio.Queue[Tuple[ETHPeer, List[DownloadedBlockPart]]] = asyncio.Queue()  # noqa: E501
         self._downloaded_bodies: asyncio.Queue[Tuple[ETHPeer, List[DownloadedBlockPart]]] = asyncio.Queue()  # noqa: E501
+        # Use CPU_COUNT - 1 processes to make sure we always leave one CPU idle so that it can run
+        # asyncio's event loop.
+        if os.cpu_count() is None:
+            # Need this because os.cpu_count() returns None when the # of CPUs is indeterminable.
+            cpu_count = 1
+        else:
+            cpu_count = os.cpu_count() - 1
+        self._executor = ProcessPoolExecutor(cpu_count)
 
     def register_peer(self, peer: BasePeer) -> None:
         asyncio.ensure_future(self.handle_peer(cast(ETHPeer, peer)))
@@ -404,7 +414,7 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
         loop = asyncio.get_event_loop()
         iterator = map(make_trie_root_and_nodes, receipts_by_block)
         receipts_tries = await wait_with_token(
-            loop.run_in_executor(None, list, iterator),
+            loop.run_in_executor(self._executor, list, iterator),
             token=self.cancel_token)
         downloaded: List[DownloadedBlockPart] = []
         for (receipts, (receipt_root, trie_dict_data)) in zip(receipts_by_block, receipts_tries):
@@ -419,7 +429,7 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
         loop = asyncio.get_event_loop()
         iterator = map(make_trie_root_and_nodes, [body.transactions for body in bodies])
         transactions_tries = await wait_with_token(
-            loop.run_in_executor(None, list, iterator),
+            loop.run_in_executor(self._executor, list, iterator),
             token=self.cancel_token)
         downloaded: List[DownloadedBlockPart] = []
         for (body, (tx_root, trie_dict_data)) in zip(bodies, transactions_tries):
@@ -592,7 +602,6 @@ def _is_receipts_empty(header: BlockHeader) -> bool:
 
 def _test() -> None:
     import argparse
-    from concurrent.futures import ProcessPoolExecutor
     import signal
     from p2p import ecies
     from evm.chains.ropsten import RopstenChain, ROPSTEN_GENESIS_HEADER
@@ -615,15 +624,10 @@ def _test() -> None:
     logging.getLogger('p2p.chain.ChainSyncer').setLevel(log_level)
 
     loop = asyncio.get_event_loop()
-    # Use a ProcessPoolExecutor as the default because the tasks we want to offload from the main
-    # thread are cpu intensive.
-    loop.set_default_executor(ProcessPoolExecutor())
 
     base_db = LevelDB(args.db)
-
     chaindb = FakeAsyncChainDB(base_db)
     chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
-
     headerdb = FakeAsyncHeaderDB(base_db)
 
     privkey = ecies.generate_privkey()

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -319,10 +319,11 @@ class BasePeer(BaseService):
         frame_data = await self.read(read_size + MAC_LEN)
         msg = self.decrypt_body(frame_data, frame_size)
         cmd = self.get_protocol_command_for(msg)
-        loop = asyncio.get_event_loop()
-        decoded_msg = await wait_with_token(
-            loop.run_in_executor(None, cmd.decode, msg),
-            token=self.cancel_token)
+        # NOTE: This used to be a bottleneck but it doesn't seem to be so anymore. If we notice
+        # too much time is being spent on this again, we need to consider running this in a
+        # ProcessPoolExecutor(). Need to make sure we don't use all CPUs in the machine for that,
+        # though, otherwise asyncio's event loop can't run and we can't keep up with other peers.
+        decoded_msg = cmd.decode(msg)
         self.logger.debug("Successfully decoded %s msg: %s", cmd, decoded_msg)
         return cmd, decoded_msg
 

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -1,5 +1,4 @@
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 import ipaddress
 import logging
 import secrets
@@ -176,10 +175,9 @@ class Server(BaseService):
         # UPnP discovery can take a long time, so use a loooong timeout here.
         discover_timeout = 10 * REPLY_TIMEOUT
         # Use loop.run_in_executor() because upnpclient.discover() is blocking and may take a
-        # while to complete. We must use a ThreadPoolExecutor() because the
-        # response from upnpclient.discover() can't be pickled.
+        # while to complete.
         devices = await wait_with_token(
-            loop.run_in_executor(ThreadPoolExecutor(max_workers=1), upnpclient.discover),
+            loop.run_in_executor(None, upnpclient.discover),
             token=self.cancel_token,
             timeout=discover_timeout)
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ deps = {
         "netifaces>=0.10.7<1",
         "pysha3>=1.0.0,<2.0.0",
         "upnpclient>=0.0.8,<1",
+        "eth-hash>=0.1.4,<1",
     ],
     'trinity': [
         "ipython>=6.2.1,<7.0.0",


### PR DESCRIPTION
Without this the fast sync is insanely slow

Closes #778