### PR TITLE
crashfix: when processing peer data after disconnect

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -448,7 +448,12 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             unexpected = received_keys.difference(key_func(header) for header in headers)
 
             work_size = len(received_keys.difference(unexpected))
-            self._get_peer_stats(peer, part_name).complete_work(work_size)
+
+            peer_stats = self._get_peer_stats(peer, part_name)
+            if peer_stats.is_tracking:
+                peer_stats.complete_work(work_size)
+            else:
+                self.logger.warning("Peer %s sent unexpected %s parts" % (peer, part_name.name))
 
             parts.extend(received)
             pending_replies -= 1

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -75,17 +75,21 @@ class ThroughputTracker:
             raise ValidationError("Smoothing factor of ThroughputTracker must be between 0 and 1")
 
     def begin_work(self) -> None:
-        if self._last_start is not None:
+        if self.is_tracking:
             raise ValidationError("Cannot start the ThroughputTracker again without completing it")
         self._last_start = time.perf_counter()
 
     def complete_work(self, work_completed: Union[int, float]) -> None:
-        if self._last_start is None:
+        if not self.is_tracking:
             raise ValidationError("Cannot end the ThroughputTracker without starting it")
         time_elapsed = time.perf_counter() - self._last_start
         last_throughput = work_completed / time_elapsed
         self._throughput = (self._throughput * (1 - self._alpha)) + (last_throughput * self._alpha)
         self._last_start = None
+
+    @property
+    def is_tracking(self) -> bool:
+        return self._last_start is not None
 
     def get_throughput(self) -> float:
         return self._throughput


### PR DESCRIPTION
Throughput tracker is reset on peer disconnect. If some peer data
for syncing block parts was sitting in the queue and we process it
after the disconnect, then the throughput tracker will think we're
trying to finish work before it began (and crash). For now, drop
the error. Later, handle the case more thoughtfully.

### What was wrong?

Fixes #1037 

### How was it fixed?

Pretty simple: don't try to track throughput data if we don't know when it started. This is maybe hiding other issues, so should have some follow-up work. (probably in the process of closing #868)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTxWd3InwKvu-RmfGztpB3xycOYB_l9sCUuKo_t_pXwGh0xV8LAuQ)
