### PR TITLE
Fix unclean shutdown

### DIFF
--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -213,3 +213,11 @@ attach_parser.add_argument(
     default=False,
     help='start a native Python shell'
 )
+
+#
+# Add `fix-unclean-shutdown` sub-command to trinity CLI
+#
+fix_unclean_shutdown_parser = subparser.add_parser(
+    'fix-unclean-shutdown',
+    help='close any dangling processes from a previous unclean shutdown',
+)

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -1,4 +1,5 @@
 import argparse
+from contextlib import contextmanager
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -35,6 +36,9 @@ from trinity.utils.chains import (
     get_logfile_path,
     get_nodekey_path,
     load_nodekey,
+)
+from trinity.utils.filesystem import (
+    PidFile,
 )
 
 if TYPE_CHECKING:
@@ -235,3 +239,8 @@ class ChainConfig:
             raise NotImplementedError(
                 "Only full and light sync modes are supported"
             )
+
+    @contextmanager
+    def process_id_file(self, process_name: str):
+        with PidFile(process_name, self.data_dir):
+            yield

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -241,6 +241,6 @@ class ChainConfig:
             )
 
     @contextmanager
-    def process_id_file(self, process_name: str):
+    def process_id_file(self, process_name: str):  # type: ignore
         with PidFile(process_name, self.data_dir):
             yield

--- a/trinity/utils/filesystem.py
+++ b/trinity/utils/filesystem.py
@@ -56,6 +56,6 @@ class PidFile:
             with self.filepath.open('x') as pidfile:
                 pidfile.write(str(os.getpid()) + "\n")
 
-    def __exit__(self, exc_type=None, exc_value=None, exc_tb=None):
+    def __exit__(self, exc_type=None, exc_value=None, exc_tb=None):  # type: ignore
         self.filepath.unlink()
         self._running = False

--- a/trinity/utils/filesystem.py
+++ b/trinity/utils/filesystem.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 
 def is_same_path(p1: str, p2: str) -> bool:
@@ -20,3 +21,41 @@ def is_under_path(base_path: str, path: str, strict: bool=True) -> bool:
     absolute_base_path = os.path.abspath(base_path)
     absolute_path = os.path.abspath(path)
     return absolute_path.startswith(absolute_base_path)
+
+
+class PidFile:
+    """
+    This class tracks the process id of the currently running process in a file.
+    Use it as a context manager so that the file gets cleaned up in a graceful shutdown.
+    There are some corner cases that may cause the pidfile to be left behind with a dead process,
+    but any running process within the context of a PidFile should always have an
+    associated pid file.
+
+    It happens to usually prevent running two processes with the same process_name
+    at the same time, but does not guarantee this behavior.
+    """
+    def __init__(self, process_name: str, path: Path) -> None:
+        self.filepath = path / (process_name + '.pid')
+        self._running = False
+
+    def __enter__(self) -> None:
+        if self.filepath.exists():
+            raise FileExistsError(
+                "File %s already exists -- cannot run the same process twice" % self.filepath
+            )
+        elif self._running:
+            raise RuntimeError("Cannot enter the same PidFile context twice")
+        if not self.filepath.parent.is_dir():
+            raise IOError(
+                "Cannot create pidfile in base directory that doesn't exist: %s" % self.filepath
+            )
+        else:
+            self._running = True
+
+            # try to create the pidfile, failing if it already exists
+            with self.filepath.open('x') as pidfile:
+                pidfile.write(str(os.getpid()) + "\n")
+
+    def __exit__(self, exc_type=None, exc_value=None, exc_tb=None):
+        self.filepath.unlink()
+        self._running = False

--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -51,3 +51,48 @@ def kill_process_gracefully(process: Process,
         return
     os.kill(process.pid, signal.SIGKILL)
     logger.info("Sent SIGKILL to process %d", process.pid)
+
+
+def kill_process_id_gracefully(
+        pid: int,
+        logger: Logger,
+        SIGINT_timeout: int=5,
+        SIGTERM_timeout: int=3) -> None:
+    try:
+        try:
+            os.kill(pid, signal.SIGINT)
+        except ProcessLookupError:
+            logger.info("Process %d has already terminated", pid)
+            return
+        logger.info(
+            "Sent SIGINT to process %d, waiting %d seconds for it to terminate",
+            pid, SIGINT_timeout)
+        time.sleep(SIGINT_timeout)
+    except KeyboardInterrupt:
+        logger.info(
+            "Waiting for process to terminate.  You may force termination "
+            "with CTRL+C two more times."
+        )
+
+    try:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            logger.info("Process %d has already terminated", pid)
+            return
+        logger.info(
+            "Sent SIGTERM to process %d, waiting %d seconds for it to terminate",
+            pid, SIGTERM_timeout)
+        time.sleep(SIGTERM_timeout)
+    except KeyboardInterrupt:
+        logger.info(
+            "Waiting for process to terminate.  You may force termination "
+            "with CTRL+C one more time."
+        )
+
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        logger.info("Process %d has already terminated", pid)
+        return
+    logger.info("Sent SIGKILL to process %d", pid)


### PR DESCRIPTION
### What was wrong?

Fixes #831 

All the apparent reasons for a failed restart involve a process that's hanging around.

### How was it fixed?

- Track running process ids in pid files
- Add a `fix-unclean-shutdown` subcommand that gracefully closes any processes that are still running

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/fHNx_3aCx6s/maxresdefault.jpg)