### PR TITLE
Fix wrong handling of logfile path

### DIFF
--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -97,18 +97,18 @@ def initialize_data_dir(chain_config: ChainConfig) -> None:
         )
 
     # Logfile
-    if (not chain_config.logfile_path.exists() and
-            is_under_xdg_trinity_root(chain_config.logfile_path)):
+    if (not chain_config.logdir_path.exists() and
+            is_under_xdg_trinity_root(chain_config.logdir_path)):
 
-        chain_config.logfile_path.parent.mkdir(parents=True, exist_ok=True)
+        chain_config.logdir_path.mkdir(parents=True, exist_ok=True)
         chain_config.logfile_path.touch()
-    elif not chain_config.logfile_path.exists():
+    elif not chain_config.logdir_path.exists():
         # we don't lazily create the base dir for non-default base directories.
         raise MissingPath(
             "The base logging directory provided does not exist: `{0}`".format(
-                chain_config.logfile_path,
+                chain_config.logdir_path,
             ),
-            chain_config.logfile_path
+            chain_config.logdir_path
         )
 
     # Chain data-dir

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -106,13 +106,20 @@ class ChainConfig:
     @property
     def logfile_path(self) -> Path:
         """
-        The logfile_path is the base directory where all log files are stored.
+        Return the path to the log file.
         """
         return self._logfile_path
 
     @logfile_path.setter
     def logfile_path(self, value: Path) -> None:
         self._logfile_path = value
+
+    @property
+    def logdir_path(self) -> Path:
+        """
+        Return the path of the directory where all log files are stored.
+        """
+        return self.logfile_path.parent
 
     @property
     def data_dir(self) -> Path:

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -57,7 +57,7 @@ LOG_FILENAME = 'trinity.log'
 
 def get_logfile_path(data_dir: Path) -> Path:
     """
-    Returns the path to the log files.
+    Return the path to the log file.
     """
     return data_dir / LOG_DIRNAME / LOG_FILENAME
 


### PR DESCRIPTION
### What was wrong?

Citing @carver from #894 

On master, if I run `trinity` in a fresh data dir, I get:
```
$ trinity --data-dir /tmp/trinity-ropsten/ --ropsten --light
   ERROR  06-11 13:23:38        main  
It appears that /tmp/trinity-ropsten/logs/trinity.log does not exist.
Trinity does not attempt to create directories outside of its root path
Either manually create the path or ensure you are using a data directory
inside the XDG_TRINITY_ROOT path
```

Ok, fair enough, so I create a logs directory and try again
```
$ mkdir -p /tmp/trinity-ropsten/logs
$ trinity --data-dir /tmp/trinity-ropsten/ --ropsten --light
   ERROR  06-11 13:23:38        main  
It appears that /tmp/trinity-ropsten/logs/trinity.log does not exist.
Trinity does not attempt to create directories outside of its root path
Either manually create the path or ensure you are using a data directory
inside the XDG_TRINITY_ROOT path
```

No dice. Maybe it means the file itself must be present?

```
$ touch /tmp/trinity-ropsten/logs/trinity.log
$ trinity --data-dir /tmp/trinity-ropsten/ --ropsten --light
    INFO  06-11 13:24:32     logging  Trinity DEBUG log file is created at /tmp/trinity-ropsten/logs/trinity.log
```

Yup, that was it. `trinity` should create the log file if it's missing (only if the folder for it already exists.

### How was it fixed?

The `logfile_path` was treated as if it meant the *directory* where logfiles go but in reality that holds the path to the file (as the name implies, just docs were wrong). I added another property `logdir_path` which is a computed property that returns the `parent` of whatever `logfile_path` returns so that it will also work if the `ChainConfig` specifies a different `logfile_path`.

As of before, we only bother the user at all if it happens that the `logdir_path` is outside of the `XDG_TRINITY_ROOT` and doesn't exist. If it happens to be outside of the `XDG_TRINITY_ROOT` but does exist, we will use that directory to create the logfile there.

In action:

```
$ trinity --data-dir /tmp/trinity-foo --ropsten --light
   ERROR  06-12 10:15:44        main  
It appears that /tmp/trinity-foo does not exist.
Trinity does not attempt to create directories outside of its root path
Either manually create the path or ensure you are using a data directory
inside the XDG_TRINITY_ROOT path

$ mkdir /tmp/trinity-foo

$ trinity --data-dir /tmp/trinity-foo --ropsten --light
   ERROR  06-12 10:16:01        main  
It appears that /tmp/trinity-foo/logs does not exist.
Trinity does not attempt to create directories outside of its root path
Either manually create the path or ensure you are using a data directory
inside the XDG_TRINITY_ROOT path

$ mkdir /tmp/trinity-foo/logs
$ trinity --data-dir /tmp/trinity-foo --ropsten --light
    INFO  06-12 10:16:18     logging  Trinity DEBUG log file is created at /tmp/trinity-foo/logs/trinity.log
    INFO  06-12 10:16:18        main  Started DB server process (pid=9515)
    INFO  06-12 10:16:19        main  Started networking process (pid=9522)
    INFO  06-12 10:16:20        main  
  ______     _       _ __       
 /_  __/____(_)___  (_) /___  __
  / / / ___/ / __ \/ / __/ / / /
 / / / /  / / / / / / /_/ /_/ / 
/_/ /_/  /_/_/ /_/_/\__/\__, /  
                       /____/   

```

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT_82F5BOEt0F8_8JmejrMxATx5PLXrYRgYt0G2CTkgnIrDSFXIAQ)
