### PR TITLE
abstracts duplicate code fixes #899

### DIFF
--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -232,12 +232,14 @@ eip8_auth_sedes = sedes.List(
         sedes.BigEndianInt()                         # version
     ], strict=False)
 
+
 def _pad_eip8_data(data: bytes) -> bytes:
     # Pad with random amount of data, as per
     # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8.md:
     # "Adding a random amount in range [100, 300] is recommended to vary the size of the
     # packet"
     return data + os.urandom(random.randint(100, 300))
+
 
 def encrypt_eip8_msg(msg: bytes, pubkey: datatypes.PublicKey) -> bytes:
     prefix = struct.pack('>H', len(msg) + ENCRYPT_OVERHEAD_LENGTH)


### PR DESCRIPTION
### What was wrong?
p2p/auth.py had diplicate code


### How was it fixed?
abstracted code into function into _pad_eip8_data(data: bytes) -> bytes

I hope this is what was expected, please let me know if i should have done it a different way 

#### Cute Animal Picture
![cute animal picture](https://scontent-sjc3-1.cdninstagram.com/vp/7919f4bf106334e02a146ef7617cf3c7/5BACD80B/t51.2885-15/e35/12907185_1752394291647674_704396958_n.jpg)
