### PR TITLE
Prefix trinity version with eth if trinity not installed

### DIFF
--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -5,7 +5,9 @@ __version__: str
 try:
     __version__ = pkg_resources.get_distribution("trinity").version
 except pkg_resources.DistributionNotFound:
-    __version__ = pkg_resources.get_distribution("py-evm").version
+    __version__ = "eth-{0}".format(
+        pkg_resources.get_distribution("py-evm").version,
+    )
 
 from .main import (  # noqa: F401
     main,


### PR DESCRIPTION
### What was wrong?

When `trinity` is not installed we fall back to the `py-evm` version for the version number.  We don't want to have any confusion when viewing this number

### How was it fixed?

When this happens, prefix the version string with `eth-`

#### Cute Animal Picture

![smiling-gorilla](https://user-images.githubusercontent.com/824194/43090587-0621dafc-8e65-11e8-8677-97ad61e97893.jpg)

