### PR TITLE
StateDownloader now handles data requests from peers

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -822,9 +822,14 @@ def _test() -> None:
         await syncer.cancel()
         loop.stop()
 
+    async def run() -> None:
+        await syncer.run()
+        syncer.logger.info("run() finished, exiting")
+        sigint_received.set()
+
     # loop.set_debug(True)
     asyncio.ensure_future(exit_on_sigint())
-    asyncio.ensure_future(syncer.run())
+    asyncio.ensure_future(run())
     loop.run_forever()
     loop.close()
 

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -39,8 +39,7 @@ from evm.rlp.accounts import Account
 
 from p2p import eth
 from p2p import protocol
-from p2p.chain import (
-    handle_get_block_bodies, handle_get_node_data, handle_get_receipts, lookup_headers)
+from p2p.chain import PeerRequestHandler
 from p2p.cancel_token import CancelToken
 from p2p.exceptions import OperationCancelled
 from p2p.peer import ETHPeer, PeerPool, PeerPoolSubscriber
@@ -71,6 +70,7 @@ class StateDownloader(BaseService, PeerPoolSubscriber):
         self.peer_pool = peer_pool
         self.root_hash = root_hash
         self.scheduler = StateSync(root_hash, account_db)
+        self._handler = PeerRequestHandler(self.chaindb, self.logger, self.cancel_token)
         self._peers_with_pending_requests: Dict[ETHPeer, float] = {}
         self._executor = get_process_pool_executor()
 
@@ -129,21 +129,17 @@ class StateDownloader(BaseService, PeerPoolSubscriber):
         elif isinstance(cmd, eth.GetBlockHeaders):
             await self._handle_get_block_headers(peer, cast(Dict[str, Any], msg))
         elif isinstance(cmd, eth.GetBlockBodies):
-            await handle_get_block_bodies(
-                self.chaindb, peer, cast(List[Hash32], msg), self.logger, self.cancel_token)
+            await self._handler.handle_get_block_bodies(peer, cast(List[Hash32], msg))
         elif isinstance(cmd, eth.GetReceipts):
-            await handle_get_receipts(
-                self.chaindb, peer, cast(List[Hash32], msg), self.logger, self.cancel_token)
+            await self._handler.handle_get_receipts(peer, cast(List[Hash32], msg))
         elif isinstance(cmd, eth.GetNodeData):
-            await handle_get_node_data(
-                self.chaindb, peer, cast(List[Hash32], msg), self.logger, self.cancel_token)
+            await self._handler.handle_get_node_data(peer, cast(List[Hash32], msg))
         else:
             self.logger.warn("%s not handled during StateSync, must be implemented", cmd)
 
     async def _handle_get_block_headers(self, peer: ETHPeer, msg: Dict[str, Any]) -> None:
-        headers = await lookup_headers(
-            self.chaindb, msg['block_number_or_hash'], msg['max_headers'],
-            msg['skip'], msg['reverse'], self.logger, self.cancel_token)
+        headers = await self._handler.lookup_headers(
+            msg['block_number_or_hash'], msg['max_headers'], msg['skip'], msg['reverse'])
         peer.sub_proto.send_block_headers(headers)
 
     async def _cleanup(self) -> None:

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -58,7 +58,7 @@ class FullNodeSyncer(BaseService):
             self.logger.info(
                 "Missing state for current head (#%d), downloading it", head.block_number)
             downloader = StateDownloader(
-                self.base_db, head.state_root, self.peer_pool, self.cancel_token)
+                self.chaindb, self.base_db, head.state_root, self.peer_pool, self.cancel_token)
             await downloader.run()
 
         # Now, loop forever, fetching missing blocks and applying them.

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -54,7 +54,8 @@ async def test_fast_syncer(request, event_loop, chaindb_fresh, chaindb_20):
     assert head == chaindb_20.get_canonical_head()
 
     # Now download the state for the chain's head.
-    state_downloader = StateDownloader(chaindb_fresh.db, head.state_root, client_peer_pool)
+    state_downloader = StateDownloader(
+        chaindb_fresh, chaindb_fresh.db, head.state_root, client_peer_pool)
     await asyncio.wait_for(state_downloader.run(), timeout=2)
 
     assert head.state_root in chaindb_fresh.db


### PR DESCRIPTION
I noticed a low peer count during a state sync (which makes it quite slow) and it turns out that's because peers attempt to fetch data from us and disconnect as we fail to reply. This should ensure we keep a high peer count, speeding up the state sync significantly

Depends on #980