### PR TITLE
p2p: Use self.wait() for chaindb operations

### DIFF
--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -633,6 +633,10 @@ class AsyncChainDB(ChainDB):
     async def coro_get_canonical_head(self) -> BlockHeader:
         raise NotImplementedError()
 
+    async def coro_get_canonical_block_header_by_number(
+            self, block_number: BlockNumber) -> BlockHeader:
+        raise NotImplementedError()
+
     async def coro_header_exists(self, block_hash: Hash32) -> bool:
         raise NotImplementedError()
 
@@ -646,4 +650,17 @@ class AsyncChainDB(ChainDB):
         raise NotImplementedError()
 
     async def coro_persist_trie_data_dict(self, trie_data_dict: Dict[bytes, bytes]) -> None:
+        raise NotImplementedError()
+
+    async def coro_get_block_transactions(
+            self,
+            header: BlockHeader,
+            transaction_class: Type['BaseTransaction']) -> Iterable['BaseTransaction']:
+        raise NotImplementedError()
+
+    async def coro_get_block_uncles(self, uncles_hash: Hash32) -> List[BlockHeader]:
+        raise NotImplementedError()
+
+    async def coro_get_receipts(
+            self, header: BlockHeader, receipt_class: Type[Receipt]) -> Iterable[Receipt]:
         raise NotImplementedError()

--- a/p2p/DEVELOPMENT.md
+++ b/p2p/DEVELOPMENT.md
@@ -11,11 +11,10 @@ we use `CancelToken`s, which are heavily inspired by https://vorpus.org/blog/tim
 
 - A `CancelToken` must be available to all our async APIs. Either as an instance attribute or as an explicit argument.
 - When one of our async APIs `await` for stdlib/third-party coroutines, it must use `wait_with_token()` to ensure the scheduled task is cancelled when the token is triggered.
-- We must never use `wait_with_token()` with coroutines that create other tasks as when the token is triggered and the coroutine passed to `wait_with_token()` is cancelled, the tasks created by it are automatically destroyed by the event loop and we'll get ERROR logs if those tasks were still pending.
 
 
 ## BaseService
 
 - If your service runs coroutines in the background (e.g. via `asyncio.ensure_future`), you must
-  ensure they exit when `is_finished` is True or when the cancel token is triggered
+  ensure they exit when `is_running` is False or when the cancel token is triggered
 - If your service runs other services in the background, you should ensure your `_cleanup()` method stops them.

--- a/p2p/cancel_token.py
+++ b/p2p/cancel_token.py
@@ -62,40 +62,49 @@ class CancelToken:
         for token in self._chain:
             futures.append(asyncio.ensure_future(token.wait(), loop=self._loop))
 
-        def cancel_pending(f):
+        def cancel_not_done(f):
             for future in futures:
                 if not future.done():
                     future.cancel()
 
+        async def _wait_for_first(futures):
+            for future in asyncio.as_completed(futures):
+                # We don't need to catch CancelledError here (and cancel not done futures)
+                # because our callback (above) takes care of that.
+                await cast(asyncio.Future, future)
+                return
+
         fut = asyncio.ensure_future(_wait_for_first(futures), loop=self._loop)
-        fut.add_done_callback(cancel_pending)
+        fut.add_done_callback(cancel_not_done)
         await fut
 
     def __str__(self):
         return self.name
 
 
-async def _wait_for_first(futures):
-    for future in asyncio.as_completed(futures):
-        await cast(asyncio.Future, future)
-        return
-
-
-async def wait_with_token(*futures: Awaitable,
+async def wait_with_token(*awaitables: Awaitable,
                           token: CancelToken,
                           timeout: float = None) -> Any:
-    """Wait for the first future to complete, unless we timeout or the cancel token is triggered.
+    """Wait for the first awaitable to complete, unless we timeout or the cancel token is triggered.
 
-    Returns the result of the first future to complete.
+    Returns the result of the first one to complete.
 
     Raises TimeoutError if we timeout or OperationCancelled if the cancel token is triggered.
 
     All pending futures are cancelled before returning.
     """
-    done, pending = await asyncio.wait(
-        futures + (token.wait(),),
-        timeout=timeout,
-        return_when=asyncio.FIRST_COMPLETED)
+    futures = [asyncio.ensure_future(a) for a in awaitables + (token.wait(),)]
+    try:
+        done, pending = await asyncio.wait(
+            futures,
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED)
+    except asyncio.futures.CancelledError:
+        # Since we use return_when=asyncio.FIRST_COMPLETED above, we can be sure none of our
+        # futures will be done here, so we don't need to check if any is done before cancelling.
+        for future in futures:
+            future.cancel()
+        raise
     for task in pending:
         task.cancel()
     if not done:

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -236,15 +236,14 @@ class BasePeer(BaseService):
 
     @property
     async def genesis(self) -> BlockHeader:
-        genesis_hash = await self.headerdb.coro_get_canonical_block_hash(
-            BlockNumber(GENESIS_BLOCK_NUMBER),
-        )
-        return await self.headerdb.coro_get_block_header_by_hash(genesis_hash)
+        genesis_hash = await self.wait(
+            self.headerdb.coro_get_canonical_block_hash(BlockNumber(GENESIS_BLOCK_NUMBER)))
+        return await self.wait(self.headerdb.coro_get_block_header_by_hash(genesis_hash))
 
     @property
     async def _local_chain_info(self) -> 'ChainInfo':
         genesis = await self.genesis
-        head = await self.headerdb.coro_get_canonical_head()
+        head = await self.wait(self.headerdb.coro_get_canonical_head())
         total_difficulty = await self.headerdb.coro_get_score(head.hash)
         return ChainInfo(
             block_number=head.block_number,

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -26,14 +26,19 @@ class BaseService(ABC):
         else:
             self.cancel_token = base_token.chain(token)
 
+    async def wait(
+            self, awaitable: Awaitable, token: CancelToken = None, timeout: float = None) -> Any:
+        """See wait_first()"""
+        return await self.wait_first(awaitable, token=token, timeout=timeout)
+
     async def wait_first(
-            self, *futures: Awaitable, token: CancelToken = None, timeout: float = None) -> Any:
-        """Wait for the first future to complete, unless we timeout or the token chain is triggered.
+            self, *awaitables: Awaitable, token: CancelToken = None, timeout: float = None) -> Any:
+        """Wait for the first awaitable to complete, unless we timeout or the token chain is triggered.
 
         The given token is chained with this service's token, so triggering either will cancel
         this.
 
-        Returns the result of the first future to complete.
+        Returns the result of the first one to complete.
 
         Raises TimeoutError if we timeout or OperationCancelled if the token chain is triggered.
 
@@ -43,7 +48,7 @@ class BaseService(ABC):
             token_chain = self.cancel_token
         else:
             token_chain = token.chain(self.cancel_token)
-        return await wait_with_token(*futures, token=token_chain, timeout=timeout)
+        return await wait_with_token(*awaitables, token=token_chain, timeout=timeout)
 
     async def run(
             self,

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -60,6 +60,8 @@ class BaseService(ABC):
         """
         if self.is_running:
             raise RuntimeError("Cannot start the service while it's already running")
+        elif self.cancel_token.triggered:
+            raise RuntimeError("Cannot restart a service that has already been cancelled")
 
         try:
             async with self._run_lock:
@@ -89,6 +91,8 @@ class BaseService(ABC):
         """Trigger the CancelToken and wait for the cleaned_up event to be set."""
         if not self.is_running:
             raise RuntimeError("Cannot cancel a service that has not been started")
+        elif self.cancel_token.triggered:
+            self.logger.warning("Tried to cancel %s, but it was already cancelled", self)
 
         self.logger.debug("Cancelling %s", self)
         self.cancel_token.trigger()

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -46,7 +46,7 @@ class FullNodeSyncer(BaseService):
             self.logger.exception("Unclean exit from FullNodeSyncer")
 
     async def _sync(self) -> None:
-        head = await self.chaindb.coro_get_canonical_head()
+        head = await self.wait(self.chaindb.coro_get_canonical_head())
         # We're still too slow at block processing, so if our local head is older than
         # FAST_SYNC_CUTOFF we first do a fast-sync run to catch up with the rest of the network.
         # See https://github.com/ethereum/py-evm/issues/654 for more details
@@ -57,7 +57,7 @@ class FullNodeSyncer(BaseService):
             await chain_syncer.run()
 
         # Ensure we have the state for our current head.
-        head = await self.chaindb.coro_get_canonical_head()
+        head = await self.wait(self.chaindb.coro_get_canonical_head())
         if head.state_root != BLANK_ROOT_HASH and head.state_root not in self.base_db:
             self.logger.info(
                 "Missing state for current head (#%d), downloading it", head.block_number)

--- a/tests/p2p/integration_test_helpers.py
+++ b/tests/p2p/integration_test_helpers.py
@@ -53,6 +53,11 @@ class FakeAsyncChainDB(AsyncChainDB):
     coro_persist_header = async_passthrough('persist_header')
     coro_persist_uncles = async_passthrough('persist_uncles')
     coro_persist_trie_data_dict = async_passthrough('persist_trie_data_dict')
+    coro_get_canonical_block_header_by_number = async_passthrough(
+        'get_canonical_block_header_by_number')
+    coro_get_block_transactions = async_passthrough('get_block_transactions')
+    coro_get_block_uncles = async_passthrough('get_block_uncles')
+    coro_get_receipts = async_passthrough('get_receipts')
 
 
 async def coro_import_block(chain, block, perform_validation=True):

--- a/trinity/db/chain.py
+++ b/trinity/db/chain.py
@@ -16,9 +16,13 @@ class ChainDBProxy(BaseProxy):
     coro_get_score = async_method('get_score')
     coro_header_exists = async_method('header_exists')
     coro_get_canonical_block_hash = async_method('get_canonical_block_hash')
+    coro_get_canonical_block_header_by_number = async_method('get_canonical_block_header_by_number')
     coro_persist_header = async_method('persist_header')
     coro_persist_uncles = async_method('persist_uncles')
     coro_persist_trie_data_dict = async_method('persist_trie_data_dict')
+    coro_get_block_transactions = async_method('get_block_transactions')
+    coro_get_block_uncles = async_method('get_block_uncles')
+    coro_get_receipts = async_method('get_receipts')
 
     get_block_header_by_hash = sync_method('get_block_header_by_hash')
     get_canonical_head = sync_method('get_canonical_head')


### PR DESCRIPTION
This ensures we exit cleanly/immediately when the sync process is
terminated while we're waiting for a chain/DB operation to complete.

Includes #859