### PR TITLE
Fix transaction pool send loop logic

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -530,6 +530,9 @@ class BasePeer(BaseService):
     def __repr__(self) -> str:
         return "{} {}".format(self.__class__.__name__, repr(self.remote))
 
+    def __hash__(self) -> int:
+        return hash(self.remote)
+
 
 class LESPeer(BasePeer):
     _supported_sub_protocols = [les.LESProtocol, les.LESProtocolV2]

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -263,9 +263,9 @@ class Server(BaseService):
         )
 
         if self.peer_pool.is_full:
-            peer.disconnect(DisconnectReason.too_many_peers)
+            await peer.disconnect(DisconnectReason.too_many_peers)
         elif not self.peer_pool.is_valid_connection_candidate(peer.remote):
-            peer.disconnect(DisconnectReason.useless_peer)
+            await peer.disconnect(DisconnectReason.useless_peer)
 
         total_peers = len(self.peer_pool.connected_nodes)
         inbound_peer_count = len([
@@ -276,7 +276,7 @@ class Server(BaseService):
         ])
         if total_peers > 1 and inbound_peer_count / total_peers > DIAL_IN_OUT_RATIO:
             # make sure to have at least 1/4 outbound connections
-            peer.disconnect(DisconnectReason.too_many_peers)
+            await peer.disconnect(DisconnectReason.too_many_peers)
         else:
             # We use self.wait() here as a workaround for
             # https://github.com/ethereum/py-evm/issues/670.

--- a/trinity/plugins/builtin/tx_pool/pool.py
+++ b/trinity/plugins/builtin/tx_pool/pool.py
@@ -87,9 +87,6 @@ class TxPool(BaseService, PeerPoolSubscriber):
             if len(filtered_tx) == 0:
                 continue
 
-            if receiving_peer.is_closing:
-                continue
-
             self.logger.trace(
                 'Sending %d transactions to %s',
                 len(filtered_tx),

--- a/trinity/plugins/builtin/tx_pool/pool.py
+++ b/trinity/plugins/builtin/tx_pool/pool.py
@@ -87,7 +87,14 @@ class TxPool(BaseService, PeerPoolSubscriber):
             if len(filtered_tx) == 0:
                 continue
 
-            self.logger.trace('Sending %d transactions to %s', len(filtered_tx), receiving_peer)
+            if receiving_peer.is_closing:
+                continue
+
+            self.logger.trace(
+                'Sending %d transactions to %s',
+                len(filtered_tx),
+                receiving_peer,
+            )
             receiving_peer.sub_proto.send_transactions(filtered_tx)
             self._add_txs_to_bloom(receiving_peer, filtered_tx)
 


### PR DESCRIPTION
### What was wrong?

- The tx pool loop was *probably* causing us to occasionally time out during sync
- The tx pool loop was trying to send to peers which had already disconnected causing lots of console warnings

### How was it fixed?

- made the loop yield for each iteration
- changed how peers are iterated over to account for in-flight disconnections.
- fixed some places where `peer.disconnect` was not being *awaited*

#### Cute Animal Picture

TODO
