### PR TITLE
Enforce max_peers limit on inbound connections

### DIFF
--- a/tests/p2p/test_server.py
+++ b/tests/p2p/test_server.py
@@ -44,6 +44,10 @@ INITIATOR_ADDRESS = Address('127.0.0.1', get_open_port() + 1)
 INITIATOR_REMOTE = Node(INITIATOR_PUBKEY, INITIATOR_ADDRESS)
 
 
+class MockPeerPool:
+    is_full = False
+
+
 def get_server(privkey, address, peer_class):
     base_db = MemoryDB()
     headerdb = HeaderDB(base_db)
@@ -91,6 +95,9 @@ async def test_server_authenticates_incoming_connections(monkeypatch, server, ev
 
     # Only test the authentication in this test.
     monkeypatch.setattr(server, 'do_handshake', mock_do_handshake)
+    # We need this to ensure the server can check if the peer pool is full for
+    # incoming connections.
+    monkeypatch.setattr(server, 'peer_pool', MockPeerPool())
 
     # Send auth init message to the server.
     reader, writer = await asyncio.wait_for(
@@ -119,6 +126,9 @@ async def test_peer_pool_connect(monkeypatch, event_loop, receiver_server_with_d
         started_peers.append(peer)
 
     monkeypatch.setattr(receiver_server_with_dumb_peer, '_start_peer', mock_start_peer)
+    # We need this to ensure the server can check if the peer pool is full for
+    # incoming connections.
+    monkeypatch.setattr(receiver_server_with_dumb_peer, 'peer_pool', MockPeerPool())
 
     network_id = 1
     discovery = None

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -54,6 +54,7 @@ class LightNode(Node):
             self._port,
         )
         self.logger.info('network: %s', self.network_id)
+        self.logger.info('peers: max_peers=%s', self._peer_pool.max_peers)
         transport, _ = await asyncio.get_event_loop().create_datagram_endpoint(
             lambda: self._discovery,
             local_addr=('0.0.0.0', self._port)


### PR DESCRIPTION
### What was wrong?

The `max_peers` limit is not being enforced for inbount peer connections.

### How was it fixed?

Added enforcement to the `Server` class which handles these.

#### Cute Animal Picture

![idkrrlunnt2gi722xp4qtmqswuvquncobhhx_-mydew](https://user-images.githubusercontent.com/824194/40855705-825bec62-6592-11e8-9ecc-3413b686a917.jpg)

