### PR TITLE
trinity: Use default preferred peers when none are provided

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -264,15 +264,11 @@ class PreferredNodeDiscoveryProtocol(DiscoveryProtocol):
                  privkey: datatypes.PrivateKey,
                  address: kademlia.Address,
                  bootstrap_nodes: Tuple[kademlia.Node, ...],
-                 preferred_nodes: Sequence[kademlia.Node] = None) -> None:
+                 preferred_nodes: Sequence[kademlia.Node]) -> None:
         super().__init__(privkey, address, bootstrap_nodes)
 
-        if preferred_nodes is not None:
-            self.preferred_nodes = preferred_nodes
-        else:
-            self.preferred_nodes = tuple()
+        self.preferred_nodes = preferred_nodes
         self.logger.info('Preferred peers: %s', self.preferred_nodes)
-
         self._preferred_node_tracker = collections.defaultdict(lambda: 0)
 
     @to_tuple

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -21,6 +21,7 @@ from p2p.constants import (
     MAINNET_BOOTNODES,
     ROPSTEN_BOOTNODES,
 )
+from p2p.peer import DEFAULT_PREFERRED_NODES
 
 from trinity.constants import (
     SYNC_FULL,
@@ -70,7 +71,11 @@ class ChainConfig:
         self.max_peers = max_peers
         self.sync_mode = sync_mode
         self.port = port
-        self.preferred_nodes = preferred_nodes
+
+        if not preferred_nodes and network_id in DEFAULT_PREFERRED_NODES:
+            self.preferred_nodes = DEFAULT_PREFERRED_NODES[self.network_id]
+        else:
+            self.preferred_nodes = preferred_nodes
 
         if bootstrap_nodes is None:
             if self.network_id == MAINNET_NETWORK_ID:

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -151,6 +151,6 @@ def construct_chain_config_params(
         yield 'port', args.port
 
     if args.preferred_nodes is None:
-        yield 'preferred_nodes', args.preferred_nodes
+        yield 'preferred_nodes', tuple()
     else:
         yield 'preferred_nodes', tuple(args.preferred_nodes)


### PR DESCRIPTION
The recently introduced PreferredNodeDiscoveryProtocol doesn't look up
the default preferred peers like the old PreferredNodePeerPool did, so
now we do that in ChainConfig when no preferred peers are specified in
the command line