### PR TITLE
Turn VM.validate_uncle() into a @classmethod

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -707,8 +707,8 @@ class Chain(BaseChain):
                     "Uncle ancestor not found: {0}".format(uncle.parent_hash)
                 )
 
-            uncle_vm = self.get_vm(uncle)
-            uncle_vm.validate_uncle(block, uncle, uncle_parent)
+            uncle_vm_class = self.get_vm_class_for_block_number(uncle.block_number)
+            uncle_vm_class.validate_uncle(block, uncle, uncle_parent)
 
 
 @to_set

--- a/evm/vm/base.py
+++ b/evm/vm/base.py
@@ -276,8 +276,10 @@ class BaseVM(Configurable, ABC):
     def validate_seal(cls, header: BlockHeader) -> None:
         raise NotImplementedError("VM classes must implement this method")
 
+    @classmethod
     @abstractmethod
-    def validate_uncle(self, block, uncle, uncle_parent):
+    def validate_uncle(
+            cls, block: BaseBlock, uncle: BlockHeader, uncle_parent: BlockHeader) -> None:
         raise NotImplementedError("VM classes must implement this method")
 
     #
@@ -714,7 +716,8 @@ class VM(BaseVM):
             header.block_number, header.mining_hash,
             header.mix_hash, header.nonce, header.difficulty)
 
-    def validate_uncle(self, block, uncle, uncle_parent):
+    @classmethod
+    def validate_uncle(cls, block, uncle, uncle_parent):
         """
         Validate the given uncle in the context of the given block.
         """


### PR DESCRIPTION
There's no reason why it should be a VM method in the first place,
and by having it as a standalone function we don't need to attempt to
get a VM for an uncle block (in Chain.validate_uncles()), which is not
supposed to work as that requires having the block's body in our DB and
we never have block bodies for uncle blocks.

Closes: #954