### PR TITLE
Piper/fix launch log display

### DIFF
--- a/setup_trinity.py
+++ b/setup_trinity.py
@@ -7,7 +7,7 @@ setup(
     name='trinity',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     # NOT CURRENTLY APPLICABLE. VERSION BUMPS MANUAL FOR NOW
-    version='0.1.0-alpha.2',
+    version='0.1.0-alpha.3',
     description='The Trinity Ethereum Client',
     author='Ethereum Foundation',
     author_email='piper@pipermerriam.com',
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     py_modules=[],
     install_requires=[
-        'py-evm[trinity,p2p]==0.2.0a18',
+        'py-evm[trinity,p2p]==0.2.0a19',
     ],
     license='MIT',
     zip_safe=False,

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -164,13 +164,6 @@ def display_launch_logs(chain_config: ChainConfig) -> None:
     logger = logging.getLogger('trinity')
     logger.info(TRINITY_HEADER)
     logger.info(construct_trinity_client_identifier())
-    logger.info(
-        "enode://%s@%s:%s",
-        chain_config.nodekey.to_hex()[2:],
-        "[:]",
-        chain_config.port,
-    )
-    logger.info('network: %s', chain_config.network_id)
 
 
 def run_service_until_quit(service: BaseService) -> None:


### PR DESCRIPTION
### What was wrong?

The private portion of the `nodekey` was being output in the terminal and in non-light mode both the nodekey and the network ID were being output twice.

### How was it fixed?

Fixed both.

#### Cute Animal Picture

![picture_7244-baby_donkey_4-02-2007](https://user-images.githubusercontent.com/824194/40689401-2dc5c040-635f-11e8-9763-7f0697d58b16.jpg)

