### PR TITLE
Add web3.sha3 endpoint

### DIFF
--- a/tests/trinity/core/json-rpc/test_ipc.py
+++ b/tests/trinity/core/json-rpc/test_ipc.py
@@ -45,8 +45,24 @@ def build_request(method, params=[]):
             build_request('web3_clientVersion'),
             {'result': construct_trinity_client_identifier(), 'id': 3, 'jsonrpc': '2.0'},
         ),
+        (
+            build_request('web3_sha3', ['0x89987239849872']),
+            {
+                'result': '0xb3406131994d9c859de3c4400e12f630638e1e992c6453358c16d0e6ce2b1a70',
+                'id': 3,
+                'jsonrpc': '2.0',
+            },
+        ),
+        (
+            build_request('web3_sha3', ['0x']),
+            {
+                'result': '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+                'id': 3,
+                'jsonrpc': '2.0',
+            },
+        ),
     ),
-    ids=['empty', 'notamethod', 'eth_mining', 'web3_clientVersion'],
+    ids=['empty', 'notamethod', 'eth_mining', 'web3_clientVersion', 'web3_sha3_1', 'web3_sha3_2'],
 )
 async def test_ipc_requests(jsonrpc_ipc_pipe_path,
                             request_msg,

--- a/trinity/rpc/modules/web3.py
+++ b/trinity/rpc/modules/web3.py
@@ -1,3 +1,6 @@
+from eth_hash.auto import keccak
+from eth_utils import decode_hex, encode_hex
+
 from trinity.utils.version import construct_trinity_client_identifier
 
 # Tell mypy to ignore this import as a workaround for https://github.com/python/mypy/issues/4049
@@ -12,3 +15,9 @@ class Web3(RPCModule):
         Returns the current client version.
         """
         return construct_trinity_client_identifier()
+
+    def sha3(self, data):
+        """
+        Returns Keccak-256 of the given data.
+        """
+        return encode_hex(keccak(decode_hex(data)))


### PR DESCRIPTION
### What was wrong?

Missing endpoint for `web3.sha3` call.

### How was it fixed?

Added it.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://uberhumor.com/wp-content/uploads/2013/03/33NcgG8.jpg)
