### PR TITLE
cleanup import logging output

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -272,10 +272,11 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
 
         head = await self.chaindb.coro_get_canonical_head()
         self.logger.info(
-            "Imported chain segment in %d seconds, new head: #%d (%s)",
+            "Imported %d headers in %0.2f seconds, new head: #%d (%s)",
+            len(headers),
             time.time() - start,
             head.block_number,
-            encode_hex(head.hash)[2:6],
+            encode_hex(head.hash)[2:8],
         )
         # Quite often the header batch we receive here includes headers past the peer's reported
         # head (via the NewBlock msg), so we can't compare our head's hash to the peer's in


### PR DESCRIPTION
### What was wrong?

Wanted a bit more output when syncing.

### How was it fixed?


```
    INFO  05-29 10:17:20       chain  Imported 192 headers in 1.87 seconds, new head: #951075 (4eadae)
    INFO  05-29 10:17:22       chain  Imported 192 headers in 1.66 seconds, new head: #951267 (d2acc5)
    INFO  05-29 10:17:23       chain  Imported 192 headers in 0.75 seconds, new head: #951459 (d761c8)
    INFO  05-29 10:17:24       chain  Imported 192 headers in 1.17 seconds, new head: #951651 (fb6700)
    INFO  05-29 10:17:25       chain  Imported 192 headers in 0.92 seconds, new head: #951843 (92fff1)
    INFO  05-29 10:17:26       chain  Imported 192 headers in 1.02 seconds, new head: #952035 (100a83)
    INFO  05-29 10:17:26       chain  Imported 192 headers in 0.55 seconds, new head: #952227 (a392f1)
    INFO  05-29 10:17:27       chain  Imported 192 headers in 0.75 seconds, new head: #952419 (0b11cb)
    INFO  05-29 10:17:28       chain  Imported 192 headers in 0.58 seconds, new head: #952611 (49924d)
    INFO  05-29 10:17:29       chain  Imported 192 headers in 1.02 seconds, new head: #952803 (020a25)
    INFO  05-29 10:17:30       chain  Imported 192 headers in 0.92 seconds, new head: #952995 (c5d351)
    INFO  05-29 10:17:30       chain  Imported 192 headers in 0.67 seconds, new head: #953187 (bebf29)
```
#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
