### PR TITLE
p2p: Some improvements to PeerPoolSubscriber

### DIFF
--- a/p2p/shard_syncer.py
+++ b/p2p/shard_syncer.py
@@ -43,7 +43,7 @@ from p2p.cancel_token import (
 from p2p.service import BaseService
 from p2p.peer import (
     PeerPool,
-    PeerPoolSubscriber,
+    PeerSubscriber,
 )
 
 from p2p.sharding_peer import (
@@ -68,7 +68,7 @@ from cytoolz import (
 COLLATION_PERIOD = 1
 
 
-class ShardSyncer(BaseService, PeerPoolSubscriber):
+class ShardSyncer(BaseService, PeerSubscriber):
 
     def __init__(self, shard: Shard, peer_pool: PeerPool, token: CancelToken=None) -> None:
         super().__init__(token)
@@ -79,6 +79,13 @@ class ShardSyncer(BaseService, PeerPoolSubscriber):
         self.collation_hashes_at_peer: Dict[ShardingPeer, Set[Hash32]] = defaultdict(set)
 
         self.start_time = time.time()
+
+    @property
+    def msg_queue_maxsize(self) -> int:
+        # This is a rather arbitrary value, but when the sync is operating normally we never see
+        # the msg queue grow past a few hundred items, so this should be a reasonable limit for
+        # now.
+        return 2000
 
     async def _cleanup(self) -> None:
         pass

--- a/tests/p2p/peer_helpers.py
+++ b/tests/p2p/peer_helpers.py
@@ -3,6 +3,7 @@ import os
 from typing import List
 
 from eth_hash.auto import keccak
+from eth.utils.logging import TraceLogger
 
 from eth.chains.mainnet import MAINNET_GENESIS_HEADER
 from eth.db.backends.memory import MemoryDB
@@ -12,7 +13,7 @@ from p2p import constants
 from p2p import ecies
 from p2p import kademlia
 from p2p.cancel_token import CancelToken
-from p2p.peer import BasePeer, LESPeer, PeerPool
+from p2p.peer import BasePeer, LESPeer, PeerPool, PeerSubscriber
 from p2p.server import decode_authentication
 
 from integration_test_helpers import FakeAsyncHeaderDB
@@ -160,3 +161,11 @@ class MockPeerPoolWithConnectedPeers(PeerPool):
 
     async def _run(self) -> None:
         raise NotImplementedError("This is a mock PeerPool implementation, you must not _run() it")
+
+
+class SamplePeerSubscriber(PeerSubscriber):
+    logger = TraceLogger("")
+
+    @property
+    def msg_queue_maxsize(self) -> int:
+        return 100

--- a/tests/p2p/test_sharding.py
+++ b/tests/p2p/test_sharding.py
@@ -44,6 +44,7 @@ from tests.p2p.peer_helpers import (
     get_directly_linked_peers,
     get_directly_linked_peers_without_handshake,
     MockPeerPoolWithConnectedPeers,
+    SamplePeerSubscriber,
 )
 
 from cytoolz import (
@@ -203,7 +204,7 @@ async def test_new_collations_notification(request, event_loop):
     # setup a-b-c topology
     peer_a_b, peer_b_a = await get_directly_linked_sharding_peers(request, event_loop)
     peer_b_c, peer_c_b = await get_directly_linked_sharding_peers(request, event_loop)
-    peer_c_b_subscriber = asyncio.Queue()
+    peer_c_b_subscriber = SamplePeerSubscriber()
     peer_c_b.add_subscriber(peer_c_b_subscriber)
     peer_pool_b = MockPeerPoolWithConnectedPeers([peer_b_a, peer_b_c])
 
@@ -223,7 +224,7 @@ async def test_new_collations_notification(request, event_loop):
     c1 = next(collations)
     peer_a_b.sub_proto.send_collations(0, [c1])
     peer, cmd, msg = await asyncio.wait_for(
-        peer_c_b_subscriber.get(),
+        peer_c_b_subscriber.msg_queue.get(),
         timeout=1,
     )
     assert peer == peer_c_b
@@ -234,7 +235,7 @@ async def test_new_collations_notification(request, event_loop):
     c2 = next(collations)
     peer_a_b.sub_proto.send_collations(0, [c1, c2])
     peer, cmd, msg = await asyncio.wait_for(
-        peer_c_b_subscriber.get(),
+        peer_c_b_subscriber.msg_queue.get(),
         timeout=1,
     )
     assert peer == peer_c_b
@@ -246,7 +247,7 @@ async def test_new_collations_notification(request, event_loop):
 async def test_syncer_requests_new_collations(request, event_loop):
     # setup a-b topology
     peer_a_b, peer_b_a = await get_directly_linked_sharding_peers(request, event_loop)
-    peer_a_b_subscriber = asyncio.Queue()
+    peer_a_b_subscriber = SamplePeerSubscriber()
     peer_a_b.add_subscriber(peer_a_b_subscriber)
     peer_pool_b = MockPeerPoolWithConnectedPeers([peer_b_a])
 
@@ -266,7 +267,7 @@ async def test_syncer_requests_new_collations(request, event_loop):
     hashes_and_periods = ((b"\xaa" * 32, 0),)
     peer_a_b.sub_proto.send_new_collation_hashes(hashes_and_periods)
     peer, cmd, msg = await asyncio.wait_for(
-        peer_a_b_subscriber.get(),
+        peer_a_b_subscriber.msg_queue.get(),
         timeout=1,
     )
     assert peer == peer_a_b
@@ -278,7 +279,7 @@ async def test_syncer_requests_new_collations(request, event_loop):
 async def test_syncer_proposing(request, event_loop):
     # setup a-b topology
     peer_a_b, peer_b_a = await get_directly_linked_sharding_peers(request, event_loop)
-    peer_a_b_subscriber = asyncio.Queue()
+    peer_a_b_subscriber = SamplePeerSubscriber()
     peer_a_b.add_subscriber(peer_a_b_subscriber)
     peer_pool_b = MockPeerPoolWithConnectedPeers([peer_b_a])
 
@@ -297,7 +298,7 @@ async def test_syncer_proposing(request, event_loop):
     # propose at b and check that it announces its proposal
     await syncer.propose()
     peer, cmd, msg = await asyncio.wait_for(
-        peer_a_b_subscriber.get(),
+        peer_a_b_subscriber.msg_queue.get(),
         timeout=1,
     )
     assert peer == peer_a_b

--- a/tests/p2p/test_tx_pool.py
+++ b/tests/p2p/test_tx_pool.py
@@ -26,6 +26,7 @@ from tests.conftest import (
 from tests.p2p.peer_helpers import (
     get_directly_linked_peers,
     MockPeerPoolWithConnectedPeers,
+    SamplePeerSubscriber,
 )
 
 # TODO: Move this file into the trinity tests (Requires refactor of peer_helpers)
@@ -166,7 +167,7 @@ async def test_tx_sending(request, event_loop, chain_with_block_validation, tx_v
         peer2_class=ETHPeer,
     )
 
-    peer2_subscriber = asyncio.Queue()
+    peer2_subscriber = SamplePeerSubscriber()
     peer2.add_subscriber(peer2_subscriber)
 
     pool = TxPool(MockPeerPoolWithConnectedPeers([peer1, peer2]), tx_validator)
@@ -183,7 +184,7 @@ async def test_tx_sending(request, event_loop, chain_with_block_validation, tx_v
 
     # Ensure that peer2 gets the transactions
     peer, cmd, msg = await asyncio.wait_for(
-        peer2_subscriber.get(),
+        peer2_subscriber.msg_queue.get(),
         timeout=0.1,
     )
 

--- a/trinity/plugins/builtin/tx_pool/pool.py
+++ b/trinity/plugins/builtin/tx_pool/pool.py
@@ -21,14 +21,14 @@ from p2p.peer import (
     BasePeer,
     ETHPeer,
     PeerPool,
-    PeerPoolSubscriber,
+    PeerSubscriber,
 )
 from p2p.service import (
     BaseService
 )
 
 
-class TxPool(BaseService, PeerPoolSubscriber):
+class TxPool(BaseService, PeerSubscriber):
     """
     The :class:`~trinity.tx_pool.pool.TxPool` class is responsible for holding and relaying
     of transactions, represented as :class:`~eth.rlp.transactions.BaseTransaction` among the
@@ -56,8 +56,12 @@ class TxPool(BaseService, PeerPoolSubscriber):
         self._bloom = BloomFilter(max_elements=1000000)
         self._bloom_salt = str(uuid.uuid4())
 
-    def register_peer(self, peer: BasePeer) -> None:
-        pass
+    @property
+    def msg_queue_maxsize(self) -> int:
+        # This is a rather arbitrary value, but when the sync is operating normally we never see
+        # the msg queue grow past a few hundred items, so this should be a reasonable limit for
+        # now.
+        return 2000
 
     async def _run(self) -> None:
         self.logger.info("Running Tx Pool")


### PR DESCRIPTION
* Renamed to PeerSubscriber because that's what it really is
* New @abstractmethod max_queue_size, to force each subscriber to define their own
* Peer now keeps a list of actual PeerSubscribers instead of just their msg queues
* PeerSubscriber provides APIs to add msgs to queue and check queue
  size, abstracting underlying implementation
* If an attempt is made to add a msg but the queue is full, we log a
  warning and drop the msg (Closes: #1032)

This should also help debug #1052 and decide how to fix it