### PR TITLE
Catch unhandled timeout during UPNP device discovery

### DIFF
--- a/p2p/server.py
+++ b/p2p/server.py
@@ -179,9 +179,13 @@ class Server(BaseService):
         discover_timeout = 10 * REPLY_TIMEOUT
         # Use loop.run_in_executor() because upnpclient.discover() is blocking and may take a
         # while to complete.
-        devices = await self.wait_first(
-            loop.run_in_executor(None, upnpclient.discover),
-            timeout=discover_timeout)
+        try:
+            devices = await self.wait_first(
+                loop.run_in_executor(None, upnpclient.discover),
+                timeout=discover_timeout)
+        except TimeoutError:
+            self.logger.info("Timeout waiting for UPNP-enabled devices")
+            return None
 
         # If there are no UPNP devices we can exit early
         if not devices:


### PR DESCRIPTION
### What was wrong?

#874 

### How was it fixed?

Caught the exception and logged a user friendly message.

```
$ trinity
    INFO  06-06 13:35:01     logging  Trinity DEBUG log file is created at /home/cburgdorf/.local/share/trinity/mainnet/logs/trinity.log
    INFO  06-06 13:35:01        main  Started DB server process (pid=8810)
    INFO  06-06 13:35:01        main  Started networking process (pid=8816)
    INFO  06-06 13:35:02        main  
  ______     _       _ __       
 /_  __/____(_)___  (_) /___  __
  / / / ___/ / __ \/ / __/ / / /
 / / / /  / / / / / / /_/ /_/ / 
/_/ /_/  /_/_/ /_/_/\__/\__, /  
                       /____/   
    INFO  06-06 13:35:02        main  Trinity/0.2.0a26/linux/cpython3.6.5
    INFO  06-06 13:35:02         ipc  IPC started at: /home/cburgdorf/.local/share/trinity/mainnet/jsonrpc.ipc
    INFO  06-06 13:35:02      server  Running server...
    INFO  06-06 13:35:02      server  Timeout waiting for UPNP-enabled devices
    INFO  06-06 13:35:02      server  No UPNP-enabled devices found
    INFO  06-06 13:35:02      server  enode://54cc0f37e6f0949ad91690df197e05b71c862473b3bc3ef670b6d960c758ea978f35a60f7992aae123ba88c1dd330708488b30b8fc55e8985153503ac9048a04@0.0.0.0:30303
    INFO  06-06 13:35:02      server  network: 1
    INFO  06-06 13:35:02      server  peers: max_peers=25
    INFO  06-06 13:35:02        peer  Running PeerPool...
    INFO  06-06 13:35:02        peer  Connected peers: 0 inbound, 0 outbound
    INFO  06-06 13:35:02        sync  Starting fast-sync; current head: #222191
```

To highlight the new part:

>INFO  06-06 13:35:02      server  Timeout waiting for UPNP-enabled devices

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS5s3tQLIQWyoTt1GwNvZ-Vg3WfoHeeWEQPvomYH6UZA_AiX3RYCQ)
