### PR TITLE
p2p: Perform DAO fork check only when peer is added to PeerPool

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -712,7 +712,7 @@ class PeerRequestHandler(CancellableMixin):
                 type(block_number_or_hash),
             )
 
-        limit = max(max_headers, eth.MAX_HEADERS_FETCH)
+        limit = min(max_headers, eth.MAX_HEADERS_FETCH)
         step = skip + 1
         if reverse:
             low = max(0, block_number - limit)

--- a/p2p/eth.py
+++ b/p2p/eth.py
@@ -1,6 +1,8 @@
 import logging
 from typing import (
+    cast,
     List,
+    Tuple,
     Union,
     TYPE_CHECKING
 )
@@ -12,8 +14,10 @@ from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransactionFields
 
 from p2p.protocol import (
+    BaseBlockHeaders,
     Command,
     Protocol,
+    _DecodedMsgType,
 )
 from p2p.rlp import BlockBody
 from p2p.sedes import HashOrNumber
@@ -62,9 +66,12 @@ class GetBlockHeaders(Command):
     ]
 
 
-class BlockHeaders(Command):
+class BlockHeaders(BaseBlockHeaders):
     _cmd_id = 4
     structure = sedes.CountableList(BlockHeader)
+
+    def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
+        return cast(Tuple[BlockHeader, ...], tuple(msg))
 
 
 class GetBlockBodies(Command):

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -31,6 +31,13 @@ class HandshakeFailure(BaseP2PError):
     pass
 
 
+class DAOForkCheckFailure(BaseP2PError):
+    """
+    Raised when the DAO fork check with a certain peer is unsuccessful.
+    """
+    pass
+
+
 class MalformedMessage(BaseP2PError):
     """
     Raised when a p2p command is received with a malformed message

--- a/p2p/les.py
+++ b/p2p/les.py
@@ -16,6 +16,7 @@ from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 
 from p2p.protocol import (
+    BaseBlockHeaders,
     Command,
     Protocol,
     _DecodedMsgType,
@@ -169,13 +170,17 @@ class GetBlockHeaders(Command):
     ]
 
 
-class BlockHeaders(Command):
+class BlockHeaders(BaseBlockHeaders):
     _cmd_id = 3
     structure = [
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
         ('headers', sedes.CountableList(BlockHeader)),
     ]
+
+    def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
+        msg = cast(Dict[str, Any], msg)
+        return cast(Tuple[BlockHeader, ...], tuple(msg['headers']))
 
 
 class GetBlockBodies(Command):

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -1,5 +1,6 @@
 import logging
 import struct
+from abc import ABC, abstractmethod
 from typing import (
     Any,
     Dict,
@@ -14,6 +15,7 @@ import rlp
 from rlp import sedes
 
 from eth.constants import NULL_BYTE
+from eth.rlp.headers import BlockHeader
 
 from p2p.utils import get_devp2p_cmd_id
 
@@ -133,6 +135,13 @@ class Protocol:
 
     def __repr__(self) -> str:
         return "(%s, %d)" % (self.name, self.version)
+
+
+class BaseBlockHeaders(ABC, Command):
+
+    @abstractmethod
+    def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("Must be implemented by subclasses")
 
 
 def _pad_to_16_byte_boundary(data: bytes) -> bytes:

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -287,12 +287,11 @@ class Server(BaseService):
     async def do_handshake(self, peer: BasePeer) -> None:
         await peer.do_p2p_handshake()
         await peer.do_sub_proto_handshake()
-        await peer.ensure_same_side_on_dao_fork(self.chain.get_vm_configuration())
-        self._start_peer(peer)
+        await self._start_peer(peer)
 
-    def _start_peer(self, peer: BasePeer) -> None:
+    async def _start_peer(self, peer: BasePeer) -> None:
         # This method exists only so that we can monkey-patch it in tests.
-        self.peer_pool.start_peer(peer)
+        await self.peer_pool.start_peer(peer)
 
 
 def _test() -> None:

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -264,10 +264,12 @@ class Server(BaseService):
 
         if self.peer_pool.is_full:
             await peer.disconnect(DisconnectReason.too_many_peers)
+            return
         elif not self.peer_pool.is_valid_connection_candidate(peer.remote):
             await peer.disconnect(DisconnectReason.useless_peer)
+            return
 
-        total_peers = len(self.peer_pool.connected_nodes)
+        total_peers = len(self.peer_pool)
         inbound_peer_count = len([
             peer
             for peer

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -64,8 +64,13 @@ class BaseService(ABC, CancellableMixin):
 
             await self.cleanup()
 
+            from p2p.peer import BasePeer  # type: ignore
             if finished_callback is not None:
                 finished_callback(self)
+            elif isinstance(self, BasePeer):
+                # XXX: Only added to help debug https://github.com/ethereum/py-evm/issues/1023;
+                # should be removed eventually.
+                self.logger.warn("%s finished but had no finished_callback", self)
 
     def run_child_service(self, child_service: 'BaseService') -> 'asyncio.Future[Any]':
         """

--- a/tests/p2p/dumb_peer.py
+++ b/tests/p2p/dumb_peer.py
@@ -14,6 +14,3 @@ class DumbPeer(ETHPeer):
 
     async def do_sub_proto_handshake(self):
         pass
-
-    async def ensure_same_side_on_dao_fork(self, vm_configuration):
-        pass


### PR DESCRIPTION
Also, instead of ignoring non-BlockHeaders messages received while the DAO
fork check is pending, we store them and re-add to subscribers' msg queues
when the fork check is successful and the peer is actually added to the
pool

Closes: #1025