### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/guides/eth/understanding_the_mining_process.rst
+++ b/docs/guides/eth/understanding_the_mining_process.rst
@@ -38,7 +38,7 @@ block first because, after all, one primary use case for the Ethereum blockchain
 For the sake of simplicity though, we'll mine an empty block as a first example (meaning the block
 will not contain any transactions)
 
-As a refresher, he's where we left of as part of the `Building Chains Guide <building_chains>`_.
+As a refresher, he's where we left of as part of the :doc:`Building Chains Guide </guides/eth/building_chains>`.
 
 ::
 


### PR DESCRIPTION
### What was wrong?

Stumbled over this broken link in the docs. Did a quick search and it seems to be the last broken link between guides.

### How was it fixed?

Converted to proper syntax.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://4.bp.blogspot.com/-ZQPQ9HhdEGw/U8gTj5Kt3nI/AAAAAAABBAE/9HGHGYhJRTY/s1600/cute-red-panda-04.jpg)
