### PR TITLE
Make it easy to profile the ChainSyncer

### DIFF
--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -75,7 +75,6 @@ class FullNodeSyncer(BaseService):
 def _test() -> None:
     import argparse
     import asyncio
-    from concurrent.futures import ProcessPoolExecutor
     import signal
     from p2p import ecies
     from p2p.kademlia import Node
@@ -104,7 +103,6 @@ def _test() -> None:
     asyncio.ensure_future(connect_to_peers_loop(peer_pool, nodes))
 
     loop = asyncio.get_event_loop()
-    loop.set_default_executor(ProcessPoolExecutor())
 
     syncer = FullNodeSyncer(chain, chaindb, chaindb.db, peer_pool)
 

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -1,9 +1,11 @@
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import Executor, ProcessPoolExecutor
 import datetime
 import logging
 import os
-import rlp
+import time
 from typing import Iterator, Tuple
+
+import rlp
 
 from eth_utils import to_tuple
 from eth_typing import BlockNumber
@@ -66,7 +68,7 @@ def get_block_numbers_for_request(
     return sequence_builder(block_number, limit, skip, reverse)
 
 
-def get_process_pool_executor() -> ProcessPoolExecutor:
+def get_asyncio_executor() -> Executor:
     # Use CPU_COUNT - 1 processes to make sure we always leave one CPU idle so that it can run
     # asyncio's event loop.
     os_cpu_count = os.cpu_count()
@@ -87,3 +89,18 @@ def time_since(start_time: datetime.datetime) -> Tuple[int, int, int, int]:
     hours, remainder = divmod(delta.seconds, 3600)
     minutes, seconds = divmod(remainder, 60)
     return delta.days, hours, minutes, seconds
+
+
+class Timer:
+    _start: float = None
+
+    def __init__(self, auto_start: bool = True) -> None:
+        if auto_start:
+            self.start()
+
+    def start(self) -> None:
+        self._start = time.time()
+
+    @property
+    def elapsed(self) -> float:
+        return time.time() - self._start


### PR DESCRIPTION
Also, when profiling, do not run anything in an asyncio executor as
those would not be profiled if we did.