### PR TITLE
p2p: wait_with_token() now cancels its subtasks when cancelled

### DIFF
--- a/p2p/DEVELOPMENT.md
+++ b/p2p/DEVELOPMENT.md
@@ -11,11 +11,10 @@ we use `CancelToken`s, which are heavily inspired by https://vorpus.org/blog/tim
 
 - A `CancelToken` must be available to all our async APIs. Either as an instance attribute or as an explicit argument.
 - When one of our async APIs `await` for stdlib/third-party coroutines, it must use `wait_with_token()` to ensure the scheduled task is cancelled when the token is triggered.
-- We must never use `wait_with_token()` with coroutines that create other tasks as when the token is triggered and the coroutine passed to `wait_with_token()` is cancelled, the tasks created by it are automatically destroyed by the event loop and we'll get ERROR logs if those tasks were still pending.
 
 
 ## BaseService
 
 - If your service runs coroutines in the background (e.g. via `asyncio.ensure_future`), you must
-  ensure they exit when `is_finished` is True or when the cancel token is triggered
+  ensure they exit when `is_running` is False or when the cancel token is triggered
 - If your service runs other services in the background, you should ensure your `_cleanup()` method stops them.

--- a/p2p/cancel_token.py
+++ b/p2p/cancel_token.py
@@ -62,40 +62,49 @@ class CancelToken:
         for token in self._chain:
             futures.append(asyncio.ensure_future(token.wait(), loop=self._loop))
 
-        def cancel_pending(f):
+        def cancel_not_done(f):
             for future in futures:
                 if not future.done():
                     future.cancel()
 
+        async def _wait_for_first(futures):
+            for future in asyncio.as_completed(futures):
+                # We don't need to catch CancelledError here (and cancel not done futures)
+                # because our callback (above) takes care of that.
+                await cast(asyncio.Future, future)
+                return
+
         fut = asyncio.ensure_future(_wait_for_first(futures), loop=self._loop)
-        fut.add_done_callback(cancel_pending)
+        fut.add_done_callback(cancel_not_done)
         await fut
 
     def __str__(self):
         return self.name
 
 
-async def _wait_for_first(futures):
-    for future in asyncio.as_completed(futures):
-        await cast(asyncio.Future, future)
-        return
-
-
-async def wait_with_token(*futures: Awaitable,
+async def wait_with_token(*awaitables: Awaitable,
                           token: CancelToken,
                           timeout: float = None) -> Any:
-    """Wait for the first future to complete, unless we timeout or the cancel token is triggered.
+    """Wait for the first awaitable to complete, unless we timeout or the cancel token is triggered.
 
-    Returns the result of the first future to complete.
+    Returns the result of the first one to complete.
 
     Raises TimeoutError if we timeout or OperationCancelled if the cancel token is triggered.
 
     All pending futures are cancelled before returning.
     """
-    done, pending = await asyncio.wait(
-        futures + (token.wait(),),
-        timeout=timeout,
-        return_when=asyncio.FIRST_COMPLETED)
+    futures = [asyncio.ensure_future(a) for a in awaitables + (token.wait(),)]
+    try:
+        done, pending = await asyncio.wait(
+            futures,
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED)
+    except asyncio.futures.CancelledError:
+        # Since we use return_when=asyncio.FIRST_COMPLETED above, we can be sure none of our
+        # futures will be done here, so we don't need to check if any is done before cancelling.
+        for future in futures:
+            future.cancel()
+        raise
     for task in pending:
         task.cancel()
     if not done:

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -26,14 +26,19 @@ class BaseService(ABC):
         else:
             self.cancel_token = base_token.chain(token)
 
+    async def wait(
+            self, awaitable: Awaitable, token: CancelToken = None, timeout: float = None) -> Any:
+        """See wait_first()"""
+        return await self.wait_first(awaitable, token=token, timeout=timeout)
+
     async def wait_first(
-            self, *futures: Awaitable, token: CancelToken = None, timeout: float = None) -> Any:
-        """Wait for the first future to complete, unless we timeout or the token chain is triggered.
+            self, *awaitables: Awaitable, token: CancelToken = None, timeout: float = None) -> Any:
+        """Wait for the first awaitable to complete, unless we timeout or the token chain is triggered.
 
         The given token is chained with this service's token, so triggering either will cancel
         this.
 
-        Returns the result of the first future to complete.
+        Returns the result of the first one to complete.
 
         Raises TimeoutError if we timeout or OperationCancelled if the token chain is triggered.
 
@@ -43,7 +48,7 @@ class BaseService(ABC):
             token_chain = self.cancel_token
         else:
             token_chain = token.chain(self.cancel_token)
-        return await wait_with_token(*futures, token=token_chain, timeout=timeout)
+        return await wait_with_token(*awaitables, token=token_chain, timeout=timeout)
 
     async def run(
             self,


### PR DESCRIPTION
Not doing so was a bug that would cause us to leave running token.wait()
tasks behind, and although those are harmless they'd cause asyncio to
emit ERROR logs when shutting down.

Also, this is why we were not using wait_with_token() on non-asyncio
native coroutines (e.g. ChainDB coro_* methods).