### PR TITLE
Also cleanup the JSON-RPC ipc socket in fix-unclean-shutdown

### DIFF
--- a/trinity/main.py
+++ b/trinity/main.py
@@ -246,6 +246,13 @@ def fix_unclean_shutdown(chain_config: ChainConfig, logger: logging.Logger) -> N
     except FileNotFoundError:
         logger.debug('The IPC socket file for database connections at %s was already gone', db_ipc)
 
+    jsonrpc_ipc = chain_config.jsonrpc_ipc_path
+    try:
+        jsonrpc_ipc.unlink()
+        logger.info('Removed a dangling IPC socket file for JSON-RPC connections at %s', jsonrpc_ipc)
+    except FileNotFoundError:
+        logger.debug('The IPC socket file for JSON-RPC connections at %s was already gone', jsonrpc_ipc)
+
 
 @setup_cprofiler('run_database_process')
 @with_queued_logging

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -249,9 +249,15 @@ def fix_unclean_shutdown(chain_config: ChainConfig, logger: logging.Logger) -> N
     jsonrpc_ipc = chain_config.jsonrpc_ipc_path
     try:
         jsonrpc_ipc.unlink()
-        logger.info('Removed a dangling IPC socket file for JSON-RPC connections at %s', jsonrpc_ipc)
+        logger.info(
+            'Removed a dangling IPC socket file for JSON-RPC connections at %s',
+            jsonrpc_ipc,
+        )
     except FileNotFoundError:
-        logger.debug('The IPC socket file for JSON-RPC connections at %s was already gone', jsonrpc_ipc)
+        logger.debug(
+            'The IPC socket file for JSON-RPC connections at %s was already gone',
+            jsonrpc_ipc,
+        )
 
 
 @setup_cprofiler('run_database_process')


### PR DESCRIPTION
### What was wrong?

`trinity fix-unclean-shutdown` was not cleaning up the JSON-RPC ipc socket file.

### How was it fixed?

Added logic to clean it up.

#### Cute Animal Picture

![hqdefault](https://user-images.githubusercontent.com/824194/43015344-b31081ba-8c0c-11e8-94f6-79afecffcb88.jpg)

