### PR TITLE
Use Path.exists() instead of os.path.exists(str)

### DIFF
--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -1,14 +1,15 @@
 import os
+import pathlib
 import signal
 import time
 from multiprocessing import Process
 from logging import Logger
 
 
-def wait_for_ipc(ipc_path: str, timeout: int=1) -> None:
+def wait_for_ipc(ipc_path: pathlib.Path, timeout: int=1) -> None:
     start_at = time.time()
     while time.time() - start_at < timeout:
-        if os.path.exists(ipc_path):
+        if ipc_path.exists():
             break
         time.sleep(0.05)
 


### PR DESCRIPTION
### What was wrong?

Path handling used old fashioned `os.path.exists(str)` style even though we are dealing with a `pathlib.Path`

### How was it fixed?

This is just a tiny refactoring making use of `Path.exists()` rather than `os.path.exists(str)`. Stumbled over this while working on #927 but I want keep #927 free from any changes that aren't type hints so that its less pain to review.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://upload.wikimedia.org/wikipedia/commons/a/af/Aris-wild-koala-tongue-out-130116p22lowres.jpg)
