### PR TITLE
let web3.py specify the eth-account dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ deps = {
         "plyvel==1.0.4",
         "coincurve>=7.0.0,<8.0.0",
         "web3==4.3.0",
-        # required for rlp>=1.0.0
-        "eth-account>=0.2.1,<1",
         "cachetools>=2.1.0,<3.0.0",
     ],
     'test': [


### PR DESCRIPTION
Before this change, web3 specified a tighter <0.3.0 constraint, so it
caused a pip conflict when trinity installed 0.3.0.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQuHvmkG6BoO5XMfI5fmtoi0UmK9YKRpbH--qZzDEya3faet8pR)
