### PR TITLE
p2p: No longer catch "unclean" exceptions anywhere

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -42,7 +42,6 @@ from p2p.exceptions import NoEligiblePeers, OperationCancelled
 from p2p.peer import BasePeer, ETHPeer, PeerPool, PeerPoolSubscriber
 from p2p.rlp import BlockBody, P2PTransaction
 from p2p.service import BaseService
-from p2p.utils import unclean_close_exceptions
 
 
 class FastChainSyncer(BaseService, PeerPoolSubscriber):
@@ -110,11 +109,6 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
             # with ensure_future()). Our caller will also get an OperationCancelled anyway, and
             # there it will be handled.
             pass
-        except unclean_close_exceptions:
-            # FIXME: These exceptions come from AsyncChain[DB] methods; instead of catching them
-            # here we should do so in our coro_* wrappers, and have them re-raise something
-            # meaningful. Or something like that.
-            self.logger.exception("Unclean exit while handling message from %s", peer)
         except Exception:
             self.logger.exception("Unexpected error when processing msg from %s", peer)
 
@@ -150,8 +144,6 @@ class FastChainSyncer(BaseService, PeerPoolSubscriber):
             await self._sync(peer)
         except OperationCancelled as e:
             self.logger.info("Sync with %s aborted: %s", peer, e)
-        except unclean_close_exceptions:
-            self.logger.exception("Unclean exit while syncing")
         finally:
             self._syncing = False
 

--- a/p2p/lightchain.py
+++ b/p2p/lightchain.py
@@ -53,7 +53,7 @@ from p2p.rlp import BlockBody
 from p2p.service import (
     BaseService,
 )
-from p2p.utils import gen_request_id, unclean_close_exceptions
+from p2p.utils import gen_request_id
 
 if TYPE_CHECKING:
     from trinity.db.header import BaseAsyncHeaderDB  # noqa: F401
@@ -151,9 +151,6 @@ class LightPeerChain(PeerPoolSubscriber, BaseService):
                 self._last_processed_announcements[peer] = head_info
             except OperationCancelled:
                 self.logger.debug("Asked to stop, breaking out of run() loop")
-                break
-            except unclean_close_exceptions:
-                self.logger.exception("Unclean exit from LightPeerChain")
                 break
             except LESAnnouncementProcessingError as e:
                 self.logger.warning(repr(e))

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -76,7 +76,6 @@ from p2p.utils import (
     get_devp2p_cmd_id,
     roundup_16,
     sxor,
-    unclean_close_exceptions,
 )
 from p2p import eth
 from p2p import les
@@ -671,8 +670,6 @@ class PeerPool(BaseService):
             self.logger.debug('Got bad Ack during peer connection', exc_info=True)
         except expected_exceptions as e:
             self.logger.debug("Could not complete handshake with %s: %s", remote, repr(e))
-        except unclean_close_exceptions:
-            self.logger.exception("Unclean exit while connecting to %s", remote)
         except Exception:
             self.logger.exception("Unexpected error during auth/p2p handshake with %s", remote)
         return None

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -57,7 +57,6 @@ from p2p.peer import (
 )
 from p2p.service import BaseService
 from p2p.sync import FullNodeSyncer
-from p2p.utils import unclean_close_exceptions
 
 if TYPE_CHECKING:
     from trinity.db.header import BaseAsyncHeaderDB  # noqa: F401
@@ -284,8 +283,6 @@ class Server(BaseService):
             await self._receive_handshake(reader, writer)
         except expected_exceptions as e:
             self.logger.debug("Could not complete handshake: %s", e)
-        except unclean_close_exceptions:
-            self.logger.exception("Unclean exit while receiving handshake")
         except OperationCancelled:
             pass
         except Exception as e:

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -11,7 +11,6 @@ from p2p.peer import PeerPool
 from p2p.chain import FastChainSyncer, RegularChainSyncer
 from p2p.service import BaseService
 from p2p.state import StateDownloader
-from p2p.utils import unclean_close_exceptions
 
 
 # How old (in seconds) must our local head be to cause us to start with a fast-sync before we
@@ -40,12 +39,6 @@ class FullNodeSyncer(BaseService):
         self.peer_pool = peer_pool
 
     async def _run(self) -> None:
-        try:
-            await self._sync()
-        except unclean_close_exceptions:
-            self.logger.exception("Unclean exit from FullNodeSyncer")
-
-    async def _sync(self) -> None:
         head = await self.wait(self.chaindb.coro_get_canonical_head())
         # We're still too slow at block processing, so if our local head is older than
         # FAST_SYNC_CUTOFF we first do a fast-sync run to catch up with the rest of the network.

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -30,10 +30,3 @@ def get_devp2p_cmd_id(msg: bytes) -> int:
     as an integer.
     """
     return rlp.decode(msg[:1], sedes=rlp.sedes.big_endian_int)
-
-
-unclean_close_exceptions = (
-    BrokenPipeError,
-    ConnectionResetError,
-    EOFError,
-)

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -1,3 +1,4 @@
+import logging
 import multiprocessing
 from multiprocessing.managers import (
     BaseManager,
@@ -51,7 +52,7 @@ def database_server_ipc_path():
         try:
             yield chain_config.database_ipc_path
         finally:
-            kill_process_gracefully(chaindb_server_process)
+            kill_process_gracefully(chaindb_server_process, logging.getLogger())
 
 
 @pytest.fixture

--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -14,33 +14,39 @@ def wait_for_ipc(ipc_path: str, timeout: int=1) -> None:
 
 
 def kill_process_gracefully(process: Process,
-                            logger: Logger=None,
+                            logger: Logger,
                             SIGINT_timeout: int=5,
                             SIGTERM_timeout: int=3) -> None:
     try:
         if not process.is_alive():
+            logger.info("Process %d has already terminated", process.pid)
             return
         os.kill(process.pid, signal.SIGINT)
+        logger.info(
+            "Sent SIGINT to process %d, waiting %d seconds for it to terminate",
+            process.pid, SIGINT_timeout)
         process.join(SIGINT_timeout)
     except KeyboardInterrupt:
-        if logger is not None:
-            logger.info(
-                "Waiting for processes to terminate.  You may force termination "
-                "with CTRL+C two more times."
-            )
+        logger.info(
+            "Waiting for process to terminate.  You may force termination "
+            "with CTRL+C two more times."
+        )
 
     try:
         if not process.is_alive():
             return
         os.kill(process.pid, signal.SIGTERM)
+        logger.info(
+            "Sent SIGTERM to process %d, waiting %d seconds for it to terminate",
+            process.pid, SIGTERM_timeout)
         process.join(SIGTERM_timeout)
     except KeyboardInterrupt:
-        if logger is not None:
-            logger.info(
-                "Waiting for processes to terminate.  You may force termination "
-                "with CTRL+C one more time."
-            )
+        logger.info(
+            "Waiting for process to terminate.  You may force termination "
+            "with CTRL+C one more time."
+        )
 
     if not process.is_alive():
         return
     os.kill(process.pid, signal.SIGKILL)
+    logger.info("Sent SIGKILL to process %d", process.pid)


### PR DESCRIPTION
Those used to happen when a trinity-proxied Chain/DB service was terminated
before the networking process, but that shouldn't happen anymore.

Also logs more info in trinity when terminating sub-processes