### PR TITLE
Move header state into special MiningChain

### DIFF
--- a/docs/guides/evm/understanding_the_mining_process.rst
+++ b/docs/guides/evm/understanding_the_mining_process.rst
@@ -1,9 +1,10 @@
 Understanding the mining process
 ================================
 
-In the :doc:`Building Chains Guide <building_chains>` we already learned how to use the
-:class:`~evm.chains.base.Chain` class to create a single blockchain as a combination of different
-virtual machines for different spans of blocks.
+In the :doc:`Building Chains Guide <building_chains>` we already learned how to
+use the :class:`~evm.chains.base.MiningChain` class to create a single
+blockchain as a combination of different virtual machines for different spans
+of blocks.
 
 In this guide we want to build up on that knowledge and look into the actual mining process.
 
@@ -20,11 +21,12 @@ The term *mining* can refer to different things depending on our point of view. 
 when we read about *mining*, we talk about the process where several parties are *competing* to be
 the first to create a new valid block and pass it on to the network.
 
-In this guide, when we talk about the :func:`~evm.chains.base.Chain.mine_block` API, we are only
-referring to the part that creates, validates and sets a block as the new canonical head of the
-chain but not necessarily as part of the mentioned competition to be the first. In fact, the
-:func:`~evm.chains.base.Chain.mine_block` API is internally also called when we import existing
-blocks that others created.
+In this guide, when we talk about the
+:func:`~evm.chains.base.MiningChain.mine_block` API, we are only referring to
+the part that creates, validates and sets a block as the new canonical head of
+the chain but not necessarily as part of the mentioned competition to be the
+first. In fact, the :func:`~evm.chains.base.MiningChain.mine_block` API is
+internally also called when we import existing blocks that others created.
 
 Mining an empty block
 ---------------------
@@ -47,7 +49,7 @@ As a refresher, he's where we left of as part of the `Building Chains Guide <bui
   chain = chain_class.from_genesis_header(MemoryDB(), MAINNET_GENESIS_HEADER)
 
 Since we decided to not add any transactions to our block let's just call
-:func:`~~evm.chains.base.Chain.mine_block` and see what happens.
+:func:`~~evm.chains.base.MiningChain.mine_block` and see what happens.
 
 ::
 
@@ -103,7 +105,7 @@ can be added to the chain.
 
 In order to produce a valid block, we have to set the correct ``mix_hash`` and ``nonce`` in the
 header. We can pass these as key-value pairs when we call
-:func:`~~evm.chains.base.Chain.mine_block` as seen below.
+:func:`~~evm.chains.base.MiningChain.mine_block` as seen below.
 
 
 ::
@@ -117,9 +119,10 @@ Retrieving a valid nonce and mix hash
 -------------------------------------
 
 
-Now that we know we can call :func:`~~evm.chains.base.Chain.mine_block` with the correct parameters
-to successfully add a block to our chain, let's briefly go over an example that demonstrates how we
-can retrieve a matching ``nonce`` and ``mix_hash``.
+Now that we know we can call :func:`~~evm.chains.base.MiningChain.mine_block`
+with the correct parameters to successfully add a block to our chain, let's
+briefly go over an example that demonstrates how we can retrieve a matching
+``nonce`` and ``mix_hash``.
 
 .. note::
 
@@ -156,12 +159,12 @@ Next, we'll create the chain itself using the defined ``GENESIS_PARAMS`` and the
 
 ::
 
-  from evm import Chain
+  from evm import MiningChain
   from evm.vm.forks.byzantium import ByzantiumVM
   from evm.db.backends.memory import MemoryDB
 
 
-  klass = Chain.configure(
+  klass = MiningChain.configure(
       __name__='TestChain',
       vm_configuration=(
           (constants.GENESIS_BLOCK_NUMBER, ByzantiumVM),
@@ -203,8 +206,8 @@ information that we need to calculate the ``nonce`` and the ``mix_hash``.
 2. We then call :func:`~evm.consensus.pow.mine_pow_nonce` to retrieve the proper ``nonce`` and
 ``mix_hash`` that we need to mine the block and satisfy the validation.
 
-3. Finally we call :func:`~evm.chain.base.Chain.mine_block` and pass along the ``nonce`` and the
-``mix_hash``
+3. Finally we call :func:`~evm.chain.base.MiningChain.mine_block` and pass
+   along the ``nonce`` and the ``mix_hash``
 
 .. note::
 
@@ -295,7 +298,7 @@ private key which is as simple as calling
 
     signed_tx = tx.as_signed_transaction(SENDER_PRIVATE_KEY)
 
-Finally, we can call :func:`~evm.chains.base.Chain.apply_transaction` and pass along the
+Finally, we can call :func:`~evm.chains.base.MiningChain.apply_transaction` and pass along the
 ``signed_tx``.
 
 ::
@@ -312,7 +315,7 @@ zero value transfer transaction.
     from eth_typing import Address
 
     from evm.consensus.pow import mine_pow_nonce
-    from evm import constants, Chain
+    from evm import constants, MiningChain
     from evm.vm.forks.byzantium import ByzantiumVM
     from evm.db.backends.memory import MemoryDB
 
@@ -339,7 +342,7 @@ zero value transfer transaction.
 
     RECEIVER = Address(b'\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\x02')
 
-    klass = Chain.configure(
+    klass = MiningChain.configure(
         __name__='TestChain',
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, ByzantiumVM),

--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -188,7 +188,7 @@ class BaseChain(Configurable, ABC):
     # Block API
     #
     @abstractmethod
-    def get_ancestors(self, limit: int, header: BlockHeader=None) -> Iterator[BaseBlock]:
+    def get_ancestors(self, limit: int, header: BlockHeader) -> Iterator[BaseBlock]:
         raise NotImplementedError("Chain classes must implement this method")
 
     @abstractmethod
@@ -412,13 +412,10 @@ class Chain(BaseChain):
     # Block API
     #
     @to_tuple
-    def get_ancestors(self, limit: int, header: BlockHeader=None) -> Iterator[BaseBlock]:
+    def get_ancestors(self, limit: int, header: BlockHeader) -> Iterator[BaseBlock]:
         """
         Return `limit` number of ancestor blocks from the current canonical head.
         """
-        if header is None:
-            header = self.get_canonical_head()
-
         lower_limit = max(header.block_number - limit, 0)
         for n in reversed(range(lower_limit, header.block_number)):
             yield self.get_canonical_block_by_number(BlockNumber(n))

--- a/evm/chains/mainnet/__init__.py
+++ b/evm/chains/mainnet/__init__.py
@@ -14,7 +14,9 @@ from .constants import (
 )
 from evm import constants
 
-from evm.chains.base import Chain
+from evm.chains.base import (
+    Chain,
+)
 from evm.exceptions import ValidationError
 from evm.rlp.headers import BlockHeader
 from evm.vm.base import BaseVM  # noqa: F401

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -414,6 +414,14 @@ class VM(BaseVM):
         """
         Import the given block to the chain.
         """
+        if self.block.number != block.number:
+            raise ValidationError(
+                "This VM can only import blocks at number #{}, the attempted block was #{}".format(
+                    self.block.number,
+                    block.number,
+                )
+            )
+
         self.block = self.block.copy(
             header=self.configure_header(
                 coinbase=block.header.coinbase,
@@ -690,6 +698,14 @@ class VM(BaseVM):
             validate_length_lte(header.extra_data, 32, title="BlockHeader.extra_data")
 
             validate_gas_limit(header.gas_limit, parent_header.gas_limit)
+
+            if header.block_number != parent_header.block_number + 1:
+                raise ValidationError(
+                    "Blocks must be numbered consecutively. Block number #{} has parent #{}".format(
+                        header.block_number,
+                        parent_header.block_number,
+                    )
+                )
 
             # timestamp
             if header.timestamp <= parent_header.timestamp:

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -394,18 +394,40 @@ class VM(BaseVM):
             transaction_context,
         )
 
-    def _apply_all_transactions(self, transactions, base_header):
+    def apply_all_transactions(self, transactions, base_header):
+        """
+        Determine the results of applying all transactions to the base header.
+        This does *not* update the current block or header of the VM.
+
+        :param transactions: an iterable of all transactions to apply
+        :param base_header: the starting header to apply transactions to
+        :return: the final header, the receipts of each transaction, and the computations
+        """
+        if base_header.block_number != self.block.number:
+            raise ValidationError(
+                "This VM instance must only work on block #{}, "
+                "but the target header has block #{}".format(
+                    self.block.number,
+                    base_header.block_number,
+                )
+            )
+
         receipts = []
+        computations = []
         previous_header = base_header
         result_header = base_header
 
         for transaction in transactions:
-            result_header, receipt, _ = self.apply_transaction(previous_header, transaction)
+            result_header, receipt, computation = self.apply_transaction(
+                previous_header,
+                transaction,
+            )
 
             previous_header = result_header
             receipts.append(receipt)
+            computations.append(computation)
 
-        return result_header, receipts
+        return result_header, receipts, computations
 
     #
     # Mining
@@ -442,11 +464,11 @@ class VM(BaseVM):
         )
 
         # run all of the transactions.
-        last_header, receipts = self._apply_all_transactions(block.transactions, self.block.header)
+        new_header, receipts, _ = self.apply_all_transactions(block.transactions, self.block.header)
 
         self.block = self.set_block_transactions(
             self.block,
-            last_header,
+            new_header,
             block.transactions,
             receipts,
         )

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -60,12 +60,8 @@ class FullNodeSyncer(BaseService):
 
         # Now, loop forever, fetching missing blocks and applying them.
         self.logger.info("Starting regular sync; current head: #%d", head.block_number)
-        # This is a bit of a hack, but self.chain is stuck in the past as during the fast-sync we
-        # did not use it to import the blocks, so we need this to get a Chain instance with our
-        # latest head so that we can start importing blocks.
-        new_chain = type(self.chain)(self.base_db)
         chain_syncer = RegularChainSyncer(
-            new_chain, self.chaindb, self.peer_pool, self.cancel_token)
+            self.chain, self.chaindb, self.peer_pool, self.cancel_token)
         await chain_syncer.run()
 
     async def _cleanup(self) -> None:

--- a/scripts/benchmark/checks/deploy_erc20.py
+++ b/scripts/benchmark/checks/deploy_erc20.py
@@ -18,7 +18,7 @@ from evm.constants import (
     CREATE_CONTRACT_ADDRESS
 )
 from evm.chains.base import (
-    Chain,
+    MiningChain,
 )
 from evm.rlp.blocks import (
     BaseBlock,
@@ -95,7 +95,7 @@ class DeployErc20(BaseBenchmark):
 
         return total_stat
 
-    def mine_blocks(self, chain: Chain, num_blocks: int, num_tx: int) -> Tuple[int, int]:
+    def mine_blocks(self, chain: MiningChain, num_blocks: int, num_tx: int) -> Tuple[int, int]:
         total_gas_used = 0
         total_num_tx = 0
 
@@ -107,7 +107,7 @@ class DeployErc20(BaseBenchmark):
         return total_gas_used, total_num_tx
 
     def mine_block(self,
-                   chain: Chain,
+                   chain: MiningChain,
                    block_number: int,
                    num_tx: int) -> BaseBlock:
 
@@ -116,7 +116,7 @@ class DeployErc20(BaseBenchmark):
 
         return chain.mine_block()
 
-    def apply_transaction(self, chain: Chain) -> None:
+    def apply_transaction(self, chain: MiningChain) -> None:
 
         # Instantiate the contract
         SimpleToken = self.w3.eth.contract(

--- a/scripts/benchmark/checks/mine_empty_blocks.py
+++ b/scripts/benchmark/checks/mine_empty_blocks.py
@@ -1,7 +1,7 @@
 import logging
 
 from evm.chains.base import (
-    Chain
+    MiningChain
 )
 
 from .base_benchmark import (
@@ -44,7 +44,7 @@ class MineEmptyBlocksBenchmark(BaseBenchmark):
 
         return total_stat
 
-    def mine_empty_blocks(self, chain: Chain, number_blocks: int) -> None:
+    def mine_empty_blocks(self, chain: MiningChain, number_blocks: int) -> None:
 
         for _ in range(1, number_blocks + 1):
             block = chain.mine_block()

--- a/scripts/benchmark/checks/simple_value_transfers.py
+++ b/scripts/benchmark/checks/simple_value_transfers.py
@@ -9,7 +9,7 @@ from eth_typing import (
     Address,
 )
 from evm.chains.base import (
-    Chain,
+    MiningChain,
 )
 from evm.rlp.blocks import (
     BaseBlock,
@@ -94,7 +94,7 @@ class SimpleValueTransferBenchmark(BaseBenchmark):
 
         return total_stat
 
-    def mine_blocks(self, chain: Chain, num_blocks: int) -> Tuple[int, int]:
+    def mine_blocks(self, chain: MiningChain, num_blocks: int) -> Tuple[int, int]:
         total_gas_used = 0
         total_num_tx = 0
 
@@ -106,13 +106,13 @@ class SimpleValueTransferBenchmark(BaseBenchmark):
 
         return total_gas_used, total_num_tx
 
-    def mine_block(self, chain: Chain, block_number: int, num_tx: int) -> BaseBlock:
+    def mine_block(self, chain: MiningChain, block_number: int, num_tx: int) -> BaseBlock:
         for i in range(1, num_tx + 1):
             self.apply_transaction(chain)
 
         return chain.mine_block()
 
-    def apply_transaction(self, chain: Chain) -> None:
+    def apply_transaction(self, chain: MiningChain) -> None:
 
         if self.config.to_address is None:
             to_address = generate_random_address()

--- a/scripts/benchmark/utils/chain_plumbing.py
+++ b/scripts/benchmark/utils/chain_plumbing.py
@@ -21,13 +21,15 @@ from eth_typing import (
 
 from evm import (
     constants,
-    Chain
+)
+from evm.chains.base import (
+    MiningChain,
 )
 from evm.vm.base import (
     BaseVM
 )
 from evm.chains.mainnet import (
-    MainnetChain
+    BaseMainnetChain,
 )
 from evm.db.backends.memory import (
     MemoryDB
@@ -39,7 +41,7 @@ AddressSetup = NamedTuple('AddressSetup', [
     ('code', bytes)
 ])
 
-ALL_VM = [vm for _, vm in MainnetChain.vm_configuration]
+ALL_VM = [vm for _, vm in BaseMainnetChain.vm_configuration]
 
 FUNDED_ADDRESS_PRIVATE_KEY = keys.PrivateKey(
     decode_hex('0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8')
@@ -80,11 +82,11 @@ def chain_without_pow(
         base_db: MemoryDB,
         vm: Type[BaseVM],
         genesis_params: Any,
-        genesis_state: Any) -> Chain:
+        genesis_state: Any) -> MiningChain:
 
     vm_without_pow = vm.configure(validate_seal=lambda block: None)
 
-    klass = Chain.configure(
+    klass = MiningChain.configure(
         __name__='TestChain',
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, vm_without_pow),
@@ -93,7 +95,7 @@ def chain_without_pow(
     return chain
 
 
-def get_chain(vm: Type[BaseVM]) -> Chain:
+def get_chain(vm: Type[BaseVM]) -> MiningChain:
     return chain_without_pow(
         MemoryDB(),
         vm,
@@ -113,7 +115,7 @@ def get_chain(vm: Type[BaseVM]) -> Chain:
     )
 
 
-def get_all_chains() -> Iterable[Chain]:
+def get_all_chains() -> Iterable[MiningChain]:
     for vm in ALL_VM:
         chain = get_chain(vm)
         yield chain

--- a/tests/core/chain-object/test_build_block_incrementally.py
+++ b/tests/core/chain-object/test_build_block_incrementally.py
@@ -1,5 +1,6 @@
 import pytest
 
+from evm.chains.base import MiningChain
 from evm.utils.address import force_bytes_to_address
 
 from tests.core.helpers import (
@@ -12,7 +13,10 @@ ADDRESS_1010 = force_bytes_to_address(b'\x10\x10')
 
 @pytest.fixture
 def chain(chain_without_block_validation):
-    return chain_without_block_validation
+    if not isinstance(chain_without_block_validation, MiningChain):
+        pytest.skip("these tests require a mining chain implementation")
+    else:
+        return chain_without_block_validation
 
 
 def test_building_block_incrementally_with_single_transaction(

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -61,16 +61,8 @@ def test_import_block(chain, tx):
         assert computation.is_success
     else:
         # working on a non-mining chain, so we have to build the block to apply manually
-        base_header = chain.create_header_from_parent(chain.get_canonical_head())
-        vm = chain.get_vm(base_header)
-
-        new_header, receipt, computation = vm.apply_transaction(base_header, tx)
-        assert computation.is_success
-
-        transactions = (tx, )
-        receipts = (receipt, )
-
-        new_block = vm.set_block_transactions(vm.block, new_header, transactions, receipts)
+        new_block, receipts, computations = chain.build_block_with_transactions([tx])
+        assert computations[0].is_success
 
     block = chain.import_block(new_block)
     assert block.transactions == (tx,)

--- a/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
+++ b/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
@@ -1,7 +1,10 @@
 import pytest
 
 
-from evm import Chain
+from evm.chains.base import (
+    Chain,
+    MiningChain,
+)
 from evm.constants import (
     GENESIS_BLOCK_NUMBER,
     GENESIS_DIFFICULTY,
@@ -73,7 +76,7 @@ def test_header_chain_get_vm_class_for_block_number(base_db, genesis_header):
 
 
 def test_header_chain_invalid_if_no_vm_configuration(base_db, genesis_header):
-    chain_class = Chain.configure('ChainNoEmptyConfiguration', vm_configuration=())
+    chain_class = MiningChain.configure('ChainNoEmptyConfiguration', vm_configuration=())
     with pytest.raises(ValueError):
         chain_class(base_db, genesis_header)
 

--- a/tests/core/chain-object/test_gas_estimation.py
+++ b/tests/core/chain-object/test_gas_estimation.py
@@ -79,7 +79,8 @@ def test_estimate_gas(
 
     if on_pending:
         # estimate on *pending* block
-        assert chain.estimate_gas(tx, chain.header) == expected
+        pending_header = chain.create_header_from_parent(chain.get_canonical_head())
+        assert chain.estimate_gas(tx, pending_header) == expected
     else:
         # estimates on top of *latest* block
         assert chain.estimate_gas(tx) == expected

--- a/tests/core/chain-object/test_mining.py
+++ b/tests/core/chain-object/test_mining.py
@@ -2,12 +2,14 @@ from eth_keys import keys
 from eth_utils import decode_hex
 
 from evm import constants
-from evm.chains.base import Chain
+from evm.chains.base import (
+    MiningChain,
+)
 from evm.db.backends.memory import MemoryDB
 from evm.vm.forks.frontier import _PoWMiningVM
 
 
-class PowMiningChain(Chain):
+class PowMiningChain(MiningChain):
     vm_configuration = ((0, _PoWMiningVM),)
     network_id = 999
 

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -1,7 +1,9 @@
 from cytoolz import curry
 
 from eth_utils import decode_hex
+import pytest
 
+from evm.chains.base import MiningChain
 from evm.exceptions import (
     ValidationError,
 )
@@ -36,6 +38,10 @@ def new_transaction(
 
 
 def fill_block(chain, from_, key, gas, data):
+    if not isinstance(chain, MiningChain):
+        pytest.skip("Cannot fill block automatically unless using a MiningChain")
+        return
+
     recipient = decode_hex('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0c')
     amount = 100
 

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -61,14 +61,11 @@ def test_import_block(chain, funded_address, funded_address_private_key):
         new_block, _, computation = chain.apply_transaction(tx)
     else:
         # Have to manually build the block for the import_block test
+        new_block, _, computations = chain.build_block_with_transactions([tx])
+        computation = computations[0]
+
+        # Generate the pending header to import the new block on
         pending_header = chain.create_header_from_parent(chain.get_canonical_head())
-        vm = chain.get_vm(pending_header)
-        new_header, receipt, computation = vm.apply_transaction(pending_header, tx)
-
-        transactions = (tx, )
-        receipts = (receipt, )
-
-        new_block = vm.set_block_transactions(vm.block, new_header, transactions, receipts)
 
     assert not computation.is_error
 

--- a/tests/p2p/integration_test_helpers.py
+++ b/tests/p2p/integration_test_helpers.py
@@ -1,7 +1,9 @@
 import asyncio
 
 from evm import MainnetChain, RopstenChain
-from evm.chains.base import Chain
+from evm.chains.base import (
+    MiningChain,
+)
 from evm.db.chain import AsyncChainDB
 
 from p2p.exceptions import OperationCancelled
@@ -62,7 +64,7 @@ class FakeAsyncMainnetChain(MainnetChain):
     coro_import_block = coro_import_block
 
 
-class FakeAsyncChain(Chain):
+class FakeAsyncChain(MiningChain):
     coro_import_block = coro_import_block
 
 

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -197,3 +197,4 @@ def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
 class ChainProxy(BaseProxy):
     coro_import_block = async_method('import_block')
     get_vm_configuration = sync_method('get_vm_configuration')
+    get_vm_class_for_block_number = sync_method('get_vm_class_for_block_number')

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -45,7 +45,7 @@ from trinity.rpc.modules import (
 
 def get_header(chain: BaseChain, at_block: Union[str, int]) -> BlockHeader:
     if at_block == 'pending':
-        at_header = chain.header
+        raise NotImplementedError("RPC interface does not support the 'pending' block at this time")
     elif at_block == 'latest':
         at_header = chain.get_canonical_head()
     elif at_block == 'earliest':


### PR DESCRIPTION
Keeping a pending block and header only really matters for mining. Remove that quirky part of state. With header gone, all critical state is held in the chaindb. Chain objects in different processes
will no longer diverge.

Note that although the chain now doesn't maintain a concept of a pending header, the VM must still be initialized on a pending header before importing a block. That's because VMs must not change block number during any operation. (So they have to "start" on the pending block they are about to import, somewhat counter-intuitively.)

If incremental activity like applying transactions are required, then use the new MiningChain class or the new `Chain.build_block_with_transactions()`.

### What was wrong?

#902 pointed out some challenges from keeping header state in the `Chain` object.

### How was it fixed?

- Pushed all the header state into `MiningChain`
- Do not explicitly manage a pending header in `Chain`
- Drop `pending` support from RPC (supporting it has weird corner cases anyway, and is a source of pain for `geth`, so maybe best to just never support it from the start)
- New convenience method: `Chain.build_block_with_transactions()` to build prospective blocks for import (ignoring PoW)
- Fixes #902 by reusing the same chain instance instead of trying to make a copy.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/de6uTMEiZf0/maxresdefault.jpg)