### PR TITLE
Change eth-hash backend to pysha3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import platform
 from setuptools import setup, find_packages
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import platform
 from setuptools import setup, find_packages
 
 
@@ -26,7 +27,8 @@ deps = {
     'evm-extra': [
         "coincurve>=7.0.0,<8.0.0",
         "plyvel==1.0.4",
-        "eth-hash[pycryptodome]",
+        "eth-hash[pysha3];implementation_name=='cpython'",
+        "eth-hash[pycryptodome];implementation_name=='pypy'",
     ],
     'p2p': [
         "aiohttp>=2.3.1,<3.0.0",
@@ -73,6 +75,7 @@ deps = {
         "tox==2.7.0",
     ],
 }
+
 
 deps['dev'] = (
     deps['dev'] +


### PR DESCRIPTION
### What was wrong?
PyCryptodome is horrifically slow and eth-hash was using it as a backend.
@jmyles laptop was getting too hot for his lap.


### How was it fixed?
Changed the eth-hash backend to use pysha3/hashlib.
@jmyles laptop cooled down.


#### Cute Animal Picture

![this cute ass penguin photo](https://wallpapercave.com/wp/u2FZQby.jpg)
