### PR TITLE
p2p: Move peer-discovery out of PeerPool

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -12,8 +12,8 @@ import time
 from typing import (
     Any,
     Callable,
-    Generator,
     Hashable,
+    Iterator,
     List,
     Set,
     Sized,
@@ -231,7 +231,7 @@ class RoutingTable:
         self.this_node = node
         self.buckets = [KBucket(0, k_max_node_id)]
 
-    def get_random_nodes(self, count: int) -> Generator[Node, None, None]:
+    def get_random_nodes(self, count: int) -> Iterator[Node]:
         if count > len(self):
             self.logger.warn(
                 "Cannot get %d nodes as RoutingTable contains only %d nodes", count, len(self))
@@ -345,7 +345,7 @@ class CallbackManager(collections.UserDict):
     @contextlib.contextmanager
     def acquire(self,
                 key: Hashable,
-                callback: Callable[..., Any]) -> Generator[CallbackLock, None, None]:
+                callback: Callable[..., Any]) -> Iterator[CallbackLock]:
         if key in self:
             if not self.locked(key):
                 del self[key]

--- a/tests/p2p/peer_helpers.py
+++ b/tests/p2p/peer_helpers.py
@@ -141,8 +141,7 @@ async def get_directly_linked_peers(
 class MockPeerPoolWithConnectedPeers(PeerPool):
 
     def __init__(self, peers: List[BasePeer]) -> None:
-        super().__init__(
-            peer_class=None, headerdb=None, network_id=None, privkey=None, discovery=None)
+        super().__init__(peer_class=None, headerdb=None, network_id=None, privkey=None)
         for peer in peers:
             self.connected_nodes[peer.remote] = peer
 

--- a/tests/p2p/test_server.py
+++ b/tests/p2p/test_server.py
@@ -131,10 +131,9 @@ async def test_peer_pool_connect(monkeypatch, event_loop, receiver_server_with_d
     monkeypatch.setattr(receiver_server_with_dumb_peer, 'peer_pool', MockPeerPool())
 
     network_id = 1
-    discovery = None
-    pool = PeerPool(DumbPeer, HeaderDB(MemoryDB()), network_id, INITIATOR_PRIVKEY, discovery)
+    pool = PeerPool(DumbPeer, HeaderDB(MemoryDB()), network_id, INITIATOR_PRIVKEY)
     nodes = [RECEIVER_REMOTE]
-    await pool._connect_to_nodes(nodes)
+    await pool.connect_to_nodes(nodes)
     # Give the receiver_server a chance to ack the handshake.
     await asyncio.sleep(0.1)
 

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -1,7 +1,4 @@
 from evm.chains.base import BaseChain
-from p2p.peer import (
-    PreferredNodePeerPool,
-)
 from p2p.server import Server
 from p2p.service import BaseService
 
@@ -19,6 +16,7 @@ class FullNode(Node):
         super().__init__(chain_config)
 
         self._bootstrap_nodes = chain_config.bootstrap_nodes
+        self._preferred_nodes = chain_config.preferred_nodes
         self._network_id = chain_config.network_id
         self._node_key = chain_config.nodekey
         self._node_port = chain_config.port
@@ -42,8 +40,8 @@ class FullNode(Node):
                 manager.get_db(),  # type: ignore
                 self._network_id,
                 max_peers=self._max_peers,
-                peer_pool_class=PreferredNodePeerPool,
                 bootstrap_nodes=self._bootstrap_nodes,
+                preferred_nodes=self._preferred_nodes,
                 token=self.cancel_token,
             )
         return self._p2p_server


### PR DESCRIPTION
We now have a separate service (DiscoveryService) that performs
discovery, when needed, and adds the peers to its PeerPool

Motivated by the discussion in #886, but also because discovery
shouldn't really be the responsibility of PeerPool