### PR TITLE
Log an informative error message when IPC file is not found

### DIFF
--- a/tests/trinity/core/cli/test_trinity_repl.py
+++ b/tests/trinity/core/cli/test_trinity_repl.py
@@ -1,15 +1,21 @@
 import pytest
 
 from trinity.console import console
+from pathlib import Path
+from trinity.utils.log_messages import (
+    create_missing_ipc_error_message,
+)
 
 
-def test_console(jsonrpc_ipc_pipe_path):
-    # Test running the console, actually start it.
-    with pytest.raises(OSError, match='^reading .* stdin .* captured$'):
-        console(jsonrpc_ipc_pipe_path)
+def test_console(caplog, jsonrpc_ipc_pipe_path):
+    # if ipc_path is not found, raise an exception with a useful message
+    with pytest.raises(FileNotFoundError):
+        console(Path(jsonrpc_ipc_pipe_path))
+        assert create_missing_ipc_error_message(jsonrpc_ipc_pipe_path) in caplog.text
 
 
-def test_python_console(jsonrpc_ipc_pipe_path):
-    # Test running the default python REPL, actually start it.
-    with pytest.raises(OSError, match='^reading .* stdin .* captured$'):
-        console(jsonrpc_ipc_pipe_path, use_ipython=False)
+def test_python_console(caplog, jsonrpc_ipc_pipe_path):
+    # if ipc_path is not found, raise an exception with a useful message
+    with pytest.raises(FileNotFoundError):
+        console(Path(jsonrpc_ipc_pipe_path), use_ipython=False)
+        assert create_missing_ipc_error_message(jsonrpc_ipc_pipe_path) in caplog.text

--- a/trinity/console.py
+++ b/trinity/console.py
@@ -5,6 +5,9 @@ from typing import (
     Any,
     Dict,
 )
+from trinity.utils.log_messages import (
+    create_missing_ipc_error_message,
+)
 
 from cytoolz import merge
 
@@ -58,6 +61,10 @@ def console(ipc_path: Path,
     """
     if env is None:
         env = {}
+
+    # if ipc_path is not found, raise an exception with a useful message
+    if not ipc_path.exists():
+        raise FileNotFoundError(create_missing_ipc_error_message(ipc_path))
 
     # cast needed until https://github.com/ethereum/web3.py/issues/867 is fixed
     w3 = web3.Web3(web3.IPCProvider(str(ipc_path)))

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -129,7 +129,7 @@ def main() -> None:
 
     # if console command, run the trinity CLI
     if args.subcommand == 'attach':
-        console(chain_config.jsonrpc_ipc_path, use_ipython=not args.vanilla_shell)
+        run_console(chain_config, not args.vanilla_shell)
         sys.exit(0)
 
     # start the listener thread to handle logs produced by other processes in
@@ -168,7 +168,7 @@ def main() -> None:
 
     try:
         if args.subcommand == 'console':
-            console(chain_config.jsonrpc_ipc_path, use_ipython=not args.vanilla_shell)
+            run_console(chain_config, not args.vanilla_shell)
         else:
             networking_process.join()
     except KeyboardInterrupt:
@@ -190,6 +190,15 @@ def main() -> None:
         import time; time.sleep(0.2)  # noqa: E702
         kill_process_gracefully(networking_process, logger)
         logger.info('Networking process (pid=%d) terminated', networking_process.pid)
+
+
+def run_console(chain_config: ChainConfig, vanilla_shell_args: bool) -> None:
+    logger = logging.getLogger("trinity")
+    try:
+        console(chain_config.jsonrpc_ipc_path, use_ipython=vanilla_shell_args)
+    except FileNotFoundError as err:
+        logger.error(str(err))
+        sys.exit(1)
 
 
 @setup_cprofiler('run_database_process')

--- a/trinity/utils/log_messages.py
+++ b/trinity/utils/log_messages.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def create_missing_ipc_error_message(ipc_path: Path) -> str:
+    log_message = (
+        "The IPC path at {0} is not found. \n"
+        "Please run "
+        "'trinity --data-dir <path-to-running-nodes-data-dir> attach' "
+        "to specify the IPC path."
+    ).format(str(ipc_path))
+    return log_message


### PR DESCRIPTION
### What was wrong?
The `trinity attach` command currently doesn't recognize when it fails to attach to a running `trinity` instance leaving users with unhandled exceptions upon `w3` usage.

Issue Reference: https://github.com/ethereum/py-evm/issues/959

### How was it fixed?
Throw `FileNotFoundError` if the `ipc_file` not found when executing `trinity attach` command

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://petcube.com/blog/content/images/2018/04/boo-the-dog-2.jpg)
