### PR TITLE
Inherit from ABC rather than setting metaclass

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod
 )
 import operator
@@ -102,7 +102,7 @@ if TYPE_CHECKING:
 AccountState = Dict[Address, Dict[str, Union[int, bytes, Dict[int, int]]]]
 
 
-class BaseChain(Configurable, metaclass=ABCMeta):
+class BaseChain(Configurable, ABC):
     """
     The base class for all Chain objects
     """

--- a/evm/chains/header.py
+++ b/evm/chains/header.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from typing import Dict, Any, Tuple, Type  # noqa: F401
 
 from eth_typing import (
@@ -18,7 +18,7 @@ from evm.utils.datatypes import (
 from evm.vm.base import BaseVM  # noqa: F401
 
 
-class BaseHeaderChain(Configurable, metaclass=ABCMeta):
+class BaseHeaderChain(Configurable, ABC):
     _base_db = None  # type: BaseDB
 
     _headerdb_class = None  # type: Type[BaseHeaderDB]

--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -1,5 +1,5 @@
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod
 )
 from uuid import UUID
@@ -59,7 +59,7 @@ from .hash_trie import HashTrie
 account_cache = LRU(2048)
 
 
-class BaseAccountDB(metaclass=ABCMeta):
+class BaseAccountDB(ABC):
 
     @abstractmethod
     def __init__(self) -> None:

--- a/evm/db/backends/base.py
+++ b/evm/db/backends/base.py
@@ -1,5 +1,5 @@
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod
 )
 from collections.abc import (
@@ -7,7 +7,7 @@ from collections.abc import (
 )
 
 
-class BaseDB(MutableMapping, metaclass=ABCMeta):
+class BaseDB(MutableMapping, ABC):
     """
     This is an abstract key/value lookup with all :class:`bytes` values,
     with some convenience methods for databases. As much as possible,

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -2,7 +2,7 @@ import functools
 import itertools
 
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod
 )
 from typing import (
@@ -76,7 +76,7 @@ class TransactionKey(rlp.Serializable):
     ]
 
 
-class BaseChainDB(metaclass=ABCMeta):
+class BaseChainDB(ABC):
     db = None  # type: BaseDB
 
     @abstractmethod

--- a/evm/db/header.py
+++ b/evm/db/header.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from typing import Tuple, Iterable
 
 import rlp
@@ -30,7 +30,7 @@ from evm.validation import (
 )
 
 
-class BaseHeaderDB(metaclass=ABCMeta):
+class BaseHeaderDB(ABC):
     db = None  # type: BaseDB
 
     def __init__(self, db: BaseDB) -> None:

--- a/evm/db/schema.py
+++ b/evm/db/schema.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 from eth_typing import (
     BlockNumber,
@@ -6,7 +6,7 @@ from eth_typing import (
 )
 
 
-class BaseSchema(metaclass=ABCMeta):
+class BaseSchema(ABC):
     @staticmethod
     @abstractmethod
     def make_canonical_head_hash_lookup_key() -> bytes:

--- a/evm/rlp/blocks.py
+++ b/evm/rlp/blocks.py
@@ -1,5 +1,5 @@
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod
 )
 from typing import (  # noqa: F401
@@ -22,7 +22,7 @@ from .transactions import BaseTransaction
 from .headers import BlockHeader
 
 
-class BaseBlock(rlp.Serializable, Configurable, metaclass=ABCMeta):
+class BaseBlock(rlp.Serializable, Configurable, ABC):
     transaction_class = None  # type: Type[BaseTransaction]
 
     @classmethod

--- a/evm/rlp/transactions.py
+++ b/evm/rlp/transactions.py
@@ -1,5 +1,5 @@
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod
 )
 from typing import (
@@ -154,7 +154,7 @@ class BaseTransaction(rlp.Serializable, BaseTransactionCommonMethods):
         raise NotImplementedError("Must be implemented by subclasses")
 
 
-class BaseUnsignedTransaction(rlp.Serializable, BaseTransactionCommonMethods, metaclass=ABCMeta):
+class BaseUnsignedTransaction(rlp.Serializable, BaseTransactionCommonMethods, ABC):
     fields = [
         ('nonce', big_endian_int),
         ('gas_price', big_endian_int),

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod,
 )
 import contextlib
@@ -63,7 +63,7 @@ from evm.vm.message import (
 from evm.vm.state import BaseState  # noqa: F401
 
 
-class BaseVM(Configurable, metaclass=ABCMeta):
+class BaseVM(Configurable, ABC):
     block = None  # type: BaseBlock
     block_class = None  # type: Type[BaseBlock]
     fork = None  # type: str

--- a/evm/vm/computation.py
+++ b/evm/vm/computation.py
@@ -1,5 +1,5 @@
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod
 )
 import itertools
@@ -81,7 +81,7 @@ def memory_gas_cost(size_in_bytes: int) -> int:
     return total_cost
 
 
-class BaseComputation(Configurable, metaclass=ABCMeta):
+class BaseComputation(Configurable, ABC):
     """
     The base class for all execution computations.
 

--- a/evm/vm/logic/call.py
+++ b/evm/vm/logic/call.py
@@ -1,5 +1,5 @@
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod
 )
 
@@ -18,7 +18,7 @@ from evm.utils.address import (
 )
 
 
-class BaseCall(Opcode, metaclass=ABCMeta):
+class BaseCall(Opcode, ABC):
     @abstractmethod
     def compute_msg_extra_gas(self, computation, gas, to, value):
         raise NotImplementedError("Must be implemented by subclasses")

--- a/evm/vm/opcode.py
+++ b/evm/vm/opcode.py
@@ -2,14 +2,14 @@ import functools
 import logging
 
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod
 )
 
 from evm.utils.datatypes import Configurable
 
 
-class Opcode(Configurable, metaclass=ABCMeta):
+class Opcode(Configurable, ABC):
     mnemonic = None  # type: str
     gas_cost = None  # type: int
 

--- a/evm/vm/state.py
+++ b/evm/vm/state.py
@@ -1,5 +1,5 @@
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod
 )
 import logging
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     )
 
 
-class BaseState(Configurable, metaclass=ABCMeta):
+class BaseState(Configurable, ABC):
     """
     The base class that encapsulates all of the various moving parts related to
     the state of the VM during execution.
@@ -228,7 +228,7 @@ class BaseState(Configurable, metaclass=ABCMeta):
         raise NotImplementedError()
 
 
-class BaseTransactionExecutor(metaclass=ABCMeta):
+class BaseTransactionExecutor(ABC):
     def __init__(self, vm_state):
         self.vm_state = vm_state
 

--- a/scripts/benchmark/checks/base_benchmark.py
+++ b/scripts/benchmark/checks/base_benchmark.py
@@ -1,5 +1,5 @@
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod,
 )
 import logging
@@ -23,7 +23,7 @@ from utils.shellart import (
 )
 
 
-class BaseBenchmark(metaclass=ABCMeta):
+class BaseBenchmark(ABC):
 
     @abstractmethod
     def execute(self) -> DefaultStat:


### PR DESCRIPTION
### What was wrong?

I noticed we had some places using the following syntax:

```python
class Foo(metaclass=ABCmeta)
```
whereas others used

```python
class Foo(ABC)
```

From StackOverflow (and citing the official documentation)

https://stackoverflow.com/questions/33335005/in-python-3-4-any-difference-between-using-abc-vs-abcmeta

>New class `ABC` has `ABCMeta` as its meta class. Using ABC as a base class has essentially the same effect as specifying  `metaclass=abc.ABCMeta`, **but is simpler to type and easier to read**.

### How was it fixed?

Inherit from `ABC` rather than setting `metaclass=abc.ABCMeta`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.guineapighub.com/wp-content/uploads/2016/10/9d4374dcf06816970a4140cc0361434a.jpg)
