### PR TITLE
Pass PeerPool to RPCModules

### DIFF
--- a/tests/trinity/conftest.py
+++ b/tests/trinity/conftest.py
@@ -73,7 +73,7 @@ def ipc_server(
     used as a fixture, so it doesn't return (yield) a value.
     '''
 
-    rpc = RPCServer(chain_with_block_validation, p2p_server)
+    rpc = RPCServer(chain_with_block_validation, p2p_server.peer_pool)
     ipc_server = IPCServer(rpc, jsonrpc_ipc_pipe_path)
 
     asyncio.ensure_future(ipc_server.run(loop=event_loop), loop=event_loop)

--- a/tests/trinity/core/json-rpc/test_ipc.py
+++ b/tests/trinity/core/json-rpc/test_ipc.py
@@ -99,26 +99,15 @@ def p2p_server(monkeypatch, p2p_server, mock_peer_pool):
             {'result': '0x0', 'id': 3, 'jsonrpc': '2.0'},
         ),
         (
-            build_request('net_peerCount'),
-            None,
-            {'result': '0x0', 'id': 3, 'jsonrpc': '2.0'},
-        ),
-        (
             build_request('net_listening'),
             MockPeerPool(),
             {'result': True, 'id': 3, 'jsonrpc': '2.0'},
-        ),
-        (
-            build_request('net_listening'),
-            None,
-            {'result': False, 'id': 3, 'jsonrpc': '2.0'},
         ),
     ),
     ids=[
         'empty', 'notamethod', 'eth_mining', 'web3_clientVersion',
         'web3_sha3_1', 'web3_sha3_2', 'net_version', 'net_peerCount_1',
-        'net_peerCount_0', 'net_peerCount_no_peer_pool', 'net_listening_true',
-        'net_listening_false'
+        'net_peerCount_0', 'net_listening_true',
     ],
 )
 async def test_ipc_requests(jsonrpc_ipc_pipe_path,

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -12,6 +12,9 @@ from typing import (
 
 from evm.chains.base import BaseChain
 
+from p2p.peer import (
+    PeerPool
+)
 from p2p.service import (
     BaseService,
     EmptyService,
@@ -62,6 +65,10 @@ class Node(BaseService):
         raise NotImplementedError("Node classes must implement this method")
 
     @abstractmethod
+    def get_peer_pool(self) -> PeerPool:
+        raise NotImplementedError("Node classes must implement this method")
+
+    @abstractmethod
     def get_p2p_server(self) -> BaseService:
         """
         This is the main service that will be run, when calling :meth:`run`.
@@ -85,7 +92,7 @@ class Node(BaseService):
 
     def make_ipc_server(self) -> Union[IPCServer, EmptyService]:
         if self._jsonrpc_ipc_path:
-            rpc = RPCServer(self.get_chain(), self.get_p2p_server())
+            rpc = RPCServer(self.get_chain(), self.get_peer_pool())
             return IPCServer(rpc, self._jsonrpc_ipc_path)
         else:
             return EmptyService()

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -2,8 +2,12 @@ from evm.chains.base import (
     BaseChain
 )
 
-from p2p.server import Server
-from p2p.service import BaseService
+from p2p.peer import (
+    PeerPool,
+)
+from p2p.server import (
+    Server
+)
 
 from trinity.nodes.base import Node
 from trinity.config import (
@@ -13,7 +17,7 @@ from trinity.config import (
 
 class FullNode(Node):
     _chain: BaseChain = None
-    _p2p_server: BaseService = None
+    _p2p_server: Server = None
 
     def __init__(self, chain_config: ChainConfig) -> None:
         super().__init__(chain_config)
@@ -31,7 +35,7 @@ class FullNode(Node):
 
         return self._chain
 
-    def get_p2p_server(self) -> BaseService:
+    def get_p2p_server(self) -> Server:
         if self._p2p_server is None:
             manager = self.db_manager
             self._p2p_server = Server(
@@ -48,3 +52,6 @@ class FullNode(Node):
                 token=self.cancel_token,
             )
         return self._p2p_server
+
+    def get_peer_pool(self) -> PeerPool:
+        return self.get_p2p_server().peer_pool

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -81,6 +81,9 @@ class LightNode(Node):
             self._p2p_server = LightPeerChain(self.headerdb, self._peer_pool, self.chain_class)
         return self._p2p_server
 
+    def get_peer_pool(self) -> PeerPool:
+        return self._peer_pool
+
     def _create_peer_pool(self, chain_config: ChainConfig) -> PeerPool:
         return PeerPool(
             LESPeer,

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -14,6 +14,10 @@ from evm.exceptions import (
     ValidationError,
 )
 
+from p2p.peer import (
+    PeerPool
+)
+
 from trinity.rpc.modules import (
     Eth,
     EVM,
@@ -69,11 +73,11 @@ class RPCServer:
         Web3,
     )
 
-    def __init__(self, chain: BaseChain, p2p_server: Any=None) -> None:
+    def __init__(self, chain: BaseChain=None, peer_pool: PeerPool=None) -> None:
         self.modules: Dict[str, RPCModule] = {}
         self.chain = chain
         for M in self.module_classes:
-            self.modules[M.__name__.lower()] = M(chain, p2p_server)
+            self.modules[M.__name__.lower()] = M(chain, peer_pool)
         if len(self.modules) != len(self.module_classes):
             raise ValueError("apparent name conflict in RPC module_classes", self.module_classes)
 

--- a/trinity/rpc/modules/main.py
+++ b/trinity/rpc/modules/main.py
@@ -2,17 +2,17 @@ from evm.chains.base import (
     BaseChain
 )
 
-from p2p.service import (
-    BaseService,
+from p2p.peer import (
+    PeerPool,
 )
 
 
 class RPCModule:
     _chain = None
 
-    def __init__(self, chain: BaseChain=None, p2p_server: BaseService=None) -> None:
+    def __init__(self, chain: BaseChain, peer_pool: PeerPool) -> None:
         self._chain = chain
-        self._p2p_server = p2p_server
+        self._peer_pool = peer_pool
 
     def set_chain(self, chain: BaseChain) -> None:
         self._chain = chain

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -14,22 +14,10 @@ class Net(RPCModule):
         """
         Return the number of peers that are currently connected to the node
         """
-        # We don't have a common type that exposes a peer_pool field
-        # inject PeerPool directly when the following issue is solved
-        # https://github.com/ethereum/py-evm/pull/934
-        if self._p2p_server.peer_pool is None:  # type: ignore
-            return '0x0'
-
-        return hex(len(self._p2p_server.peer_pool))  # type: ignore
+        return hex(len(self._peer_pool))  # type: ignore
 
     def listening(self) -> bool:
         """
         Return `True` if the client is actively listening for network connections
         """
-        # We don't have a common type that exposes a peer_pool field
-        # inject PeerPool directly when the following issue is solved
-        # https://github.com/ethereum/py-evm/pull/934
-        if self._p2p_server.peer_pool is None:  # type: ignore
-            return False
-
         return True


### PR DESCRIPTION
### What was wrong?

Previously the RPCModules had to deal with either a Server or a LightPeerChain which both just happend to had a `peer_pool` property that the RPCModules could read from.

That alone prevented us from properly typing things out which is why we silenced mypy.

Furthermore, the reason we had it this way was because the `peer_pool` property appeared asynchronously on the server and hence the RPCModules had to check for its existence.

Since we have the PeerPool available synchronously now, we don't need that hack anymore.

### How was it fixed?

Refactored code so that the `RPCModule` deals with `PeerPool` directly

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://c1.staticflickr.com/8/7713/27447462060_9daa68514d_b.jpg)
