### PR TITLE
Use consistent version range scheme in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ deps = {
         "web3==4.3.0",
         # required for rlp>=1.0.0
         "eth-account>=0.2.1,<1",
-        "cachetools==2.1.*",
+        "cachetools>=2.1.0,<3.0.0",
     ],
     'test': [
         "hypothesis==3.44.26",
@@ -57,7 +57,7 @@ deps = {
         "mypy==0.610",
     ],
     'benchmark': [
-        "termcolor==1.1.*",
+        "termcolor>=1.1.0,<2.0.0",
         "web3>=4.1.0,<5.0.0",
     ],
     'doc': [


### PR DESCRIPTION
### What was wrong?

This is a follow up to the [discussion about the version scheme used in setup.py](https://github.com/ethereum/py-evm/pull/997#discussion_r200872726). I brought in some inconsistency which this PR fixes.

### How was it fixed?

Used range based version selection only bound by the major version.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://c1.staticflickr.com/4/3262/2463346624_c0889bc8d9_b.jpg)
