### PR TITLE
Validate headers cleanup

### DIFF
--- a/p2p/lightchain.py
+++ b/p2p/lightchain.py
@@ -75,14 +75,14 @@ class LightPeerChain(PeerPoolSubscriber, BaseService):
             self,
             headerdb: 'BaseAsyncHeaderDB',
             peer_pool: PeerPool,
-            Chain: Type[BaseChain]) -> None:
+            chain_class: Type[BaseChain]) -> None:
         super().__init__()
         self.headerdb = headerdb
         self.peer_pool = peer_pool
         self._announcement_queue: asyncio.Queue[Tuple[LESPeer, les.HeadInfo]] = asyncio.Queue()
         self._last_processed_announcements: Dict[LESPeer, les.HeadInfo] = {}
         self._pending_replies: Dict[int, Callable[[protocol._DecodedMsgType], None]] = {}
-        self.Chain = Chain
+        self.chain_class = chain_class
 
     def register_peer(self, peer: BasePeer) -> None:
         peer = cast(LESPeer, peer)
@@ -256,7 +256,7 @@ class LightPeerChain(PeerPoolSubscriber, BaseService):
             parent_header = None
         else:
             parent_header = await self.headerdb.coro_get_block_header_by_hash(header.parent_hash)
-        VM = self.Chain.get_vm_class_for_block_number(header.block_number)
+        VM = self.chain_class.get_vm_class_for_block_number(header.block_number)
         # TODO push validation into process pool executor
         VM.validate_header(header, parent_header)
 

--- a/tests/core/vm/test_mainnet_dao_fork.py
+++ b/tests/core/vm/test_mainnet_dao_fork.py
@@ -273,9 +273,12 @@ def header_pairs(VM, headers, valid):
     'VM, header, previous_header, valid',
     header_pairs(MainnetHomesteadVM, ETH_HEADERS_NEAR_FORK, valid=True) + (
         (MainnetHomesteadVM, ETC_HEADER_AT_FORK, ETH_HEADERS_NEAR_FORK[1], False),
+        # ETC VM should accept the header right before the DAO fork
+        (ETC_VM, ETH_HEADERS_NEAR_FORK[1], ETH_HEADERS_NEAR_FORK[0], True),
+        # ... and accept its own non-fork header at the fork block
         (ETC_VM, ETC_HEADER_AT_FORK, ETH_HEADERS_NEAR_FORK[1], True),
-        # This block is not valid on ETC chain, but header-only validation cannot confirm that:
-        (ETC_VM, ETH_HEADERS_NEAR_FORK[2], ETH_HEADERS_NEAR_FORK[1], True),
+        # ... and reject the DAO-fork header at the fork
+        (ETC_VM, ETH_HEADERS_NEAR_FORK[2], ETH_HEADERS_NEAR_FORK[1], False),
     ),
 )
 def test_mainnet_dao_fork_header_validation(VM, header, previous_header, valid):


### PR DESCRIPTION
### What was wrong?

#883 had some more review comments after my (hasty) merge.

### How was it fixed?

- use `chain_class` instead of `Chain`
- use `self.wait` when awaiting external things

Bonus change:
- ETC VM now rejects headers that support the DAO fork

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.nuts.zone/wp-content/uploads/2014/06/schildkroete11.jpg)
