### PR TITLE
re-order tests for faster runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,18 +231,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - lint-py35
-      - lint-py36
-      - py35-native-state-byzantium
-      - py35-native-state-frontier
-      - py35-native-state-homestead
-      - py35-native-state-eip150
-      - py35-native-state-eip158
-      - py35-native-blockchain
-      - py35-vm
-      - py35-core
-      - py35-transactions
-      - py35-database
       - py36-native-state-byzantium
       - py36-native-state-frontier
       - py36-native-state-homestead
@@ -262,3 +250,15 @@ workflows:
       - py36-p2p
       - py36-database
       - py36-rpc-state-quadratic
+      - py35-native-state-byzantium
+      - py35-native-state-frontier
+      - py35-native-state-homestead
+      - py35-native-state-eip150
+      - py35-native-state-eip158
+      - py35-native-blockchain
+      - py35-vm
+      - py35-core
+      - py35-transactions
+      - py35-database
+      - lint-py35
+      - lint-py36


### PR DESCRIPTION
### What was wrong?

The order of CI runs always resulted in one long running test case waiting to finish

### How was it fixed?

Re-ordered to hopefully have faster test runs.

#### Cute Animal Picture

![donkey-2](https://user-images.githubusercontent.com/824194/40735274-fa754f6e-63f7-11e8-8c0a-25fda7ec3deb.jpg)

