### PR TITLE
Inherit BaseChain from LightDispatchChain

### DIFF
--- a/evm/chains/base.py
+++ b/evm/chains/base.py
@@ -124,9 +124,8 @@ class BaseChain(Configurable, ABC):
         raise NotImplementedError("Chain classes must implement this method")
 
     @classmethod
-    @abstractmethod
     def get_vm_configuration(cls) -> Tuple[Tuple[int, Type['BaseVM']], ...]:
-        raise NotImplementedError("Chain classes must implement this method")
+        return cls.vm_configuration
 
     #
     # Chain API
@@ -149,9 +148,11 @@ class BaseChain(Configurable, ABC):
     #
     # VM API
     #
-    @abstractmethod
-    def get_vm_class(self, header: BlockHeader=None) -> Type['BaseVM']:
-        raise NotImplementedError("Chain classes must implement this method")
+    def get_vm_class(self, header: BlockHeader) -> Type['BaseVM']:
+        """
+        Returns the VM instance for the given block number.
+        """
+        return self.get_vm_class_for_block_number(header.block_number)
 
     @abstractmethod
     def get_vm(self, header: BlockHeader=None) -> 'BaseVM':
@@ -310,10 +311,6 @@ class Chain(BaseChain):
             raise AttributeError("`chaindb_class` not set")
         return cls.chaindb_class
 
-    @classmethod
-    def get_vm_configuration(cls) -> Tuple[Tuple[int, Type['BaseVM']], ...]:
-        return cls.vm_configuration
-
     #
     # Chain API
     #
@@ -371,13 +368,6 @@ class Chain(BaseChain):
     #
     # VM API
     #
-    def get_vm_class(self, at_header: BlockHeader=None) -> Type['BaseVM']:
-        """
-        Returns the VM instance for the given block number.
-        """
-        header = self.ensure_header(at_header)
-        return self.get_vm_class_for_block_number(header.block_number)
-
     def get_vm(self, at_header: BlockHeader=None) -> 'BaseVM':
         """
         Returns the VM instance for the given block number.

--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -8,11 +8,11 @@ from evm.chains.base import (
 )
 from evm.chains.mainnet import (
     BYZANTIUM_MAINNET_BLOCK,
-    MainnetChain,
+    BaseMainnetChain,
 )
 from evm.chains.ropsten import (
     BYZANTIUM_ROPSTEN_BLOCK,
-    RopstenChain,
+    BaseRopstenChain,
 )
 
 from p2p.cancel_token import (
@@ -71,14 +71,14 @@ class TxPlugin(BasePlugin):
         return all((self.peer_pool is not None, self.chain is not None, self.is_enabled))
 
     def start(self, context: PluginContext) -> None:
-        if isinstance(self.chain, MainnetChain):
+        if isinstance(self.chain, BaseMainnetChain):
             validator = DefaultTransactionValidator(self.chain, BYZANTIUM_MAINNET_BLOCK)
-        elif isinstance(self.chain, RopstenChain):
+        elif isinstance(self.chain, BaseRopstenChain):
             validator = DefaultTransactionValidator(self.chain, BYZANTIUM_ROPSTEN_BLOCK)
         else:
             # TODO: We could hint the user about e.g. a --tx-pool-no-validation flag to run the
             # tx pool without tx validation in this case
-            raise ValueError("The TxPool plugin does only support MainnetChain or RopstenChain")
+            raise ValueError("The TxPool plugin only supports MainnetChain or RopstenChain")
 
         tx_pool = TxPool(self.peer_pool, validator, self.cancel_token)
         asyncio.ensure_future(tx_pool.run())

--- a/trinity/plugins/builtin/tx_pool/validators.py
+++ b/trinity/plugins/builtin/tx_pool/validators.py
@@ -49,7 +49,8 @@ class DefaultTransactionValidator():
 
     @cachetools.func.ttl_cache(maxsize=1024, ttl=300)
     def get_appropriate_tx_class(self) -> Type[BaseTransaction]:
-        current_tx_class = self.chain.get_vm_class().get_transaction_class()
+        head = self.chain.get_canonical_head()
+        current_tx_class = self.chain.get_vm_class(head).get_transaction_class()
         # If the current head of the chain is still on a fork that is before the currently
         # active fork (syncing), ensure that we use the specified initial tx class
         if self._is_outdated_tx_class(current_tx_class):


### PR DESCRIPTION
### What was wrong?

#998 introduced inheritance of `LightDispatchChain` -> `Chain`. For many methods, the `Chain` implementations will are broken if run in a `LightDispatchChain`. They expect a `chaindb`, but the dispatch chain only has a `headerdb`. It seems safer, easier to reason about, and quicker to isolate problems, if we only inherit `BaseChain`.

### How was it fixed?

- Move some key methods that don't depend on `chaindb` from `Chain` to `BaseChain`.
- Require header as part of `get_vm_class()` so that it can be implemented in `BaseChain`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/B5cTJre.jpg)
