### PR TITLE
p2p: Wrap peer.handshake() calls with wait_with_token()

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -654,9 +654,12 @@ class PeerPool(BaseService):
         )
         try:
             self.logger.debug("Connecting to %s...", remote)
-            peer = await handshake(
-                remote, self.privkey, self.peer_class, self.headerdb, self.network_id,
-                self.cancel_token)
+            # We use self.wait() as well as passing our CancelToken to handshake() as a workaround
+            # for https://github.com/ethereum/py-evm/issues/670.
+            peer = await self.wait(
+                handshake(
+                    remote, self.privkey, self.peer_class, self.headerdb, self.network_id,
+                    self.cancel_token))
 
             return peer
         except OperationCancelled:


### PR DESCRIPTION
That ensures it gets cancelled when the caller's token is triggered, even
if it is in the middle of an operation that uses the newly created Peer's
cancel token and wouldn't be otherwise cancellable.

Closes: #670