### PR TITLE
Docs: Add generic virtualenv explainer

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -13,15 +13,8 @@ First we need to clone the Py-EVM repository. Py-EVM depends on a submodule of t
     $ git clone --recursive https://github.com/ethereum/py-evm.git
 
 
-Py-EVM requires Python 3. Often, the best way to guarantee a clean Python 3 environment is with `virtualenv <https://virtualenv.pypa.io/en/stable/>`_, like:
 
-.. code:: sh
-
-    # once:
-    $ virtualenv -p python3 venv
-
-    # each session:
-    $ . venv/bin/activate
+.. include:: /fragments/virtualenv_explainer.rst
 
 After we have activated our virtual environment, installing all dependencies that are needed to run, develop and test all code in this repository is as easy as:
 

--- a/docs/fragments/virtualenv_explainer.rst
+++ b/docs/fragments/virtualenv_explainer.rst
@@ -1,0 +1,22 @@
+**Optional:** Often, the best way to guarantee a clean Python 3 environment is with
+`virtualenv <https://virtualenv.pypa.io/en/stable/>`_. If we don't have ``virtualenv`` installed
+already, we first need to install it via pip.
+
+.. code:: sh
+
+  pip install virtualenv
+
+Then, we can initialize a new virtual environment ``venv``, like:
+
+.. code:: sh
+
+  virtualenv -p python3 venv
+
+This creates a new directory ``venv`` where packages are installed isolated from any other global
+packages.
+
+To activate the virtual directory we have to *source* it
+
+.. code:: sh
+
+  . venv/bin/activate

--- a/docs/guides/trinity/quickstart.rst
+++ b/docs/guides/trinity/quickstart.rst
@@ -26,6 +26,9 @@ we need to install the ``python3-pip`` package through the following command.
 
   apt-get python3-pip
 
+.. note::
+  .. include:: /fragments/virtualenv_explainer.rst
+
 Finally, we can install the ``trinity`` package via pip.
 
 .. code:: sh
@@ -40,6 +43,9 @@ First, install LevelDB and the latest Python 3 with brew:
 .. code:: sh
 
   brew install python3 leveldb
+
+.. note::
+  .. include:: /fragments/virtualenv_explainer.rst
 
 Then, install the ``trinity`` package via pip:
 


### PR DESCRIPTION
### What was wrong?

Someone pointed out that the Quickstart was missing an explanation on `virtualenv`. 

### How was it fixed?

We had that covered in the contributing guide and I decided to compile that into a generic explainer that we can stick into different places.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSLL0DxapJrx3VNBoGsi42Bfo0xlA3rRifFFSkignC9-kO74kg_)
