### PR TITLE
quiet logging of StateSyncer during state sync

### DIFF
--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -97,6 +97,7 @@ def setup_queue_logging(log_queue: 'Queue[str]', level: int) -> None:
     # the INFO level for it until https://github.com/ethereum/py-evm/issues/806 is fixed.
     logging.getLogger('p2p.kademlia').setLevel(logging.INFO)
     logging.getLogger('p2p.discovery').setLevel(logging.INFO)
+    logging.getLogger('p2p.state.StateSync').setLevel(logging.INFO)
     logger.debug('Logging initialized: PID=%s', os.getpid())
 
 


### PR DESCRIPTION
### What was wrong?

During state sync the logs were innundated with logging statements for every single trie node being scheduled for retrieval.

### How was it fixed?

Reduce logging level to `INFO` for that logger.

#### Cute Animal Picture

![5647974260_9259437f91_b](https://user-images.githubusercontent.com/824194/43146167-e44bfdb8-8f1d-11e8-9984-d6f113796efa.jpg)
