### PR TITLE
Fix escaped NoConnectedPeers error

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -705,8 +705,6 @@ class PeerPool(BaseService):
         return random.choice(peers_by_td[max_td])
 
     def get_peers(self, min_td: int) -> List[BasePeer]:
-        if not self.connected_nodes:
-            raise NoConnectedPeers()
         return [peer for peer in self.peers if peer.head_td >= min_td]
 
     async def _periodically_report_stats(self):


### PR DESCRIPTION
### What was wrong?

During fast sync, there could escape a `NoConnectedPeers` exception as shown in #933

### How was it fixed?

Removed raising that error in `get_peers()`. It seems wrong to me to have `PeerPool.get_peers()` raise an exception instead of simply returning an empty list.

Notice that by simply removing the exception, the calling code will properly recognize the empty list and throw a `NoEligblePeers` error which is later properly catched and handled as seen here.

https://github.com/ethereum/py-evm/blob/3dfbfa90e97d6066549db20343187e15d3633dd5/p2p/chain.py#L321-L323

On a similar note, I'm not totally sold on `highest_td_peer` property raising that exception either. Returning `None` strikes me as more natural here as well.

https://github.com/ethereum/py-evm/blob/3dfbfa90e97d6066549db20343187e15d3633dd5/p2p/peer.py#L700-L706

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i1.wp.com/blog.aba.org/wp-content/uploads/2012/10/6a00e5505da1178834017ee414dc55970d.jpg)
