### PR TITLE
Handle ListDeserializationError during connection

### DIFF
--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -26,6 +26,12 @@ class HandshakeFailure(BaseP2PError):
     pass
 
 
+class MalformedMessage(BaseP2PError):
+    """
+    Raised when a p2p command is received with a malformed message
+    """
+
+
 class UnknownProtocolCommand(BaseP2PError):
     """
     Raised when the received protocal command isn't known.

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -69,6 +69,7 @@ from p2p.exceptions import (
     DecryptionError,
     EmptyGetBlockHeadersReply,
     HandshakeFailure,
+    MalformedMessage,
     NoEligibleNodes,
     NoMatchingPeerCapabilities,
     OperationCancelled,
@@ -736,6 +737,7 @@ class PeerPool(BaseService):
             PeerConnectionLost,
             TimeoutError,
             UnreachablePeer,
+            MalformedMessage,
         )
         try:
             self.logger.debug("Connecting to %s...", remote)

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -41,6 +41,10 @@ class Command:
         self.cmd_id = cmd_id_offset + self._cmd_id
 
     @property
+    def logger(self):
+        return logging.getLogger("p2p.protocol.{0}".format(self.__class__.__name__))
+
+    @property
     def is_base_protocol(self) -> bool:
         return self.cmd_id_offset == 0
 

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -36,13 +36,19 @@ class Command:
     decode_strict = True
     structure: List[Tuple[str, Any]] = []
 
+    _logger: logging.Logger = None
+
     def __init__(self, cmd_id_offset: int) -> None:
         self.cmd_id_offset = cmd_id_offset
         self.cmd_id = cmd_id_offset + self._cmd_id
 
     @property
     def logger(self):
-        return logging.getLogger("p2p.protocol.{0}".format(self.__class__.__name__))
+        if self._logger is None:
+            self._logger = logging.getLogger(
+                "p2p.protocol.{0}".format(self.__class__.__name__)
+            )
+        return self._logger
 
     @property
     def is_base_protocol(self) -> bool:


### PR DESCRIPTION
### What was wrong?

#775 

### How was it fixed?

Catch the `rlp` error within the `Disconnect` command class and log a warning, then raise a new exception `MalformedMessage` which is caught within `Peer.connect` as one of the *expected* exceptions.

#### Cute Animal Picture

![cute-baby-donkey](https://user-images.githubusercontent.com/824194/40750501-c34145e8-6424-11e8-9f4e-fd8b03d04011.jpg)

