### PR TITLE
Early exit when peer pool is full during _connect_to_nodes

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -726,6 +726,11 @@ class PeerPool(BaseService):
             # as discussed in
             # https://github.com/ethereum/py-evm/pull/139#discussion_r152067425
             peer = await self.connect(node)
+            if self.is_full:
+                self.logger.debug("Peer pool is full: disconnecting from %s", peer)
+                peer.disconnect(DisconnectReason.other)
+                break
+
             if peer is not None:
                 self.logger.info("Successfully connected to %s", peer)
                 self.start_peer(peer)


### PR DESCRIPTION
### What was wrong?

Yet another code path that didn't respect the max peers.  In the case where max peers is set to 10 and we are currently connected to 9 peers, the code would connect to *up-to* 10 more peers, allowing us to end up with approximately `max_peers * 2 - 1` peer connections.

### How was it fixed?

Early break from the loop in `_connect_to_nodes` when the peer pool is full.

#### Cute Animal Picture

![flat 800x800 070 f](https://user-images.githubusercontent.com/824194/40862401-a03b25f6-65a9-11e8-915a-0afea1bf6a0c.jpg)

