### PR TITLE
Add integration tests for Trinity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-trinity
+  py36-trinity-integration:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-trinity-integration
   py36-transactions:
     <<: *common
     docker:
@@ -253,6 +259,7 @@ workflows:
       - py36-benchmark
       - py36-core
       - py36-trinity
+      - py36-trinity-integration
       - py36-transactions
       - py36-p2p
       - py36-database

--- a/tests/trinity/conftest.py
+++ b/tests/trinity/conftest.py
@@ -29,7 +29,7 @@ def xdg_trinity_root(monkeypatch, tmpdir):
     """
     Ensure proper test isolation as well as protecting the real directories.
     """
-    dir_path = tmpdir.mkdir('xdg_trinity_root')
+    dir_path = tmpdir.mkdir('trinity')
     monkeypatch.setenv('XDG_TRINITY_ROOT', str(dir_path))
 
     assert not is_under_path(os.path.expandvars('$HOME'), get_xdg_trinity_root())

--- a/tests/trinity/integration/test_boot.py
+++ b/tests/trinity/integration/test_boot.py
@@ -1,0 +1,123 @@
+import pytest
+
+from trinity.tools.async_process_runner import AsyncProcessRunner
+from trinity.utils.async_iter import (
+    contains_all
+)
+
+
+# IMPORTANT: Test names are intentionally short here because they end up
+# in the path name of the isolated Trinity paths that pytest produces for
+# us.
+# e.g. /tmp/pytest-of-circleci/pytest-0/popen-gw3/test_light_boot_comman0/xdg/mainnet/jsonrpc.ipc)
+#
+# However, UNIX IPC paths can only be 100 chars which means long paths
+# *WILL* break these tests. See: https://unix.stackexchange.com/q/367008
+
+# This fixture provides a tear down to run after each test that uses it.
+# This ensures the AsyncProcessRunner will never leave a process behind
+@pytest.fixture(scope="function")
+def async_process_runner():
+    runner = AsyncProcessRunner(
+        # This allows running pytest with -s and observing the output
+        debug_fn=lambda line: print(line)
+    )
+    yield runner
+    runner.kill()
+
+# Great for debugging the AsyncProcessRunner
+# @pytest.mark.asyncio
+# async def test_ping(async_process_runner):
+#     await async_process_runner.run(['ping', 'www.google.de'])
+#     assert await contains_all(async_process_runner.iterate_stdout(), ['byytes from'])
+
+
+@pytest.mark.parametrize(
+    'command',
+    (
+        ['trinity'],
+        ['trinity', '--ropsten'],
+    )
+)
+@pytest.mark.asyncio
+async def test_full_boot(async_process_runner, command):
+    # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
+    await async_process_runner.run(command, timeout_sec=40)
+    assert await contains_all(async_process_runner.stderr, {
+        "Started DB server process",
+        "Started networking process",
+        "Running server",
+        "IPC started at",
+    })
+
+
+@pytest.mark.parametrize(
+    'command',
+    (
+        ['trinity', '--tx-pool'],
+        ['trinity', '--tx-pool', '--ropsten'],
+    )
+)
+@pytest.mark.asyncio
+async def test_txpool_full_boot(async_process_runner, command):
+    # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
+    await async_process_runner.run(command, timeout_sec=40)
+    assert await contains_all(async_process_runner.stderr, {
+        "Started DB server process",
+        "Started networking process",
+        "Running Tx Pool",
+        "Running server",
+        "IPC started at",
+    })
+
+
+@pytest.mark.parametrize(
+    'command',
+    (
+        ['trinity', '--light'],
+        ['trinity', '--light', '--ropsten'],
+    )
+)
+@pytest.mark.asyncio
+async def test_light_boot(async_process_runner, command):
+    # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
+    await async_process_runner.run(command, timeout_sec=40)
+    assert await contains_all(async_process_runner.stderr, {
+        "Started DB server process",
+        "Started networking process",
+        "IPC started at",
+    })
+
+
+@pytest.mark.parametrize(
+    'command',
+    (
+        # mainnet
+        ['trinity'],
+        ['trinity', '--light'],
+        # ropsten
+        ['trinity', '--ropsten'],
+        ['trinity', '--light', '--ropsten'],
+    )
+)
+@pytest.mark.asyncio
+async def test_does_not_throw(async_process_runner, command):
+    # This is our last line of defence. This test basically observes the first
+    # 20 seconds of the Trinity boot process and fails if Trinity logs any exceptions
+    lines_since_error = 0
+    await async_process_runner.run(command, timeout_sec=20)
+    async for line in async_process_runner.stderr:
+
+        # We detect errors by some string at the beginning of the Traceback and keep
+        # counting lines from there to be able to read and report more valuable info
+        if "Traceback (most recent call last)" in line and lines_since_error == 0:
+            lines_since_error = 1
+        elif lines_since_error > 0:
+            lines_since_error += 1
+
+        # Keep on listening for output for a maxmimum of 100 lines after the error
+        if lines_since_error >= 100:
+            break
+
+    if lines_since_error > 0:
+        raise Exception("Exception during Trinity boot detected")

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,26 @@ basepython =
     py35: python3.5
     py36: python3.6
 
+
+[testenv:py36-trinity-integration]
+deps = .[eth-extras, test]
+basepython=python3.6
+passenv =
+    PYTEST_ADDOPTS
+    TRAVIS_EVENT_TYPE
+commands=
+    # We don't want to run these tests concurrently to avoid running into errors
+    # due to multiple Trinity instances competing for the same ports
+    py.test -n 1 {posargs:tests/trinity/integration/}
+
+
+[testenv:py36-benchmark]
+deps = .[eth-extras, benchmark]
+basepython=python3.6
+commands=
+    benchmark: {toxinidir}/scripts/benchmark/run.py
+
+
 [testenv:lint-py35]
 deps = .[lint]
 basepython=python3.5
@@ -72,9 +92,3 @@ commands=
     mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p p2p -p trinity
 
 
-
-[testenv:py36-benchmark]
-deps = .[eth-extras, benchmark]
-basepython=python3.6
-commands=
-    benchmark: {toxinidir}/scripts/benchmark/run.py

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -1,0 +1,65 @@
+import asyncio
+import os
+import signal
+from typing import (
+    AsyncIterable,
+    Awaitable,
+    Callable,
+    Iterable,
+)
+
+
+class AsyncProcessRunner():
+
+    def __init__(self, debug_fn: Callable[[bytes], None] = None) -> None:
+        self.debug_fn = debug_fn
+
+    @classmethod
+    async def create_and_run(cls, cmds: Iterable[str], timeout_sec: int=10) -> 'AsyncProcessRunner':
+        runner = cls()
+        await runner.run(cmds, timeout_sec)
+        return runner
+
+    async def run(self, cmds: Iterable[str], timeout_sec: int=10) -> None:
+        proc = await asyncio.create_subprocess_exec(
+            *cmds,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            # We need this because Trinity spawns multiple processes and we need to take down
+            # the entire group of processes.
+            preexec_fn=os.setsid
+        )
+        self.proc = proc
+        asyncio.ensure_future(self.kill_after_timeout(timeout_sec))
+
+    @property
+    async def stdout(self) -> AsyncIterable[str]:
+        async for line in self._iterate_until_empty(self.proc.stdout.readline):
+            yield line
+
+    @property
+    async def stderr(self) -> AsyncIterable[str]:
+        async for line in self._iterate_until_empty(self.proc.stderr.readline):
+            yield line
+
+    async def _iterate_until_empty(
+            self,
+            awaitable_bytes_fn: Callable[[], Awaitable[bytes]]) -> AsyncIterable[str]:
+
+        while True:
+            line = await awaitable_bytes_fn()
+            if self.debug_fn:
+                self.debug_fn(line)
+            if line == b'':
+                return
+            else:
+                yield line.decode('utf-8')
+
+    async def kill_after_timeout(self, timeout_sec: int) -> None:
+        await asyncio.sleep(timeout_sec)
+        self.kill()
+        raise TimeoutError('Killed process after {} seconds'.format(timeout_sec))
+
+    def kill(self) -> None:
+        # TODO: investigate if we could do this more gracefully
+        os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -61,5 +61,4 @@ class AsyncProcessRunner():
         raise TimeoutError('Killed process after {} seconds'.format(timeout_sec))
 
     def kill(self) -> None:
-        # TODO: investigate if we could do this more gracefully
         os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)

--- a/trinity/utils/async_iter.py
+++ b/trinity/utils/async_iter.py
@@ -1,0 +1,21 @@
+from typing import (
+    AsyncIterable,
+    Set,
+)
+
+
+async def contains_all(async_gen: AsyncIterable[str], keywords: Set[str]) -> bool:
+    """
+    Check wether an ``AsyncIterable[str]`` contains all of the given keywords. The keywords
+    can be embedded in some larger string. Return ``True`` as soon as all keywords were matched.
+    If not all keywords were matched by the time that the async iterable is done, return ``False``.
+    """
+    seen_keywords: Set[str] = set()
+    async for line in async_gen:
+        for check in keywords - seen_keywords:
+            if check in line:
+                seen_keywords.add(check)
+        if seen_keywords == keywords:
+            return True
+
+    return False


### PR DESCRIPTION
### What was wrong?

We currently do not have any integration tests for Trinity, that really test it on the command line level. That is, run Trinity the same way as a user would run it and check whether it behaves the way we assume it should behave.

This has biten us over and over as it is **very hard** to guarantee to ship software that works™ when one has to rely on manual human testing for these things.

### How was it fixed?

This adds some new testing facilities to run Trinity, the same way a user would do, and then do certain assertions about the things it responds.

In particular we test that,

- Trinity logs out sequence of expected messages
- Trinity does not log out `Traceback (most recent call last)` in the first 20 seconds of booting

These assertions are provided for the following invocations

```
trinity,
trinity --light
trinity --ropsten
trinity --light --ropsten
```

Additionally, there are tests that run Trinity as a full node with the tx pool enabled and observe whether it is starting.

**I've ran these tests on CI over and over again and haven't seen a single sign of flakiness**

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/7c/ab/a9/7caba9e42636185e2609eacd2c243b0d.jpg)
