### PR TITLE
trinity: Fix fallout from latest changes

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -306,6 +306,10 @@ class Chain(BaseChain):
             raise AttributeError("`chaindb_class` not set")
         return cls.chaindb_class
 
+    @classmethod
+    def get_vm_configuration(cls) -> Tuple[Tuple[int, Type['BaseVM']], ...]:
+        return cls.vm_configuration
+
     #
     # Chain API
     #

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -148,7 +148,7 @@ class Server(BaseService):
             self.headerdb,
             self.network_id,
             self.privkey,
-            self.chain.vm_configuration,
+            self.chain.get_vm_configuration(),
             max_peers=self.max_peers,
         )
 
@@ -293,7 +293,7 @@ class Server(BaseService):
         except MalformedMessage as e:
             raise HandshakeFailure() from e
         await peer.do_sub_proto_handshake()
-        await peer.ensure_same_side_on_dao_fork(self.chain.vm_configuration)
+        await peer.ensure_same_side_on_dao_fork(self.chain.get_vm_configuration())
         self._start_peer(peer)
 
     def _start_peer(self, peer: BasePeer) -> None:

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -39,6 +39,7 @@ from trinity.db.header import (
 )
 from trinity.utils.mp import (
     async_method,
+    sync_method,
 )
 from trinity.utils.xdg import (
     is_under_xdg_trinity_root,
@@ -195,3 +196,4 @@ def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
 
 class ChainProxy(BaseProxy):
     coro_import_block = async_method('import_block')
+    get_vm_configuration = sync_method('get_vm_configuration')


### PR DESCRIPTION
My previous commit made some p2p code access Chain.vm_configuration, but
the trinity-proxied Chain doesn't expose that. This fixes it by adding a
get_vm_configuration() method to Chain and its trinity-proxied
counterpart