### PR TITLE
PeerPool is now an asynchronous iterable

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -11,6 +11,8 @@ from abc import (
 
 from typing import (
     Any,
+    AsyncIterable,
+    AsyncIterator,
     cast,
     Dict,
     Iterator,
@@ -333,6 +335,10 @@ class BasePeer(BaseService):
         self.reader.feed_eof()
         self.writer.close()
 
+    @property
+    def is_closing(self) -> bool:
+        return self.writer.transport.is_closing()
+
     async def _cleanup(self) -> None:
         self.close()
 
@@ -476,6 +482,9 @@ class BasePeer(BaseService):
     def send(self, header: bytes, body: bytes) -> None:
         cmd_id = rlp.decode(body[:1], sedes=sedes.big_endian_int)
         self.logger.trace("Sending msg with cmd_id: %s", cmd_id)
+        if self.is_closing:
+            self.logger.error("Attempted to send %s to disconnected peer", cmd_id)
+            return
         self.writer.write(self.encrypt(header, body))
 
     async def disconnect(self, reason: DisconnectReason) -> None:
@@ -708,7 +717,7 @@ class PeerPoolSubscriber(ABC):
             peer_pool.unsubscribe(self)
 
 
-class PeerPool(BaseService):
+class PeerPool(BaseService, AsyncIterable[BasePeer]):
     """
     PeerPool maintains connections to up-to max_peers on a given network.
     """
@@ -844,20 +853,24 @@ class PeerPool(BaseService):
             self.logger.info("%s finished, removing from pool", peer)
             self.connected_nodes.pop(peer.remote)
 
-    @property
-    def peers(self) -> List[BasePeer]:
-        return list(self.connected_nodes.values())
+    def __aiter__(self) -> AsyncIterator[BasePeer]:
+        return ConnectedPeersIterator(tuple(self.connected_nodes.values()))
 
     @property
     def highest_td_peer(self) -> BasePeer:
-        if not self.connected_nodes:
+        peers = tuple(self.connected_nodes.values())
+        if not peers:
             raise NoConnectedPeers()
-        peers_by_td = groupby(operator.attrgetter('head_td'), self.peers)
+        peers_by_td = groupby(operator.attrgetter('head_td'), peers)
         max_td = max(peers_by_td.keys())
         return random.choice(peers_by_td[max_td])
 
     def get_peers(self, min_td: int) -> List[BasePeer]:
-        return [peer for peer in self.peers if peer.head_td >= min_td]
+        # TODO: Consider turning this into a method that returns an AsyncIterator, to make it
+        # harder for callsites to get a list of peers while making blocking calls, as those peers
+        # might disconnect in the meantime.
+        peers = tuple(self.connected_nodes.values())
+        return [peer for peer in peers if peer.head_td >= min_td]
 
     async def _periodically_report_stats(self) -> None:
         while self.is_running:
@@ -880,6 +893,24 @@ class PeerPool(BaseService):
                 await self.wait(asyncio.sleep(self._report_interval))
             except OperationCancelled:
                 break
+
+
+class ConnectedPeersIterator(AsyncIterator[BasePeer]):
+
+    def __init__(self, peers: Tuple[BasePeer, ...]) -> None:
+        self.iter = iter(peers)
+
+    async def __anext__(self) -> BasePeer:
+        while True:
+            # Yield control to ensure we process any disconnection requests from peers. Otherwise
+            # we could return peers that should have been disconnected already.
+            await asyncio.sleep(0)
+            try:
+                peer = next(self.iter)
+                if not peer.is_closing:
+                    return peer
+            except StopIteration:
+                raise StopAsyncIteration
 
 
 DEFAULT_PREFERRED_NODES: Dict[int, Tuple[Node, ...]] = {
@@ -976,10 +1007,10 @@ def _test() -> None:
         # Request some stuff from ropsten's block 2440319
         # (https://ropsten.etherscan.io/block/2440319), just as a basic test.
         nonlocal peer_pool
-        while not peer_pool.peers:
+        while not peer_pool.connected_nodes:
             peer_pool.logger.info("Waiting for peer connection...")
             await asyncio.sleep(0.2)
-        peer = peer_pool.peers[0]
+        peer = peer_pool.highest_td_peer
         block_hash = decode_hex(
             '0x59af08ab31822c992bb3dad92ddb68d820aa4c69e9560f07081fa53f1009b152')
         if peer_class == ETHPeer:

--- a/p2p/shard_syncer.py
+++ b/p2p/shard_syncer.py
@@ -83,7 +83,7 @@ class ShardSyncer(BaseService, PeerPoolSubscriber):
     async def _cleanup(self) -> None:
         pass
 
-    def propose(self) -> Collation:
+    async def propose(self) -> Collation:
         """Broadcast a new collation to the network, add it to the local shard, and return it."""
         # create collation for current period
         period = self.get_current_period()
@@ -97,7 +97,7 @@ class ShardSyncer(BaseService, PeerPoolSubscriber):
         self.shard.add_collation(collation)
 
         # broadcast collation
-        for peer in self.peer_pool.peers:
+        async for peer in self.peer_pool:
             cast(ShardingProtocol, peer.sub_proto).send_new_collation_hashes(
                 [(collation.hash, collation.period)]
             )
@@ -166,7 +166,7 @@ class ShardSyncer(BaseService, PeerPoolSubscriber):
             self.shard.add_collation(collation)
 
         # inform peers about new collations they might not know about already
-        for pool_peer in self.peer_pool.peers:
+        async for pool_peer in self.peer_pool:
             pool_peer = cast(ShardingPeer, pool_peer)
             known_hashes = self.collation_hashes_at_peer[pool_peer]
             new_hashes = set(new_collations_by_hash.keys()) - known_hashes

--- a/tests/p2p/peer_helpers.py
+++ b/tests/p2p/peer_helpers.py
@@ -24,15 +24,27 @@ def get_fresh_mainnet_headerdb():
     return headerdb
 
 
+class MockTransport:
+    def __init__(self):
+        self._is_closing = False
+
+    def close(self):
+        self._is_closing = True
+
+    def is_closing(self):
+        return self._is_closing
+
+
 class MockStreamWriter:
     def __init__(self, write_target):
         self._target = write_target
+        self.transport = MockTransport()
 
     def write(self, *args, **kwargs):
         self._target(*args, **kwargs)
 
     def close(self):
-        pass
+        self.transport.close()
 
 
 async def get_directly_linked_peers_without_handshake(

--- a/tests/p2p/test_lightchain_integration.py
+++ b/tests/p2p/test_lightchain_integration.py
@@ -104,7 +104,7 @@ async def test_lightchain_integration(request, event_loop, caplog):
         '0xf709ed2c57efc18a1675e8c740f3294c9e2cb36ba7bb3b89d3ab4c8fef9d8860')
 
     assert len(peer_pool) == 1
-    head_info = peer_pool.peers[0].head_info
+    head_info = peer_pool.highest_td_peer.head_info
     head = await peer_chain.get_block_header_by_hash(head_info.block_hash)
     assert head.block_number == head_info.block_number
 

--- a/tests/p2p/test_sharding.py
+++ b/tests/p2p/test_sharding.py
@@ -295,7 +295,7 @@ async def test_syncer_proposing(request, event_loop):
     request.addfinalizer(finalizer)
 
     # propose at b and check that it announces its proposal
-    syncer.propose()
+    await syncer.propose()
     peer, cmd, msg = await asyncio.wait_for(
         peer_a_b_subscriber.get(),
         timeout=1,

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ basepython=python3.5
 setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
 commands=
     flake8 {toxinidir}/eth
-    flake8 {toxinidir}/tests --exclude="trinity"
+    flake8 {toxinidir}/tests --exclude="trinity,p2p"
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
     mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs -p eth
 

--- a/trinity/plugins/builtin/tx_pool/pool.py
+++ b/trinity/plugins/builtin/tx_pool/pool.py
@@ -77,7 +77,7 @@ class TxPool(BaseService, PeerPoolSubscriber):
 
         self._add_txs_to_bloom(peer, txs)
 
-        for receiving_peer in self._peer_pool.peers:
+        async for receiving_peer in self._peer_pool:
             receiving_peer = cast(ETHPeer, receiving_peer)
 
             if receiving_peer is peer:


### PR DESCRIPTION
This way callsites are less likely to get a list of peers and hold them while making blocking calls, as these peers may disconnect in the meantime.

Closes: #1016