### PR TITLE
Lock web3 dependency to 0.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ deps = {
         "ipython>=6.2.1,<7.0.0",
         "plyvel==1.0.4",
         "coincurve>=7.0.0,<8.0.0",
-        "web3>=4.1.0,<5.0.0",
+        "web3==4.3.0",
         # required for rlp>=1.0.0
         "eth-account>=0.2.1,<1",
     ],


### PR DESCRIPTION
### What was wrong?

Lock down web3.py dependency to fix dependency issue with eth-pm. Eth-PM is a dependency of web3.py from 0.4.4 onwards and it's currently demanding for a lower version py-evm version, leaving us with a broken install.

### How was it fixed?

Stick to version 0.4.3 for now

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://qph.fs.quoracdn.net/main-qimg-0d0cb8914f228e43229d30dbe48bddc9)
