### PR TITLE
Create MsgQueueExposer/MsgQueueSubscriber as generic pattern

### DIFF
--- a/p2p/msg_queue.py
+++ b/p2p/msg_queue.py
@@ -1,0 +1,44 @@
+from abc import (
+    ABC,
+    abstractmethod
+)
+import asyncio
+import contextlib
+from typing import (
+    Iterator,
+    Generic,
+    TypeVar
+)
+
+_TMsg = TypeVar('_TMsg')
+
+
+class MsgQueueExposer(ABC, Generic[_TMsg]):
+
+    @abstractmethod
+    def subscribe(self, subscriber: 'MsgQueueSubscriber[_TMsg]') -> None:
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    @abstractmethod
+    def unsubscribe(self, subscriber: 'MsgQueueSubscriber[_TMsg]') -> None:
+        raise NotImplementedError("Must be implemented by subclasses")
+
+
+class MsgQueueSubscriber(Generic[_TMsg]):
+    _msg_queue: 'asyncio.Queue[_TMsg]' = None
+
+    @property
+    def msg_queue(self) -> 'asyncio.Queue[_TMsg]':
+        if self._msg_queue is None:
+            self._msg_queue = asyncio.Queue(maxsize=10000)
+        return self._msg_queue
+
+    @contextlib.contextmanager
+    def subscribe(
+            self,
+            msg_queue_exposer: MsgQueueExposer[_TMsg]) -> Iterator[None]:
+        msg_queue_exposer.subscribe(self)
+        try:
+            yield
+        finally:
+            msg_queue_exposer.unsubscribe(self)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -1,11 +1,9 @@
 import asyncio
-import contextlib
 import logging
 import operator
 import random
 import struct
 from abc import (
-    ABC,
     abstractmethod
 )
 
@@ -54,6 +52,10 @@ from evm.vm.forks import HomesteadVM
 from p2p import auth
 from p2p import ecies
 from p2p.kademlia import Address, Node
+from p2p.msg_queue import (
+    MsgQueueExposer,
+    MsgQueueSubscriber
+)
 from p2p import protocol
 from p2p.exceptions import (
     BadAckMessage,
@@ -634,8 +636,7 @@ class ETHPeer(BasePeer):
             return header, parent
 
 
-class PeerPoolSubscriber(ABC):
-    _msg_queue: 'asyncio.Queue[PEER_MSG_TYPE]' = None
+class PeerPoolSubscriber(MsgQueueSubscriber['PEER_MSG_TYPE']):
 
     def register_peer(self, peer: BasePeer) -> None:
         """
@@ -648,22 +649,8 @@ class PeerPoolSubscriber(ABC):
         """
         pass
 
-    @property
-    def msg_queue(self) -> 'asyncio.Queue[PEER_MSG_TYPE]':
-        if self._msg_queue is None:
-            self._msg_queue = asyncio.Queue(maxsize=10000)
-        return self._msg_queue
 
-    @contextlib.contextmanager
-    def subscribe(self, peer_pool: 'PeerPool') -> Iterator[None]:
-        peer_pool.subscribe(self)
-        try:
-            yield
-        finally:
-            peer_pool.unsubscribe(self)
-
-
-class PeerPool(BaseService):
+class PeerPool(BaseService, MsgQueueExposer['PEER_MSG_TYPE']):
     """
     PeerPool maintains connections to up-to max_peers on a given network.
     """
@@ -687,7 +674,7 @@ class PeerPool(BaseService):
         self.vm_configuration = vm_configuration
         self.max_peers = max_peers
         self.connected_nodes: Dict[Node, BasePeer] = {}
-        self._subscribers: List[PeerPoolSubscriber] = []
+        self._subscribers: List[MsgQueueSubscriber['PEER_MSG_TYPE']] = []
 
     def __len__(self) -> int:
         return len(self.connected_nodes)
@@ -705,13 +692,14 @@ class PeerPool(BaseService):
         matching_ip_nodes = nodes_by_ip.get(candidate.address.ip, [])
         return len(matching_ip_nodes) <= 2
 
-    def subscribe(self, subscriber: PeerPoolSubscriber) -> None:
+    def subscribe(self, subscriber: MsgQueueSubscriber['PEER_MSG_TYPE']) -> None:
+        subscriber = cast(PeerPoolSubscriber, subscriber)
         self._subscribers.append(subscriber)
         for peer in self.connected_nodes.values():
             subscriber.register_peer(peer)
             peer.add_subscriber(subscriber.msg_queue)
 
-    def unsubscribe(self, subscriber: PeerPoolSubscriber) -> None:
+    def unsubscribe(self, subscriber: MsgQueueSubscriber['PEER_MSG_TYPE']) -> None:
         if subscriber in self._subscribers:
             self._subscribers.remove(subscriber)
         for peer in self.connected_nodes.values():
@@ -725,6 +713,7 @@ class PeerPool(BaseService):
         self.logger.info('Adding peer: %s', peer)
         self.connected_nodes[peer.remote] = peer
         for subscriber in self._subscribers:
+            subscriber = cast(PeerPoolSubscriber, subscriber)
             subscriber.register_peer(peer)
             peer.add_subscriber(subscriber.msg_queue)
 


### PR DESCRIPTION
### What was wrong?

We currently use `asyncio.Queue` as a mean to do async communication in our code base. The way we use that in the `PeerPool` is to implement a `PeerPoolSubscriber` class and have the `PeerPool` expose `subscribe` and `unsubscribe` methods.

We may need the same pattern in the tx pool and probably other places as well. (Depends if other areas of our code are interested in certain events of the tx pool)

### How was it fixed?

This is still a wip but I extracted the reusable bits into generic `MsgQueueExposer` and `MsgQueueSubscriber` classes that can be reused.

Notice that I'm not quite happy with the typing just yet because I would really like to get rid of the currently needed casts.

Also notice that I *think* if we want this pattern to be extracted, then I think it should live somewhere outside of this repo to be reusable in other places. Maybe put it in `eth_utils` idk.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
