### PR TITLE
validate genesis header in light sync

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -609,6 +609,8 @@ class Chain(BaseChain):
         Since block validation (specifically the uncle validation) must have
         access to the ancestor blocks, this validation must occur at the Chain
         level.
+
+        Cannot be used to validate genesis block.
         """
         VM = self.get_vm_class_for_block_number(BlockNumber(block.number))
         parent_block = self.get_block_by_hash(block.header.parent_hash)

--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -612,6 +612,8 @@ class Chain(BaseChain):
 
         Cannot be used to validate genesis block.
         """
+        if block.is_genesis:
+            raise ValidationError("Cannot validate genesis block this way")
         VM = self.get_vm_class_for_block_number(BlockNumber(block.number))
         parent_block = self.get_block_by_hash(block.header.parent_hash)
         VM.validate_header(block.header, parent_block.header)

--- a/evm/rlp/blocks.py
+++ b/evm/rlp/blocks.py
@@ -51,7 +51,7 @@ class BaseBlock(rlp.Serializable, Configurable, metaclass=ABCMeta):
 
     @property
     def is_genesis(self) -> bool:
-        return self.number == 0
+        return self.header.is_genesis
 
     def __repr__(self) -> str:
         return '<{class_name}(#{b})>'.format(


### PR DESCRIPTION
### What was wrong?

Fixes #892 

### How was it fixed?

When receiving a genesis header, check if it matches the canonical header already at block number 0. If they are not equal, raise a validation error that will drop the peer. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://farm8.staticflickr.com/7108/7603686408_8a0b51a3e5.jpg)
