### PR TITLE
add ttl to validators.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ deps = {
         "web3==4.3.0",
         # required for rlp>=1.0.0
         "eth-account>=0.2.1,<1",
+        "cachetools>=2.1.0"
     ],
     'test': [
         "hypothesis==3.44.26",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ deps = {
         "web3==4.3.0",
         # required for rlp>=1.0.0
         "eth-account>=0.2.1,<1",
-        "cachetools>=2.1.0"
+        "cachetools==2.1.*",
     ],
     'test': [
         "hypothesis==3.44.26",

--- a/trinity/tx_pool/validators.py
+++ b/trinity/tx_pool/validators.py
@@ -1,3 +1,5 @@
+import cachetools.func
+
 from typing import (
     Type
 )
@@ -45,6 +47,7 @@ class DefaultTransactionValidator():
         else:
             return True
 
+    @cachetools.func.ttl_cache(maxsize=1024, ttl=300)
     def get_appropriate_tx_class(self) -> Type[BaseTransaction]:
         current_tx_class = self.chain.get_vm_class().get_transaction_class()
         # If the current head of the chain is still on a fork that is before the currently


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/py-evm/blob/46f956ea048eafed6606f59a465af375f1be7a9a/trinity/tx_pool/validators.py#L47-L56

get called quite often and impact `ChainProxy`

### How was it fixed?

Add time to live caching through @cachetools.func.ttl_cache decorator.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://img.qnong.com.cn/uploadfile/2015/0323/20150323025829498.jpeg)

Closes #992 
