### PR TITLE
Ensure Transaction Pool does not relay invalid transactions

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -123,6 +123,11 @@ class BaseChain(Configurable, ABC):
     def get_chaindb_class(cls) -> Type[BaseChainDB]:
         raise NotImplementedError("Chain classes must implement this method")
 
+    @classmethod
+    @abstractmethod
+    def get_vm_configuration(cls) -> Tuple[Tuple[int, Type['BaseVM']], ...]:
+        raise NotImplementedError("Chain classes must implement this method")
+
     #
     # Chain API
     #

--- a/tests/p2p/test_tx_pool.py
+++ b/tests/p2p/test_tx_pool.py
@@ -33,9 +33,7 @@ class TxsRecorder():
         self.recorded_tx.extend(txs)
         self.send_count = self.send_count + 1
 
-
-@pytest.mark.asyncio
-async def test_tx_propagation(monkeypatch, request, event_loop):
+async def bootstrap_test_setup(monkeypatch, request, event_loop):
     peer1, peer2 = await get_directly_linked_peers(
         request,
         event_loop,
@@ -55,6 +53,16 @@ async def test_tx_propagation(monkeypatch, request, event_loop):
     def finalizer():
         event_loop.run_until_complete(pool.cancel())
     request.addfinalizer(finalizer)
+
+    return peer1, peer1_txs_recorder, peer2, peer2_txs_recorder, pool
+
+@pytest.mark.asyncio
+async def test_tx_propagation(monkeypatch, request, event_loop):
+    peer1, peer1_txs_recorder, peer2, peer2_txs_recorder, pool = await bootstrap_test_setup(
+        monkeypatch,
+        request,
+        event_loop
+    )
 
     txs_broadcasted_by_peer1 = [create_random_tx()]
 

--- a/tests/p2p/test_tx_pool.py
+++ b/tests/p2p/test_tx_pool.py
@@ -1,6 +1,6 @@
 import asyncio
 import pytest
-import random
+import uuid
 
 from p2p.peer import (
     ETHPeer,
@@ -8,14 +8,21 @@ from p2p.peer import (
 from p2p.eth import (
     Transactions
 )
-from evm.rlp.transactions import (
-    BaseTransactionFields
+
+from evm.utils.address import (
+    force_bytes_to_address
 )
 
 from trinity.tx_pool.pool import (
     TxPool,
 )
+from trinity.tx_pool.validators import (
+    DefaultTransactionValidator
+)
 
+from tests.conftest import (
+    funded_address_private_key
+)
 from tests.p2p.peer_helpers import (
     get_directly_linked_peers,
     MockPeerPoolWithConnectedPeers,
@@ -33,7 +40,8 @@ class TxsRecorder():
         self.recorded_tx.extend(txs)
         self.send_count = self.send_count + 1
 
-async def bootstrap_test_setup(monkeypatch, request, event_loop):
+
+async def bootstrap_test_setup(monkeypatch, request, event_loop, chain, tx_validator):
     peer1, peer2 = await get_directly_linked_peers(
         request,
         event_loop,
@@ -46,7 +54,10 @@ async def bootstrap_test_setup(monkeypatch, request, event_loop):
     peer1_txs_recorder = create_tx_recorder(monkeypatch, peer1)
     peer2_txs_recorder = create_tx_recorder(monkeypatch, peer2)
 
-    pool = TxPool(MockPeerPoolWithConnectedPeers([peer1, peer2]))
+    pool = TxPool(
+        MockPeerPoolWithConnectedPeers([peer1, peer2]),
+        tx_validator
+    )
 
     asyncio.ensure_future(pool.run())
 
@@ -56,15 +67,28 @@ async def bootstrap_test_setup(monkeypatch, request, event_loop):
 
     return peer1, peer1_txs_recorder, peer2, peer2_txs_recorder, pool
 
+
+@pytest.fixture
+def tx_validator(chain_with_block_validation):
+    return DefaultTransactionValidator(chain_with_block_validation, 0)
+
+
 @pytest.mark.asyncio
-async def test_tx_propagation(monkeypatch, request, event_loop):
+async def test_tx_propagation(monkeypatch,
+                              request,
+                              event_loop,
+                              chain_with_block_validation,
+                              tx_validator):
+
     peer1, peer1_txs_recorder, peer2, peer2_txs_recorder, pool = await bootstrap_test_setup(
         monkeypatch,
         request,
-        event_loop
+        event_loop,
+        chain_with_block_validation,
+        tx_validator
     )
 
-    txs_broadcasted_by_peer1 = [create_random_tx()]
+    txs_broadcasted_by_peer1 = [create_random_tx(chain_with_block_validation)]
 
     # Peer1 sends some txs
     await pool._handle_tx(peer1, txs_broadcasted_by_peer1)
@@ -91,7 +115,10 @@ async def test_tx_propagation(monkeypatch, request, event_loop):
     assert peer1_txs_recorder.send_count == 0
 
     # Peer2 sends old + new tx
-    txs_broadcasted_by_peer2 = [create_random_tx(), txs_broadcasted_by_peer1[0]]
+    txs_broadcasted_by_peer2 = [
+        create_random_tx(chain_with_block_validation),
+        txs_broadcasted_by_peer1[0]
+    ]
     await pool._handle_tx(peer2, txs_broadcasted_by_peer2)
 
     # Check that Peer1 receives only the one tx that it didn't know about
@@ -101,7 +128,35 @@ async def test_tx_propagation(monkeypatch, request, event_loop):
 
 
 @pytest.mark.asyncio
-async def test_tx_sending(request, event_loop):
+async def test_does_not_propagate_invalid_tx(monkeypatch,
+                                             request,
+                                             event_loop,
+                                             chain_with_block_validation,
+                                             tx_validator):
+
+    peer1, peer1_txs_recorder, peer2, peer2_txs_recorder, pool = await bootstrap_test_setup(
+        monkeypatch,
+        request,
+        event_loop,
+        chain_with_block_validation,
+        tx_validator
+    )
+
+    txs_broadcasted_by_peer1 = [
+        create_random_tx(chain_with_block_validation, is_valid=False),
+        create_random_tx(chain_with_block_validation)
+    ]
+
+    # Peer1 sends some txs
+    await pool._handle_tx(peer1, txs_broadcasted_by_peer1)
+
+    # Check that Peer2 received only the second tx which is valid
+    assert len(peer2_txs_recorder.recorded_tx) == 1
+    assert peer2_txs_recorder.recorded_tx[0].hash == txs_broadcasted_by_peer1[1].hash
+
+
+@pytest.mark.asyncio
+async def test_tx_sending(request, event_loop, chain_with_block_validation, tx_validator):
     # This test covers the communication end to end whereas the previous
     # focusses on the rules of the transaction pool on when to send tx to whom
     peer1, peer2 = await get_directly_linked_peers(
@@ -114,7 +169,7 @@ async def test_tx_sending(request, event_loop):
     peer2_subscriber = asyncio.Queue()
     peer2.add_subscriber(peer2_subscriber)
 
-    pool = TxPool(MockPeerPoolWithConnectedPeers([peer1, peer2]))
+    pool = TxPool(MockPeerPoolWithConnectedPeers([peer1, peer2]), tx_validator)
 
     asyncio.ensure_future(pool.run())
 
@@ -122,7 +177,7 @@ async def test_tx_sending(request, event_loop):
         event_loop.run_until_complete(pool.cancel())
     request.addfinalizer(finalizer)
 
-    txs = [create_random_tx()]
+    txs = [create_random_tx(chain_with_block_validation)]
 
     peer1.sub_proto.send_transactions(txs)
 
@@ -147,15 +202,14 @@ def create_tx_recorder(monkeypatch, peer):
     return recorder
 
 
-def create_random_tx():
-    return BaseTransactionFields(
+def create_random_tx(chain, is_valid=True):
+    return chain.create_unsigned_transaction(
         nonce=0,
         gas_price=1,
-        gas=21000,
-        data=b'',
-        to=b'',
-        value=random.randint(0, 1000),
-        r=random.randint(0, 1000),
-        s=random.randint(0, 1000),
-        v=random.randint(0, 1000)
-    )
+        gas=2100000000000 if is_valid else 0,
+        # For simplicity, both peers create tx with the same private key.
+        # We rely on unique data to create truly unique txs
+        data=uuid.uuid4().bytes,
+        to=force_bytes_to_address(b'\x10\x10'),
+        value=1,
+    ).as_signed_transaction(funded_address_private_key())

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -198,4 +198,5 @@ class ChainProxy(BaseProxy):
     coro_import_block = async_method('import_block')
     coro_validate_chain = async_method('validate_chain')
     get_vm_configuration = sync_method('get_vm_configuration')
+    get_vm_class = sync_method('get_vm_class')
     get_vm_class_for_block_number = sync_method('get_vm_class_for_block_number')

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -44,6 +44,9 @@ from trinity.config import (
 from trinity.tx_pool.pool import (
     TxPool
 )
+from trinity.tx_pool.validators import (
+    DefaultTransactionValidator
+)
 
 
 class Node(BaseService):
@@ -52,6 +55,7 @@ class Node(BaseService):
     unset attributes.
     """
     chain_class: Type[BaseChain] = None
+    initial_tx_validation_block_number: int = None
 
     def __init__(self, chain_config: ChainConfig) -> None:
         super().__init__()
@@ -97,7 +101,11 @@ class Node(BaseService):
             self._auxiliary_services.append(service)
 
     def create_and_add_tx_pool(self) -> None:
-        self.tx_pool = TxPool(self.get_peer_pool(), self.cancel_token)
+        self.tx_pool = TxPool(
+            self.get_peer_pool(),
+            DefaultTransactionValidator(self.get_chain(), self.initial_tx_validation_block_number),
+            self.cancel_token
+        )
         self.add_service(self.tx_pool)
 
     def make_ipc_server(self) -> Union[IPCServer, EmptyService]:

--- a/trinity/nodes/mainnet.py
+++ b/trinity/nodes/mainnet.py
@@ -1,5 +1,6 @@
 from evm.chains.mainnet import (
     MainnetChain,
+    BYZANTIUM_MAINNET_BLOCK
 )
 
 from trinity.chains.mainnet import (
@@ -11,7 +12,9 @@ from trinity.nodes.full import FullNode
 
 class MainnetFullNode(FullNode):
     chain_class = MainnetChain
+    initial_tx_validation_block_number = BYZANTIUM_MAINNET_BLOCK
 
 
 class MainnetLightNode(LightNode):
     chain_class = MainnetLightDispatchChain
+    initial_tx_validation_block_number = BYZANTIUM_MAINNET_BLOCK

--- a/trinity/nodes/ropsten.py
+++ b/trinity/nodes/ropsten.py
@@ -1,5 +1,6 @@
 from evm.chains.ropsten import (
     RopstenChain,
+    BYZANTIUM_ROPSTEN_BLOCK
 )
 
 from trinity.chains.ropsten import (
@@ -11,7 +12,9 @@ from trinity.nodes.full import FullNode
 
 class RopstenFullNode(FullNode):
     chain_class = RopstenChain
+    initial_tx_validation_block_number = BYZANTIUM_ROPSTEN_BLOCK
 
 
 class RopstenLightNode(LightNode):
     chain_class = RopstenLightDispatchChain
+    initial_tx_validation_block_number = BYZANTIUM_ROPSTEN_BLOCK

--- a/trinity/tx_pool/validators.py
+++ b/trinity/tx_pool/validators.py
@@ -1,0 +1,62 @@
+from typing import (
+    Type
+)
+
+from evm.chains.base import (
+    BaseChain
+)
+from evm.exceptions import (
+    ValidationError
+)
+from evm.rlp.transactions import (
+    BaseTransaction,
+    BaseTransactionFields
+)
+
+
+class DefaultTransactionValidator():
+    """
+    The :class:`~trinity.tx_pool.validators.DefaultTransactionValidator` class is responsible to
+    decide wether transactions should be relayed to peers or not. This implementation validates
+    transactions against a transaction class inferred from a ``initial_tx_validation_block_number``
+    but will switch to a different one as soon as the tip of the chain uses a more up to date
+    transaction class than the one that corresponds to the ``initial_tx_validation_block_number``.
+    """
+
+    def __init__(self, chain: BaseChain, initial_tx_validation_block_number: int) -> None:
+        self.chain = chain
+        self._initial_tx_class = self._get_tx_class_for_block_number(
+            initial_tx_validation_block_number
+        )
+        self._ordered_tx_classes = [
+            vm_class.get_transaction_class()
+            for _, vm_class in chain.get_vm_configuration()
+        ]
+        self._initial_tx_class_index = self._ordered_tx_classes.index(self._initial_tx_class)
+
+    def __call__(self, transaction: BaseTransactionFields) -> bool:
+
+        transaction_class = self.get_appropriate_tx_class()
+        tx = transaction_class(**transaction.as_dict())
+        try:
+            tx.validate()
+        except ValidationError:
+            return False
+        else:
+            return True
+
+    def get_appropriate_tx_class(self) -> Type[BaseTransaction]:
+        current_tx_class = self.chain.get_vm_class().get_transaction_class()
+        # If the current head of the chain is still on a fork that is before the currently
+        # active fork (syncing), ensure that we use the specified initial tx class
+        if self._is_outdated_tx_class(current_tx_class):
+            return self._initial_tx_class
+
+        return current_tx_class
+
+    def _is_outdated_tx_class(self, tx_class: Type[BaseTransaction]) -> bool:
+        return self._ordered_tx_classes.index(tx_class) < self._initial_tx_class_index
+
+    def _get_tx_class_for_block_number(self, block_number: int) -> Type[BaseTransaction]:
+        vm_class = self.chain.get_vm_class_for_block_number(block_number)
+        return vm_class.get_transaction_class()


### PR DESCRIPTION
### What was wrong?

Currently the transaction pool relays transactions even if they are invalid making that an attack vector (see #945) 

### How was it fixed?

- added a `validate_signed_transaction` API to the Chain
- make the `TxPool` take a `Callable[[BaseTransactionFields], None]` in its constructor as a validation method
- make the `TxPool` validate txs against the passed validation function

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://1.bp.blogspot.com/-nq8jw88aeWM/UD3zJum_sQI/AAAAAAAAFmI/T1M8tvRmTCo/s1600/cute%2Bwild%2Banimals.jpg)
