### PR TITLE
p2p: Track whether a peer connection is inbound or outbound

### DIFF
--- a/p2p/server.py
+++ b/p2p/server.py
@@ -353,7 +353,8 @@ class Server(BaseService):
             egress_mac=egress_mac,
             ingress_mac=ingress_mac,
             headerdb=self.headerdb,
-            network_id=self.network_id
+            network_id=self.network_id,
+            inbound=True,
         )
 
         await self.do_handshake(peer)


### PR DESCRIPTION
Also periodically (every 60s) reports number of connected peers.