### PR TITLE
Make register_peer of PeerPoolSubscriber non-abstract

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -536,9 +536,16 @@ class ETHPeer(BasePeer):
 class PeerPoolSubscriber(ABC):
     _msg_queue: 'asyncio.Queue[PEER_MSG_TYPE]' = None
 
-    @abstractmethod
     def register_peer(self, peer: BasePeer) -> None:
-        raise NotImplementedError("Must be implemented by subclasses")
+        """
+        Notify about each registered peer in the :class:`~p2p.peer.PeerPool`. Is called upon
+        subscription for each :class:`~p2p.peer.BasePeer` that exists in the pool at that time and
+        then for each :class:`~p2p.peer.BasePeer` that joins the pool later on.
+
+        A :class:`~p2p.peer.PeerPoolSubscriber` that wants to act upon peer registration needs to
+        overwrite this method to provide an implementation.
+        """
+        pass
 
     @property
     def msg_queue(self) -> 'asyncio.Queue[PEER_MSG_TYPE]':

--- a/p2p/shard_syncer.py
+++ b/p2p/shard_syncer.py
@@ -42,7 +42,6 @@ from p2p.cancel_token import (
 )
 from p2p.service import BaseService
 from p2p.peer import (
-    BasePeer,
     PeerPool,
     PeerPoolSubscriber,
 )
@@ -109,9 +108,6 @@ class ShardSyncer(BaseService, PeerPoolSubscriber):
     #
     # Peer handling
     #
-    def register_peer(self, peer: BasePeer) -> None:
-        pass
-
     async def _run(self) -> None:
         with self.subscribe(self.peer_pool):
             while True:

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -33,7 +33,7 @@ from p2p import eth
 from p2p import protocol
 from p2p.cancel_token import CancelToken
 from p2p.exceptions import OperationCancelled
-from p2p.peer import BasePeer, ETHPeer, PeerPool, PeerPoolSubscriber
+from p2p.peer import ETHPeer, PeerPool, PeerPoolSubscriber
 from p2p.service import BaseService
 from p2p.utils import get_process_pool_executor
 
@@ -58,9 +58,6 @@ class StateDownloader(BaseService, PeerPoolSubscriber):
         self.scheduler = StateSync(root_hash, account_db)
         self._peers_with_pending_requests: Dict[ETHPeer, float] = {}
         self._executor = get_process_pool_executor()
-
-    def register_peer(self, peer: BasePeer) -> None:
-        pass
 
     @property
     def idle_peers(self) -> List[ETHPeer]:


### PR DESCRIPTION
### What was wrong?

Three out of five `PeerPoolSubscriber` do not actually need to act upon the registration of other peers (counting the TxPool as well that still sits in a PR).

Instead, the majority of `PeerPoolSubscriber` provides the following implementation for `register_peer`

```python
    def register_peer(self, peer: BasePeer) -> None:
        pass
```
This strikes me as a hint that `register_peer` isn't a great candidate for being an abstract method on `PeerPoolSubscriber`.

### How was it fixed?

I considered moving it to a whole different abstract class but it strikes me as most natural to keep it on `PeerPoolSubscriber` but just don't dictate to overwrite it.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/9c/65/73/9c6573dfff65de3d68075359d135df31--country-babies-country-life.jpg)
