### PR TITLE
[WIP] Add CLI argument to Trinity to limit number of connected peers

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -59,3 +59,6 @@ ROPSTEN_BOOTNODES = (
 # Default configuration
 # Minimum peers number, we'll try to keep open connections to at least this number of peers
 DEFAULT_MIN_PEERS = 5
+
+# Maximum peers number, we'll try to keep open connections up to this number of peers
+DEFAULT_MAX_PEERS = 25

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -103,6 +103,7 @@ from p2p.p2p_proto import (
 from .constants import (
     CONN_IDLE_TIMEOUT,
     DEFAULT_MIN_PEERS,
+    DEFAULT_MAX_PEERS,
     HEADER_LEN,
     MAC_LEN,
     REPLY_TIMEOUT,
@@ -670,6 +671,7 @@ class PeerPool(BaseService):
                  privkey: datatypes.PrivateKey,
                  discovery: DiscoveryProtocol,
                  min_peers: int = DEFAULT_MIN_PEERS,
+                 max_peers: int = DEFAULT_MAX_PEERS
                  ) -> None:
         super().__init__()
         self.peer_class = peer_class
@@ -678,6 +680,7 @@ class PeerPool(BaseService):
         self.privkey = privkey
         self.discovery = discovery
         self.min_peers = min_peers
+        self.max_peers = max_peers
         self.connected_nodes: Dict[Node, BasePeer] = {}
         self._subscribers: List[PeerPoolSubscriber] = []
 
@@ -693,6 +696,7 @@ class PeerPool(BaseService):
             raise Exception(
                 "We cannot handle multiple subscribers yet; "
                 "see https://github.com/ethereum/py-evm/issues/768 for details")
+
         self._subscribers.append(subscriber)
         for peer in self.connected_nodes.values():
             subscriber.register_peer(peer)
@@ -749,6 +753,15 @@ class PeerPool(BaseService):
             peer = await handshake(
                 remote, self.privkey, self.peer_class, self.headerdb, self.network_id,
                 self.cancel_token)
+
+            """
+            There is max_peers defined from CLI.
+            We drop the subscriber if it's already maxed out.
+            """
+            if len(self.connected_nodes) >= self.max_peers:
+                peer.disconnect(DisconnectReason.too_many_peers)
+                return None
+
             return peer
         except OperationCancelled:
             # Pass it on to instruct our main loop to stop.
@@ -787,11 +800,12 @@ class PeerPool(BaseService):
                 self._discovery_last_lookup = time.time()
 
     async def maybe_connect_to_more_peers(self) -> None:
-        """Connect to more peers if we're not yet connected to at least self.min_peers."""
-        if len(self.connected_nodes) >= self.min_peers:
+        """Connect to more peers if we're not yet maxed out to max_peers"""
+        num_connected_nodes = len(self.connected_nodes)
+        if num_connected_nodes >= self.max_peers:
             self.logger.debug(
                 "Already connected to %s peers: %s; sleeping",
-                len(self.connected_nodes),
+                num_connected_nodes,
                 [remote for remote in self.connected_nodes])
             return
 
@@ -946,6 +960,7 @@ class PreferredNodePeerPool(PeerPool):
                  privkey: datatypes.PrivateKey,
                  discovery: DiscoveryProtocol,
                  min_peers: int = DEFAULT_MIN_PEERS,
+                 max_peers: int = DEFAULT_MAX_PEERS,
                  preferred_nodes: Sequence[Node] = None,
                  ) -> None:
         super().__init__(peer_class, headerdb, network_id, privkey, discovery, min_peers)

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -33,6 +33,7 @@ from p2p.cancel_token import (
 from p2p.constants import (
     ENCRYPTED_AUTH_MSG_LEN,
     DEFAULT_MIN_PEERS,
+    DEFAULT_MAX_PEERS,
     HASH_LEN,
     REPLY_TIMEOUT,
 )
@@ -75,6 +76,7 @@ class Server(BaseService):
                  headerdb: 'BaseAsyncHeaderDB',
                  base_db: BaseDB,
                  network_id: int,
+                 max_peers: int = DEFAULT_MAX_PEERS,
                  min_peers: int = DEFAULT_MIN_PEERS,
                  peer_class: Type[BasePeer] = ETHPeer,
                  peer_pool_class: Type[PeerPool] = PeerPool,
@@ -91,8 +93,12 @@ class Server(BaseService):
         self.network_id = network_id
         self.peer_class = peer_class
         self.peer_pool_class = peer_pool_class
+        self.max_peers = max_peers
         self.min_peers = min_peers
         self.bootstrap_nodes = bootstrap_nodes
+
+        if self.max_peers < self.min_peers:
+            raise ValueError("The maximum peers must be greater than min peers.")
 
         if not bootstrap_nodes:
             self.logger.warn("Running with no bootstrap nodes")
@@ -236,6 +242,7 @@ class Server(BaseService):
             self.privkey,
             discovery,
             min_peers=self.min_peers,
+            max_peers=self.max_peers,
         )
 
     async def _run(self) -> None:

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -118,6 +118,14 @@ network_parser.add_argument(
     ),
 )
 
+network_parser.add_argument(
+    '--max-peers',
+    help=(
+        "Maximum number of network peers"
+    ),
+    type=int,
+)
+
 
 #
 # Sync Mode

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -16,6 +16,7 @@ from evm.chains.ropsten import (
 )
 from p2p.kademlia import Node as KademliaNode
 from p2p.constants import (
+    DEFAULT_MAX_PEERS,
     MAINNET_BOOTNODES,
     ROPSTEN_BOOTNODES,
 )
@@ -55,6 +56,7 @@ class ChainConfig:
 
     def __init__(self,
                  network_id: int,
+                 max_peers: int=DEFAULT_MAX_PEERS,
                  data_dir: str=None,
                  nodekey_path: str=None,
                  logfile_path: str=None,
@@ -64,6 +66,7 @@ class ChainConfig:
                  preferred_nodes: Tuple[KademliaNode, ...]=None,
                  bootstrap_nodes: Tuple[KademliaNode, ...]=None) -> None:
         self.network_id = network_id
+        self.max_peers = max_peers
         self.sync_mode = sync_mode
         self.port = port
         self.preferred_nodes = preferred_nodes

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -22,6 +22,7 @@ class FullNode(Node):
         self._network_id = chain_config.network_id
         self._node_key = chain_config.nodekey
         self._node_port = chain_config.port
+        self._max_peers = chain_config.max_peers
 
     def get_chain(self):
         if self._chain is None:
@@ -40,6 +41,7 @@ class FullNode(Node):
                 self.headerdb,
                 manager.get_db(),  # type: ignore
                 self._network_id,
+                max_peers=self._max_peers,
                 peer_pool_class=PreferredNodePeerPool,
                 bootstrap_nodes=self._bootstrap_nodes,
                 token=self.cancel_token,

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -137,6 +137,9 @@ def construct_chain_config_params(args):
     if args.sync_mode is not None:
         yield 'sync_mode', args.sync_mode
 
+    if args.max_peers is not None:
+        yield 'max_peers', args.max_peers
+
     if args.port is not None:
         yield 'port', args.port
 


### PR DESCRIPTION
### What was wrong?

We accept incoming peer connections but there's no way to limit the number of simultaneous connections.

Issue Reference: https://github.com/ethereum/py-evm/issues/771

### How was it fixed?

Add a CLI flag to specify max number of peers, and have `p2p.Server` reject new connections once we reach that.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://i2.wp.com/favimages.com/wp-content/uploads/2012/08/pitbull-dog-puppy-grey-cute-photos.jpg)