### PR TITLE
A few small fixes

### DIFF
--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -5,7 +5,7 @@ from abc import (
 from uuid import UUID
 import logging
 from lru import LRU
-from typing import Set, Tuple  # noqa: F401
+from typing import cast, Set, Tuple  # noqa: F401
 
 from eth_typing import (
     Address,
@@ -43,6 +43,9 @@ from evm.validation import (
     validate_canonical_address,
 )
 
+from evm.utils.logging import (
+    TraceLogger
+)
 from evm.utils.numeric import (
     int_to_big_endian,
 )
@@ -174,7 +177,7 @@ class BaseAccountDB(ABC):
 
 class AccountDB(BaseAccountDB):
 
-    logger = logging.getLogger('evm.db.account.AccountDB')
+    logger = cast(TraceLogger, logging.getLogger('evm.db.account.AccountDB'))
 
     def __init__(self, db, state_root=BLANK_ROOT_HASH):
         r"""
@@ -403,7 +406,7 @@ class AccountDB(BaseAccountDB):
         self._journaltrie.commit(trie_changeset)
 
     def make_state_root(self) -> Hash32:
-        self.logger.debug("Generating AccountDB trie")
+        self.logger.trace("Generating AccountDB trie")
         self._journaldb.persist()
         self._journaltrie.persist()
         return self.state_root
@@ -424,7 +427,7 @@ class AccountDB(BaseAccountDB):
                 else:
                     accounts_displayed.add(address)
                     account = self._get_account(address)
-                    self.logger.debug(
+                    self.logger.trace(
                         "Account %s: balance %d, nonce %d, storage root %s, code hash %s",
                         encode_hex(address),
                         account.balance,

--- a/evm/db/account.py
+++ b/evm/db/account.py
@@ -70,8 +70,7 @@ class BaseAccountDB(ABC):
             "Must be implemented by subclasses"
         )
 
-    # We need to ignore this until https://github.com/python/mypy/issues/4165 is resolved
-    @property  # tyoe: ignore
+    @property
     @abstractmethod
     def state_root(self):
         raise NotImplementedError("Must be implemented by subclasses")

--- a/evm/db/chain.py
+++ b/evm/db/chain.py
@@ -184,6 +184,10 @@ class BaseChainDB(ABC):
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
+    def get(self, key: bytes) -> bytes:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
     def persist_trie_data_dict(self, trie_data_dict: Dict[bytes, bytes]) -> None:
         raise NotImplementedError("ChainDB classes must implement this method")
 
@@ -606,6 +610,12 @@ class ChainDB(BaseChainDB):
         """
         return self.db.exists(key)
 
+    def get(self, key: bytes) -> bytes:
+        """
+        Return the value for the given key or a KeyError if it doesn't exist in the database.
+        """
+        return self.db[key]
+
     def persist_trie_data_dict(self, trie_data_dict: Dict[bytes, bytes]) -> None:
         """
         Store raw trie data to db from a dict
@@ -624,6 +634,9 @@ def _decode_block_header(header_rlp: bytes) -> BlockHeader:
 
 
 class AsyncChainDB(ChainDB):
+    async def coro_get(self, key: bytes) -> bytes:
+        raise NotImplementedError()
+
     async def coro_get_score(self, block_hash: Hash32) -> int:
         raise NotImplementedError()
 

--- a/evm/vm/computation.py
+++ b/evm/vm/computation.py
@@ -228,7 +228,7 @@ class BaseComputation(Configurable, ABC):
         before_cost = memory_gas_cost(before_size)
         after_cost = memory_gas_cost(after_size)
 
-        self.logger.debug(
+        self.logger.trace(
             "MEMORY: size (%s -> %s) | cost (%s -> %s)",
             before_size,
             after_size,
@@ -449,7 +449,7 @@ class BaseComputation(Configurable, ABC):
     # Context Manager API
     #
     def __enter__(self) -> 'BaseComputation':
-        self.logger.debug(
+        self.logger.trace(
             (
                 "COMPUTATION STARTING: gas: %s | from: %s | to: %s | value: %s "
                 "| depth %s | static: %s"
@@ -466,7 +466,7 @@ class BaseComputation(Configurable, ABC):
 
     def __exit__(self, exc_type: None, exc_value: None, traceback: None) -> None:
         if exc_value and isinstance(exc_value, VMError):
-            self.logger.debug(
+            self.logger.trace(
                 (
                     "COMPUTATION ERROR: gas: %s | from: %s | to: %s | value: %s | "
                     "depth: %s | static: %s | error: %s"
@@ -492,7 +492,7 @@ class BaseComputation(Configurable, ABC):
             # suppress VM exceptions
             return True
         elif exc_type is None:
-            self.logger.debug(
+            self.logger.trace(
                 (
                     "COMPUTATION SUCCESS: from: %s | to: %s | value: %s | "
                     "depth: %s | static: %s | gas-used: %s | gas-remaining: %s"

--- a/evm/vm/forks/frontier/computation.py
+++ b/evm/vm/forks/frontier/computation.py
@@ -1,6 +1,9 @@
 from eth_hash.auto import keccak
 
-from evm import constants
+from evm.constants import (
+    GAS_CODEDEPOSIT,
+    STACK_DEPTH_LIMIT,
+)
 from evm import precompiles
 from evm.vm.computation import (
     BaseComputation
@@ -39,7 +42,7 @@ class FrontierComputation(BaseComputation):
     def apply_message(self):
         snapshot = self.state.snapshot()
 
-        if self.msg.depth > constants.STACK_DEPTH_LIMIT:
+        if self.msg.depth > STACK_DEPTH_LIMIT:
             raise StackDepthLimit("Stack depth limit reached")
 
         if self.msg.should_transfer_value and self.msg.value:
@@ -53,7 +56,7 @@ class FrontierComputation(BaseComputation):
             self.state.account_db.delta_balance(self.msg.sender, -1 * self.msg.value)
             self.state.account_db.delta_balance(self.msg.storage_address, self.msg.value)
 
-            self.logger.debug(
+            self.logger.trace(
                 "TRANSFERRED: %s from %s -> %s",
                 self.msg.value,
                 encode_hex(self.msg.sender),
@@ -84,7 +87,7 @@ class FrontierComputation(BaseComputation):
             contract_code = computation.output
 
             if contract_code:
-                contract_code_gas_fee = len(contract_code) * constants.GAS_CODEDEPOSIT
+                contract_code_gas_fee = len(contract_code) * GAS_CODEDEPOSIT
                 try:
                     computation.consume_gas(
                         contract_code_gas_fee,
@@ -93,7 +96,7 @@ class FrontierComputation(BaseComputation):
                 except OutOfGas:
                     computation.output = b''
                 else:
-                    self.logger.debug(
+                    self.logger.trace(
                         "SETTING CODE: %s -> length: %s | hash: %s",
                         encode_hex(self.msg.storage_address),
                         len(contract_code),

--- a/evm/vm/forks/frontier/state.py
+++ b/evm/vm/forks/frontier/state.py
@@ -3,7 +3,7 @@ from typing import Type  # noqa: F401
 
 from eth_hash.auto import keccak
 
-from evm import constants
+from evm.constants import CREATE_CONTRACT_ADDRESS
 from evm.db.account import (
     AccountDB,
 )
@@ -58,7 +58,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
         # Setup VM Message
         message_gas = transaction.gas - transaction.intrinsic_gas
 
-        if transaction.to == constants.CREATE_CONTRACT_ADDRESS:
+        if transaction.to == CREATE_CONTRACT_ADDRESS:
             contract_address = generate_contract_address(
                 transaction.sender,
                 self.vm_state.account_db.get_nonce(transaction.sender) - 1,
@@ -70,7 +70,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
             data = transaction.data
             code = self.vm_state.account_db.get_code(transaction.to)
 
-        self.vm_state.logger.debug(
+        self.vm_state.logger.trace(
             (
                 "TRANSACTION: sender: %s | to: %s | value: %s | gas: %s | "
                 "gas-price: %s | s: %s | r: %s | v: %s | data-hash: %s"
@@ -114,7 +114,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
                         encode_hex(message.storage_address),
                     )
                 )
-                self.vm_state.logger.debug(
+                self.vm_state.logger.trace(
                     "Address collision while creating contract: %s",
                     encode_hex(message.storage_address),
                 )
@@ -144,7 +144,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
         gas_refund_amount = (gas_refund + gas_remaining) * transaction.gas_price
 
         if gas_refund_amount:
-            self.vm_state.logger.debug(
+            self.vm_state.logger.trace(
                 'TRANSACTION REFUND: %s -> %s',
                 gas_refund_amount,
                 encode_hex(computation.msg.sender),
@@ -155,7 +155,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
         # Miner Fees
         transaction_fee = \
             (transaction.gas - gas_remaining - gas_refund) * transaction.gas_price
-        self.vm_state.logger.debug(
+        self.vm_state.logger.trace(
             'TRANSACTION FEE: %s -> %s',
             transaction_fee,
             encode_hex(self.vm_state.coinbase),
@@ -166,7 +166,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
         for account, beneficiary in computation.get_accounts_for_deletion():
             # TODO: need to figure out how we prevent multiple selfdestructs from
             # the same account and if this is the right place to put this.
-            self.vm_state.logger.debug('DELETING ACCOUNT: %s', encode_hex(account))
+            self.vm_state.logger.trace('DELETING ACCOUNT: %s', encode_hex(account))
 
             # TODO: this balance setting is likely superflous and can be
             # removed since `delete_account` does this.

--- a/evm/vm/forks/homestead/computation.py
+++ b/evm/vm/forks/homestead/computation.py
@@ -47,7 +47,7 @@ class HomesteadComputation(FrontierComputation):
                     self.state.revert(snapshot)
                 else:
                     if self.logger:
-                        self.logger.debug(
+                        self.logger.trace(
                             "SETTING CODE: %s -> length: %s | hash: %s",
                             encode_hex(self.msg.storage_address),
                             len(contract_code),

--- a/evm/vm/forks/spurious_dragon/computation.py
+++ b/evm/vm/forks/spurious_dragon/computation.py
@@ -60,7 +60,7 @@ class SpuriousDragonComputation(HomesteadComputation):
                     self.state.revert(snapshot)
                 else:
                     if self.logger:
-                        self.logger.debug(
+                        self.logger.trace(
                             "SETTING CODE: %s -> length: %s | hash: %s",
                             encode_hex(self.msg.storage_address),
                             len(contract_code),

--- a/evm/vm/forks/spurious_dragon/state.py
+++ b/evm/vm/forks/spurious_dragon/state.py
@@ -26,7 +26,7 @@ class SpuriousDragonTransactionExecutor(HomesteadTransactionExecutor):
                 self.vm_state.account_db.account_is_empty(account)
             )
             if should_delete:
-                self.vm_state.logger.debug(
+                self.vm_state.logger.trace(
                     "CLEARING EMPTY ACCOUNT: %s",
                     encode_hex(account),
                 )

--- a/evm/vm/logic/call.py
+++ b/evm/vm/logic/call.py
@@ -84,7 +84,7 @@ class BaseCall(Opcode, ABC):
             else:
                 raise Exception("Invariant: Unreachable code path")
 
-            self.logger.debug(
+            self.logger.trace(
                 "%s failure: %s",
                 self.mnemonic,
                 err_message,

--- a/evm/vm/logic/system.py
+++ b/evm/vm/logic/system.py
@@ -81,7 +81,7 @@ def _selfdestruct(computation, beneficiary):
     # beneficiary.
     computation.state.account_db.set_balance(computation.msg.storage_address, 0)
 
-    computation.logger.debug(
+    computation.logger.trace(
         "SELFDESTRUCT: %s (%s) -> %s",
         encode_hex(computation.msg.storage_address),
         local_balance,
@@ -134,7 +134,7 @@ class Create(Opcode):
         is_collision = computation.state.account_db.account_has_code_or_nonce(contract_address)
 
         if is_collision:
-            self.logger.debug(
+            self.logger.trace(
                 "Address collision while creating contract: %s",
                 encode_hex(contract_address),
             )

--- a/p2p/__init__.py
+++ b/p2p/__init__.py
@@ -1,0 +1,2 @@
+# This is to ensure we call setup_trace_logging() before anything else.
+import evm  # noqa: F401

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -317,7 +317,6 @@ class PreferredNodeDiscoveryProtocol(DiscoveryProtocol):
 
 
 class DiscoveryService(BaseService):
-    logger = logging.getLogger("p2p.discovery.DiscoveryService")
     _lookup_running = asyncio.Lock()
     _last_lookup: float = 0
     _lookup_interval: int = 30

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -765,6 +765,7 @@ class PeerPool(BaseService):
     async def _run(self) -> None:
         # FIXME: PeerPool should probably no longer be a BaseService, but for now we're keeping it
         # so in order to ensure we cancel all peers when we terminate.
+        asyncio.ensure_future(self._periodically_report_stats())
         await self.cancel_token.wait()
 
     async def stop_all_peers(self) -> None:

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -68,7 +68,6 @@ DIAL_IN_OUT_RATIO = 0.75
 
 class Server(BaseService):
     """Server listening for incoming connections"""
-    logger = logging.getLogger("p2p.server.Server")
     _tcp_listener = None
     _udp_listener = None
 

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -4,22 +4,26 @@ import logging
 from typing import (
     Awaitable,
     Callable,
+    cast,
     Optional,
     TypeVar
 )
+
+from evm.utils.logging import TraceLogger
 
 from p2p.cancel_token import CancelToken, wait_with_token
 from p2p.exceptions import OperationCancelled
 
 
 class BaseService(ABC):
-    logger: logging.Logger = None
+    logger: TraceLogger = None
     # Number of seconds cancel() will wait for run() to finish.
     _wait_until_finished_timeout = 5
 
     def __init__(self, token: CancelToken=None) -> None:
         if self.logger is None:
-            self.logger = logging.getLogger(self.__module__ + '.' + self.__class__.__name__)
+            self.logger = cast(
+                TraceLogger, logging.getLogger(self.__module__ + '.' + self.__class__.__name__))
 
         self._run_lock = asyncio.Lock()
         self.cleaned_up = asyncio.Event()

--- a/p2p/shard_syncer.py
+++ b/p2p/shard_syncer.py
@@ -1,7 +1,6 @@
 from collections import (
     defaultdict,
 )
-import logging
 import time
 from typing import (
     Any,
@@ -70,7 +69,6 @@ COLLATION_PERIOD = 1
 
 
 class ShardSyncer(BaseService, PeerPoolSubscriber):
-    logger = logging.getLogger("p2p.sharding.ShardSyncer")
 
     def __init__(self, shard: Shard, peer_pool: PeerPool, token: CancelToken=None) -> None:
         super().__init__(token)

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -46,7 +46,6 @@ from p2p.utils import get_process_pool_executor
 
 
 class StateDownloader(BaseService, PeerPoolSubscriber):
-    logger = logging.getLogger("p2p.state.StateDownloader")
     _pending_nodes: Dict[Any, float] = {}
     _total_processed_nodes = 0
     _report_interval = 10  # Number of seconds between progress reports.

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -19,8 +19,6 @@ FAST_SYNC_CUTOFF = 60 * 60 * 24
 
 
 class FullNodeSyncer(BaseService):
-    logger = logging.getLogger("p2p.sync.FullNodeSyncer")
-
     chain: AsyncChain = None
     chaindb: AsyncChainDB = None
     base_db: BaseDB = None

--- a/tests/p2p/integration_test_helpers.py
+++ b/tests/p2p/integration_test_helpers.py
@@ -32,6 +32,7 @@ def async_passthrough(base_name):
 
 
 class FakeAsyncChainDB(AsyncChainDB):
+    coro_get = async_passthrough('get')
     coro_get_score = async_passthrough('get_score')
     coro_get_block_header_by_hash = async_passthrough('get_block_header_by_hash')
     coro_get_canonical_head = async_passthrough('get_canonical_head')

--- a/trinity/db/chain.py
+++ b/trinity/db/chain.py
@@ -11,6 +11,7 @@ from trinity.utils.mp import (
 
 
 class ChainDBProxy(BaseProxy):
+    coro_get = async_method('get')
     coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
     coro_get_canonical_head = async_method('get_canonical_head')
     coro_get_score = async_method('get_score')
@@ -24,6 +25,7 @@ class ChainDBProxy(BaseProxy):
     coro_get_block_uncles = async_method('get_block_uncles')
     coro_get_receipts = async_method('get_receipts')
 
+    get = sync_method('get')
     get_block_header_by_hash = sync_method('get_block_header_by_hash')
     get_canonical_head = sync_method('get_canonical_head')
     get_score = sync_method('get_score')

--- a/trinity/tx_pool/pool.py
+++ b/trinity/tx_pool/pool.py
@@ -1,4 +1,3 @@
-import logging
 from typing import (
     cast,
     Iterable,
@@ -39,7 +38,6 @@ class TxPool(BaseService, PeerPoolSubscriber):
         This is a minimal viable implementation that only relays transactions but doesn't actually
         hold on to them yet. It's still missing many features of a grown up transaction pool.
     """
-    logger = logging.getLogger("trinity.tx_pool.TxPool")
 
     def __init__(self, peer_pool: PeerPool, token: CancelToken = None) -> None:
         super().__init__(token)

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -95,7 +95,6 @@ def setup_queue_logging(log_queue: 'Queue[str]', level: int) -> None:
     logger.setLevel(logging.DEBUG)
     # These loggers generates too much DEBUG noise, drowning out the important things, so force
     # the INFO level for it until https://github.com/ethereum/py-evm/issues/806 is fixed.
-    logging.getLogger('p2p.peer.Peer').setLevel(logging.INFO)
     logging.getLogger('p2p.kademlia').setLevel(logging.INFO)
     logging.getLogger('p2p.discovery').setLevel(logging.INFO)
     logger.debug('Logging initialized: PID=%s', os.getpid())


### PR DESCRIPTION
## Fix ChainSyncer handling of body/receipts/node requests from peers

- When handling body/receipts requests for blocks we don't know, we'd
 fail with an undhandled HeaderNotFound
- Handling of trie Node requests didn't work on trinity because it
 used a ChainDB method that was not exposed in trinity's ChainDBProxy

## Re-enable PeerPool's periodically reporting of peer stats

It had been accidentally removed.

## Make logging less noisy by using a new (LOG_TRACE) level

Peer was logging (with DEBUG level) all received/sent msgs, making it so
noisy that we had to forcibly set its level to INFO on trinity. This
changes it to log those on a different level that is currently never shown
when running trinity

Similaryly, change all debug() logs in evm/vm to use the new level as those
make trinity's log pretty much useless when syncing in regular
(block processing) mode