### PR TITLE
Track peer performance, favor fast peers

### DIFF
--- a/eth/precompiles/modexp.py
+++ b/eth/precompiles/modexp.py
@@ -103,7 +103,6 @@ def _modexp(data):
         to_size=exponent_length,
     )
     exponent = big_endian_to_int(exponent_bytes)
-    print('base', base, 'exponent', exponent, 'modulus', modulus)
 
     result = pow(base, exponent, modulus)
 

--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -1,8 +1,14 @@
+from abc import abstractmethod
 import asyncio
+from collections import defaultdict
+from enum import (
+    Enum,
+    auto,
+)
+from functools import partial
 import logging
 import math
 import time
-from abc import abstractmethod
 from typing import (
     Any,
     AsyncGenerator,
@@ -18,7 +24,7 @@ from typing import (
 )
 
 from cytoolz import (
-    partition_all,
+    take,
     unique,
 )
 
@@ -38,13 +44,19 @@ from p2p import protocol
 from p2p import eth
 from p2p import les
 from p2p.cancel_token import CancellableMixin, CancelToken
-from p2p.constants import MAX_REORG_DEPTH, SEAL_CHECK_RANDOM_SAMPLE_RATE
+from p2p.constants import (
+    MAX_REORG_DEPTH,
+    NEW_PEER_THROUGHPUT_DEFAULT,
+    SEAL_CHECK_RANDOM_SAMPLE_RATE,
+    THROUGHPUT_SMOOTHING_FACTOR,
+)
 from p2p.exceptions import NoEligiblePeers, OperationCancelled
 from p2p.p2p_proto import DisconnectReason
 from p2p.peer import BasePeer, ETHPeer, LESPeer, PeerPool, PeerPoolSubscriber
 from p2p.rlp import BlockBody
 from p2p.service import BaseService
 from p2p.utils import (
+    ThroughputTracker,
     get_process_pool_executor,
 )
 
@@ -55,6 +67,11 @@ if TYPE_CHECKING:
 
 
 HeaderRequestingPeer = Union[LESPeer, ETHPeer]
+
+
+class BlockPartEnum(Enum):
+    body = auto()
+    receipt = auto()
 
 
 class BaseHeaderChainSyncer(BaseService, PeerPoolSubscriber):
@@ -324,6 +341,13 @@ class FastChainSyncer(BaseHeaderChainSyncer):
         # bodies/receipts for a given chain segment.
         self._downloaded_receipts: asyncio.Queue[Tuple[ETHPeer, List[DownloadedBlockPart]]] = asyncio.Queue()  # noqa: E501
         self._downloaded_bodies: asyncio.Queue[Tuple[ETHPeer, List[DownloadedBlockPart]]] = asyncio.Queue()  # noqa: E501
+        create_stats = partial(
+            ThroughputTracker,
+            default_throughput=NEW_PEER_THROUGHPUT_DEFAULT,
+            smoothing_factor=THROUGHPUT_SMOOTHING_FACTOR,
+        )
+        # mypy is confused -- https://github.com/python/typeshed/issues/2329
+        self._throughput_stats = {part: defaultdict(create_stats) for part in BlockPartEnum}  # type: ignore # noqa: E501
 
     async def _calculate_td(self, headers: Tuple[BlockHeader, ...]) -> int:
         """Return the score (total difficulty) of the last header in the given list.
@@ -350,7 +374,8 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             self.request_bodies,
             self._downloaded_bodies,
             _body_key,
-            'body')
+            BlockPartEnum.body,
+        )
         self.logger.debug("Got block bodies for chain segment")
 
         missing_receipts = [header for header in headers if not _is_receipts_empty(header)]
@@ -364,7 +389,8 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             self.request_receipts,
             self._downloaded_receipts,
             _receipts_key,
-            'receipt')
+            BlockPartEnum.receipt,
+        )
         self.logger.debug("Got block receipts for chain segment")
 
         for header in headers:
@@ -390,7 +416,7 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             request_func: Callable[[int, List[BlockHeader]], int],
             download_queue: 'asyncio.Queue[Tuple[ETHPeer, List[DownloadedBlockPart]]]',
             key_func: Callable[[BlockHeader], Union[bytes, Tuple[bytes, bytes]]],
-            part_name: str
+            part_name: BlockPartEnum,
     ) -> 'Dict[Union[bytes, Tuple[bytes, bytes]], Union[BlockBody, List[Receipt]]]':
         """Download block parts for the given headers, using the given request_func.
 
@@ -422,13 +448,16 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             duplicates = received_keys.intersection(part.unique_key for part in parts)
             unexpected = received_keys.difference(key_func(header) for header in headers)
 
+            work_size = len(received_keys.difference(unexpected))
+            self._get_throughput_stats(peer, part_name).complete_work(work_size)
+
             parts.extend(received)
             pending_replies -= 1
 
             if unexpected:
-                self.logger.debug("Got unexpected %s from %s: %s", part_name, peer, unexpected)
+                self.logger.debug("Got unexpected %s from %s: %s", part_name.name, peer, unexpected)
             if duplicates:
-                self.logger.debug("Got duplicate %s from %s: %s", part_name, peer, duplicates)
+                self.logger.debug("Got duplicate %s from %s: %s", part_name.name, peer, duplicates)
 
             missing = [
                 header
@@ -438,19 +467,57 @@ class FastChainSyncer(BaseHeaderChainSyncer):
 
         return dict((part.unique_key, part.part) for part in parts)
 
+    def _get_throughput_stats(self, peer: BasePeer, body_part: BlockPartEnum) -> ThroughputTracker:
+        return self._throughput_stats[body_part][peer]
+
+    def deregister_peer(self, peer: BasePeer) -> None:
+        # Delete all in-progress stats for the given peer. Otherwise, if a peer disconnects before
+        # sending a block part, stats would fail when starting to track throughput the 2nd time.
+        # Also, we don't want a perpetually growing dict of stats.
+        for part in BlockPartEnum:
+            if peer in self._throughput_stats[part]:
+                del self._throughput_stats[part][peer]
+
     def _request_block_parts(
             self,
             target_td: int,
             headers: List[BlockHeader],
-            request_func: Callable[[ETHPeer, List[BlockHeader]], None]) -> int:
+            request_func: Callable[[ETHPeer, List[BlockHeader]], None],
+            block_part: BlockPartEnum,
+    ) -> int:
         peers = self.peer_pool.get_peers(target_td)
         if not peers:
             raise NoEligiblePeers()
-        length = math.ceil(len(headers) / len(peers))
-        batches = list(partition_all(length, headers))
+        batches = self._select_headers_by_peer(headers, peers, block_part)
         for peer, batch in zip(peers, batches):
+            self._get_throughput_stats(peer, block_part).begin_work()
             request_func(cast(ETHPeer, peer), batch)
         return len(batches)
+
+    def _select_headers_by_peer(
+            self,
+            headers: List[BlockHeader],
+            peers: List[BasePeer],
+            block_part: BlockPartEnum,
+    ) -> List[List[BlockHeader]]:
+        speeds = [self._get_throughput_stats(peer, block_part).get_throughput() for peer in peers]
+        speed_sum = sum(speeds)
+        fractional_speeds = [speed / speed_sum for speed in speeds]
+
+        # request headers proportionally, so faster peers are asked for more parts than slow peers
+        num_headers = len(headers)
+        header_iter = iter(headers)
+        batches = []
+        for peer, fractional_speed in zip(peers, fractional_speeds):
+            num_to_take = math.floor(fractional_speed * num_headers)
+            header_batch = list(take(num_to_take, header_iter))
+            batches.append(header_batch)
+
+        # any headers missed due to rounding error will go to the fastest peer
+        fastest_peer_idx = fractional_speeds.index(max(fractional_speeds))
+        batches[fastest_peer_idx] += list(header_iter)
+
+        return batches
 
     def _send_get_block_bodies(self, peer: ETHPeer, headers: List[BlockHeader]) -> None:
         self.logger.debug("Requesting %d block bodies to %s", len(headers), peer)
@@ -465,7 +532,12 @@ class FastChainSyncer(BaseHeaderChainSyncer):
 
         See request_receipts() for details of how this is done.
         """
-        return self._request_block_parts(target_td, headers, self._send_get_block_bodies)
+        return self._request_block_parts(
+            target_td,
+            headers,
+            self._send_get_block_bodies,
+            BlockPartEnum.body,
+        )
 
     def request_receipts(self, target_td: int, headers: List[BlockHeader]) -> int:
         """Ask our peers for receipts for the given headers.
@@ -478,7 +550,12 @@ class FastChainSyncer(BaseHeaderChainSyncer):
 
         Returns the number of requests made.
         """
-        return self._request_block_parts(target_td, headers, self._send_get_receipts)
+        return self._request_block_parts(
+            target_td,
+            headers,
+            self._send_get_receipts,
+            BlockPartEnum.receipt,
+        )
 
     async def _handle_msg(self, peer: HeaderRequestingPeer, cmd: protocol.Command,
                           msg: protocol._DecodedMsgType) -> None:
@@ -593,7 +670,8 @@ class RegularChainSyncer(FastChainSyncer):
             self.request_bodies,
             self._downloaded_bodies,
             _body_key,
-            'body')
+            BlockPartEnum.body,
+        )
         self.logger.info("Got block bodies for chain segment")
 
         for header in headers:

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -75,3 +75,17 @@ MAX_REORG_DEPTH = 24
 # (https://github.com/ethereum/go-ethereum/pull/1889#issue-47241762), but in order to err on the
 # side of caution, we use a higher value.
 SEAL_CHECK_RANDOM_SAMPLE_RATE = 48
+
+#
+# Parameters for tracking average throughput of a peer
+#
+
+# Smoothing factor, or "alpha" of the exponential moving average.
+# Closer to 0 gives you smoother, slower-to-update, data
+# Closer to 1 gives you choppier, quicker-to-update, data
+# (1 would completely ignore history, and 0 would completely ignore new data)
+THROUGHPUT_SMOOTHING_FACTOR = 0.05
+
+# Default starting value for throughput for a new peer, for all types of throughput tracking
+# Default receipt download speed, for example, would be 1 receipt per second
+NEW_PEER_THROUGHPUT_DEFAULT = 1.0

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -691,6 +691,12 @@ class PeerPoolSubscriber(ABC):
         """
         pass
 
+    def deregister_peer(self, peer: BasePeer) -> None:
+        """
+        Called when a peer connection is closed
+        """
+        pass
+
     @property
     def msg_queue(self) -> 'asyncio.Queue[PEER_MSG_TYPE]':
         if self._msg_queue is None:
@@ -841,6 +847,8 @@ class PeerPool(BaseService):
         if peer.remote in self.connected_nodes:
             self.logger.info("%s finished, removing from pool", peer)
             self.connected_nodes.pop(peer.remote)
+        for subscriber in self._subscribers:
+            subscriber.deregister_peer(peer)
 
     @property
     def peers(self) -> List[BasePeer]:

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -1,9 +1,14 @@
 from concurrent.futures import ProcessPoolExecutor
+from cytoolz import take
 import logging
+import math
 import os
 import rlp
 import time
 from typing import (
+    List,
+    TypeVar,
+    Tuple,
     Union,
 )
 
@@ -61,9 +66,9 @@ class ThroughputTracker:
     Tracks throughput using an exponential moving average.
     https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
     """
-    def __init__(self, default_throughput: Union[int, float], smoothing_factor: float) -> None:
+    def __init__(self, default_throughput: float, smoothing_factor: float) -> None:
         self._last_start: float = None
-        self._throughput = float(default_throughput)
+        self._throughput = default_throughput
         if 0 < smoothing_factor < 1:
             self._alpha = smoothing_factor
         else:
@@ -84,3 +89,58 @@ class ThroughputTracker:
 
     def get_throughput(self) -> float:
         return self._throughput
+
+
+T = TypeVar('T')
+
+
+def get_scaled_batches(
+        scales: Tuple[float, ...],
+        source: List[T],
+) -> List[List[T]]:
+    """
+    Group elements from source into scaled batches. Each element from source will be present
+    in exactly one of the batches. Batch lengths always round down, and any remaining elements
+    from source will be batched into the highest-scale index.
+
+    :param scales: amount to scale batches - must be >=0 and !=NaN
+    :param source: list of elements to group into scaled batches
+
+    :return: list of batches, the same length as scales. Batches *may be empty*.
+    """
+    if len(set(source)) != len(source):
+        raise ValidationError("Elements to batch must be unique")
+    elif len(scales) == 0:
+        raise ValidationError("Must have at least one target to batch elements into")
+    elif any(math.isnan(scale) for scale in scales):
+        raise ValidationError("All scale values must be a number (ie~ not a NaN)")
+
+    scale_sum = sum(scales)
+    if scale_sum == 0:
+        normalized_scales = (1.0, ) * len(scales)
+        total = float(len(scales))
+    elif any(math.isinf(scale) for scale in scales):
+        normalized_scales = tuple(
+            1.0 if math.isinf(scale) else 0.0
+            for scale in scales
+        )
+        total = sum(normalized_scales)
+    else:
+        normalized_scales = scales
+        total = scale_sum
+
+    fractional_scales = [scale / total for scale in normalized_scales]
+
+    num_elements = len(source)
+    element_iter = iter(source)
+    batches = []
+    for fraction in fractional_scales:
+        num_to_take = math.floor(fraction * num_elements)
+        batch = list(take(num_to_take, element_iter))
+        batches.append(batch)
+
+    # any elements missed due to rounding error will go to the largest scaled index
+    largest_idx = fractional_scales.index(max(fractional_scales))
+    batches[largest_idx] += list(element_iter)
+
+    return batches

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -2,7 +2,14 @@ from concurrent.futures import ProcessPoolExecutor
 import logging
 import os
 import rlp
+import time
+from typing import (
+    Union,
+)
 
+from eth.exceptions import (
+    ValidationError,
+)
 from eth.utils.numeric import big_endian_to_int
 
 
@@ -47,3 +54,33 @@ def get_process_pool_executor() -> ProcessPoolExecutor:
     else:
         cpu_count = os_cpu_count - 1
     return ProcessPoolExecutor(cpu_count)
+
+
+class ThroughputTracker:
+    """
+    Tracks throughput using an exponential moving average.
+    https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+    """
+    def __init__(self, default_throughput: Union[int, float], smoothing_factor: float) -> None:
+        self._last_start: float = None
+        self._throughput = float(default_throughput)
+        if 0 < smoothing_factor < 1:
+            self._alpha = smoothing_factor
+        else:
+            raise ValidationError("Smoothing factor of ThroughputTracker must be between 0 and 1")
+
+    def begin_work(self) -> None:
+        if self._last_start is not None:
+            raise ValidationError("Cannot start the ThroughputTracker again without completing it")
+        self._last_start = time.perf_counter()
+
+    def complete_work(self, work_completed: Union[int, float]) -> None:
+        if self._last_start is None:
+            raise ValidationError("Cannot end the ThroughputTracker without starting it")
+        time_elapsed = time.perf_counter() - self._last_start
+        last_throughput = work_completed / time_elapsed
+        self._throughput = (self._throughput * (1 - self._alpha)) + (last_throughput * self._alpha)
+        self._last_start = None
+
+    def get_throughput(self) -> float:
+        return self._throughput

--- a/tests/p2p/test_utils.py
+++ b/tests/p2p/test_utils.py
@@ -10,34 +10,51 @@ from p2p.utils import get_scaled_batches
 
 
 @given(
-    st.lists(st.floats(min_value=0), min_size=1),
+    # doesn't matter what the worker type is, picked binary (mostly) arbitrarily:
+    st.dictionaries(keys=st.binary(), values=st.floats(min_value=0), min_size=1),
     # doesn't matter what the source element type is, picked text (mostly) arbitrarily:
     st.lists(elements=st.text(), unique=True),
 )
-def test_scaled_batches_are_complete(scales_list, source):
-    scales = tuple(scales_list)
-    batches = get_scaled_batches(scales, source)
+def test_scaled_batches_are_complete(scaled_workers, source):
+    batches = get_scaled_batches(scaled_workers, source)
 
-    # the batches must be the same length as the scaled workers
-    assert len(scales) == len(batches)
+    # every resulting worker must be in the input workers set
+    assert all(worker in scaled_workers for worker in batches.keys())
+
+    # no batches may be empty
+    assert all(len(batch) > 0 for batch in batches.values())
 
     # the total number of elements returned must be equal to the length of the source
-    assert sum(map(len, batches)) == len(source)
+    assert sum(map(len, batches.values())) == len(source)
 
     # all the elements must be found in the batches
-    batched_set = set(el for batch in batches for el in batch)
+    batched_set = set(el for batch in batches.values() for el in batch)
     assert batched_set == set(source)
 
     # there must be no duplicates
-    batched_tuple = tuple(el for batch in batches for el in batch)
+    batched_tuple = tuple(el for batch in batches.values() for el in batch)
     assert len(batched_tuple) == len(batched_set)
+
+
+@pytest.mark.parametrize(
+    'scaled_workers, source, expected_batch_sizes',
+    (
+        ({b'slow': 1.5, b'fast': 1.6}, ['job-a'], {b'fast': 1}),
+        ({b'slow': 1.5, b'fast': 1.6}, ['job-a', 'job-b'], {b'fast': 2}),
+        ({b'slow': 1.0, b'fast': 1.9}, ['A', 'B', 'C'], {b'slow': 1, b'fast': 2}),
+    ),
+)
+def test_scaled_batches(scaled_workers, source, expected_batch_sizes):
+    batches = get_scaled_batches(scaled_workers, source)
+    batch_sizes = {worker: len(batch) for worker, batch in batches.items()}
+    assert batch_sizes == expected_batch_sizes
 
 
 def test_scaled_batches_empty():
     with pytest.raises(ValidationError):
-        get_scaled_batches(tuple(), ['has source data'])
+        get_scaled_batches({}, ['has source data'])
 
 
 def test_scaled_batches_nan():
     with pytest.raises(ValidationError):
-        get_scaled_batches(tuple([1.2, float('nan')]), ['has source data'])
+        get_scaled_batches({b'a': 1.2, b'b': float('nan')}, ['has source data'])

--- a/tests/p2p/test_utils.py
+++ b/tests/p2p/test_utils.py
@@ -1,0 +1,43 @@
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+import pytest
+
+from eth.exceptions import ValidationError
+from p2p.utils import get_scaled_batches
+
+
+@given(
+    st.lists(st.floats(min_value=0), min_size=1),
+    # doesn't matter what the source element type is, picked text (mostly) arbitrarily:
+    st.lists(elements=st.text(), unique=True),
+)
+def test_scaled_batches_are_complete(scales_list, source):
+    scales = tuple(scales_list)
+    batches = get_scaled_batches(scales, source)
+
+    # the batches must be the same length as the scaled workers
+    assert len(scales) == len(batches)
+
+    # the total number of elements returned must be equal to the length of the source
+    assert sum(map(len, batches)) == len(source)
+
+    # all the elements must be found in the batches
+    batched_set = set(el for batch in batches for el in batch)
+    assert batched_set == set(source)
+
+    # there must be no duplicates
+    batched_tuple = tuple(el for batch in batches for el in batch)
+    assert len(batched_tuple) == len(batched_set)
+
+
+def test_scaled_batches_empty():
+    with pytest.raises(ValidationError):
+        get_scaled_batches(tuple(), ['has source data'])
+
+
+def test_scaled_batches_nan():
+    with pytest.raises(ValidationError):
+        get_scaled_batches(tuple([1.2, float('nan')]), ['has source data'])


### PR DESCRIPTION
### What was wrong?

Related to #868 -- slow peers can dramatically slow down syncing

### How was it fixed?

- track throughput performance of peers
- favor high-throughput peers, sending them bigger requests
- if performance of a peer is bad enough, we will eventually not request anything from them (this happens naturally in the current approach, because the proportional number of block parts requested is `floor`ed and so you can end up with 0 parts requested if a peer is slow enough)

As mentioned in #868 a better solution is eventually to stream all block part requests, rather than batching them into header chunks of 192. This is a performance patch on the way there, although significant parts of PR would be obsoleted by such a solution. It would take a while to get that solution right, and probably belongs in the next release instead of the current one.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.earthtouchnews.com/media/1516420/tumblr_inline_nzojqp1f3G1qk45js_1280.jpg?width=710&height=474&mode=crop&upscale=false)
