### PR TITLE
Catch and log exception about malformed msg

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -122,6 +122,8 @@ async def handshake(remote: Node,
          ) = await auth.handshake(remote, privkey, token)
     except (ConnectionRefusedError, OSError) as e:
         raise UnreachablePeer(e)
+    except MalformedMessage as e:
+        raise HandshakeFailure(e)
     peer = peer_class(
         remote=remote, privkey=privkey, reader=reader, writer=writer,
         aes_secret=aes_secret, mac_secret=mac_secret, egress_mac=egress_mac,
@@ -638,7 +640,6 @@ class PeerPool(BaseService):
             PeerConnectionLost,
             TimeoutError,
             UnreachablePeer,
-            MalformedMessage,
         )
         try:
             self.logger.debug("Connecting to %s...", remote)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -121,9 +121,9 @@ async def handshake(remote: Node,
          writer
          ) = await auth.handshake(remote, privkey, token)
     except (ConnectionRefusedError, OSError) as e:
-        raise UnreachablePeer(e)
+        raise UnreachablePeer() from e
     except MalformedMessage as e:
-        raise HandshakeFailure(e)
+        raise HandshakeFailure() from e
     peer = peer_class(
         remote=remote, privkey=privkey, reader=reader, writer=writer,
         aes_secret=aes_secret, mac_secret=mac_secret, egress_mac=egress_mac,

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -39,6 +39,7 @@ from p2p.discovery import (
 from p2p.exceptions import (
     DecryptionError,
     HandshakeFailure,
+    MalformedMessage,
     OperationCancelled,
     PeerConnectionLost,
 )
@@ -267,7 +268,10 @@ class Server(BaseService):
         else:
             # We use self.wait() here as a workaround for
             # https://github.com/ethereum/py-evm/issues/670.
-            await self.wait(self.do_handshake(peer))
+            try:
+                await self.wait(self.do_handshake(peer))
+            except MalformedMessage as e:
+                self.logger.debug("Could not complete handshake with %r: %s", peer.remote, repr(e))
 
     async def do_handshake(self, peer: BasePeer) -> None:
         await peer.do_p2p_handshake(),

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -274,7 +274,10 @@ class Server(BaseService):
                 self.logger.debug("Could not complete handshake with %r: %s", peer.remote, repr(e))
 
     async def do_handshake(self, peer: BasePeer) -> None:
-        await peer.do_p2p_handshake(),
+        try:
+            await peer.do_p2p_handshake(),
+        except MalformedMessage as e:
+            raise HandshakeFailure(e)
         await peer.do_sub_proto_handshake()
         self._start_peer(peer)
 

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -268,10 +268,7 @@ class Server(BaseService):
         else:
             # We use self.wait() here as a workaround for
             # https://github.com/ethereum/py-evm/issues/670.
-            try:
-                await self.wait(self.do_handshake(peer))
-            except MalformedMessage as e:
-                self.logger.debug("Could not complete handshake with %r: %s", peer.remote, repr(e))
+            await self.wait(self.do_handshake(peer))
 
     async def do_handshake(self, peer: BasePeer) -> None:
         try:

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -277,7 +277,7 @@ class Server(BaseService):
         try:
             await peer.do_p2p_handshake(),
         except MalformedMessage as e:
-            raise HandshakeFailure(e)
+            raise HandshakeFailure() from e
         await peer.do_sub_proto_handshake()
         self._start_peer(peer)
 


### PR DESCRIPTION
### What was wrong?

As described in #882 there's a `MalformedMessage` error escaping.

### How was it fixed?

Caught and logged exception. I'm not entirely sure if that is the right level to handle this but it's inspired by how we treat the exact same error in [`peer`](https://github.com/ethereum/py-evm/blob/7b660dc30fa6fd62df97e38c5d43dcf29d102437/p2p/peer.py#L679)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTyBdyLgGEsspFP6s2e3GZ4BJyDWRO8XHz4hbuTxpiodLfuBUPm4Q)
