### PR TITLE
Add type hints for p2p package and enable stricter checks

### DIFF
--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -662,5 +662,5 @@ class AsyncChainDB(ChainDB):
         raise NotImplementedError()
 
     async def coro_get_receipts(
-            self, header: BlockHeader, receipt_class: Type[Receipt]) -> Iterable[Receipt]:
+            self, header: BlockHeader, receipt_class: Type[Receipt]) -> List[Receipt]:
         raise NotImplementedError()

--- a/p2p/ecies.py
+++ b/p2p/ecies.py
@@ -34,7 +34,7 @@ CURVE = ec.SECP256K1()
 KEY_LEN = 32
 
 
-def generate_privkey():
+def generate_privkey() -> datatypes.PrivateKey:
     """Generate a new SECP256K1 private key and return it"""
     privkey = ec.generate_private_key(CURVE, default_backend())
     return keys.PrivateKey(pad32(int_to_big_endian(privkey.private_numbers().private_value)))
@@ -120,7 +120,7 @@ def decrypt(data: bytes, privkey: datatypes.PrivateKey, shared_mac_data: bytes =
     return ctx.update(ciphertext) + ctx.finalize()
 
 
-def kdf(key_material):
+def kdf(key_material: bytes) -> bytes:
     """NIST SP 800-56a Concatenation Key Derivation Function (see section 5.8.1).
 
     Pretty much copied from geth's implementation:
@@ -139,7 +139,7 @@ def kdf(key_material):
     return key[:KEY_LEN]
 
 
-def hmac_sha256(key, msg):
+def hmac_sha256(key: bytes, msg: bytes) -> bytes:
     mac = hmac.HMAC(key, hashes.SHA256(), default_backend())
     mac.update(msg)
     return mac.finalize()

--- a/p2p/eth.py
+++ b/p2p/eth.py
@@ -1,5 +1,9 @@
 import logging
-from typing import List, Union
+from typing import (
+    List,
+    Union,
+    TYPE_CHECKING
+)
 
 from rlp import sedes
 
@@ -14,6 +18,10 @@ from p2p.protocol import (
 from p2p.rlp import BlockBody
 from p2p.sedes import HashOrNumber
 
+if TYPE_CHECKING:
+    from p2p.peer import (  # noqa: F401
+        ChainInfo
+    )
 
 # Max number of items we can ask for in ETH requests. These are the values used in geth and if we
 # ask for more than this the peers will disconnect from us.
@@ -108,7 +116,7 @@ class ETHProtocol(Protocol):
     cmd_length = 17
     logger = logging.getLogger("p2p.eth.ETHProtocol")
 
-    def send_handshake(self, head_info):
+    def send_handshake(self, head_info: 'ChainInfo') -> None:
         resp = {
             'protocol_version': self.version,
             'network_id': self.peer.network_id,
@@ -174,7 +182,7 @@ class ETHProtocol(Protocol):
         header, body = cmd.encode(block_hashes)
         self.send(header, body)
 
-    def send_receipts(self, receipts: List[Receipt]) -> None:
+    def send_receipts(self, receipts: List[List[Receipt]]) -> None:
         cmd = Receipts(self.cmd_id_offset)
         header, body = cmd.encode(receipts)
         self.send(header, body)

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -1,3 +1,8 @@
+from typing import (
+    Any
+)
+
+
 class BaseP2PError(Exception):
     """
     The base class for all p2p errors.
@@ -141,6 +146,6 @@ class NoInternalAddressMatchesDevice(BaseP2PError):
     """
     Raised when no internal IP address matches the UPnP device that is being configured.
     """
-    def __init__(self, *args, device_hostname=None, **kwargs):
+    def __init__(self, *args: Any, device_hostname: str=None, **kwargs: Any) -> None:
         super.__init__(*args, **kwargs)
         self.device_hostname = device_hostname

--- a/p2p/nat.py
+++ b/p2p/nat.py
@@ -66,7 +66,7 @@ class UPnPService(BaseService):
         self.port = port
         self._mapping: PortMapping = None  # when called externally, this never returns None
 
-    async def _run(self):
+    async def _run(self) -> None:
         """Run an infinite loop refreshing our NAT port mapping.
 
         On every iteration we configure the port mapping with a lifetime of 30 minutes and then
@@ -82,10 +82,10 @@ class UPnPService(BaseService):
             except Exception:
                 self.logger.exception("Failed to setup NAT portmap")
 
-    async def _cleanup(self):
+    async def _cleanup(self) -> None:
         pass
 
-    async def add_nat_portmap(self):
+    async def add_nat_portmap(self) -> str:
         """
         Set up the port mapping
 
@@ -115,6 +115,7 @@ class UPnPService(BaseService):
                 self.logger.exception("Failed to setup NAT portmap")
 
         self._mapping = None
+        return None
 
     def current_mapping(self) -> PortMapping:
         if self._mapping is None:

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -1,5 +1,9 @@
 import enum
-from typing import cast, Dict
+from typing import (
+    cast,
+    Dict,
+    TYPE_CHECKING
+)
 
 from cytoolz import assoc
 
@@ -7,11 +11,17 @@ import rlp
 from rlp import sedes
 
 from p2p.exceptions import MalformedMessage
+
 from p2p.protocol import (
     Command,
     Protocol,
     _DecodedMsgType,
 )
+
+if TYPE_CHECKING:
+    from p2p.peer import (  # noqa: F401
+        BasePeer
+    )
 
 
 class Hello(Command):
@@ -77,11 +87,11 @@ class P2PProtocol(Protocol):
     _commands = [Hello, Ping, Pong, Disconnect]
     cmd_length = 16
 
-    def __init__(self, peer):
+    def __init__(self, peer: 'BasePeer') -> None:
         # For the base protocol the cmd_id_offset is always 0.
         super().__init__(peer, cmd_id_offset=0)
 
-    def send_handshake(self):
+    def send_handshake(self) -> None:
         # TODO: move import out once this is in the trinity codebase
         from trinity.utils.version import construct_trinity_client_identifier
         data = dict(version=self.version,
@@ -92,10 +102,10 @@ class P2PProtocol(Protocol):
         header, body = Hello(self.cmd_id_offset).encode(data)
         self.send(header, body)
 
-    def send_disconnect(self, reason):
+    def send_disconnect(self, reason: DisconnectReason) -> None:
         header, body = Disconnect(self.cmd_id_offset).encode(dict(reason=reason))
         self.send(header, body)
 
-    def send_pong(self):
+    def send_pong(self) -> None:
         header, body = Pong(self.cmd_id_offset).encode({})
         self.send(header, body)

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -43,7 +43,7 @@ class Command:
         self.cmd_id = cmd_id_offset + self._cmd_id
 
     @property
-    def logger(self):
+    def logger(self) -> logging.Logger:
         if self._logger is None:
             self._logger = logging.getLogger(
                 "p2p.protocol.{0}".format(self.__class__.__name__)
@@ -54,7 +54,7 @@ class Command:
     def is_base_protocol(self) -> bool:
         return self.cmd_id_offset == 0
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "{} (cmd_id={})".format(self.__class__.__name__, self.cmd_id)
 
     def encode_payload(self, data: Union[_DecodedMsgType, sedes.CountableList]) -> bytes:
@@ -131,11 +131,11 @@ class Protocol:
     def send(self, header: bytes, body: bytes) -> None:
         self.peer.send(header, body)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "(%s, %d)" % (self.name, self.version)
 
 
-def _pad_to_16_byte_boundary(data):
+def _pad_to_16_byte_boundary(data: bytes) -> bytes:
     """Pad the given data with NULL_BYTE up to the next 16-byte boundary."""
     remainder = len(data) % 16
     if remainder != 0:

--- a/p2p/sedes.py
+++ b/p2p/sedes.py
@@ -3,12 +3,12 @@ from rlp import sedes
 
 class HashOrNumber:
 
-    def serialize(self, obj):
+    def serialize(self, obj: int) -> bytes:
         if isinstance(obj, int):
             return sedes.big_endian_int.serialize(obj)
         return sedes.binary.serialize(obj)
 
-    def deserialize(self, serial):
+    def deserialize(self, serial: bytes) -> int:
         if len(serial) == 32:
             return sedes.binary.deserialize(serial)
         return sedes.big_endian_int.deserialize(serial)

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -365,7 +365,7 @@ def _test() -> None:
     for sig in [signal.SIGINT, signal.SIGTERM]:
         loop.add_signal_handler(sig, sigint_received.set)
 
-    async def exit_on_sigint():
+    async def exit_on_sigint() -> None:
         await sigint_received.wait()
         await server.cancel()
         loop.stop()

--- a/p2p/sharding_peer.py
+++ b/p2p/sharding_peer.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import (
+    Any,
     cast,
     Dict,
     List,
@@ -48,7 +49,7 @@ from p2p.exceptions import (
 class ShardingPeer(BasePeer):
     _supported_sub_protocols = [ShardingProtocol]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.known_collation_hashes: Set[Hash32] = set()
         self._pending_replies: Dict[
@@ -102,7 +103,7 @@ class ShardingPeer(BasePeer):
         self._pending_replies[request_id] = pending_reply
         cast(ShardingProtocol, self.sub_proto).send_get_collations(request_id, collation_hashes)
         cmd, msg = await wait_with_token(pending_reply, token=cancel_token)
-
+        msg = cast(Dict[str, Any], msg)
         if not isinstance(cmd, Collations):
             raise UnexpectedMessage(
                 "Expected Collations as response to GetCollations, but got %s",

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -68,12 +68,12 @@ class FullNodeSyncer(BaseService):
             new_chain, self.chaindb, self.peer_pool, self.cancel_token)
         await chain_syncer.run()
 
-    async def _cleanup(self):
+    async def _cleanup(self) -> None:
         # We don't run anything in the background, so nothing to do here.
         pass
 
 
-def _test():
+def _test() -> None:
     import argparse
     import asyncio
     from concurrent.futures import ProcessPoolExecutor
@@ -113,7 +113,7 @@ def _test():
     for sig in [signal.SIGINT, signal.SIGTERM]:
         loop.add_signal_handler(sig, sigint_received.set)
 
-    async def exit_on_sigint():
+    async def exit_on_sigint() -> None:
         await sigint_received.wait()
         await syncer.cancel()
         await peer_pool.cancel()

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -12,7 +12,7 @@ def sxor(s1: bytes, s2: bytes) -> bytes:
     return bytes(x ^ y for x, y in zip(s1, s2))
 
 
-def roundup_16(x):
+def roundup_16(x: int) -> int:
     """Rounds up the given value to the next multiple of 16."""
     remainder = x % 16
     if remainder != 0:
@@ -33,7 +33,7 @@ def get_devp2p_cmd_id(msg: bytes) -> int:
     return rlp.decode(msg[:1], sedes=rlp.sedes.big_endian_int)
 
 
-def get_process_pool_executor():
+def get_process_pool_executor() -> ProcessPoolExecutor:
     # Use CPU_COUNT - 1 processes to make sure we always leave one CPU idle so that it can run
     # asyncio's event loop.
     os_cpu_count = os.cpu_count()

--- a/tox.ini
+++ b/tox.ini
@@ -68,10 +68,9 @@ commands=
     flake8 {toxinidir}/tests
     flake8 {toxinidir}/scripts
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
-    mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs -p p2p
-    # Trinity and Benchmark use more restrictive type checking
     mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics scripts/benchmark
-    mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p trinity
+    mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p p2p -p trinity
+
 
 
 [testenv:py36-benchmark]

--- a/trinity/tx_pool/pool.py
+++ b/trinity/tx_pool/pool.py
@@ -60,7 +60,6 @@ class TxPool(BaseService, PeerPoolSubscriber):
                 peer, cmd, msg = await self.wait(
                     self.msg_queue.get(), token=self.cancel_token)
                 peer = cast(ETHPeer, peer)
-                cmd = cast(Transactions, cmd)
                 msg = cast(List[BaseTransactionFields], msg)
                 if isinstance(cmd, Transactions):
                     await self._handle_tx(peer, msg)

--- a/trinity/tx_pool/pool.py
+++ b/trinity/tx_pool/pool.py
@@ -57,10 +57,11 @@ class TxPool(BaseService, PeerPoolSubscriber):
 
         with self.subscribe(self._peer_pool):
             while True:
-                peer: ETHPeer
                 peer, cmd, msg = await self.wait(
                     self.msg_queue.get(), token=self.cancel_token)
-
+                peer = cast(ETHPeer, peer)
+                cmd = cast(Transactions, cmd)
+                msg = cast(List[BaseTransactionFields], msg)
                 if isinstance(cmd, Transactions):
                     await self._handle_tx(peer, msg)
 


### PR DESCRIPTION
### What was wrong?

P2P was missing many type hints and didn't have the `--disallow-untyped-defs` check yet which means that new code could potentially land without type hints (making the fight for 100 % coverage a bit of a fight against windmills)

### How was it fixed?

Added type hints and enabled `--disallow-untyped-defs` check

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://metrouk2.files.wordpress.com/2015/07/fuzzberta-the-guinea-pig-dressed-as-people-and-things-princess-leia-e1436630730651.jpg)
