### PR TITLE
Use Tuple[str, ...] instead of Iterable[str] in AsyncProcessRunner

### DIFF
--- a/tests/trinity/integration/test_boot.py
+++ b/tests/trinity/integration/test_boot.py
@@ -35,8 +35,8 @@ def async_process_runner():
 @pytest.mark.parametrize(
     'command',
     (
-        ['trinity'],
-        ['trinity', '--ropsten'],
+        ('trinity',),
+        ('trinity', '--ropsten',),
     )
 )
 @pytest.mark.asyncio
@@ -54,8 +54,8 @@ async def test_full_boot(async_process_runner, command):
 @pytest.mark.parametrize(
     'command',
     (
-        ['trinity', '--tx-pool'],
-        ['trinity', '--tx-pool', '--ropsten'],
+        ('trinity', '--tx-pool',),
+        ('trinity', '--tx-pool', '--ropsten',),
     )
 )
 @pytest.mark.asyncio
@@ -74,8 +74,8 @@ async def test_txpool_full_boot(async_process_runner, command):
 @pytest.mark.parametrize(
     'command',
     (
-        ['trinity', '--light'],
-        ['trinity', '--light', '--ropsten'],
+        ('trinity', '--light',),
+        ('trinity', '--light', '--ropsten',),
     )
 )
 @pytest.mark.asyncio
@@ -93,11 +93,11 @@ async def test_light_boot(async_process_runner, command):
     'command',
     (
         # mainnet
-        ['trinity'],
-        ['trinity', '--light'],
+        ('trinity',),
+        ('trinity', '--light',),
         # ropsten
-        ['trinity', '--ropsten'],
-        ['trinity', '--light', '--ropsten'],
+        ('trinity', '--ropsten',),
+        ('trinity', '--light', '--ropsten',),
     )
 )
 @pytest.mark.asyncio

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -5,7 +5,7 @@ from typing import (
     AsyncIterable,
     Awaitable,
     Callable,
-    Iterable,
+    Tuple,
 )
 
 
@@ -15,12 +15,14 @@ class AsyncProcessRunner():
         self.debug_fn = debug_fn
 
     @classmethod
-    async def create_and_run(cls, cmds: Iterable[str], timeout_sec: int=10) -> 'AsyncProcessRunner':
+    async def create_and_run(cls,
+                             cmds: Tuple[str, ...],
+                             timeout_sec: int=10) -> 'AsyncProcessRunner':
         runner = cls()
         await runner.run(cmds, timeout_sec)
         return runner
 
-    async def run(self, cmds: Iterable[str], timeout_sec: int=10) -> None:
+    async def run(self, cmds: Tuple[str, ...], timeout_sec: int=10) -> None:
         proc = await asyncio.create_subprocess_exec(
             *cmds,
             stdout=asyncio.subprocess.PIPE,


### PR DESCRIPTION
### What was wrong?

As @pipermerriam pointed out `Iterable[str]` is satisfied by any `str` itself but will be an Iterable of any single char of that string which isn't quite what our API expects.

### How was it fixed?

Turn it into `Tuple[str, ...]`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.walldevil.com/wallpapers/w18/cute-red-panda.jpg)
