### PR TITLE
Send disconnect reasons

### DIFF
--- a/p2p/lightchain.py
+++ b/p2p/lightchain.py
@@ -169,7 +169,6 @@ class LightPeerChain(PeerPoolSubscriber, BaseService):
                 self._last_processed_announcements[peer] = head_info
             except OperationCancelled:
                 self.logger.debug("Asked to stop, breaking out of run() loop")
-                await self.disconnect_peer(peer, DisconnectReason.client_quitting)
                 break
             except LESAnnouncementProcessingError as e:
                 self.logger.warning(repr(e))

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -28,6 +28,7 @@ class Hello(Command):
 
 @enum.unique
 class DisconnectReason(enum.Enum):
+    """More details at https://github.com/ethereum/wiki/wiki/%C3%90%CE%9EVp2p-Wire-Protocol#p2p"""
     disconnect_requested = 0
     tcp_sub_system_error = 1
     bad_protocol = 2
@@ -40,8 +41,7 @@ class DisconnectReason(enum.Enum):
     unexpected_identity = 9
     connected_to_self = 10
     timeout = 11
-    subprotocol_error = 12
-    other = 16
+    subprotocol_error = 16
 
 
 class Disconnect(Command):

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -623,8 +623,12 @@ class PeerPool(BaseService):
 
     async def stop_all_peers(self) -> None:
         self.logger.info("Stopping all peers ...")
-        await asyncio.gather(
-            *[peer.cancel() for peer in self.connected_nodes.values()])
+
+        peers = self.connected_nodes.values()
+        for peer in peers:
+            peer.disconnect(DisconnectReason.client_quitting)
+
+        await asyncio.gather(*[peer.cancel() for peer in peers])
 
     async def _cleanup(self) -> None:
         await self.stop_all_peers()

--- a/p2p/sharding_peer.py
+++ b/p2p/sharding_peer.py
@@ -64,7 +64,7 @@ class ShardingPeer(BasePeer):
                                           cmd: Command,
                                           msg: protocol._DecodedMsgType) -> None:
         if not isinstance(cmd, Status):
-            self.disconnect(DisconnectReason.other)
+            self.disconnect(DisconnectReason.subprotocol_error)
             raise HandshakeFailure("Expected status msg, got {}, disconnecting".format(cmd))
 
     #


### PR DESCRIPTION
### What was wrong?

We weren't accurately reporting the disconnect reason to peers.

### How was it fixed?

- Switched `subprotocol_error` from 0xc to 0x10
- Removed old usages of `error` reason
- Used more specific reasons in places that used to have `other`
- Let `TimeoutError` bubble up, and disconnect from peer with timeout reason

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://hotanimalnews.com/wp-content/uploads/2014/02/Cute-Budgetts-Frog-Cries-Like-Human-Baby-526x330.jpg)
