### PR TITLE
p2p: Log more details on peer authentication errors

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -107,8 +107,11 @@ class Node:
         pubkey = keys.PublicKey(decode_hex(parsed.username))
         return cls(pubkey, Address(parsed.hostname, parsed.port))
 
-    def __repr__(self):
+    def __str__(self) -> str:
         return '<Node(%s@%s)>' % (self.pubkey.to_hex()[:6], self.address.ip)
+
+    def __repr__(self) -> str:
+        return '<Node(%s@%s:%d)>' % (self.pubkey.to_hex(), self.address.ip, self.address.tcp_port)
 
     def distance_to(self, id):
         return self.id ^ id

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -662,18 +662,13 @@ class PeerPool(BaseService):
             # Pass it on to instruct our main loop to stop.
             raise
         except BadAckMessage:
-            # TODO: This is kept separate from the `expected_exceptions` to be
-            # sure that we aren't silencing an error in our authentication
-            # code.
-            self.logger.info('Got bad Ack during peer connection')
-            # We intentionally log this twice, once in INFO to be sure we don't
-            # forget about this and once in DEBUG which includes the stack
-            # trace.
-            self.logger.debug('Got bad Ack during peer connection', exc_info=True)
+            # This is kept separate from the `expected_exceptions` to be sure that we aren't
+            # silencing an error in our authentication code.
+            self.logger.info('Got bad auth ack from %r', remote)
         except expected_exceptions as e:
-            self.logger.debug("Could not complete handshake with %s: %s", remote, repr(e))
+            self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))
         except Exception:
-            self.logger.exception("Unexpected error during auth/p2p handshake with %s", remote)
+            self.logger.exception("Unexpected error during auth/p2p handshake with %r", remote)
         return None
 
     async def maybe_lookup_random_node(self) -> None:


### PR DESCRIPTION
> 2018-06-13 09:48:22,063 DEBUG: Connecting to <Node(0x2b8d@127.0.0.1)>...
2018-06-13 09:48:22,069 DEBUG: Could not complete handshake with <Node(0x2b8d5ad2d96607d5b9e66ea93bcf26e106f8502d9dab855aaa31d94b8a9f17fec2659dbcfb8b752b641154368f079dcf85e402ea5699cfd205136417a06dc4e2@127.0.0.1:30303)>: UnreachablePeer(ConnectionRefusedError(111, "Connect call failed ('127.0.0.1', 30303)"),)

With this we can try and reproduce #901 