### PR TITLE
Support multiple UPnP devices

### DIFF
--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -128,3 +128,12 @@ class BadLESResponse(BaseP2PError):
     Raised when the response to a LES request doesn't contain the data we asked for.
     """
     pass
+
+
+class NoInternalAddressMatchesDevice(BaseP2PError):
+    """
+    Raised when no internal IP address matches the UPnP device that is being configured.
+    """
+    def __init__(self, *args, device_hostname=None, **kwargs):
+        super.__init__(*args, **kwargs)
+        self.device_hostname = device_hostname

--- a/p2p/nat.py
+++ b/p2p/nat.py
@@ -13,6 +13,7 @@ from p2p.cancel_token import (
     CancelToken,
 )
 from p2p.exceptions import (
+    NoInternalAddressMatchesDevice,
     OperationCancelled,
 )
 import netifaces
@@ -27,11 +28,6 @@ UPNP_DISCOVER_TIMEOUT_SECONDS = 30
 class PortMapping(NamedTuple):
     internal: str  # of the form "192.2.3.4:56"
     external: str  # of the form "192.2.3.4:56"
-
-
-class NoInternalAddressMatchesDevice(Exception):
-    def __init__(self, *args, device_hostname=None, **kwargs):
-        self.device_hostname = device_hostname
 
 
 def find_internal_ip_on_device_network(upnp_dev: upnpclient.upnp.Device) -> str:

--- a/p2p/nat.py
+++ b/p2p/nat.py
@@ -1,0 +1,168 @@
+import asyncio
+from concurrent.futures import (
+    ThreadPoolExecutor,
+)
+import ipaddress
+from typing import (
+    AsyncGenerator,
+    Tuple,
+)
+from urllib.parse import urlparse
+
+from p2p.cancel_token import (
+    CancelToken,
+)
+from p2p.exceptions import (
+    OperationCancelled,
+)
+import netifaces
+from p2p.constants import (
+    REPLY_TIMEOUT,
+)
+from p2p.service import BaseService
+import upnpclient
+
+
+def find_internal_ip_on_device_network(upnp_dev: upnpclient.upnp.Device) -> str:
+    """
+    For a given UPnP device, return the internal IP address of this host machine that can
+    be used for a NAT mapping.
+    """
+    parsed_url = urlparse(upnp_dev.location)
+    # Get an ipaddress.IPv4Network instance for the upnp device's network.
+    upnp_dev_net = ipaddress.ip_network(parsed_url.hostname + '/24', strict=False)
+    for iface in netifaces.interfaces():
+        for family, addresses in netifaces.ifaddresses(iface).items():
+            # TODO: Support IPv6 addresses as well.
+            if family != netifaces.AF_INET:
+                continue
+            for item in addresses:
+                if ipaddress.ip_address(item['addr']) in upnp_dev_net:
+                    return item['addr']
+    return None
+
+
+class UPnPService(BaseService):
+    """
+    Generate a mapping of external network IP address/port to internal IP address/port,
+    using the Universal Plug 'n' Play standard.
+    """
+
+    _nat_portmap_lifetime = 30 * 60
+
+    def __init__(self, port: int, token: CancelToken = None) -> None:
+        """
+        :param port: The port that a server wants to bind to on this machine, and
+        make publicly accessible.
+        """
+        super().__init__(token)
+        self.port = port
+        self._mapping: Tuple[str, str] = None  # internal, external: ('192.2.3.4:56', '18.2.3.4:56')
+
+    async def _run(self):
+        """Run an infinite loop refreshing our NAT port mapping.
+
+        On every iteration we configure the port mapping with a lifetime of 30 minutes and then
+        sleep for that long as well.
+        """
+        while self.is_running:
+            try:
+                # Wait for the port mapping lifetime, and then try registering it again
+                await self.wait(asyncio.sleep(self._nat_portmap_lifetime))
+                await self.add_nat_portmap()
+            except OperationCancelled:
+                break
+            except Exception:
+                self.logger.exception("Failed to setup NAT portmap")
+
+    async def _cleanup(self):
+        pass
+
+    async def add_nat_portmap(self):
+        """
+        Set up the port mapping
+
+        :return: the IP address of the new mapping (or None if failed)
+        """
+        self.logger.info("Setting up NAT portmap...")
+        # This is experimental and it's OK if it fails, hence the bare except.
+        try:
+            async for upnp_dev in self._discover_upnp_devices():
+                external_ip = await self._add_nat_portmap(upnp_dev)
+                if external_ip is not None:
+                    return external_ip
+        except upnpclient.soap.SOAPError as e:
+            if e.args == (718, 'ConflictInMappingEntry'):
+                # An entry already exists with the parameters we specified. Maybe the router
+                # didn't clean it up after it expired or it has been configured by other piece
+                # of software, either way we should not override it.
+                # https://tools.ietf.org/id/draft-ietf-pcp-upnp-igd-interworking-07.html#errors
+                self.logger.info("NAT port mapping already configured, not overriding it")
+            else:
+                self.logger.exception("Failed to setup NAT portmap")
+
+        self._mapping = None
+
+    def current_mapping(self) -> Tuple[str, str]:
+        if self._mapping is None:
+            return None
+        else:
+            return self._mapping
+
+    async def _add_nat_portmap(self, upnp_dev: upnpclient.upnp.Device) -> str:
+        # Detect our internal IP address (or abort if we can't determine
+        # the internal IP address
+        internal_ip = find_internal_ip_on_device_network(upnp_dev)
+        if internal_ip is None:
+            self.logger.warn(
+                "Unable to detect internal IP address in order to setup NAT portmap"
+            )
+            return None
+
+        external_ip = upnp_dev.WANIPConn1.GetExternalIPAddress()['NewExternalIPAddress']
+        for protocol, description in [('TCP', 'ethereum p2p'), ('UDP', 'ethereum discovery')]:
+            upnp_dev.WANIPConn1.AddPortMapping(
+                NewRemoteHost=external_ip,
+                NewExternalPort=self.port,
+                NewProtocol=protocol,
+                NewInternalPort=self.port,
+                NewInternalClient=internal_ip,
+                NewEnabled='1',
+                NewPortMappingDescription=description,
+                NewLeaseDuration=self._nat_portmap_lifetime,
+            )
+        self._mapping = (
+            '%s:%d' % (internal_ip, self.port),
+            '%s:%d' % (external_ip, self.port),
+        )
+        self.logger.info("NAT port forwarding successfully set up: %r", self._mapping)
+        return external_ip
+
+    async def _discover_upnp_devices(self) -> AsyncGenerator[upnpclient.upnp.Device, None]:
+        loop = asyncio.get_event_loop()
+        # UPnP discovery can take a long time, so use a loooong timeout here.
+        discover_timeout = 10 * REPLY_TIMEOUT
+        # Use loop.run_in_executor() because upnpclient.discover() is blocking and may take a
+        # while to complete. We must use a ThreadPoolExecutor() because the
+        # response from upnpclient.discover() can't be pickled.
+        try:
+            devices = await self.wait(
+                loop.run_in_executor(ThreadPoolExecutor(max_workers=1), upnpclient.discover),
+                timeout=discover_timeout,
+            )
+        except TimeoutError:
+            self.logger.info("Timeout waiting for UPNP-enabled devices")
+            return
+
+        # If there are no UPNP devices we can exit early
+        if not devices:
+            self.logger.info("No UPNP-enabled devices found")
+            return
+
+        # Now we loop over all of the devices until we find one that we can use.
+        for device in devices:
+            try:
+                device.WANIPConn1
+            except AttributeError:
+                continue
+            yield device

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -89,10 +89,10 @@ class BaseService(ABC):
 
     async def cancel(self):
         """Trigger the CancelToken and wait for the cleaned_up event to be set."""
-        if not self.is_running:
-            raise RuntimeError("Cannot cancel a service that has not been started")
-        elif self.cancel_token.triggered:
+        if self.cancel_token.triggered:
             self.logger.warning("Tried to cancel %s, but it was already cancelled", self)
+        elif not self.is_running:
+            raise RuntimeError("Cannot cancel a service that has not been started")
 
         self.logger.debug("Cancelling %s", self)
         self.cancel_token.trigger()


### PR DESCRIPTION
### What was wrong?

If the first UPnP device you found was not working (say, because it was on a different subnet), then we just gave up.

Fixes #787 

### How was it fixed?

- If setting up NAT on the first device fails, attempt to set up on the others
- Extracted UPnP logic out of p2p.server

Bonus fix:
- bugfix when canceling an already canceled service (now it will only warn instead of raise an exception)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://cdn.earthporm.com/wp-content/uploads/2014/12/cute-reptiles-1011__605.jpg)
