### PR TITLE
trinity: Proper cleanup in RopstenLightNode

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -323,8 +323,9 @@ class DiscoveryService(BaseService):
     _last_lookup: float = 0
     _lookup_interval: int = 30
 
-    def __init__(self, proto: DiscoveryProtocol, peer_pool: PeerPool) -> None:
-        super().__init__()
+    def __init__(
+            self, proto: DiscoveryProtocol, peer_pool: PeerPool, token: CancelToken = None) -> None:
+        super().__init__(token)
         self.proto = proto
         self.peer_pool = peer_pool
 

--- a/p2p/lightchain.py
+++ b/p2p/lightchain.py
@@ -46,6 +46,7 @@ from p2p.exceptions import (
     OperationCancelled,
     TooManyTimeouts,
 )
+from p2p.cancel_token import CancelToken
 from p2p import les
 from p2p import protocol
 from p2p.constants import REPLY_TIMEOUT
@@ -78,8 +79,10 @@ class LightPeerChain(PeerPoolSubscriber, BaseService):
             self,
             headerdb: 'BaseAsyncHeaderDB',
             peer_pool: PeerPool,
-            chain_class: Type[BaseChain]) -> None:
-        super().__init__()
+            chain_class: Type[BaseChain],
+            token: CancelToken = None) -> None:
+        PeerPoolSubscriber.__init__(self)
+        BaseService.__init__(self, token)
         self.headerdb = headerdb
         self.peer_pool = peer_pool
         self._announcement_queue: asyncio.Queue[Tuple[LESPeer, les.HeadInfo]] = asyncio.Queue()
@@ -258,7 +261,7 @@ class LightPeerChain(PeerPoolSubscriber, BaseService):
             VM.validate_header(header, parent_header)
 
     async def _cleanup(self):
-        self.logger.info("Stopping LightPeerChain...")
+        pass
 
     async def _wait_for_reply(self, request_id: int) -> Dict[str, Any]:
         reply = None

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -676,8 +676,9 @@ class PeerPool(BaseService):
                  privkey: datatypes.PrivateKey,
                  vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...],
                  max_peers: int = DEFAULT_MAX_PEERS,
+                 token: CancelToken = None,
                  ) -> None:
-        super().__init__()
+        super().__init__(token)
         self.peer_class = peer_class
         self.headerdb = headerdb
         self.network_id = network_id

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -183,6 +183,9 @@ def main() -> None:
         logger.info('Keyboard Interrupt: Stopping')
         kill_process_gracefully(database_server_process, logger)
         logger.info('DB server process (pid=%d) terminated', database_server_process.pid)
+        # XXX: This short sleep here seems to avoid us hitting a deadlock when attempting to
+        # join() the networking subprocess: https://github.com/ethereum/py-evm/issues/940
+        import time; time.sleep(0.2)  # noqa: E702
         kill_process_gracefully(networking_process, logger)
         logger.info('Networking process (pid=%d) terminated', networking_process.pid)
 

--- a/trinity/tx_pool/pool.py
+++ b/trinity/tx_pool/pool.py
@@ -13,6 +13,7 @@ from bloom_filter import (
 from evm.rlp.transactions import (
     BaseTransactionFields
 )
+from p2p.cancel_token import CancelToken
 from p2p.eth import (
     Transactions
 )
@@ -40,8 +41,8 @@ class TxPool(BaseService, PeerPoolSubscriber):
     """
     logger = logging.getLogger("trinity.tx_pool.TxPool")
 
-    def __init__(self, peer_pool: PeerPool) -> None:
-        super().__init__()
+    def __init__(self, peer_pool: PeerPool, token: CancelToken = None) -> None:
+        super().__init__(token)
         self._peer_pool = peer_pool
         # 1m should give us 9000 blocks before that filter becomes less reliable
         # It should take up about 1mb of memory


### PR DESCRIPTION
RopstenLightNode wasn't passing its CancelToken down to its
sub-services, so its _cleanup() method could return while we still had
pending asyncio tasks

Closes: #918