### PR TITLE
WIP: add tests that cover trinity attach with basic web3 interaction

### DIFF
--- a/tests/trinity/integration/test_trinity_cli.py
+++ b/tests/trinity/integration/test_trinity_cli.py
@@ -116,14 +116,14 @@ async def test_web3(event_loop, command, async_process_runner, second_async_proc
         "IPC started at",
     })
     await second_async_process_runner.run(['trinity', 'attach'], timeout_sec=30)
-    assert await contains_all(second_async_process_runner.stdout, {
+    assert await contains_all(second_async_process_runner.stderr, {
         "An instance of Web3",
-        "In [1]:",
+        ">>>"
     })
 
     stdout, stderr = await second_async_process_runner.proc.communicate(b'w3\n')
 
-    async for line in stdout:
+    async for line in stderr:
         print(line)
 
 

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -22,6 +22,7 @@ def is_ipython_available() -> bool:
 # config file which plugin is enabled or not
 
 ENABLED_PLUGINS = [
-    AttachPlugin() if is_ipython_available() else AttachPlugin(use_ipython=False),
+    AttachPlugin(use_ipython=False),
+    #AttachPlugin() if is_ipython_available() else AttachPlugin(use_ipython=False),
     TxPlugin(),
 ]

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -27,6 +27,7 @@ class AsyncProcessRunner():
             *cmds,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.PIPE,
             # We need this because Trinity spawns multiple processes and we need to take down
             # the entire group of processes.
             preexec_fn=os.setsid


### PR DESCRIPTION
## WIP: DON'T CARE REVIEWING YET

This builds on top of #1049 

### What was wrong?

We currently do not have integration tests that spin up two Trinity instances, one with `trinity attach`, and do some basic web3 interaction.

### How was it fixed?

Not at all yet.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
