### PR TITLE
Update mypy to version 0.610

### DIFF
--- a/evm/db/journal.py
+++ b/evm/db/journal.py
@@ -1,5 +1,5 @@
 import collections
-from typing import Dict, Union  # noqa: F401
+from typing import cast, Dict, Union  # noqa: F401
 import uuid
 
 from cytoolz import (
@@ -119,7 +119,7 @@ class Journal(BaseDB):
     #
     # Database API
     #
-    def __getitem__(self, key: bytes) -> bytes:
+    def __getitem__(self, key: bytes) -> Union[bytes, DeletedEntry]:
         """
         For key lookups we need to iterate through the changesets in reverse
         order, returning from the first one in which the key is present.
@@ -178,7 +178,9 @@ class JournalDB(BaseDB):
         elif val is None:
             return self.wrapped_db[key]
         else:
-            return val
+            # mypy doesn't allow custom type guards yet so we need to cast here
+            # even though we know it can only be `bytes` at this point.
+            return cast(bytes, val)
 
     def __setitem__(self, key: bytes, value: bytes) -> None:
         """

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ deps = {
     ],
     'lint': [
         "flake8==3.5.0",
-        "mypy<0.600",
+        "mypy==0.610",
     ],
     'benchmark': [
         "termcolor==1.1.*",

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands=
     flake8 {toxinidir}/evm
     flake8 {toxinidir}/tests --exclude="trinity"
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
-    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p evm
+    mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs -p evm
 
 
 [testenv:lint-py36]
@@ -68,10 +68,10 @@ commands=
     flake8 {toxinidir}/tests
     flake8 {toxinidir}/scripts
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
-    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p p2p
+    mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs -p p2p
     # Trinity and Benchmark use more restrictive type checking
-    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics scripts/benchmark
-    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p trinity
+    mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics scripts/benchmark
+    mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p trinity
 
 
 [testenv:py36-benchmark]


### PR DESCRIPTION
### What was wrong?

Mypy was on an outdated version.

### How was it fixed?

Updated to `0.610` but disabled the `strict-optional` check for now as our code base does not pass it yet.

### Mypy highlights for that new version 

- [`reveal_locals()`](https://github.com/python/mypy/pull/3425)
- The type of the object returned by calling an async function used to be Awaitable; it’s changed to Coroutine since such objects support calling send() and throw() on them 

[More in the blog post](http://mypy-lang.blogspot.com/2018/06/mypy-0610-released.html)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://c2.staticflickr.com/4/3174/2632858545_2a85880f1b_b.jpg)
