### PR TITLE
Move methods from trinity to tests

### DIFF
--- a/trinity/rpc/format.py
+++ b/trinity/rpc/format.py
@@ -2,11 +2,9 @@ import functools
 
 from cytoolz import (
     compose,
-    identity,
 )
 
 from eth_utils import (
-    add_0x_prefix,
     encode_hex,
     int_to_big_endian,
 )
@@ -99,67 +97,3 @@ def empty_to_0x(val):
 
 
 remove_leading_zeros = compose(hex, functools.partial(int, base=16))
-
-RPC_STATE_NORMALIZERS = {
-    'balance': remove_leading_zeros,
-    'code': empty_to_0x,
-    'nonce': remove_leading_zeros,
-}
-
-
-def fixture_state_in_rpc_format(state):
-    return {
-        key: RPC_STATE_NORMALIZERS.get(key, identity)(value)
-        for key, value in state.items()
-    }
-
-
-RPC_BLOCK_REMAPPERS = {
-    'bloom': 'logsBloom',
-    'coinbase': 'miner',
-    'transactionsTrie': 'transactionsRoot',
-    'uncleHash': 'sha3Uncles',
-    'receiptTrie': 'receiptsRoot',
-}
-
-RPC_BLOCK_NORMALIZERS = {
-    'difficulty': remove_leading_zeros,
-    'extraData': empty_to_0x,
-    'gasLimit': remove_leading_zeros,
-    'gasUsed': remove_leading_zeros,
-    'number': remove_leading_zeros,
-    'timestamp': remove_leading_zeros,
-}
-
-
-def fixture_block_in_rpc_format(state):
-    return {
-        RPC_BLOCK_REMAPPERS.get(key, key):
-        RPC_BLOCK_NORMALIZERS.get(key, identity)(value)
-        for key, value in state.items()
-    }
-
-
-RPC_TRANSACTION_REMAPPERS = {
-    'data': 'input',
-}
-
-RPC_TRANSACTION_NORMALIZERS = {
-    'nonce': remove_leading_zeros,
-    'gasLimit': remove_leading_zeros,
-    'gasPrice': remove_leading_zeros,
-    'value': remove_leading_zeros,
-    'data': empty_to_0x,
-    'to': add_0x_prefix,
-    'r': remove_leading_zeros,
-    's': remove_leading_zeros,
-    'v': remove_leading_zeros,
-}
-
-
-def fixture_transaction_in_rpc_format(state):
-    return {
-        RPC_TRANSACTION_REMAPPERS.get(key, key):
-        RPC_TRANSACTION_NORMALIZERS.get(key, identity)(value)
-        for key, value in state.items()
-    }


### PR DESCRIPTION
### What was wrong?

There were some methods in `trinity.rpc.formatter` that weren't used by trinity at all. They were used in the tests though.

### How was it fixed?

Moved methods to tests as they seem to have no business in trinity.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.animalgalleries.org/albums/Small-Land-Mammals/Fox-Galleries/Fennec-Fox-Gallery/Fennec%20Fox%20cute%20ears%20family%20pups.jpg)
