### PR TITLE
Ensure trinity.nodes is a proper python module

### DIFF
--- a/evm/db/backends/level.py
+++ b/evm/db/backends/level.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from .base import (
     BaseDB,
 )
@@ -6,7 +8,7 @@ from .base import (
 class LevelDB(BaseDB):
 
     # Creates db as a class variable to avoid level db lock error
-    def __init__(self, db_path: str = None) -> None:
+    def __init__(self, db_path: Path = None) -> None:
         if not db_path:
             raise TypeError("Please specifiy a valid path for your database.")
         try:
@@ -15,7 +17,7 @@ class LevelDB(BaseDB):
             raise ImportError("LevelDB requires the plyvel \
                                library which is not available for import.")
         self.db_path = db_path
-        self.db = plyvel.DB(db_path, create_if_missing=True, error_if_exists=False)
+        self.db = plyvel.DB(str(db_path), create_if_missing=True, error_if_exists=False)
 
     def __getitem__(self, key: bytes) -> bytes:
         v = self.db.get(key)

--- a/tests/trinity/core/chains-utils/test_chain_config_object.py
+++ b/tests/trinity/core/chains-utils/test_chain_config_object.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from eth_utils import (
@@ -27,7 +25,7 @@ def test_chain_config_computed_properties():
 
     assert chain_config.network_id == 1234
     assert chain_config.data_dir == data_dir
-    assert chain_config.database_dir == os.path.join(data_dir, DATABASE_DIR_NAME, "full")
+    assert chain_config.database_dir == data_dir / DATABASE_DIR_NAME / "full"
     assert chain_config.nodekey_path == get_nodekey_path(data_dir)
 
 

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -62,7 +62,7 @@ def manager(database_server_ipc_path):
     DBManager.register('get_db', proxytype=DBProxy)
     DBManager.register('get_chaindb', proxytype=ChainDBProxy)
 
-    _manager = DBManager(address=database_server_ipc_path)
+    _manager = DBManager(address=str(database_server_ipc_path))
     _manager.connect()
     return _manager
 

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -157,7 +157,7 @@ def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
         proxytype=AsyncHeaderChainProxy,
     )
 
-    manager = DBManager(address=chain_config.database_ipc_path)  # type: ignore
+    manager = DBManager(address=str(chain_config.database_ipc_path))  # type: ignore
     server = manager.get_server()  # type: ignore
 
     server.serve_forever()  # type: ignore

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -106,20 +106,20 @@ class ChainConfig:
         self._data_dir = Path(value).resolve()
 
     @property
-    def database_dir(self) -> str:
+    def database_dir(self) -> Path:
         if self.sync_mode == SYNC_FULL:
-            return str(self.data_dir / DATABASE_DIR_NAME / "full")
+            return self.data_dir / DATABASE_DIR_NAME / "full"
         elif self.sync_mode == SYNC_LIGHT:
-            return str(self.data_dir / DATABASE_DIR_NAME / "light")
+            return self.data_dir / DATABASE_DIR_NAME / "light"
         else:
             raise ValueError("Unknown sync mode: {}}".format(self.sync_mode))
 
     @property
-    def database_ipc_path(self) -> str:
+    def database_ipc_path(self) -> Path:
         return get_database_socket_path(self.data_dir)
 
     @property
-    def jsonrpc_ipc_path(self) -> str:
+    def jsonrpc_ipc_path(self) -> Path:
         return get_jsonrpc_socket_path(self.data_dir)
 
     @property

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -5,10 +5,13 @@ from multiprocessing.managers import (
     BaseManager,
 )
 from threading import Thread
-from typing import Type
+from typing import (
+    Type,
+    Union
+)
 
 from evm.chains.base import BaseChain
-from evm.db.header import BaseHeaderDB
+
 from p2p.service import (
     BaseService,
     EmptyService,
@@ -22,7 +25,10 @@ from trinity.chains.header import (
 )
 from trinity.db.chain import ChainDBProxy
 from trinity.db.base import DBProxy
-from trinity.db.header import AsyncHeaderDBProxy
+from trinity.db.header import (
+    BaseAsyncHeaderDB,
+    AsyncHeaderDBProxy
+)
 from trinity.rpc.main import (
     RPCServer,
 )
@@ -68,7 +74,7 @@ class Node(BaseService):
         return self._db_manager
 
     @property
-    def headerdb(self) -> BaseHeaderDB:
+    def headerdb(self) -> BaseAsyncHeaderDB:
         return self._headerdb
 
     def add_service(self, service: BaseService) -> None:
@@ -77,7 +83,7 @@ class Node(BaseService):
         else:
             self._auxiliary_services.append(service)
 
-    def make_ipc_server(self) -> IPCServer:
+    def make_ipc_server(self) -> Union[IPCServer, BaseService]:
         if self._jsonrpc_ipc_path:
             rpc = RPCServer(self.get_chain())
             return IPCServer(rpc, self._jsonrpc_ipc_path)

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -35,10 +35,10 @@ class FullNode(Node):
             self._p2p_server = Server(
                 self._node_key,
                 self._node_port,
-                manager.get_chain(),
-                manager.get_chaindb(),
+                manager.get_chain(),  # type: ignore
+                manager.get_chaindb(),  # type: ignore
                 self.headerdb,
-                manager.get_db(),
+                manager.get_db(),  # type: ignore
                 self._network_id,
                 peer_pool_class=PreferredNodePeerPool,
                 bootstrap_nodes=self._bootstrap_nodes,

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -9,9 +9,6 @@ from p2p.peer import (
     PeerPool,
     PreferredNodePeerPool,
 )
-from p2p.service import (
-    BaseService,
-)
 
 from trinity.chains.light import (
     LightDispatchChain,
@@ -26,7 +23,7 @@ class LightNode(Node):
     chain_class: Type[LightDispatchChain] = None
 
     _chain: LightDispatchChain = None
-    _p2p_server: BaseService = None
+    _p2p_server: LightPeerChain = None
 
     def __init__(self, chain_config: ChainConfig) -> None:
         super().__init__(chain_config)
@@ -60,7 +57,7 @@ class LightNode(Node):
 
         return self._chain
 
-    def get_p2p_server(self) -> BaseService:
+    def get_p2p_server(self) -> LightPeerChain:
         if self._p2p_server is None:
             self._p2p_server = LightPeerChain(self.headerdb, self._peer_pool)
         return self._p2p_server

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -67,33 +67,33 @@ def get_nodekey_path(data_dir: Path) -> Path:
 DATABASE_SOCKET_FILENAME = 'db.ipc'
 
 
-def get_database_socket_path(data_dir: Path) -> str:
+def get_database_socket_path(data_dir: Path) -> Path:
     """
     Returns the path to the private key used for devp2p connections.
 
     We're still returning 'str' here on ipc-related path because an issue with
     multi-processing not being able to interpret 'Path' objects correctly.
     """
-    return os.environ.get(
+    return Path(os.environ.get(
         'TRINITY_DATABASE_IPC',
-        str(data_dir / DATABASE_SOCKET_FILENAME),
-    )
+        data_dir / DATABASE_SOCKET_FILENAME,
+    ))
 
 
 JSONRPC_SOCKET_FILENAME = 'jsonrpc.ipc'
 
 
-def get_jsonrpc_socket_path(data_dir: Path) -> str:
+def get_jsonrpc_socket_path(data_dir: Path) -> Path:
     """
     Returns the path to the ipc socket for the JSON-RPC server.
 
     We're still returning 'str' here on ipc-related path because an issue with
     multi-processing not being able to interpret 'Path' objects correctly.
     """
-    return os.environ.get(
+    return Path(os.environ.get(
         'TRINITY_JSONRPC_IPC',
-        str(data_dir / JSONRPC_SOCKET_FILENAME),
-    )
+        data_dir / JSONRPC_SOCKET_FILENAME,
+    ))
 
 
 #


### PR DESCRIPTION
### What was wrong?

When trying to run Trinity on a fresh Ubuntu I ran into the following error.

```
    INFO  05-28 12:52:55        main  
  ______     _       _ __       
 /_  __/____(_)___  (_) /___  __
  / / / ___/ / __ \/ / __/ / / /
 / / / /  / / / / / / /_/ /_/ / 
/_/ /_/  /_/_/ /_/_/\__/\__, /  
                       /____/   
    INFO  05-28 12:52:55        main  Trinity/0.2.0a18/linux/cpython3.6.5
    INFO  05-28 12:52:55        main  enode://781245c14c5885cf79df99e233733ec7a8fcdf8a9e3bfeef50aedd43b3e42d03@[:]:30303
    INFO  05-28 12:52:55        main  network: 1
Process SpawnProcess-2:
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/py-evm/venv/lib/python3.6/site-packages/trinity/utils/logging.py", line 63, in inner
    return fn(*args, **inner_kwargs)
  File "/py-evm/venv/lib/python3.6/site-packages/trinity/main.py", line 156, in launch_node
    NodeClass = chain_config.node_class
  File "/py-evm/venv/lib/python3.6/site-packages/trinity/config.py", line 173, in node_class
    from trinity.nodes.mainnet import (
ModuleNotFoundError: No module named 'trinity.nodes'
^CError in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/popen_fork.py", line 28, in poll
    pid, sts = os.waitpid(self.pid, flag)
```

To highlight the important part

```
ModuleNotFoundError: No module named 'trinity.nodes'
```

### How was it fixed?

Added `__init__.py` to ensure `trinity.nodes` is an actual python module. 

However, after I made that a proper Python module, it started to get type checked and there were a bunch of errors. Most of them boiled down to APIs expecting are more concrete type than what was passed into (e.g. an API expecting a `SportsCar` isn't satisfied when getting a `Car` passed, as a `Car` might be missing `go_real_fast()` API)

There were also cases where we were expecting to deal with a `Path` but where passed an `str`. I first tried to get rid of the `str` return types in the `ChainConfig` altogether but that turned out to be problematic so for now I just fixed that by wrapping the `str` as `Path`.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.pixabay.com/photo/2016/09/04/00/49/donkey-1643069_960_720.jpg)
