### PR TITLE
Remove unmaintained pytest-logging dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ deps = {
         "pytest~=3.2",
         "pytest-asyncio==0.8.0",
         "pytest-cov==2.5.1",
-        "pytest-logging>=2015.11.4",
         "pytest-xdist==1.18.1",
         "pytest-watch>=4.1.0,<5",
     ],


### PR DESCRIPTION
### What was wrong?

I tried installing `py-evm` on a fresh Ubuntu (with `python3.6-dev` and `python3-pip` installed) and ran into the following error with the `pytest-logging`

```
Collecting pytest-logging>=2015.11.4 (from py-evm==0.2.0a18)
  Using cached https://files.pythonhosted.org/packages/dc/1e/fb11174c9eaebcec27d36e9e994b90ffa168bc3226925900b9dbbf16c9da/pytest-logging-2015.11.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-p6kq5wup/pytest-logging/setup.py", line 34, in <module>
        exec(rfh.read(), None, _LOCALS)  # pylint: disable=exec-used
      File "/py-evm/venv/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 105: ordinal not in range(128)
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-p6kq5wup/pytest-logging/
```

### How was it fixed?

Upon further investigation it seems that this project is abandoned and the functionality is now provided by pytest directly. That said, I'm not sure if there's anything left to configure so I'm just sending this PR to see if anything falls apart or anyone raises concerns why this may still be needed.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.pixabay.com/photo/2014/05/28/09/49/animal-356362_960_720.jpg)
