### PR TITLE
Piper/handle header not found during difficulty calculation

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -223,6 +223,13 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
                     self.logger.warn("No common ancestry found from %s, aborting sync", peer)
                     break
                 start_at = max(0, start_at - eth.MAX_HEADERS_FETCH)
+                if start_at < head.block_number - 10000:
+                    self.logger.warn(
+                        "No common ancestor found with %s within 10,000 blocks, "
+                        "aborting sync",
+                        peer,
+                    )
+                    break
                 continue
             except NoEligiblePeers:
                 self.logger.info("No peers have the blocks we want, aborting sync")

--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -219,6 +219,8 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
             try:
                 head_number = await self._process_headers(peer, headers)
             except HeaderNotFound:
+                # This is comes from when we attempt to compute the difficulty
+                # of a header whos parent is not in our database.
                 if start_at == 0:
                     self.logger.warn("No common ancestry found from %s, aborting sync", peer)
                     break
@@ -230,6 +232,9 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
                         peer,
                     )
                     break
+                self.logger.info(
+                    "Missing ancestor header.  Trying earlier header at #%s", start_at
+                )
                 continue
             except NoEligiblePeers:
                 self.logger.info("No peers have the blocks we want, aborting sync")

--- a/setup_trinity.py
+++ b/setup_trinity.py
@@ -7,7 +7,7 @@ setup(
     name='trinity',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     # NOT CURRENTLY APPLICABLE. VERSION BUMPS MANUAL FOR NOW
-    version='0.1.0-alpha.4',
+    version='0.1.0-alpha.5',
     description='The Trinity Ethereum Client',
     author='Ethereum Foundation',
     author_email='piper@pipermerriam.com',
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     py_modules=[],
     install_requires=[
-        'py-evm[trinity,p2p]==0.2.0a19',
+        'py-evm[trinity,p2p]==0.2.0a20',
     ],
     license='MIT',
     zip_safe=False,


### PR DESCRIPTION
### What was wrong?

```bash
   ERROR  05-30 17:56:58  base_events  Task exception was never retrieved
future: <Task finished coro=<FastChainSyncer.sync() done, defined at /home/ubuntu/py-evm/venv/lib/python3.6/site-packages/p2p/chain.py:161> exception=HeaderNotFound('No header with hash 0xe3b100bfd7ab6e5c28bda5e469fb7c3c9082245efda142d26a12220e8e9cb153 found',)>
Traceback (most recent call last):
  File "/home/ubuntu/py-evm/venv/lib/python3.6/site-packages/p2p/chain.py", line 174, in sync
    await self._sync(peer)
  File "/home/ubuntu/py-evm/venv/lib/python3.6/site-packages/p2p/chain.py", line 220, in _sync
    head_number = await self._process_headers(peer, headers)
  File "/home/ubuntu/py-evm/venv/lib/python3.6/site-packages/p2p/chain.py", line 244, in _process_headers
    target_td = await self._calculate_td(headers)
  File "/home/ubuntu/py-evm/venv/lib/python3.6/site-packages/p2p/chain.py", line 237, in _calculate_td
    td = await self.chaindb.coro_get_score(headers[0].parent_hash)
  File "/home/ubuntu/py-evm/venv/lib/python3.6/site-packages/trinity/utils/mp.py", line 23, in method
    args,
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3.6/multiprocessing/managers.py", line 772, in _callmethod
    raise convert_to_error(kind, result)
evm.exceptions.HeaderNotFound: No header with hash 0xe3b100bfd7ab6e5c28bda5e469fb7c3c9082245efda142d26a12220e8e9cb153 found
```

A `HeaderNotFound` exception is not being handled.

### How was it fixed?

When the `HeaderNotFound` occurs while we're trying to calculate the header difficult, we now catch the exception in the main `_sync` loop.  When this occurs, we step backwards to try and find a common ancestor in our chains.  If we reach the genesis block

#### Cute Animal Picture

![4358238267_2ffe7a1bff_o](https://user-images.githubusercontent.com/824194/40739226-d3d5c46e-6402-11e8-8c80-d61eb8c45171.jpg)

