### PR TITLE
trinity: Force INFO level for Peer/kademlia/discovery loggers

### DIFF
--- a/p2p/server.py
+++ b/p2p/server.py
@@ -280,7 +280,7 @@ class Server(BaseService):
         try:
             await self._receive_handshake(reader, writer)
         except expected_exceptions as e:
-            self.logger.debug("Could not complete handshake", exc_info=True)
+            self.logger.debug("Could not complete handshake: %s", e)
         except unclean_close_exceptions:
             self.logger.exception("Unclean exit while receiving handshake")
         except OperationCancelled:
@@ -315,7 +315,7 @@ class Server(BaseService):
                 ephem_pubkey, initiator_nonce, initiator_pubkey = decode_authentication(
                     msg, self.privkey)
             except DecryptionError as e:
-                self.logger.debug("Failed to decrypt handshake", exc_info=True)
+                self.logger.debug("Failed to decrypt handshake: %s", e)
                 return
 
         # Create `HandshakeResponder(remote: kademlia.Node, privkey: datatypes.PrivateKey)` instance

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -73,6 +73,11 @@ def setup_queue_logging(log_queue: Queue, level: int) -> None:
     logger = logging.getLogger()
     logger.addHandler(queue_handler)
     logger.setLevel(logging.DEBUG)
+    # These loggers generates too much DEBUG noise, drowning out the important things, so force
+    # the INFO level for it until https://github.com/ethereum/py-evm/issues/806 is fixed.
+    logging.getLogger('p2p.peer.Peer').setLevel(logging.INFO)
+    logging.getLogger('p2p.kademlia').setLevel(logging.INFO)
+    logging.getLogger('p2p.discovery').setLevel(logging.INFO)
     logger.debug('Logging initialized: PID=%s', os.getpid())
 
 


### PR DESCRIPTION
Those loggers are too noisy when in DEBUG level and they end up drowning
the important stuff