### PR TITLE
Make the transaction pool disabled by default

### DIFF
--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -45,7 +45,7 @@ class TxPlugin(BasePlugin):
         self.peer_pool: PeerPool = None
         self.cancel_token: CancelToken = None
         self.chain: BaseChain = None
-        self.is_enabled: bool = None
+        self.is_enabled: bool = False
 
     @property
     def name(self) -> str:
@@ -53,14 +53,14 @@ class TxPlugin(BasePlugin):
 
     def configure_parser(self, arg_parser: ArgumentParser) -> None:
         arg_parser.add_argument(
-            "--disable-tx-pool",
+            "--tx-pool",
             action="store_true",
-            help="Disable the Transaction Pool",
+            help="Enables the Transaction Pool (experimental)",
         )
 
     def handle_event(self, activation_event: BaseEvent) -> None:
         if isinstance(activation_event, TrinityStartupEvent):
-            self.is_enabled = not activation_event.args.disable_tx_pool
+            self.is_enabled = activation_event.args.tx_pool
         if isinstance(activation_event, ResourceAvailableEvent):
             if activation_event.resource_type is PeerPool:
                 self.peer_pool, self.cancel_token = activation_event.resource


### PR DESCRIPTION
### What was wrong?

The transaction pool has had some unexpected side effects which are effecting connectivity to peers as well as syncing.

### How was it fixed?

Change the transaction pool to be opt-in, and have it be disabled by default.

#### Cute Animal Picture

![65533521-720px](https://user-images.githubusercontent.com/824194/42832401-54e89484-89ae-11e8-9c33-e9bfd412b614.jpg)
