### PR TITLE
Add macOS section to quickstart guide

### DIFF
--- a/docs/guides/trinity/quickstart.rst
+++ b/docs/guides/trinity/quickstart.rst
@@ -32,6 +32,21 @@ Finally, we can install the ``trinity`` package via pip.
 
   pip3 install trinity
 
+Installing on macOS
+-------------------
+
+First, install LevelDB and the latest Python 3 with brew:
+
+.. code:: sh
+
+  brew install python3 leveldb
+
+Then, install the ``trinity`` package via pip:
+
+.. code:: sh
+
+  pip3 install trinity
+
 Running Trinity
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
### What was wrong?

Installation fails on macOS if LevelDB is not installed.

### How was it fixed?

Added a quickstart section for macOS installation.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cpb-us-e1.wpmucdn.com/blogs.ntu.edu.sg/dist/7/832/files/2014/11/proboscis-monkey.jpg)
