### PR TITLE
Add type hints for entire Trinity code base and enable stricter mypy checks

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -109,6 +109,12 @@ class BaseChain(Configurable, metaclass=ABCMeta):
     chaindb = None  # type: BaseChainDB
     chaindb_class = None  # type: Type[BaseChainDB]
     vm_configuration = None  # type: Tuple[Tuple[int, Type[BaseVM]], ...]
+    header = None  # type: BlockHeader
+    network_id = None  # type: int
+
+    @abstractmethod
+    def __init__(self) -> None:
+        raise NotImplementedError("Chain classes must implement this method")
 
     #
     # Helpers
@@ -271,8 +277,6 @@ class Chain(BaseChain):
     current block number.
     """
     logger = logging.getLogger("evm.chain.chain.Chain")
-    header = None  # type: BlockHeader
-    network_id = None  # type: int
     gas_estimator = None  # type: Callable
 
     chaindb_class = ChainDB  # type: Type[BaseChainDB]

--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -7,7 +7,10 @@ import logging
 from lru import LRU
 from typing import Set, Tuple  # noqa: F401
 
-from eth_typing import Hash32
+from eth_typing import (
+    Address,
+    Hash32
+)
 
 import rlp
 
@@ -83,6 +86,17 @@ class BaseAccountDB(metaclass=ABCMeta):
 
     @abstractmethod
     def set_storage(self, address, slot, value):
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    #
+    # Nonce
+    #
+    @abstractmethod
+    def get_nonce(self, address: Address) -> int:
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    @abstractmethod
+    def set_nonce(self, address: Address, nonce: int) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
 
     #

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from abc import (
     ABCMeta,
-    abstractmethod
+    abstractmethod,
 )
 import contextlib
 import functools
@@ -69,6 +69,11 @@ class BaseVM(Configurable, metaclass=ABCMeta):
     fork = None  # type: str
     chaindb = None  # type: BaseChainDB
     _state_class = None  # type: Type[BaseState]
+
+    @property
+    @abstractmethod
+    def state(self):
+        raise NotImplementedError("VM classes must implement this property")
 
     @abstractmethod
     def __init__(self, header, chaindb):

--- a/scripts/benchmark/checks/base_benchmark.py
+++ b/scripts/benchmark/checks/base_benchmark.py
@@ -1,7 +1,6 @@
 from abc import (
     ABCMeta,
     abstractmethod,
-    abstractproperty
 )
 import logging
 from typing import (
@@ -32,7 +31,8 @@ class BaseBenchmark(metaclass=ABCMeta):
             "Must be implemented by subclasses"
         )
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def name(self) -> DefaultStat:
         raise NotImplementedError(
             "Must be implemented by subclasses"

--- a/tox.ini
+++ b/tox.ini
@@ -68,9 +68,10 @@ commands=
     flake8 {toxinidir}/tests
     flake8 {toxinidir}/scripts
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
-    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p p2p -p trinity
-    # benchmark uses more restrictive type checking
+    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p p2p
+    # Trinity and Benchmark use more restrictive type checking
     mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics scripts/benchmark
+    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p trinity
 
 
 [testenv:py36-benchmark]

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -1,11 +1,11 @@
 import pkg_resources
 
 # TODO: update this to use the `trinity` version once extracted from py-evm
+__version__: str
 try:
-    __version__: str = pkg_resources.get_distribution("trinity").version
+    __version__ = pkg_resources.get_distribution("trinity").version
 except pkg_resources.DistributionNotFound:
-    # mypy doesn't like that `__version__` is defined twice
-    __version__: str = pkg_resources.get_distribution("py-evm").version  # type: ignore
+    __version__ = pkg_resources.get_distribution("py-evm").version
 
 from .main import (  # noqa: F401
     main,

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -5,8 +5,14 @@ from multiprocessing.managers import (  # type: ignore
     BaseProxy,
 )
 import os
+from typing import (
+    Type
+)
 
 from evm import MainnetChain, RopstenChain
+from evm.chains.base import (
+    BaseChain
+)
 from evm.chains.mainnet import (
     MAINNET_GENESIS_HEADER,
     MAINNET_NETWORK_ID,
@@ -140,18 +146,18 @@ def initialize_database(chain_config: ChainConfig, chaindb: AsyncChainDB) -> Non
 
 def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
     chaindb = AsyncChainDB(base_db)
-
+    chain_class: Type[BaseChain]
     if not is_database_initialized(chaindb):
         initialize_database(chain_config, chaindb)
     if chain_config.network_id == MAINNET_NETWORK_ID:
-        chain_class = MainnetChain  # type: ignore
+        chain_class = MainnetChain
     elif chain_config.network_id == ROPSTEN_NETWORK_ID:
-        chain_class = RopstenChain  # type: ignore
+        chain_class = RopstenChain
     else:
         raise NotImplementedError(
             "Only the mainnet and ropsten chains are currently supported"
         )
-    chain = chain_class(base_db)  # type: ignore
+    chain = chain_class(base_db)
 
     headerdb = AsyncHeaderDB(base_db)
     header_chain = AsyncHeaderChain(base_db)
@@ -184,7 +190,7 @@ def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
     manager = DBManager(address=str(chain_config.database_ipc_path))  # type: ignore
     server = manager.get_server()  # type: ignore
 
-    server.serve_forever()  # type: ignore
+    server.serve_forever()
 
 
 class ChainProxy(BaseProxy):

--- a/trinity/chains/header.py
+++ b/trinity/chains/header.py
@@ -25,7 +25,7 @@ from trinity.utils.mp import (
 
 class BaseAsyncHeaderChain(BaseHeaderChain):
     @abstractmethod
-    async def coro_get_canonical_head(self):
+    async def coro_get_canonical_head(self) -> BlockHeader:
         raise NotImplementedError("Chain classes must implement this method")
 
     @abstractmethod
@@ -36,7 +36,7 @@ class BaseAsyncHeaderChain(BaseHeaderChain):
 class AsyncHeaderChain(HeaderChain, BaseAsyncHeaderChain):
     _headerdb_class: Type[BaseAsyncHeaderDB] = AsyncHeaderDB
 
-    async def coro_get_canonical_head(self):
+    async def coro_get_canonical_head(self) -> BlockHeader:
         raise NotImplementedError("Chain classes must implement this method")
 
     async def coro_import_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
@@ -51,7 +51,7 @@ class AsyncHeaderChainProxy(BaseProxy, BaseAsyncHeaderChain, BaseHeaderChain):
         raise NotImplementedError("Chain classes must implement this method")
 
     @classmethod
-    def get_headerdb_class(cls):
+    def get_headerdb_class(cls) -> BaseDB:
         raise NotImplementedError("Chain classes must implement this method")
 
     coro_get_block_header_by_hash = async_method('get_block_header_by_hash')

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -1,4 +1,7 @@
 import argparse
+from typing import (
+    Any,
+)
 
 from evm.chains.mainnet import (
     MAINNET_NETWORK_ID,
@@ -17,7 +20,11 @@ from trinity.constants import (
 
 
 class ValidateAndStoreEnodes(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self,
+                 parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace,
+                 values: Any,
+                 option_string: str=None) -> None:
         if values is None:
             return
 

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -1,3 +1,4 @@
+import argparse
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -193,7 +194,7 @@ class ChainConfig:
             )
 
     @classmethod
-    def from_parser_args(cls, parser_args):
+    def from_parser_args(cls, parser_args: argparse.Namespace) -> 'ChainConfig':
         constructor_kwargs = construct_chain_config_params(parser_args)
         return cls(**constructor_kwargs)
 

--- a/trinity/db/base.py
+++ b/trinity/db/base.py
@@ -17,26 +17,26 @@ class DBProxy(BaseProxy):
         'set',
     )
 
-    def get(self, key):
+    def get(self, key: bytes) -> bytes:
         return self._callmethod('get', (key,))
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: bytes) -> bytes:
         return self._callmethod('__getitem__', (key,))
 
-    def set(self, key, value):
+    def set(self, key: bytes, value: bytes) -> None:
         return self._callmethod('set', (key, value))
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: bytes, value: bytes) -> None:
         return self._callmethod('__setitem__', (key, value))
 
-    def delete(self, key):
+    def delete(self, key: bytes) -> None:
         return self._callmethod('delete', (key,))
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: bytes) -> None:
         return self._callmethod('__delitem__', (key,))
 
-    def exists(self, key):
+    def exists(self, key: bytes) -> bool:
         return self._callmethod('exists', (key,))
 
-    def __contains__(self, key):
+    def __contains__(self, key: bytes) -> bool:
         return self._callmethod('__contains__', (key,))

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -1,3 +1,6 @@
+import pathlib
+
+
 class BaseTrinityError(Exception):
     """
     The base class for all Trinity errors.
@@ -16,6 +19,6 @@ class MissingPath(BaseTrinityError):
     """
     Raised when an expected path is missing
     """
-    def __init__(self, msg, path):
+    def __init__(self, msg: str, path: pathlib.Path) -> None:
         super(MissingPath, self).__init__(msg)
         self.path = path

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -1,4 +1,7 @@
-from evm.chains.base import BaseChain
+from evm.chains.base import (
+    BaseChain
+)
+
 from p2p.server import Server
 from p2p.service import BaseService
 
@@ -22,9 +25,9 @@ class FullNode(Node):
         self._node_port = chain_config.port
         self._max_peers = chain_config.max_peers
 
-    def get_chain(self):
+    def get_chain(self) -> BaseChain:
         if self._chain is None:
-            self._chain = self.chain_class(self.db_manager.get_db())
+            self._chain = self.chain_class(self.db_manager.get_db())  # type: ignore
 
         return self._chain
 

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -46,7 +46,7 @@ class LightNode(Node):
         self._discovery = DiscoveryService(self._discovery_proto, self._peer_pool)
         self.add_service(self._peer_pool)
 
-    async def _run(self):
+    async def _run(self) -> None:
         # TODO add a datagram endpoint service that can be added with self.add_service
         self.logger.info(
             "enode://%s@%s:%s",

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -1,12 +1,34 @@
 from cytoolz import (
     identity,
 )
+from typing import (
+    Dict,
+    List,
+    Union,
+)
 
+from eth_typing import (
+    Address,
+    Hash32,
+)
 from eth_utils import (
     decode_hex,
     encode_hex,
     int_to_big_endian,
     is_integer,
+)
+
+from evm.chains.base import (
+    BaseChain
+)
+from evm.rlp.blocks import (
+    BaseBlock
+)
+from evm.rlp.headers import (
+    BlockHeader
+)
+from evm.vm.state import (
+    BaseAccountDB
 )
 
 from trinity.rpc.format import (
@@ -16,13 +38,12 @@ from trinity.rpc.format import (
     to_int_if_hex,
     transaction_to_dict,
 )
-# Tell mypy to ignore this import as a workaround for https://github.com/python/mypy/issues/4049
-from trinity.rpc.modules import (  # type: ignore
+from trinity.rpc.modules import (
     RPCModule,
 )
 
 
-def get_header(chain, at_block):
+def get_header(chain: BaseChain, at_block: Union[str, int]) -> BlockHeader:
     if at_block == 'pending':
         at_header = chain.header
     elif at_block == 'latest':
@@ -30,7 +51,9 @@ def get_header(chain, at_block):
     elif at_block == 'earliest':
         # TODO find if genesis block can be non-zero. Why does 'earliest' option even exist?
         at_header = chain.get_canonical_block_by_number(0).header
-    elif is_integer(at_block) and at_block >= 0:
+    # mypy doesn't have user defined type guards yet
+    # https://github.com/python/mypy/issues/5206
+    elif is_integer(at_block) and at_block >= 0:  # type: ignore
         at_header = chain.get_canonical_block_by_number(at_block).header
     else:
         raise TypeError("Unrecognized block reference: %r" % at_block)
@@ -38,14 +61,18 @@ def get_header(chain, at_block):
     return at_header
 
 
-def account_db_at_block(chain, at_block, read_only=True):
+def account_db_at_block(chain: BaseChain,
+                        at_block: Union[str, int],
+                        read_only: bool=True) ->BaseAccountDB:
     at_header = get_header(chain, at_block)
     vm = chain.get_vm(at_header)
     return vm.state.account_db
 
 
-def get_block_at_number(chain, at_block):
-    if is_integer(at_block) and at_block >= 0:
+def get_block_at_number(chain: BaseChain, at_block: Union[str, int]) -> BaseBlock:
+    # mypy doesn't have user defined type guards yet
+    # https://github.com/python/mypy/issues/5206
+    if is_integer(at_block) and at_block >= 0:  # type: ignore
         # optimization to avoid requesting block, then header, then block again
         return chain.get_canonical_block_by_number(at_block)
     else:
@@ -60,54 +87,58 @@ class Eth(RPCModule):
     Any attribute without an underscore is publicly accessible.
     '''
 
-    def accounts(self):
+    def accounts(self) -> None:
         raise NotImplementedError()
 
-    def blockNumber(self):
+    def blockNumber(self) -> str:
         num = self._chain.get_canonical_head().block_number
         return hex(num)
 
-    def coinbase(self):
+    def coinbase(self) -> Hash32:
         raise NotImplementedError()
 
-    def gasPrice(self):
+    def gasPrice(self) -> int:
         raise NotImplementedError()
 
     @format_params(decode_hex, to_int_if_hex)
-    def getBalance(self, address, at_block):
+    def getBalance(self, address: Address, at_block: Union[str, int]) -> str:
         account_db = account_db_at_block(self._chain, at_block)
         balance = account_db.get_balance(address)
 
         return hex(balance)
 
     @format_params(decode_hex, identity)
-    def getBlockByHash(self, block_hash, include_transactions):
+    def getBlockByHash(self,
+                       block_hash: Hash32,
+                       include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
         block = self._chain.get_block_by_hash(block_hash)
         return block_to_dict(block, self._chain, include_transactions)
 
     @format_params(to_int_if_hex, identity)
-    def getBlockByNumber(self, at_block, include_transactions):
+    def getBlockByNumber(self,
+                         at_block: Union[str, int],
+                         include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
         block = get_block_at_number(self._chain, at_block)
         return block_to_dict(block, self._chain, include_transactions)
 
     @format_params(decode_hex)
-    def getBlockTransactionCountByHash(self, block_hash):
+    def getBlockTransactionCountByHash(self, block_hash: Hash32) -> str:
         block = self._chain.get_block_by_hash(block_hash)
         return hex(len(block.transactions))
 
     @format_params(to_int_if_hex)
-    def getBlockTransactionCountByNumber(self, at_block):
+    def getBlockTransactionCountByNumber(self, at_block: Union[str, int]) -> str:
         block = get_block_at_number(self._chain, at_block)
         return hex(len(block.transactions))
 
     @format_params(decode_hex, to_int_if_hex)
-    def getCode(self, address, at_block):
+    def getCode(self, address: Address, at_block: Union[str, int]) -> str:
         account_db = account_db_at_block(self._chain, at_block)
         code = account_db.get_code(address)
         return encode_hex(code)
 
     @format_params(decode_hex, to_int_if_hex, to_int_if_hex)
-    def getStorageAt(self, address, position, at_block):
+    def getStorageAt(self, address: Address, position: int, at_block: Union[str, int]) -> str:
         if not is_integer(position) or position < 0:
             raise TypeError("Position of storage must be a whole number, but was: %r" % position)
 
@@ -116,53 +147,57 @@ class Eth(RPCModule):
         return encode_hex(int_to_big_endian(stored_val))
 
     @format_params(decode_hex, to_int_if_hex)
-    def getTransactionByBlockHashAndIndex(self, block_hash, index):
+    def getTransactionByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
         block = self._chain.get_block_by_hash(block_hash)
         transaction = block.transactions[index]
         return transaction_to_dict(transaction)
 
     @format_params(to_int_if_hex, to_int_if_hex)
-    def getTransactionByBlockNumberAndIndex(self, at_block, index):
+    def getTransactionByBlockNumberAndIndex(self,
+                                            at_block: Union[str, int],
+                                            index: int) -> Dict[str, str]:
         block = get_block_at_number(self._chain, at_block)
         transaction = block.transactions[index]
         return transaction_to_dict(transaction)
 
     @format_params(decode_hex, to_int_if_hex)
-    def getTransactionCount(self, address, at_block):
+    def getTransactionCount(self, address: Address, at_block: Union[str, int]) -> str:
         account_db = account_db_at_block(self._chain, at_block)
         nonce = account_db.get_nonce(address)
         return hex(nonce)
 
     @format_params(decode_hex)
-    def getUncleCountByBlockHash(self, block_hash):
+    def getUncleCountByBlockHash(self, block_hash: Hash32) -> str:
         block = self._chain.get_block_by_hash(block_hash)
         return hex(len(block.uncles))
 
     @format_params(to_int_if_hex)
-    def getUncleCountByBlockNumber(self, at_block):
+    def getUncleCountByBlockNumber(self, at_block: Union[str, int]) -> str:
         block = get_block_at_number(self._chain, at_block)
         return hex(len(block.uncles))
 
     @format_params(decode_hex, to_int_if_hex)
-    def getUncleByBlockHashAndIndex(self, block_hash, index):
+    def getUncleByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
         block = self._chain.get_block_by_hash(block_hash)
         uncle = block.uncles[index]
         return header_to_dict(uncle)
 
     @format_params(to_int_if_hex, to_int_if_hex)
-    def getUncleByBlockNumberAndIndex(self, at_block, index):
+    def getUncleByBlockNumberAndIndex(self,
+                                      at_block: Union[str, int],
+                                      index: int) -> Dict[str, str]:
         block = get_block_at_number(self._chain, at_block)
         uncle = block.uncles[index]
         return header_to_dict(uncle)
 
-    def hashrate(self):
+    def hashrate(self) -> str:
         raise NotImplementedError()
 
-    def mining(self):
+    def mining(self) -> bool:
         return False
 
-    def protocolVersion(self):
+    def protocolVersion(self) -> str:
         return "63"
 
-    def syncing(self):
+    def syncing(self) -> bool:
         raise NotImplementedError()

--- a/trinity/rpc/modules/evm.py
+++ b/trinity/rpc/modules/evm.py
@@ -1,7 +1,13 @@
+from typing import (
+    Any
+)
 from eth_utils import (
     encode_hex,
 )
 
+from evm.chains.base import (
+    Chain
+)
 from evm.tools.fixture_tests import (
     apply_fixture_block_to_chain,
     new_chain_from_fixture,
@@ -12,15 +18,14 @@ from evm.tools.fixture_tests import (
 from trinity.rpc.format import (
     format_params,
 )
-# Tell mypy to ignore this import as a workaround for https://github.com/python/mypy/issues/4049
-from trinity.rpc.modules import (  # type: ignore
+from trinity.rpc.modules import (
     RPCModule,
 )
 
 
 class EVM(RPCModule):
     @format_params(normalize_blockchain_fixtures)
-    def resetToGenesisFixture(self, chain_info):
+    def resetToGenesisFixture(self, chain_info: Any) -> Chain:
         '''
         This method is a special case. It returns a new chain object
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`
@@ -29,7 +34,7 @@ class EVM(RPCModule):
         return new_chain_from_fixture(chain_info)
 
     @format_params(normalize_block)
-    def applyBlockFixture(self, block_info):
+    def applyBlockFixture(self, block_info: Any) -> str:
         '''
         This method is a special case. It returns a new chain object
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`

--- a/trinity/rpc/modules/main.py
+++ b/trinity/rpc/modules/main.py
@@ -1,9 +1,18 @@
+from evm.chains.base import (
+    BaseChain
+)
+
+from p2p.service import (
+    BaseService,
+)
+
+
 class RPCModule:
     _chain = None
 
-    def __init__(self, chain=None, p2p_server=None):
+    def __init__(self, chain: BaseChain=None, p2p_server: BaseService=None) -> None:
         self._chain = chain
         self._p2p_server = p2p_server
 
-    def set_chain(self, chain):
+    def set_chain(self, chain: BaseChain) -> None:
         self._chain = chain

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -1,30 +1,35 @@
-# Tell mypy to ignore this import as a workaround for https://github.com/python/mypy/issues/4049
-from trinity.rpc.modules import (  # type: ignore
+from trinity.rpc.modules import (
     RPCModule,
 )
 
 
 class Net(RPCModule):
-    def version(self):
+    def version(self) -> str:
         """
         Returns the current network ID.
         """
         return str(self._chain.network_id)
 
-    def peerCount(self):
+    def peerCount(self) -> str:
         """
         Return the number of peers that are currently connected to the node
         """
-        if self._p2p_server.peer_pool is None:
+        # We don't have a common type that exposes a peer_pool field
+        # inject PeerPool directly when the following issue is solved
+        # https://github.com/ethereum/py-evm/pull/934
+        if self._p2p_server.peer_pool is None:  # type: ignore
             return '0x0'
 
-        return hex(len(self._p2p_server.peer_pool))
+        return hex(len(self._p2p_server.peer_pool))  # type: ignore
 
-    def listening(self):
+    def listening(self) -> bool:
         """
         Return `True` if the client is actively listening for network connections
         """
-        if self._p2p_server.peer_pool is None:
+        # We don't have a common type that exposes a peer_pool field
+        # inject PeerPool directly when the following issue is solved
+        # https://github.com/ethereum/py-evm/pull/934
+        if self._p2p_server.peer_pool is None:  # type: ignore
             return False
 
         return True

--- a/trinity/rpc/modules/web3.py
+++ b/trinity/rpc/modules/web3.py
@@ -3,20 +3,19 @@ from eth_utils import decode_hex, encode_hex
 
 from trinity.utils.version import construct_trinity_client_identifier
 
-# Tell mypy to ignore this import as a workaround for https://github.com/python/mypy/issues/4049
-from trinity.rpc.modules import (  # type: ignore
+from trinity.rpc.modules import (
     RPCModule,
 )
 
 
 class Web3(RPCModule):
-    def clientVersion(self):
+    def clientVersion(self) -> str:
         """
         Returns the current client version.
         """
         return construct_trinity_client_identifier()
 
-    def sha3(self, data):
+    def sha3(self, data: str) -> str:
         """
         Returns Keccak-256 of the given data.
         """

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -1,5 +1,11 @@
+import argparse
 import os
 from pathlib import Path
+from typing import (
+    Iterable,
+    Tuple,
+    Union,
+)
 
 from eth_utils import (
     decode_hex,
@@ -118,7 +124,8 @@ def load_nodekey(nodekey_path: Path) -> PrivateKey:
 
 
 @to_dict
-def construct_chain_config_params(args):
+def construct_chain_config_params(
+        args: argparse.Namespace) -> Iterable[Tuple[str, Union[str, Tuple[str, ...]]]]:
     """
     Helper function for constructing the kwargs to initialize a ChainConfig object.
     """

--- a/trinity/utils/mp.py
+++ b/trinity/utils/mp.py
@@ -2,7 +2,11 @@ import asyncio
 import functools
 import multiprocessing
 import os
-from typing import Callable, Any
+from typing import (
+    Any,
+    Awaitable,
+    Callable
+)
 
 
 MP_CONTEXT = os.environ.get('TRINITY_MP_CONTEXT', 'spawn')
@@ -13,7 +17,7 @@ ctx = multiprocessing.get_context(MP_CONTEXT)
 
 
 def async_method(method_name: str) -> Callable[..., Any]:
-    async def method(self, *args, **kwargs):
+    async def method(self: Any, *args: Any, **kwargs: Any) -> Awaitable[Any]:
         loop = asyncio.get_event_loop()
 
         return await loop.run_in_executor(
@@ -26,6 +30,6 @@ def async_method(method_name: str) -> Callable[..., Any]:
 
 
 def sync_method(method_name: str) -> Callable[..., Any]:
-    def method(self, *args, **kwargs):
+    def method(self: Any, *args: Any, **kwargs: Any) -> Any:
         return self._callmethod(method_name, args, kwargs)
     return method

--- a/trinity/utils/profiling.py
+++ b/trinity/utils/profiling.py
@@ -1,11 +1,15 @@
 import contextlib
 import cProfile
 import functools
-from typing import Callable
+from typing import (
+    Any,
+    Callable,
+    Iterator,
+)
 
 
 @contextlib.contextmanager
-def profiler(filename):
+def profiler(filename: str) -> Iterator[None]:
     pr = cProfile.Profile()
     pr.enable()
     try:
@@ -15,10 +19,10 @@ def profiler(filename):
         pr.dump_stats(filename)
 
 
-def setup_cprofiler(filename):
-    def outer(fn: Callable) -> Callable:
+def setup_cprofiler(filename: str) -> Callable[..., Any]:
+    def outer(fn: Callable[..., Any]) -> Callable[..., Any]:
         @functools.wraps(fn)
-        def inner(*args, **kwargs):
+        def inner(*args: Any, **kwargs: Any) -> None:
             should_profile = kwargs.pop('profile', False)
             if should_profile:
                 with profiler(filename):

--- a/trinity/utils/version.py
+++ b/trinity/utils/version.py
@@ -3,7 +3,7 @@ import sys
 from trinity import __version__
 
 
-def construct_trinity_client_identifier():
+def construct_trinity_client_identifier() -> str:
     """
     Constructs the client identifier string
 

--- a/trinity/utils/xdg.py
+++ b/trinity/utils/xdg.py
@@ -11,28 +11,28 @@ from .filesystem import (
 )
 
 
-def get_home():
+def get_home() -> str:
     try:
         return os.environ['HOME']
     except KeyError:
         raise AmbigiousFileSystem('$HOME environment variable not set')
 
 
-def get_xdg_cache_home():
+def get_xdg_cache_home() -> str:
     try:
         return os.environ['XDG_CACHE_HOME']
     except KeyError:
         return os.path.join(get_home(), '.cache')
 
 
-def get_xdg_config_home():
+def get_xdg_config_home() -> str:
     try:
         return os.environ['XDG_CONFIG_HOME']
     except KeyError:
         return os.path.join(get_home(), '.config')
 
 
-def get_xdg_data_home():
+def get_xdg_data_home() -> str:
     try:
         return os.environ['XDG_DATA_HOME']
     except KeyError:


### PR DESCRIPTION
### What was wrong?

- The Trinity code base mixed typed defs with untyped defs and the
- `mypy` didn't protect us from further untyped defs landing in the code base
- `mypy` didn't protect us from implicit `Any` in generics (e.g. `Queue` which implicitly becomes `Queue[Any]`)
- there were lots of places that used `# type: ignore` effectively silencing `mypy`

### How was it fixed?

- added all missing type annotations for Trinity
- enabled  `--disallow-untyped-defs` and `--disallow-untyped-defs` for Trinity to protect the code base from further untyped defs to land
- removed almost all `# type: ignore` comments from Trinity

### Known issues

- There are some places typed as `Any` that could be further improved
- There's one `# type: ignore` because `EmptyService` isn't a proper substitute for `IPCServer` (no common base clase, no matching `run(...)` signature. I didn't want to address this in this PR though.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://c1.staticflickr.com/5/4732/25485530618_196b2d7412_b.jpg)
