### PR TITLE
During fast/light sync, check seal on a small subset of headers

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -5,6 +5,7 @@ from abc import (
     abstractmethod
 )
 import operator
+import random
 from typing import (  # noqa: F401
     Any,
     Optional,
@@ -273,7 +274,7 @@ class BaseChain(Configurable, ABC):
         raise NotImplementedError("Chain classes must implement this method")
 
     @abstractmethod
-    def validate_chain(self, chain: Tuple[BlockHeader, ...]) -> None:
+    def validate_chain(self, chain: Tuple[BlockHeader, ...], seal_check_frequency: int = 1) -> None:
         raise NotImplementedError("Chain classes must implement this method")
 
 
@@ -600,7 +601,7 @@ class Chain(BaseChain):
             raise ValidationError("Cannot validate genesis block this way")
         VM = self.get_vm_class_for_block_number(BlockNumber(block.number))
         parent_block = self.get_block_by_hash(block.header.parent_hash)
-        VM.validate_header(block.header, parent_block.header)
+        VM.validate_header(block.header, parent_block.header, check_seal=True)
         self.validate_uncles(block)
         self.validate_gaslimit(block.header)
 
@@ -686,15 +687,26 @@ class Chain(BaseChain):
             uncle_vm_class = self.get_vm_class_for_block_number(uncle.block_number)
             uncle_vm_class.validate_uncle(block, uncle, uncle_parent)
 
-    def validate_chain(self, chain: Tuple[BlockHeader, ...]) -> None:
+    def validate_chain(self, chain: Tuple[BlockHeader, ...], seal_check_frequency: int = 1) -> None:
         parent = self.chaindb.get_block_header_by_hash(chain[0].parent_hash)
-        for header in chain:
+        all_indices = list(range(len(chain)))
+        if seal_check_frequency == 1:
+            headers_to_check_seal = all_indices
+        else:
+            headers_to_check_seal = random.sample(
+                all_indices, len(all_indices) // seal_check_frequency)
+
+        for i, header in enumerate(chain):
             if header.parent_hash != parent.hash:
                 raise ValidationError(
                     "Invalid header chain; {} has parent {}, but expected {}".format(
                         header, header.parent_hash, parent.hash))
             vm_class = self.get_vm_class_for_block_number(header.block_number)
-            vm_class.validate_header(header, parent)
+            if i in headers_to_check_seal:
+                check_seal = True
+            else:
+                check_seal = False
+            vm_class.validate_header(header, parent, check_seal)
             parent = header
 
 
@@ -770,5 +782,6 @@ class AsyncChain(Chain):
                                 perform_validation: bool=True) -> BaseBlock:
         raise NotImplementedError()
 
-    async def coro_validate_chain(self, chain: Tuple[BlockHeader, ...]) -> None:
+    async def coro_validate_chain(
+            self, chain: Tuple[BlockHeader, ...], seal_check_frequency: int = 1) -> None:
         raise NotImplementedError()

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -33,9 +33,9 @@ class MainnetDAOValidatorVM:
     """Only on mainnet, TheDAO fork is accompanied by special extra data. Validate those headers"""
 
     @classmethod
-    def validate_header(cls, header, previous_header):
+    def validate_header(cls, header, previous_header, check_seal):
         # ignore mypy warnings, because super's validate_header is defined by mixing w/ other class
-        super().validate_header(header, previous_header)  # type: ignore
+        super().validate_header(header, previous_header, check_seal)  # type: ignore
 
         # The special extra_data is set on the ten headers starting at the fork
         extra_data_block_nums = range(cls.dao_fork_block_number, cls.dao_fork_block_number + 10)

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -33,7 +33,7 @@ class MainnetDAOValidatorVM:
     """Only on mainnet, TheDAO fork is accompanied by special extra data. Validate those headers"""
 
     @classmethod
-    def validate_header(cls, header, previous_header, check_seal):
+    def validate_header(cls, header, previous_header, check_seal=True):
         # ignore mypy warnings, because super's validate_header is defined by mixing w/ other class
         super().validate_header(header, previous_header, check_seal)  # type: ignore
 

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -256,7 +256,8 @@ class BaseVM(Configurable, ABC):
 
     @classmethod
     @abstractmethod
-    def validate_header(cls, header: BlockHeader, parent_header: BlockHeader) -> None:
+    def validate_header(
+            cls, header: BlockHeader, parent_header: BlockHeader, check_seal: bool) -> None:
         raise NotImplementedError("VM classes must implement this method")
 
     @abstractmethod
@@ -677,7 +678,7 @@ class VM(BaseVM):
             validate_length_lte(block.header.extra_data, 32, title="BlockHeader.extra_data")
         else:
             parent_header = get_parent_header(block.header, self.chaindb)
-            self.validate_header(block.header, parent_header)
+            self.validate_header(block.header, parent_header, check_seal=True)
 
         tx_root_hash, _ = make_trie_root_and_nodes(block.transactions)
         if tx_root_hash != block.header.transaction_root:
@@ -712,7 +713,8 @@ class VM(BaseVM):
             )
 
     @classmethod
-    def validate_header(cls, header: BlockHeader, parent_header: BlockHeader) -> None:
+    def validate_header(
+            cls, header: BlockHeader, parent_header: BlockHeader, check_seal: bool) -> None:
         """
         :raise eth.exceptions.ValidationError: if the header is not valid
         """
@@ -744,7 +746,8 @@ class VM(BaseVM):
                     )
                 )
 
-            cls.validate_seal(header)
+            if check_seal:
+                cls.validate_seal(header)
 
     @classmethod
     def validate_seal(cls, header: BlockHeader) -> None:

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -257,7 +257,7 @@ class BaseVM(Configurable, ABC):
     @classmethod
     @abstractmethod
     def validate_header(
-            cls, header: BlockHeader, parent_header: BlockHeader, check_seal: bool) -> None:
+            cls, header: BlockHeader, parent_header: BlockHeader, check_seal: bool = True) -> None:
         raise NotImplementedError("VM classes must implement this method")
 
     @abstractmethod
@@ -678,7 +678,7 @@ class VM(BaseVM):
             validate_length_lte(block.header.extra_data, 32, title="BlockHeader.extra_data")
         else:
             parent_header = get_parent_header(block.header, self.chaindb)
-            self.validate_header(block.header, parent_header, check_seal=True)
+            self.validate_header(block.header, parent_header)
 
         tx_root_hash, _ = make_trie_root_and_nodes(block.transactions)
         if tx_root_hash != block.header.transaction_root:
@@ -714,7 +714,7 @@ class VM(BaseVM):
 
     @classmethod
     def validate_header(
-            cls, header: BlockHeader, parent_header: BlockHeader, check_seal: bool) -> None:
+            cls, header: BlockHeader, parent_header: BlockHeader, check_seal: bool = True) -> None:
         """
         :raise eth.exceptions.ValidationError: if the header is not valid
         """

--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -38,7 +38,7 @@ from p2p import protocol
 from p2p import eth
 from p2p import les
 from p2p.cancel_token import CancellableMixin, CancelToken
-from p2p.constants import FAST_SYNC_SEAL_CHECK_FREQUENCY, MAX_REORG_DEPTH
+from p2p.constants import MAX_REORG_DEPTH, SEAL_CHECK_RANDOM_SAMPLE_RATE
 from p2p.exceptions import NoEligiblePeers, OperationCancelled
 from p2p.p2p_proto import DisconnectReason
 from p2p.peer import BasePeer, ETHPeer, LESPeer, PeerPool, PeerPoolSubscriber
@@ -71,7 +71,7 @@ class BaseHeaderChainSyncer(BaseService, PeerPoolSubscriber):
     # TODO: Instead of a fixed timeout, we should use a variable one that gets adjusted based on
     # the round-trip times from our download requests.
     _reply_timeout = 60
-    _seal_check_frequency = FAST_SYNC_SEAL_CHECK_FREQUENCY
+    _seal_check_random_sample_rate = SEAL_CHECK_RANDOM_SAMPLE_RATE
 
     def __init__(self,
                  chain: AsyncChain,
@@ -206,7 +206,7 @@ class BaseHeaderChainSyncer(BaseService, PeerPoolSubscriber):
             self.logger.debug("Got new header chain starting at #%d", first.block_number)
             start = time.time()
             try:
-                await self.chain.coro_validate_chain(headers, self._seal_check_frequency)
+                await self.chain.coro_validate_chain(headers, self._seal_check_random_sample_rate)
             except ValidationError as e:
                 self.logger.warn("Received invalid headers from %s, aborting sync: %s", peer, e)
                 break
@@ -576,7 +576,7 @@ class RegularChainSyncer(FastChainSyncer):
     Here, the run() method will execute the sync loop forever, until our CancelToken is triggered.
     """
     _exit_on_sync_complete = False
-    _seal_check_frequency = 1
+    _seal_check_random_sample_rate = 1
 
     async def _handle_block_receipts(
             self, peer: ETHPeer, receipts_by_block: List[List[eth.Receipt]]) -> None:

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -70,9 +70,8 @@ DEFAULT_MAX_PEERS = 25
 # Maximum allowed depth for chain reorgs.
 MAX_REORG_DEPTH = 24
 
-# Seal check frequency of headers downloaded during light/fast sync. Apparently 100 was the
-# optimal value determined by geth devs
+# Random sampling rate (i.e. every K-th) for header seal checks during light/fast sync. Apparently
+# 100 was the optimal value determined by geth devs
 # (https://github.com/ethereum/go-ethereum/pull/1889#issue-47241762), but in order to err on the
-# side of caution, we use 192/4 to ensure we check 4 headers out of every batch (of length
-# MAX_HEADERS_FETCH).
-FAST_SYNC_SEAL_CHECK_FREQUENCY = 192 // 4
+# side of caution, we use a higher value.
+SEAL_CHECK_RANDOM_SAMPLE_RATE = 48

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -69,3 +69,10 @@ DEFAULT_MAX_PEERS = 25
 
 # Maximum allowed depth for chain reorgs.
 MAX_REORG_DEPTH = 24
+
+# Seal check frequency of headers downloaded during light/fast sync. Apparently 100 was the
+# optimal value determined by geth devs
+# (https://github.com/ethereum/go-ethereum/pull/1889#issue-47241762), but in order to err on the
+# side of caution, we use 192/4 to ensure we check 4 headers out of every batch (of length
+# MAX_HEADERS_FETCH).
+FAST_SYNC_SEAL_CHECK_FREQUENCY = 192 // 4

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -219,7 +219,7 @@ class BasePeer(BaseService):
                 raise HandshakeFailure("Peer failed DAO fork check retrieval: {}".format(e))
 
             try:
-                vm_class.validate_header(header, parent)
+                vm_class.validate_header(header, parent, check_seal=True)
             except ValidationError as e:
                 raise HandshakeFailure("Peer failed DAO fork check validation: {}".format(e))
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ deps = {
     ],
     'test': [
         "hypothesis==3.44.26",
-        "pytest~=3.2",
+        "pytest~=3.3",
         "pytest-asyncio==0.8.0",
         "pytest-cov==2.5.1",
         "pytest-xdist==1.18.1",

--- a/tests/core/vm/test_mainnet_dao_fork.py
+++ b/tests/core/vm/test_mainnet_dao_fork.py
@@ -283,10 +283,10 @@ def header_pairs(VM, headers, valid):
 )
 def test_mainnet_dao_fork_header_validation(VM, header, previous_header, valid):
     if valid:
-        VM.validate_header(header, previous_header)
+        VM.validate_header(header, previous_header, check_seal=True)
     else:
         try:
-            VM.validate_header(header, previous_header)
+            VM.validate_header(header, previous_header, check_seal=True)
         except ValidationError:
             pass
         else:

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -213,7 +213,7 @@ class LightDispatchChain(BaseChain):
     def validate_uncles(self, block: BaseBlock) -> None:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
-    def validate_chain(self, chain: Tuple[BlockHeader, ...]) -> None:
+    def validate_chain(self, chain: Tuple[BlockHeader, ...], seal_check_frequency: int = 1) -> None:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
     #


### PR DESCRIPTION
For every header batch, pick a random subset and check the seal only on those.

Before this change: ```Imported 192 headers in 1.33 seconds, new head: #3583663```

After this change: ```Imported 192 headers in 0.53 seconds, new head: #3585558```

Closes: #932