### PR TITLE
Improve logic to find common ancestor when starting sync

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -62,3 +62,6 @@ ROPSTEN_BOOTNODES = (
 
 # Maximum peers number, we'll try to keep open connections up to this number of peers
 DEFAULT_MAX_PEERS = 25
+
+# Maximum allowed depth for chain reorgs.
+MAX_REORG_DEPTH = 24


### PR DESCRIPTION
When starting a sync with a peer, ChainSyncer used to always fetch the 192
headers prior to the current local head and reprocess them, which is very
wasteful specially when we're already fully synced. Now it only fetches
MAX_REORG_DEPTH previous headers and skips processing the ones we already
have.

Depends on #966
Closes: #967