### PR TITLE
Remove superfluous tx gas validation

### DIFF
--- a/evm/rlp/transactions.py
+++ b/evm/rlp/transactions.py
@@ -108,7 +108,7 @@ class BaseTransaction(BaseTransactionFields, BaseTransactionMethods):
         Hook called during instantiation to ensure that all transaction
         parameters pass validation rules.
         """
-        if self.intrinsic_gas > self.gas:
+        if self.gas < self.intrinsic_gas:
             raise ValidationError("Insufficient gas")
         self.check_signature_validity()
 

--- a/evm/vm/forks/frontier/state.py
+++ b/evm/vm/forks/frontier/state.py
@@ -9,7 +9,6 @@ from evm.db.account import (
 )
 from evm.exceptions import (
     ContractCreationCollision,
-    ValidationError,
 )
 from evm.vm.message import (
     Message,
@@ -40,10 +39,6 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
     def validate_transaction(self, transaction):
 
         # Validate the transaction
-
-        if transaction.intrinsic_gas > transaction.gas:
-            raise ValidationError("Insufficient gas")
-
         transaction.validate()
         self.vm_state.validate_transaction(transaction)
 


### PR DESCRIPTION
### What was wrong?

The `transaction.validate()` call in the next
line has exactly the same logic making this a
superfluous extra check.

https://github.com/ethereum/py-evm/blob/042cd4bc215d8567d560f43564dbee2aba5c970d/evm/rlp/transactions.py#L106-L113

### How was it fixed?

Removed superfluous check

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://can-pets-eat.com/wp-content/uploads/2017/06/Can-Guinea-Pigs-Eat-Bell-Peppers.jpg)
