### PR TITLE
Logs to stderr

### DIFF
--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -150,5 +150,5 @@ class NoInternalAddressMatchesDevice(BaseP2PError):
     Raised when no internal IP address matches the UPnP device that is being configured.
     """
     def __init__(self, *args: Any, device_hostname: str=None, **kwargs: Any) -> None:
-        super.__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.device_hostname = device_hostname

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -38,10 +38,12 @@ class ValidateAndStoreEnodes(argparse.Action):
 
 DEFAULT_LOG_LEVEL = 'info'
 LOG_LEVEL_CHOICES = (
+    'trace',
     'debug',
     'info',
     'warning',
     'error',
+    'critical',
 )
 
 

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -40,6 +40,8 @@ DEFAULT_LOG_LEVEL = 'info'
 LOG_LEVEL_CHOICES = (
     'debug',
     'info',
+    'warning',
+    'error',
 )
 
 

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -48,7 +48,7 @@ from trinity.utils.ipc import (
     kill_process_gracefully,
 )
 from trinity.utils.logging import (
-    setup_trinity_stdout_logging,
+    setup_trinity_stderr_logging,
     setup_trinity_file_and_queue_logging,
     with_queued_logging,
 )
@@ -103,7 +103,7 @@ def main() -> None:
             "networks are supported.".format(args.network_id)
         )
 
-    logger, formatter, handler_stream = setup_trinity_stdout_logging(log_level)
+    logger, formatter, handler_stream = setup_trinity_stderr_logging(log_level)
 
     try:
         chain_config = ChainConfig.from_parser_args(args)

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -33,11 +33,11 @@ LOG_BACKUP_COUNT = 10
 LOG_MAX_MB = 5
 
 
-def setup_trinity_stdout_logging(level: int) -> Tuple[Logger, Formatter, StreamHandler]:
+def setup_trinity_stderr_logging(level: int) -> Tuple[Logger, Formatter, StreamHandler]:
     logger = logging.getLogger('trinity')
     logger.setLevel(logging.DEBUG)
 
-    handler_stream = logging.StreamHandler(sys.stdout)
+    handler_stream = logging.StreamHandler(sys.stderr)
     handler_stream.setLevel(level)
 
     # TODO: allow configuring `detailed` logging


### PR DESCRIPTION
### What was wrong?

logs to stdout are annoying, especially when invoking `trinity console`

### How was it fixed?

- move logs to stderr
- add warning and error options to cli logging parser
- bonus syntax fix in upnp exception

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/4486599168/h6F5856AA/)
