### PR TITLE
bug fix: cpu_count should always be above 0

### DIFF
--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -57,7 +57,7 @@ def get_process_pool_executor() -> ProcessPoolExecutor:
         )
         cpu_count = 1
     else:
-        cpu_count = os_cpu_count - 1
+        cpu_count = max(1, os_cpu_count - 1)
     return ProcessPoolExecutor(cpu_count)
 
 


### PR DESCRIPTION
### What was wrong?

```
veselin@p2p-id:~$ venv/bin/trinity 
    INFO  07-18 12:29:26        main  
      ______     _       _ __       
     /_  __/____(_)___  (_) /___  __
      / / / ___/ / __ \/ / __/ / / /
     / / / /  / / / / / / /_/ /_/ / 
    /_/ /_/  /_/_/ /_/_/\__/\__, /  
                           /____/   
    INFO  07-18 12:29:26        main  Trinity/0.2.0a26/linux/cpython3.6.6
    INFO  07-18 12:29:26        main  Trinity DEBUG log file is created at /home/veselin/.local/share/trinity/mainnet/logs/trinity.log
    INFO  07-18 12:29:26        main  Started DB server process (pid=860)
    INFO  07-18 12:29:27        main  Started networking process (pid=862)
    INFO  07-18 12:29:29      server  Running server...
    INFO  07-18 12:29:29         nat  Setting up NAT portmap...
    INFO  07-18 12:29:29         ipc  IPC started at: /home/veselin/.local/share/trinity/mainnet/jsonrpc.ipc
    INFO  07-18 12:29:34         nat  No UPNP-enabled devices found
    INFO  07-18 12:29:34      server  enode://71c69853eef63cef29793096b6762799c5d04056046a17677144495e3b8a486db28a99d671300df27e1162254ba9522c3b15215e339fbefba69d63397f901145@0.0.0.0:30303
    INFO  07-18 12:29:34      server  network: 1
    INFO  07-18 12:29:34      server  peers: max_peers=25
    INFO  07-18 12:29:34   discovery  Preferred peers: (<Node(0x1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082@52.74.57.123:30303)>, <Node(0x78de8a0916848093c73790ead81d1928bec737d565119932b98c6b100d944b7a95e94f847f689fc723399d2e31129d182f7ef3863f2b4c820abbf3ab2722344d@191.235.84.50:30303)>, <Node(0xddd81193df80128880232fc1deb45f72746019839589eeb642d3d44efbb8b2dda2c1a46a348349964a6066f8afb016eb2a8c0f3c66f32fadf4370a236a4b5286@52.231.202.145:30303)>, <Node(0x3f1d12044546b76342d59d4a05532c14b85aa669704bfe1f864fe079415aa2c02d743e03218e57a33fb94523adb54032871a6c51b2cc5514cb7c7e35b3ed0a99@13.93.211.84:30303)>)
    INFO  07-18 12:29:34        peer  Connected peers: 0 inbound, 0 outbound
    INFO  07-18 12:29:34   discovery  boostrapping with (<Node(0xa979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303)>, <Node(0xaa36fdf33dd030378a0168efe6ed7d5cc587fafa3cdd375854fe735a2e11ea3650ba29644e2db48368c46e1f60e716300ba49396cd63778bf8a818c09bded46f@13.93.211.84:30303)>, <Node(0x78de8a0916848093c73790ead81d1928bec737d565119932b98c6b100d944b7a95e94f847f689fc723399d2e31129d182f7ef3863f2b4c820abbf3ab2722344d@191.235.84.50:30303)>, <Node(0x158f8aab45f6d19c6cbf4a089c2670541a8da11978a2f90dbf6a502a4a3bab80d288afdbeb7ec0ef6d92de563767f3b1ea9e8e334ca711e9f8e2df5a0385e8e6@13.75.154.138:30303)>, <Node(0x1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082@52.74.57.123:30303)>)
    INFO  07-18 12:29:34        sync  Starting fast-sync; current head: #0
   ERROR  07-18 12:29:34     service  Unexpected error in <p2p.sync.FullNodeSyncer object at 0x7fe1442074a8>, exiting
Traceback (most recent call last):
  File "/home/veselin/venv/lib/python3.6/site-packages/p2p/service.py", line 55, in run
    await self._run()
  File "/home/veselin/venv/lib/python3.6/site-packages/p2p/sync.py", line 52, in _run
    self.chain, self.chaindb, self.peer_pool, self.cancel_token)
  File "/home/veselin/venv/lib/python3.6/site-packages/p2p/chain.py", line 338, in __init__
    super().__init__(chain, db, peer_pool, token)
  File "/home/veselin/venv/lib/python3.6/site-packages/p2p/chain.py", line 106, in __init__
    self._executor = get_process_pool_executor()
  File "/home/veselin/venv/lib/python3.6/site-packages/p2p/utils.py", line 61, in get_process_pool_executor
    return ProcessPoolExecutor(cpu_count)
  File "/usr/lib/python3.6/concurrent/futures/process.py", line 394, in __init__
    raise ValueError("max_workers must be greater than 0")
ValueError: max_workers must be greater than 0
    INFO  07-18 12:29:34      server  Closing server...
    INFO  07-18 12:29:34        peer  Stopping all peers ...
    INFO  07-18 12:29:34     service  <p2p.discovery.DiscoveryService object at 0x7fe144a6cac8> finished: Cancellation requested by PeerPool:Server:MainnetFullNode token
    INFO  07-18 12:29:34   discovery  stopping discovery
    INFO  07-18 12:29:34   discovery  Bootstrapping cancelled: Cancellation requested by DiscoveryProtocol token
```


### How was it fixed?



#### Cute Animal Picture

![pic](https://fsmedia.imgix.net/d6/07/53/b5/86bb/43b5/9b48/7a59522acb30/dinosaur-chicken-hybrid.png)
