### PR TITLE
Convert IPCServer to a BaseService

### DIFF
--- a/tests/trinity/core/json-rpc/test_ipc.py
+++ b/tests/trinity/core/json-rpc/test_ipc.py
@@ -117,7 +117,7 @@ async def test_ipc_requests(jsonrpc_ipc_pipe_path,
                             ipc_server):
     assert wait_for(jsonrpc_ipc_pipe_path), "IPC server did not successfully start with IPC file"
 
-    reader, writer = await asyncio.open_unix_connection(jsonrpc_ipc_pipe_path, loop=event_loop)
+    reader, writer = await asyncio.open_unix_connection(str(jsonrpc_ipc_pipe_path), loop=event_loop)
 
     writer.write(request_msg)
     await writer.drain()

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -221,6 +221,7 @@ def trinity_boot(args: Namespace,
 def fix_unclean_shutdown(chain_config: ChainConfig, logger: logging.Logger) -> None:
     logger.info("Cleaning up unclean shutdown...")
 
+    logger.info("Searching for process id files in %s..." % chain_config.data_dir)
     pidfiles = tuple(chain_config.data_dir.glob('*.pid'))
     if len(pidfiles) > 1:
         logger.info('Found %d processes from a previous run. Closing...' % len(pidfiles))

--- a/trinity/rpc/ipc.py
+++ b/trinity/rpc/ipc.py
@@ -158,3 +158,4 @@ class IPCServer(BaseService):
     async def _cleanup(self) -> None:
         self.server.close()
         await self.server.wait_closed()
+        self.ipc_path.unlink()


### PR DESCRIPTION
### What was wrong?

Fixes #689

Also, the ipc socket file is left dangling when the service is cleaned up.

### How was it fixed?

- convert to BaseService
- can set custom asyncio loop on BaseService
- cancel a service running on a different thread
- remove ipc socket file on server shutdown
- some helpful contextual info: show the target data folder that fix-unclean-shutdown is using to fix (I was trying to clean a bad `trinity --ropsten` with a `trinity fix-unclean-shutdown`. I needed `trinity --ropsten fix-unclean-shutdown` but that wasn't obvious without a little extra logging)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://latimesblogs.latimes.com/.a/6a00d8341c630a53ef0134810d4b0b970c-600wi)
