### PR TITLE
Get rid of old fashioned super() invocations

### DIFF
--- a/evm/rlp/accounts.py
+++ b/evm/rlp/accounts.py
@@ -33,4 +33,4 @@ class Account(rlp.Serializable):
                  storage_root: bytes=BLANK_ROOT_HASH,
                  code_hash: bytes=EMPTY_SHA3,
                  **kwargs: Any) -> None:
-        super(Account, self).__init__(nonce, balance, storage_root, code_hash, **kwargs)
+        super().__init__(nonce, balance, storage_root, code_hash, **kwargs)

--- a/evm/rlp/headers.py
+++ b/evm/rlp/headers.py
@@ -145,7 +145,7 @@ class BlockHeader(rlp.Serializable):
                  nonce=GENESIS_NONCE):
         if timestamp is None:
             timestamp = int(time.time())
-        super(BlockHeader, self).__init__(
+        super().__init__(
             parent_hash=parent_hash,
             uncles_hash=uncles_hash,
             coinbase=coinbase,

--- a/evm/rlp/logs.py
+++ b/evm/rlp/logs.py
@@ -18,7 +18,7 @@ class Log(rlp.Serializable):
     ]
 
     def __init__(self, address: bytes, topics: bytes, data: bytes) -> None:
-        super(Log, self).__init__(address, topics, data)
+        super().__init__(address, topics, data)
 
     @property
     def bloomables(self):

--- a/evm/rlp/receipts.py
+++ b/evm/rlp/receipts.py
@@ -40,7 +40,7 @@ class Receipt(rlp.Serializable):
             bloomables = itertools.chain.from_iterable(log.bloomables for log in logs)
             bloom = int(BloomFilter.from_iterable(bloomables))
 
-        super(Receipt, self).__init__(
+        super().__init__(
             state_root=state_root,
             gas_used=gas_used,
             bloom=bloom,

--- a/evm/vm/forks/frontier/blocks.py
+++ b/evm/vm/forks/frontier/blocks.py
@@ -49,7 +49,7 @@ class FrontierBlock(BaseBlock):
 
         self.bloom_filter = BloomFilter(header.bloom)
 
-        super(FrontierBlock, self).__init__(
+        super().__init__(
             header=header,
             transactions=transactions,
             uncles=uncles,

--- a/evm/vm/forks/frontier/transactions.py
+++ b/evm/vm/forks/frontier/transactions.py
@@ -54,7 +54,7 @@ class FrontierTransaction(BaseTransaction):
         validate_gte(self.v, minimum=self.v_min, title="Transaction.v")
         validate_lte(self.v, maximum=self.v_max, title="Transaction.v")
 
-        super(FrontierTransaction, self).validate()
+        super().validate()
 
     def check_signature_validity(self):
         validate_transaction_signature(self)
@@ -90,7 +90,7 @@ class FrontierUnsignedTransaction(BaseUnsignedTransaction):
             validate_canonical_address(self.to, title="Transaction.to")
         validate_uint256(self.value, title="Transaction.value")
         validate_is_bytes(self.data, title="Transaction.data")
-        super(FrontierUnsignedTransaction, self).validate()
+        super().validate()
 
     def as_signed_transaction(self, private_key):
         v, r, s = create_transaction_signature(self, private_key)

--- a/evm/vm/forks/homestead/transactions.py
+++ b/evm/vm/forks/homestead/transactions.py
@@ -23,7 +23,7 @@ from evm.utils.transactions import (
 
 class HomesteadTransaction(FrontierTransaction):
     def validate(self):
-        super(HomesteadTransaction, self).validate()
+        super().validate()
         validate_lt_secpk1n2(self.s, title="Transaction.s")
 
     def get_intrinsic_gas(self):

--- a/evm/vm/logic/call.py
+++ b/evm/vm/logic/call.py
@@ -332,7 +332,7 @@ class StaticCall(CallEIP161):
 
 class CallByzantium(CallEIP161):
     def get_call_params(self, computation):
-        call_params = super(CallByzantium, self).get_call_params(computation)
+        call_params = super().get_call_params(computation)
         value = call_params[1]
         if computation.msg.is_static and value != 0:
             raise WriteProtection("Cannot modify state while inside of a STATICCALL context")

--- a/evm/vm/logic/invalid.py
+++ b/evm/vm/logic/invalid.py
@@ -8,7 +8,7 @@ class InvalidOpcode(Opcode):
 
     def __init__(self, value):
         self.value = value
-        super(InvalidOpcode, self).__init__()
+        super().__init__()
 
     def __call__(self, computation):
         raise InvalidInstruction("Invalid opcode 0x{0:x} @ {1}".format(

--- a/evm/vm/logic/system.py
+++ b/evm/vm/logic/system.py
@@ -168,4 +168,4 @@ class CreateByzantium(CreateEIP150):
     def __call__(self, computation):
         if computation.msg.is_static:
             raise WriteProtection("Cannot modify state while inside of a STATICCALL context")
-        return super(CreateEIP150, self).__call__(computation)
+        return super().__call__(computation)

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -118,12 +118,12 @@ class Node:
 
     def __lt__(self, other):
         if not isinstance(other, self.__class__):
-            return super(Node, self).__lt__(other)
+            return super().__lt__(other)
         return self.id < other.id
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return super(Node, self).__eq__(other)
+            return super().__eq__(other)
         return self.pubkey == other.pubkey
 
     def __ne__(self, other):

--- a/p2p/les.py
+++ b/p2p/les.py
@@ -72,7 +72,7 @@ class Status(Command):
 
     @to_dict
     def decode_payload(self, rlp_data: bytes) -> Generator[Tuple[str, Any], None, None]:
-        data = cast(List[Tuple[str, bytes]], super(Status, self).decode_payload(rlp_data))
+        data = cast(List[Tuple[str, bytes]], super().decode_payload(rlp_data))
         # The LES/Status msg contains an arbitrary list of (key, value) pairs, where values can
         # have different types and unknown keys should be ignored for forward compatibility
         # reasons, so here we need an extra pass to deserialize each of the key/value pairs we
@@ -92,7 +92,7 @@ class Status(Command):
             for key, value
             in sorted(data.items())
         ]
-        return super(Status, self).encode_payload(response)
+        return super().encode_payload(response)
 
     def as_head_info(self, decoded: _DecodedMsgType) -> HeadInfo:
         decoded = cast(Dict[str, Any], decoded)

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -56,7 +56,7 @@ class Disconnect(Command):
 
     def decode(self, data: bytes) -> _DecodedMsgType:
         try:
-            raw_decoded = cast(Dict[str, int], super(Disconnect, self).decode(data))
+            raw_decoded = cast(Dict[str, int], super().decode(data))
         except rlp.exceptions.ListDeserializationError:
             self.logger.warn("Malformed Disconnect message: %s", data)
             raise MalformedMessage("Malformed Disconnect message: {0}".format(data))
@@ -79,7 +79,7 @@ class P2PProtocol(Protocol):
 
     def __init__(self, peer):
         # For the base protocol the cmd_id_offset is always 0.
-        super(P2PProtocol, self).__init__(peer, cmd_id_offset=0)
+        super().__init__(peer, cmd_id_offset=0)
 
     def send_handshake(self):
         # TODO: move import out once this is in the trinity codebase

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -20,5 +20,5 @@ class MissingPath(BaseTrinityError):
     Raised when an expected path is missing
     """
     def __init__(self, msg: str, path: pathlib.Path) -> None:
-        super(MissingPath, self).__init__(msg)
+        super().__init__(msg)
         self.path = path


### PR DESCRIPTION
### What was wrong?

[In Python 3, a call to `super()` without arguments is equivalent to `super(T, self)`](https://stackoverflow.com/questions/19776056/the-difference-between-super-method-versus-superself-class-self-method/19776143#19776143).

### How was it fixed?

Removed superflous `T, self` from all invocations.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/ee/73/0a/ee730ab1a4ce50969ede8ded84818881--cute-guinea-pigs-cute-hamsters.jpg)
