### PR TITLE
Use Ethereum Foundation for copyright info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2017 Piper Merriam
+Copyright 2017-2018 Ethereum Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = about['__name__']
-copyright = '2017, Piper Merriam, Jason Carver'
+copyright = '2017-2018 Ethereum Foundation'
 author = about['__author__']
 
 # The version info for the project you're documenting, acts as replacement for

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     version='0.2.0-alpha.26',
     description='Python implementation of the Ethereum Virtual Machine',
     long_description_markdown_filename='README.md',
-    author='Piper Merriam',
+    author='Ethereum Foundation',
     author_email='piper@pipermerriam.com',
     url='https://github.com/ethereum/py-evm',
     include_package_data=True,


### PR DESCRIPTION
### What was wrong?

Different parts (license, docs, package info) used different copyright info.

### How was it fixed?

Erased @pipermerriam and @carver from history :sweat_smile: and replaced with "Ethereum Foundation" for the family spirit :family_woman_girl_boy: :family_man_girl_boy: 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://thumbs.dreamstime.com/b/group-banded-mongoose-16428576.jpg)
