### PR TITLE
Handle missing $HOME and report better info to user

### DIFF
--- a/tests/trinity/conftest.py
+++ b/tests/trinity/conftest.py
@@ -11,7 +11,6 @@ from trinity.rpc.ipc import (
     IPCServer,
 )
 from trinity.utils.xdg import (
-    XDG_DATA_HOME,
     get_xdg_trinity_root,
 )
 from trinity.utils.filesystem import (
@@ -27,7 +26,7 @@ def xdg_trinity_root(monkeypatch, tmpdir):
     dir_path = tmpdir.mkdir('xdg_trinity_root')
     monkeypatch.setenv('XDG_TRINITY_ROOT', str(dir_path))
 
-    assert not is_under_path(XDG_DATA_HOME, get_xdg_trinity_root())
+    assert not is_under_path(os.path.expandvars('$HOME'), get_xdg_trinity_root())
 
     return str(dir_path)
 

--- a/tests/trinity/utils/test_xdg_paths.py
+++ b/tests/trinity/utils/test_xdg_paths.py
@@ -22,13 +22,16 @@ AFFECTED_ENVS = [
     'XDG_CACHE_HOME'
 ]
 
+
 def clear_envs(monkeypatch):
     for env in AFFECTED_ENVS:
         monkeypatch.delenv(env, raising=False)
 
+
 def set_envs(monkeypatch, envs):
     for pair in envs:
         monkeypatch.setenv(pair[0], pair[1])
+
 
 @pytest.mark.parametrize(
     'envs, resolver, expected',
@@ -36,7 +39,7 @@ def set_envs(monkeypatch, envs):
         # get_xdg_data_home()
         ([('HOME', 'home'), ('XDG_DATA_HOME', 'test')], get_xdg_data_home, 'test'),
         ([('XDG_DATA_HOME', 'test')], get_xdg_data_home, 'test'),
-        ([('HOME', 'test')], get_xdg_data_home,'test/.local/share'),
+        ([('HOME', 'test')], get_xdg_data_home, 'test/.local/share'),
         ([], get_xdg_data_home, AmbigiousFileSystem),
         # get_xdg_trinity_root()
         ([('HOME', 'home'), ('XDG_TRINITY_ROOT', 'test')], get_xdg_trinity_root, 'test'),
@@ -64,5 +67,3 @@ def test_xdg_path_handling(monkeypatch, envs, resolver, expected):
             resolver()
     else:
         assert resolver() == expected
-
-

--- a/tests/trinity/utils/test_xdg_paths.py
+++ b/tests/trinity/utils/test_xdg_paths.py
@@ -1,0 +1,96 @@
+import pytest
+
+from trinity.exceptions import (
+    AmbigiousFileSystem
+)
+
+from trinity.utils.xdg import (
+    get_xdg_trinity_root,
+    get_xdg_cache_home,
+    get_xdg_config_home,
+    get_xdg_data_home,
+)
+
+
+def test_data_home_discovery(monkeypatch):
+
+    # Only XDG_DATA_HOME is set but HOME isn't
+    monkeypatch.setenv('XDG_DATA_HOME', 'test')
+    monkeypatch.delenv('HOME')
+
+    assert get_xdg_data_home() == 'test'
+
+    # Only HOME is set
+    monkeypatch.delenv('XDG_DATA_HOME')
+    monkeypatch.setenv('HOME', 'test2')
+
+    assert get_xdg_data_home() == 'test2/.local/share'
+
+    # Nothing is set
+    monkeypatch.delenv('HOME')
+
+    with pytest.raises(AmbigiousFileSystem):
+        get_xdg_data_home()
+
+
+def test_trinity_root_discovery(monkeypatch):
+
+    # Only XDG_TRINITY_ROOT is set but HOME isn't
+    monkeypatch.setenv('XDG_TRINITY_ROOT', 'test')
+    monkeypatch.delenv('HOME')
+
+    assert get_xdg_trinity_root() == 'test'
+
+    # Only HOME is set
+    monkeypatch.delenv('XDG_TRINITY_ROOT')
+    monkeypatch.setenv('HOME', 'test2')
+
+    assert get_xdg_trinity_root() == 'test2/.local/share/trinity'
+
+    # Nothing is set
+    monkeypatch.delenv('HOME')
+
+    with pytest.raises(AmbigiousFileSystem):
+        get_xdg_trinity_root()
+
+
+def test_config_home_discovery(monkeypatch):
+
+    # Only XDG_CONFIG_HOME is set but HOME isn't
+    monkeypatch.setenv('XDG_CONFIG_HOME', 'test')
+    monkeypatch.delenv('HOME')
+
+    assert get_xdg_config_home() == 'test'
+
+    # Only HOME is set
+    monkeypatch.delenv('XDG_CONFIG_HOME')
+    monkeypatch.setenv('HOME', 'test2')
+
+    assert get_xdg_config_home() == 'test2/.config'
+
+    # Nothing is set
+    monkeypatch.delenv('HOME')
+
+    with pytest.raises(AmbigiousFileSystem):
+        get_xdg_config_home()
+
+
+def test_cache_home_discovery(monkeypatch):
+
+    # Only XDG_CACHE_HOME is set but HOME isn't
+    monkeypatch.setenv('XDG_CACHE_HOME', 'test')
+    monkeypatch.delenv('HOME')
+
+    assert get_xdg_cache_home() == 'test'
+
+    # Only HOME is set
+    monkeypatch.delenv('XDG_CACHE_HOME')
+    monkeypatch.setenv('HOME', 'test2')
+
+    assert get_xdg_cache_home() == 'test2/.cache'
+
+    # Nothing is set
+    monkeypatch.delenv('HOME')
+
+    with pytest.raises(AmbigiousFileSystem):
+        get_xdg_cache_home()

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -85,11 +85,9 @@ def is_database_initialized(chaindb: AsyncChainDB) -> bool:
 
 
 def initialize_data_dir(chain_config: ChainConfig) -> None:
-    if (not os.path.exists(chain_config.data_dir) and
-            is_under_xdg_trinity_root(chain_config.data_dir)):
-
+    if not chain_config.data_dir.exists() and is_under_xdg_trinity_root(chain_config.data_dir):
         chain_config.data_dir.mkdir(parents=True, exist_ok=True)
-    elif not os.path.exists(chain_config.data_dir):
+    elif not chain_config.data_dir.exists():
         # we don't lazily create the base dir for non-default base directories.
         raise AmbigiousFileSystem(
             "The base chain directory provided does not exist: `{0}`".format(
@@ -98,12 +96,10 @@ def initialize_data_dir(chain_config: ChainConfig) -> None:
         )
 
     # Logfile
-    if (not os.path.exists(chain_config.logfile_path) and
-            is_under_xdg_trinity_root(chain_config.logfile_path)):
-
+    if not chain_config.logfile_path.exists() and is_under_xdg_trinity_root(chain_config.logfile_path):
         chain_config.logfile_path.parent.mkdir(parents=True, exist_ok=True)
         chain_config.logfile_path.touch()
-    elif not os.path.exists(chain_config.logfile_path):
+    elif not chain_config.logfile_path.exists():
         # we don't lazily create the base dir for non-default base directories.
         raise AmbigiousFileSystem(
             "The base logging directory provided does not exist: `{0}`".format(

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -21,6 +21,9 @@ from evm.exceptions import CanonicalHeadNotFound
 
 from p2p import ecies
 
+from trinity.exceptions import (
+    AmbigiousFileSystem
+)
 from trinity.config import ChainConfig
 from trinity.db.base import DBProxy
 from trinity.db.chain import ChainDBProxy
@@ -82,29 +85,31 @@ def is_database_initialized(chaindb: AsyncChainDB) -> bool:
 
 
 def initialize_data_dir(chain_config: ChainConfig) -> None:
-    if is_under_xdg_trinity_root(chain_config.data_dir):
+    if (not os.path.exists(chain_config.data_dir) and
+            is_under_xdg_trinity_root(chain_config.data_dir)):
+
         chain_config.data_dir.mkdir(parents=True, exist_ok=True)
     elif not os.path.exists(chain_config.data_dir):
         # we don't lazily create the base dir for non-default base directories.
-        raise ValueError(
+        raise AmbigiousFileSystem(
             "The base chain directory provided does not exist: `{0}`".format(
                 chain_config.data_dir,
             )
         )
 
     # Logfile
-    if is_under_xdg_trinity_root(chain_config.logfile_path):
+    if (not os.path.exists(chain_config.logfile_path) and
+            is_under_xdg_trinity_root(chain_config.logfile_path)):
+
         chain_config.logfile_path.parent.mkdir(parents=True, exist_ok=True)
-    elif not os.path.exists(chain_config.data_dir):
+        chain_config.logfile_path.touch()
+    elif not os.path.exists(chain_config.logfile_path):
         # we don't lazily create the base dir for non-default base directories.
-        raise ValueError(
+        raise AmbigiousFileSystem(
             "The base logging directory provided does not exist: `{0}`".format(
                 chain_config.logfile_path,
             )
         )
-
-    if not chain_config.logfile_path.exists():
-        chain_config.logfile_path.touch()
 
     # Chain data-dir
     os.makedirs(chain_config.database_dir, exist_ok=True)

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -22,7 +22,6 @@ from evm.exceptions import CanonicalHeadNotFound
 from p2p import ecies
 
 from trinity.exceptions import (
-    AmbigiousFileSystem,
     MissingPath,
 )
 from trinity.config import ChainConfig
@@ -98,7 +97,9 @@ def initialize_data_dir(chain_config: ChainConfig) -> None:
         )
 
     # Logfile
-    if not chain_config.logfile_path.exists() and is_under_xdg_trinity_root(chain_config.logfile_path):
+    if (not chain_config.logfile_path.exists() and
+            is_under_xdg_trinity_root(chain_config.logfile_path)):
+
         chain_config.logfile_path.parent.mkdir(parents=True, exist_ok=True)
         chain_config.logfile_path.touch()
     elif not chain_config.logfile_path.exists():

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -22,7 +22,8 @@ from evm.exceptions import CanonicalHeadNotFound
 from p2p import ecies
 
 from trinity.exceptions import (
-    AmbigiousFileSystem
+    AmbigiousFileSystem,
+    MissingPath,
 )
 from trinity.config import ChainConfig
 from trinity.db.base import DBProxy
@@ -89,10 +90,11 @@ def initialize_data_dir(chain_config: ChainConfig) -> None:
         chain_config.data_dir.mkdir(parents=True, exist_ok=True)
     elif not chain_config.data_dir.exists():
         # we don't lazily create the base dir for non-default base directories.
-        raise AmbigiousFileSystem(
+        raise MissingPath(
             "The base chain directory provided does not exist: `{0}`".format(
                 chain_config.data_dir,
-            )
+            ),
+            chain_config.data_dir
         )
 
     # Logfile
@@ -101,10 +103,11 @@ def initialize_data_dir(chain_config: ChainConfig) -> None:
         chain_config.logfile_path.touch()
     elif not chain_config.logfile_path.exists():
         # we don't lazily create the base dir for non-default base directories.
-        raise AmbigiousFileSystem(
+        raise MissingPath(
             "The base logging directory provided does not exist: `{0}`".format(
                 chain_config.logfile_path,
-            )
+            ),
+            chain_config.logfile_path
         )
 
     # Chain data-dir

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -1,0 +1,12 @@
+class BaseTrinityError(Exception):
+    """
+    The base class for all Trinity errors.
+    """
+    pass
+
+
+class AmbigiousFileSystem(BaseTrinityError):
+    """
+    Raised when the file system paths are unclear
+    """
+    pass

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -10,3 +10,12 @@ class AmbigiousFileSystem(BaseTrinityError):
     Raised when the file system paths are unclear
     """
     pass
+
+
+class MissingPath(BaseTrinityError):
+    """
+    Raised when an expected path is missing
+    """
+    def __init__(self, msg, path):
+        super(MissingPath, self).__init__(msg)
+        self.path = path

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -16,7 +16,8 @@ from evm.db.backends.level import LevelDB
 from p2p.service import BaseService
 
 from trinity.exceptions import (
-    AmbigiousFileSystem
+    AmbigiousFileSystem,
+    MissingPath,
 )
 from trinity.chains import (
     initialize_data_dir,
@@ -102,6 +103,17 @@ def main() -> None:
             initialize_data_dir(chain_config)
         except AmbigiousFileSystem:
             exit_because_ambigious_filesystem(logger)
+        except MissingPath as e:
+            msg = (
+                "\n"
+                "It appears that {} does not exist.\n"
+                "Trinity does not attempt to create directories outside of its root path\n"
+                "Either manually create the path or ensure you are using a data directory\n"
+                "inside the XDG_TRINITY_ROOT path"
+                ).format(e.path)
+            logger.error(msg)
+            sys.exit(1)
+
 
     logger, log_queue, listener = setup_trinity_file_and_queue_logging(
         logger,

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -110,10 +110,9 @@ def main() -> None:
                 "Trinity does not attempt to create directories outside of its root path\n"
                 "Either manually create the path or ensure you are using a data directory\n"
                 "inside the XDG_TRINITY_ROOT path"
-                ).format(e.path)
+            ).format(e.path)
             logger.error(msg)
             sys.exit(1)
-
 
     logger, log_queue, listener = setup_trinity_file_and_queue_logging(
         logger,

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -15,6 +15,9 @@ from evm.db.backends.level import LevelDB
 
 from p2p.service import BaseService
 
+from trinity.exceptions import (
+    AmbigiousFileSystem
+)
 from trinity.chains import (
     initialize_data_dir,
     is_data_dir_initialized,
@@ -34,7 +37,8 @@ from trinity.utils.ipc import (
     kill_process_gracefully,
 )
 from trinity.utils.logging import (
-    setup_trinity_logging,
+    setup_trinity_stdout_logging,
+    setup_trinity_file_and_queue_logging,
     with_queued_logging,
 )
 from trinity.utils.mp import (
@@ -58,6 +62,19 @@ TRINITY_HEADER = (
     "                       /____/   "
 )
 
+TRINITY_AMBIGIOUS_FILESYSTEM_INFO = (
+    "Could not initialize data directory\n\n"
+    "   One of these conditions must be met:\n"
+    "   * HOME environment variable set\n"
+    "   * XDG_TRINITY_ROOT environment variable set\n"
+    "   * TRINITY_DATA_DIR environment variable set\n"
+    "   * --data-dir command line argument is passed\n"
+    "\n"
+    "   In case the data directory is outside of the trinity root directory\n"
+    "   Make sure all paths are pre-initialized as Trinity won't attempt\n"
+    "   to create directories outside of the trinity root directory\n"
+)
+
 
 def main() -> None:
     args = parser.parse_args()
@@ -70,15 +87,29 @@ def main() -> None:
             "networks are supported.".format(args.network_id)
         )
 
-    chain_config = ChainConfig.from_parser_args(args)
+    logger, formatter, handler_stream = setup_trinity_stdout_logging(log_level)
+
+    try:
+        chain_config = ChainConfig.from_parser_args(args)
+    except AmbigiousFileSystem:
+            exit_because_ambigious_filesystem(logger)
 
     if not is_data_dir_initialized(chain_config):
         # TODO: this will only work as is for chains with known genesis
         # parameters.  Need to flesh out how genesis parameters for custom
         # chains are defined and passed around.
-        initialize_data_dir(chain_config)
+        try:
+            initialize_data_dir(chain_config)
+        except AmbigiousFileSystem:
+            exit_because_ambigious_filesystem(logger)
 
-    logger, log_queue, listener = setup_trinity_logging(chain_config, log_level)
+    logger, log_queue, listener = setup_trinity_file_and_queue_logging(
+        logger,
+        formatter,
+        handler_stream,
+        chain_config,
+        log_level
+    )
 
     # if console command, run the trinity CLI
     if args.subcommand == 'attach':
@@ -134,6 +165,11 @@ def run_database_process(chain_config: ChainConfig, db_class: Type[BaseDB]) -> N
     base_db = db_class(db_path=chain_config.database_dir)
 
     serve_chaindb(chain_config, base_db)
+
+
+def exit_because_ambigious_filesystem(logger: logging.Logger) -> None:
+    logger.error(TRINITY_AMBIGIOUS_FILESYSTEM_INFO)
+    sys.exit(1)
 
 
 async def exit_on_signal(service_to_exit: BaseService) -> None:

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -92,7 +92,7 @@ def main() -> None:
     try:
         chain_config = ChainConfig.from_parser_args(args)
     except AmbigiousFileSystem:
-            exit_because_ambigious_filesystem(logger)
+        exit_because_ambigious_filesystem(logger)
 
     if not is_data_dir_initialized(chain_config):
         # TODO: this will only work as is for chains with known genesis

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -34,10 +34,10 @@ def get_local_data_dir(chain_name: str) -> Path:
     """
     Returns the base directory path where data for a given chain will be stored.
     """
-    return Path(os.environ.get(
-        'TRINITY_DATA_DIR',
-        os.path.join(get_xdg_trinity_root(), chain_name),
-    ))
+    try:
+        return Path(os.environ['TRINITY_DATA_DIR'])
+    except KeyError:
+        return Path(os.path.join(get_xdg_trinity_root(), chain_name))
 
 
 def get_data_dir_for_network_id(network_id: int) -> Path:

--- a/trinity/utils/xdg.py
+++ b/trinity/utils/xdg.py
@@ -2,35 +2,51 @@ import os
 
 from pathlib import Path
 
+from trinity.exceptions import (
+    AmbigiousFileSystem
+)
+
 from .filesystem import (
     is_under_path,
 )
 
 
-XDG_CACHE_HOME = os.environ.get(
-    'XDG_CACHE_HOME',
-    os.path.expandvars(os.path.join('$HOME', '.cache'))
-)
+def get_home():
+    try:
+        return os.environ['HOME']
+    except KeyError:
+        raise AmbigiousFileSystem('$HOME environment variable not set')
 
-XDG_CONFIG_HOME = os.environ.get(
-    'XDG_CONFIG_HOME',
-    os.path.expandvars(os.path.join('$HOME', '.config')),
-)
 
-XDG_DATA_HOME = os.environ.get(
-    'XDG_DATA_HOME',
-    os.path.expandvars(os.path.join('$HOME', '.local', 'share')),
-)
+def get_xdg_cache_home():
+    try:
+        return os.environ['XDG_CACHE_HOME']
+    except KeyError:
+        return os.path.join(get_home(), '.cache')
+
+
+def get_xdg_config_home():
+    try:
+        return os.environ['XDG_CONFIG_HOME']
+    except KeyError:
+        return os.path.join(get_home(), '.config')
+
+
+def get_xdg_data_home():
+    try:
+        return os.environ['XDG_DATA_HOME']
+    except KeyError:
+        return os.path.join(get_home(), '.local', 'share')
 
 
 def get_xdg_trinity_root() -> str:
     """
     Returns the base directory under which trinity will store all data.
     """
-    return os.environ.get(
-        'XDG_TRINITY_ROOT',
-        os.path.join(XDG_DATA_HOME, 'trinity'),
-    )
+    try:
+        return os.environ['XDG_TRINITY_ROOT']
+    except KeyError:
+        return os.path.join(get_xdg_data_home(), 'trinity')
 
 
 def is_under_xdg_trinity_root(path: Path) -> bool:


### PR DESCRIPTION
### What was wrong?

This fixes #784 where Trinity would not boot correctly if the `$HOME` variable isn't set.

### How was it fixed?

Work through all fallbacks (e.g. `XDG_TRINITY_ROOT`, `TRINITY_DATA_DIR`) until we hit `$HOME` and if `$HOME` is also missing give a clear explanation to the user.

If the user decides to provide the `TRINITY_DATA_DIR` or passes `--data-dir` but that is outside of the `XDG_TRINITY_ROOT` all paths must be pre-initialized as trinity won't attempt to create any directories outside of the `XDG_TRINITY_ROOT`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://c1.staticflickr.com/4/3435/3189870179_2dbe02c132_b.jpg)
