### PR TITLE
Add CI check to ensure docs are valid and use doctest to validate examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: lint-py36
+  py36-docs:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-docs
   py35-native-state-byzantium:
     <<: *common
     docker:
@@ -243,6 +249,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - py36-docs
       - py36-native-state-byzantium
       - py36-native-state-frontier
       - py36-native-state-homestead

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ coverage:
 	open htmlcov/index.html
 
 build-docs:
-	cd docs/; sphinx-build -T -E . _build/html
+	cd docs/; sphinx-build -W -T -E . _build/html
 
 doctest:
 	cd docs/; sphinx-build -T -b doctest . _build/doctest

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ coverage:
 build-docs:
 	cd docs/; sphinx-build -T -E . _build/html
 
+doctest:
+	cd docs/; sphinx-build -T -b doctest . _build/doctest
+
+validate-docs: build-docs doctest
+
 docs: build-docs
 	open docs/_build/html/index.html
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ needs_sphinx = '1.5'
 extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.asyncio',
 ]
@@ -180,3 +181,14 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3.5', None),
     'eth-typing': ('https://eth-typing.readthedocs.io/en/latest', None),
 }
+
+# -- Doctest configuration ----------------------------------------
+
+import doctest
+
+doctest_default_flags = (0
+    | doctest.DONT_ACCEPT_TRUE_FOR_1
+    | doctest.ELLIPSIS
+    | doctest.IGNORE_EXCEPTION_DETAIL
+    | doctest.NORMALIZE_WHITESPACE
+)

--- a/docs/guides/eth/building_chains.rst
+++ b/docs/guides/eth/building_chains.rst
@@ -15,32 +15,32 @@ after you define the VM ranges. For example, to set up a chain that would track
 the mainnet Ethereum network until block 1920000, you could create this chain
 class:
 
-::
+.. doctest::
 
-  from eth import constants, Chain
-  from eth.vm.forks.frontier import FrontierVM
-  from eth.vm.forks.homestead import HomesteadVM
-  from eth.chains.mainnet import HOMESTEAD_MAINNET_BLOCK
+  >>> from eth import constants, Chain
+  >>> from eth.vm.forks.frontier import FrontierVM
+  >>> from eth.vm.forks.homestead import HomesteadVM
+  >>> from eth.chains.mainnet import HOMESTEAD_MAINNET_BLOCK
 
-  chain_class = Chain.configure(
-      __name__='Test Chain',
-      vm_configuration=(
-          (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
-          (HOMESTEAD_MAINNET_BLOCK, HomesteadVM),
-      ),
-  )
+  >>> chain_class = Chain.configure(
+  ...     __name__='Test Chain',
+  ...     vm_configuration=(
+  ...         (constants.GENESIS_BLOCK_NUMBER, FrontierVM),
+  ...         (HOMESTEAD_MAINNET_BLOCK, HomesteadVM),
+  ...     ),
+  ... )
 
 Then to initialize, you can start it up with an in-memory database:
 
-::
+.. doctest::
 
-  from eth.db.backends.memory import MemoryDB
-  from eth.chains.mainnet import MAINNET_GENESIS_HEADER
+  >>> from eth.db.backends.memory import MemoryDB
+  >>> from eth.chains.mainnet import MAINNET_GENESIS_HEADER
 
-  # start a fresh in-memory db
+  >>> # start a fresh in-memory db
 
-  # initialize a fresh chain
-  chain = chain_class.from_genesis_header(MemoryDB(), MAINNET_GENESIS_HEADER)
+  >>> # initialize a fresh chain
+  >>> chain = chain_class.from_genesis_header(MemoryDB(), MAINNET_GENESIS_HEADER)
 
 
 Using the LightPeerChain object

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,18 @@ basepython =
     py36: python3.6
 
 
+[testenv:py36-docs]
+whitelist_externals=
+    make
+deps = .[doc]
+basepython=python3.6
+passenv =
+    PYTEST_ADDOPTS
+    TRAVIS_EVENT_TYPE
+commands=
+    make validate-docs
+
+
 [testenv:py36-trinity-integration]
 deps = .[eth-extras, test]
 basepython=python3.6


### PR DESCRIPTION
### What was wrong?

1. We have no job that checks if the docs can still be built (e.g. source files get moved/deleted but docs aren't updated will cause failure)

2. The examples in our docs aren't validated which means they can get out of date quickly

### How was it fixed?

1. This configures `doctest` to validate examples (only one example so far)

2. This adds a `py36-docs` job to our CI which validates that docs can be built and also validates the examples using `doctest`.

3. The `building chains` example was updated to be validated with `doctest`. Notice that only the first part of the example uses doctest yet. The second one needs to be updated and moved but I'll tackle that in a separate PR. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://s.hswstatic.com/gif/otters-playful-169788211.jpg)
