### PR TITLE
Remove AsyncChainDB from evm api docs

### DIFF
--- a/docs/api/eth/db/api.db.chain.rst
+++ b/docs/api/eth/db/api.db.chain.rst
@@ -12,9 +12,3 @@ ChainDB
 
 .. autoclass:: eth.db.chain.ChainDB
   :members:
-
-AsyncChainDB
-------------
-
-.. autoclass:: eth.db.chain.AsyncChainDB
-  :members:


### PR DESCRIPTION
### What was wrong?

The `AsyncChainDB` was recently moved into Trinity but wasn't removed from the documentation, leaving us with broken docs.

```
WARNING: autodoc: failed to import class 'AsyncChainDB' from module 'eth.db.chain'; the following exception was raised:
Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/venv/lib/python3.6/site-packages/sphinx/util/inspect.py", line 204, in safe_getattr
    return getattr(obj, name, *defargs)
AttributeError: module 'eth.db.chain' has no attribute 'AsyncChainDB'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/venv/lib/python3.6/site-packages/sphinx/ext/autodoc/importer.py", line 176, in import_object
    obj = attrgetter(obj, attrname)
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/venv/lib/python3.6/site-packages/sphinx/ext/autodoc/__init__.py", line 274, in get_attr
    return autodoc_attrgetter(self.env.app, obj, name, *defargs)
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/venv/lib/python3.6/site-packages/sphinx/ext/autodoc/__init__.py", line 1517, in autodoc_attrgetter
    return safe_getattr(obj, name, *defargs)
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/venv/lib/python3.6/site-packages/sphinx/util/inspect.py", line 220, in safe_getattr
    raise AttributeError(name)
AttributeError: AsyncChainDB
```

### How was it fixed?

Removed it from the evm API docs. (Not adding it to Trinity yet, as we haven't started with Trinity API docs)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://2.bp.blogspot.com/-h1Fg2RrgOuU/VNicZIGqCYI/AAAAAAAABx4/xOV-xLAIrsk/s1600/18990-Cute%2BWild%2BAnimal%2BHD%2BWallpaperz.jpg)
