### PR TITLE
Further flesh out round trip request/response API

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -305,6 +305,9 @@ class LightChainSyncer(BaseHeaderChainSyncer):
         elif isinstance(cmd, les.GetBlockHeaders):
             msg = cast(Dict[str, Any], msg)
             await self._handle_get_block_headers(cast(LESPeer, peer), msg)
+        elif isinstance(cmd, les.BlockHeaders):
+            # `BlockHeaders` messages are handled at the peer level.
+            pass
         else:
             self.logger.debug("Ignoring %s message from %s", cmd, peer)
 
@@ -533,6 +536,9 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             await self._handle_new_block(peer, cast(Dict[str, Any], msg))
         elif isinstance(cmd, eth.GetBlockHeaders):
             await self._handle_get_block_headers(peer, cast(Dict[str, Any], msg))
+        elif isinstance(cmd, eth.BlockHeaders):
+            # `BlockHeaders` messages are handled at the peer level.
+            pass
         elif isinstance(cmd, eth.GetBlockBodies):
             # Only serve up to eth.MAX_BODIES_FETCH items in every request.
             block_hashes = cast(List[Hash32], msg)[:eth.MAX_BODIES_FETCH]

--- a/p2p/eth.py
+++ b/p2p/eth.py
@@ -74,7 +74,7 @@ class GetBlockHeaders(Command):
 
 
 class HeaderRequest(BaseHeaderRequest):
-    MAX_HEADERS_FETCH = MAX_HEADERS_FETCH
+    max_size = MAX_HEADERS_FETCH
 
     def __init__(self,
                  block_number_or_hash: BlockIdentifier,

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -159,3 +159,10 @@ class NoInternalAddressMatchesDevice(BaseP2PError):
     def __init__(self, *args: Any, device_hostname: str=None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.device_hostname = device_hostname
+
+
+class ValidationError(BaseP2PError):
+    """
+    Raised when something does not pass a validation check.
+    """
+    pass

--- a/p2p/les.py
+++ b/p2p/les.py
@@ -16,8 +16,12 @@ from eth_typing import (
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 
+from p2p.exceptions import (
+    ValidationError,
+)
 from p2p.protocol import (
     BaseBlockHeaders,
+    BaseHeaderRequest,
     Command,
     Protocol,
     _DecodedMsgType,
@@ -161,6 +165,44 @@ class GetBlockHeadersQuery(rlp.Serializable):
         ('skip', sedes.big_endian_int),
         ('reverse', sedes.boolean),
     ]
+
+
+class HeaderRequest(BaseHeaderRequest):
+    request_id: int
+
+    MAX_HEADERS_FETCH = MAX_HEADERS_FETCH
+
+    def __init__(self,
+                 block_number_or_hash: BlockIdentifier,
+                 max_headers: int,
+                 skip: int,
+                 reverse: bool,
+                 request_id: int) -> None:
+        self.block_number_or_hash = block_number_or_hash
+        self.max_headers = max_headers
+        self.skip = skip
+        self.reverse = reverse
+        self.request_id = request_id
+
+    def validate_response(self, response: Any) -> None:
+        """
+        Core `Request` API used for validation.
+        """
+        if not isinstance(response, dict):
+            raise ValidationError("Response to `HeaderRequest` must be a dict")
+
+        request_id = response['request_id']
+        if request_id != self.request_id:
+            raise ValidationError(
+                "Response `request_id` does not match.  expected: %s | got: %s".format(
+                    self.request_id,
+                    request_id,
+                )
+            )
+        elif not all(isinstance(item, BlockHeader) for item in response['headers']):
+            raise ValidationError("Response must be a tuple of `BlockHeader` objects")
+
+        return self.validate_headers(cast(Tuple[BlockHeader, ...], response['headers']))
 
 
 class GetBlockHeaders(Command):

--- a/p2p/les.py
+++ b/p2p/les.py
@@ -170,7 +170,7 @@ class GetBlockHeadersQuery(rlp.Serializable):
 class HeaderRequest(BaseHeaderRequest):
     request_id: int
 
-    MAX_HEADERS_FETCH = MAX_HEADERS_FETCH
+    max_size = MAX_HEADERS_FETCH
 
     def __init__(self,
                  block_number_or_hash: BlockIdentifier,

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -20,7 +20,6 @@ from typing import (
     Dict,
     Iterator,
     List,
-    NamedTuple,
     TYPE_CHECKING,
     Tuple,
     Type,
@@ -60,8 +59,10 @@ from eth.vm.forks import HomesteadVM
 
 from p2p import auth
 from p2p import ecies
-from p2p.kademlia import Address, Node
+from p2p import eth
+from p2p import les
 from p2p import protocol
+from p2p.kademlia import Address, Node
 from p2p.exceptions import (
     BadAckMessage,
     DAOForkCheckFailure,
@@ -75,17 +76,16 @@ from p2p.exceptions import (
     UnexpectedMessage,
     UnknownProtocolCommand,
     UnreachablePeer,
+    ValidationError,
 )
 from p2p.service import BaseService
 from p2p.utils import (
-    gen_request_id,
+    gen_request_id as _gen_request_id,
     get_devp2p_cmd_id,
     roundup_16,
     sxor,
     time_since,
 )
-from p2p import eth
-from p2p import les
 from p2p.p2p_proto import (
     Disconnect,
     DisconnectReason,
@@ -143,105 +143,6 @@ async def handshake(remote: Node,
     return peer
 
 
-class HeaderRequest(NamedTuple):
-    block_number_or_hash: BlockIdentifier
-    max_headers: int
-    skip: int
-    reverse: bool
-
-    def generate_block_numbers(self,
-                               block_number: BlockNumber=None) -> Tuple[BlockNumber, ...]:
-        if block_number is None and not self.is_numbered:
-            raise TypeError(
-                "A `block_number` must be supplied to generate block numbers "
-                "for hash based header requests"
-            )
-        elif block_number is not None and self.is_numbered:
-            raise TypeError(
-                "The `block_number` parameter may not be used for number based "
-                "header requests"
-            )
-        elif block_number is None:
-            block_number = cast(BlockNumber, self.block_number_or_hash)
-
-        max_headers = min(eth.MAX_HEADERS_FETCH, self.max_headers)
-
-        # inline import until this module is moved to `trinity`
-        from trinity.utils.headers import sequence_builder
-        return sequence_builder(
-            block_number,
-            max_headers,
-            self.skip,
-            self.reverse,
-        )
-
-    @property
-    def is_numbered(self) -> bool:
-        return isinstance(self.block_number_or_hash, int)
-
-    def validate_headers(self,
-                         headers: Tuple[BlockHeader, ...]) -> None:
-        if not headers:
-            # An empty response is always valid
-            return
-        elif not self.is_numbered:
-            first_header = headers[0]
-            if first_header.hash != self.block_number_or_hash:
-                raise ValueError(
-                    "Returned headers cannot be matched to header request. "
-                    "Expected first header to have hash of {0} but instead got "
-                    "{1}.".format(
-                        encode_hex(self.block_number_or_hash),
-                        encode_hex(first_header.hash),
-                    )
-                )
-
-        block_numbers: Tuple[BlockNumber, ...] = tuple(
-            header.block_number for header in headers
-        )
-        return self.validate_sequence(block_numbers)
-
-    def validate_sequence(self, block_numbers: Tuple[BlockNumber, ...]) -> None:
-        if not block_numbers:
-            return
-        elif self.is_numbered:
-            expected_numbers = self.generate_block_numbers()
-        else:
-            expected_numbers = self.generate_block_numbers(block_numbers[0])
-
-        # check for numbers that should not be present.
-        unexpected_numbers = set(block_numbers).difference(expected_numbers)
-        if unexpected_numbers:
-            raise ValueError(
-                'Unexpected numbers: {0}'.format(unexpected_numbers))
-
-        # check that the numbers are correctly ordered.
-        expected_order = tuple(sorted(
-            block_numbers,
-            reverse=self.reverse,
-        ))
-        if block_numbers != expected_order:
-            raise ValueError(
-                'Returned headers are not correctly ordered.\n'
-                'Expected: {0}\n'
-                'Got     : {1}\n'.format(expected_order, block_numbers)
-            )
-
-        # check that all provided numbers are an ordered subset of the master
-        # sequence.
-        iter_expected = iter(expected_numbers)
-        for number in block_numbers:
-            for value in iter_expected:
-                if value == number:
-                    break
-            else:
-                raise ValueError(
-                    'Returned headers contain an unexpected block number.\n'
-                    'Unexpected Number: {0}\n'
-                    'Expected Numbers : {1}'.format(number, expected_numbers)
-                )
-
-
 class BasePeer(BaseService):
     conn_idle_timeout = CONN_IDLE_TIMEOUT
     # Must be defined in subclasses. All items here must be Protocol classes representing
@@ -253,6 +154,14 @@ class BasePeer(BaseService):
     sub_proto: protocol.Protocol = None
     head_td: int = None
     head_hash: Hash32 = None
+
+    # TODO: Instead of a fixed timeout, we should instead monitor response
+    # times for the peer and adjust our timeout accordingly
+    _response_timeout = 60
+    pending_requests: Dict[
+        Type[protocol.Command],
+        Tuple[protocol.BaseRequest, 'asyncio.Future[protocol._DecodedMsgType]'],
+    ]
 
     def __init__(self,
                  remote: Node,
@@ -279,6 +188,8 @@ class BasePeer(BaseService):
         self._subscribers: List[PeerSubscriber] = []
         self.start_time = datetime.datetime.now()
         self.received_msgs: Dict[protocol.Command, int] = collections.defaultdict(int)
+
+        self.pending_requests = {}
 
         self.egress_mac = egress_mac
         self.ingress_mac = ingress_mac
@@ -620,10 +531,21 @@ class LESPeer(BasePeer):
         return les.MAX_HEADERS_FETCH
 
     def handle_sub_proto_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
+        cmd_type = type(cmd)
+
         if isinstance(cmd, les.Announce):
             self.head_info = cmd.as_head_info(msg)
             self.head_td = self.head_info.total_difficulty
             self.head_hash = self.head_info.block_hash
+        elif cmd_type in self.pending_requests:
+            request, future = self.pending_requests[cmd_type]
+            try:
+                request.validate_response(msg)
+            except ValidationError:
+                pass
+            else:
+                future.set_result(msg)
+                self.pending_requests.pop(cmd_type)
         super().handle_sub_proto_msg(cmd, msg)
 
     async def send_sub_proto_handshake(self) -> None:
@@ -652,19 +574,23 @@ class LESPeer(BasePeer):
         self.head_td = self.head_info.total_difficulty
         self.head_hash = self.head_info.block_hash
 
+    def gen_request_id(self) -> int:
+        return _gen_request_id()
+
     def request_block_headers(self,
                               block_number_or_hash: BlockIdentifier,
                               max_headers: int = None,
                               skip: int = 0,
-                              reverse: bool = False) -> HeaderRequest:
+                              reverse: bool = False) -> les.HeaderRequest:
         if max_headers is None:
             max_headers = self.max_headers_fetch
-        request_id = gen_request_id()
-        request = HeaderRequest(
+        request_id = self.gen_request_id()
+        request = les.HeaderRequest(
             block_number_or_hash,
             max_headers,
             skip,
             reverse,
+            request_id,
         )
         self.sub_proto.send_get_block_headers(
             request.block_number_or_hash,
@@ -674,6 +600,26 @@ class LESPeer(BasePeer):
             request_id,
         )
         return request
+
+    async def wait_for_block_headers(self, request: les.HeaderRequest) -> Tuple[BlockHeader, ...]:
+        future: 'asyncio.Future[protocol._DecodedMsgType]' = asyncio.Future()
+        self.pending_requests[les.BlockHeaders] = cast(
+            Tuple[protocol.BaseRequest, 'asyncio.Future[protocol._DecodedMsgType]'],
+            (request, future),
+        )
+        response = cast(
+            Dict[str, Any],
+            await self.wait(future, timeout=self._response_timeout),
+        )
+        return cast(Tuple[BlockHeader, ...], response['headers'])
+
+    async def get_block_headers(self,
+                                block_number_or_hash: BlockIdentifier,
+                                max_headers: int = None,
+                                skip: int = 0,
+                                reverse: bool = True) -> Tuple[BlockHeader, ...]:
+        request = self.request_block_headers(block_number_or_hash, max_headers, skip, reverse)
+        return await self.wait_for_block_headers(request)
 
 
 class ETHPeer(BasePeer):
@@ -685,6 +631,8 @@ class ETHPeer(BasePeer):
         return eth.MAX_HEADERS_FETCH
 
     def handle_sub_proto_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
+        cmd_type = type(cmd)
+
         if isinstance(cmd, eth.NewBlock):
             msg = cast(Dict[str, Any], msg)
             header, _, _ = msg['block']
@@ -693,6 +641,17 @@ class ETHPeer(BasePeer):
             if actual_td > self.head_td:
                 self.head_hash = actual_head
                 self.head_td = actual_td
+
+        if cmd_type in self.pending_requests:
+            request, future = self.pending_requests[cmd_type]
+            try:
+                request.validate_response(msg)
+            except ValidationError:
+                pass
+            else:
+                future.set_result(msg)
+                self.pending_requests.pop(cmd_type)
+
         super().handle_sub_proto_msg(cmd, msg)
 
     async def send_sub_proto_handshake(self) -> None:
@@ -723,10 +682,10 @@ class ETHPeer(BasePeer):
                               block_number_or_hash: BlockIdentifier,
                               max_headers: int = None,
                               skip: int = 0,
-                              reverse: bool = True) -> HeaderRequest:
+                              reverse: bool = True) -> eth.HeaderRequest:
         if max_headers is None:
             max_headers = self.max_headers_fetch
-        request = HeaderRequest(
+        request = eth.HeaderRequest(
             block_number_or_hash,
             max_headers,
             skip,
@@ -739,6 +698,23 @@ class ETHPeer(BasePeer):
             request.reverse,
         )
         return request
+
+    async def wait_for_block_headers(self, request: eth.HeaderRequest) -> Tuple[BlockHeader, ...]:
+        future: 'asyncio.Future[Tuple[BlockHeader, ...]]' = asyncio.Future()
+        self.pending_requests[eth.BlockHeaders] = cast(
+            Tuple[protocol.BaseRequest, 'asyncio.Future[protocol._DecodedMsgType]'],
+            (request, future),
+        )
+        response = await self.wait(future, timeout=self._response_timeout)
+        return response
+
+    async def get_block_headers(self,
+                                block_number_or_hash: BlockIdentifier,
+                                max_headers: int = None,
+                                skip: int = 0,
+                                reverse: bool = True) -> Tuple[BlockHeader, ...]:
+        request = self.request_block_headers(block_number_or_hash, max_headers, skip, reverse)
+        return await self.wait_for_block_headers(request)
 
 
 class PeerSubscriber(ABC):
@@ -984,7 +960,7 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
 
             try:
                 request.validate_headers(headers)
-            except ValueError as err:
+            except ValidationError as err:
                 raise DAOForkCheckFailure(
                     "Invalid header response during DAO fork check: {}".format(err)
                 )

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -3,6 +3,7 @@ import struct
 from abc import ABC, abstractmethod
 from typing import (
     Any,
+    cast,
     Dict,
     List,
     Tuple,
@@ -14,9 +15,14 @@ from typing import (
 import rlp
 from rlp import sedes
 
+from eth_utils import encode_hex
+
+from eth_typing import BlockIdentifier, BlockNumber
+
 from eth.constants import NULL_BYTE
 from eth.rlp.headers import BlockHeader
 
+from p2p.exceptions import ValidationError
 from p2p.utils import get_devp2p_cmd_id
 
 
@@ -114,6 +120,120 @@ class Command:
 
         body = _pad_to_16_byte_boundary(enc_cmd_id + payload)
         return header, body
+
+
+class BaseRequest(ABC):
+    """
+    Base representation of a *request* to a connected peer which has a matching
+    *response*.
+    """
+    @abstractmethod
+    def validate_response(self, response: Any) -> None:
+        pass
+
+
+class BaseHeaderRequest(BaseRequest):
+    block_number_or_hash: BlockIdentifier
+    max_headers: int
+    skip: int
+    reverse: bool
+
+    @property
+    @abstractmethod
+    def MAX_HEADERS_FETCH(self) -> int:
+        pass
+
+    def generate_block_numbers(self,
+                               block_number: BlockNumber=None) -> Tuple[BlockNumber, ...]:
+        if block_number is None and not self.is_numbered:
+            raise TypeError(
+                "A `block_number` must be supplied to generate block numbers "
+                "for hash based header requests"
+            )
+        elif block_number is not None and self.is_numbered:
+            raise TypeError(
+                "The `block_number` parameter may not be used for number based "
+                "header requests"
+            )
+        elif block_number is None:
+            block_number = cast(BlockNumber, self.block_number_or_hash)
+
+        max_headers = min(self.MAX_HEADERS_FETCH, self.max_headers)
+
+        # inline import until this module is moved to `trinity`
+        from trinity.utils.headers import sequence_builder
+        return sequence_builder(
+            block_number,
+            max_headers,
+            self.skip,
+            self.reverse,
+        )
+
+    @property
+    def is_numbered(self) -> bool:
+        return isinstance(self.block_number_or_hash, int)
+
+    def validate_headers(self,
+                         headers: Tuple[BlockHeader, ...]) -> None:
+        if not headers:
+            # An empty response is always valid
+            return
+        elif not self.is_numbered:
+            first_header = headers[0]
+            if first_header.hash != self.block_number_or_hash:
+                raise ValidationError(
+                    "Returned headers cannot be matched to header request. "
+                    "Expected first header to have hash of {0} but instead got "
+                    "{1}.".format(
+                        encode_hex(self.block_number_or_hash),
+                        encode_hex(first_header.hash),
+                    )
+                )
+
+        block_numbers: Tuple[BlockNumber, ...] = tuple(
+            header.block_number for header in headers
+        )
+        return self.validate_sequence(block_numbers)
+
+    def validate_sequence(self, block_numbers: Tuple[BlockNumber, ...]) -> None:
+        if not block_numbers:
+            return
+        elif self.is_numbered:
+            expected_numbers = self.generate_block_numbers()
+        else:
+            expected_numbers = self.generate_block_numbers(block_numbers[0])
+
+        # check for numbers that should not be present.
+        unexpected_numbers = set(block_numbers).difference(expected_numbers)
+        if unexpected_numbers:
+            raise ValidationError(
+                'Unexpected numbers: {0}'.format(unexpected_numbers))
+
+        # check that the numbers are correctly ordered.
+        expected_order = tuple(sorted(
+            block_numbers,
+            reverse=self.reverse,
+        ))
+        if block_numbers != expected_order:
+            raise ValidationError(
+                'Returned headers are not correctly ordered.\n'
+                'Expected: {0}\n'
+                'Got     : {1}\n'.format(expected_order, block_numbers)
+            )
+
+        # check that all provided numbers are an ordered subset of the master
+        # sequence.
+        iter_expected = iter(expected_numbers)
+        for number in block_numbers:
+            for value in iter_expected:
+                if value == number:
+                    break
+            else:
+                raise ValidationError(
+                    'Returned headers contain an unexpected block number.\n'
+                    'Unexpected Number: {0}\n'
+                    'Expected Numbers : {1}'.format(number, expected_numbers)
+                )
 
 
 class Protocol:

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -140,7 +140,7 @@ class BaseHeaderRequest(BaseRequest):
 
     @property
     @abstractmethod
-    def MAX_HEADERS_FETCH(self) -> int:
+    def max_size(self) -> int:
         pass
 
     def generate_block_numbers(self,
@@ -158,7 +158,7 @@ class BaseHeaderRequest(BaseRequest):
         elif block_number is None:
             block_number = cast(BlockNumber, self.block_number_or_hash)
 
-        max_headers = min(self.MAX_HEADERS_FETCH, self.max_headers)
+        max_headers = min(self.max_size, self.max_headers)
 
         # inline import until this module is moved to `trinity`
         from trinity.utils.headers import sequence_builder

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -49,7 +49,7 @@ from p2p import eth
 from p2p import protocol
 from p2p.chain import PeerRequestHandler
 from p2p.exceptions import NoEligiblePeers, NoIdlePeers
-from p2p.peer import BasePeer, ETHPeer, HeaderRequest, PeerPool, PeerSubscriber
+from p2p.peer import BasePeer, ETHPeer, PeerPool, PeerSubscriber
 from p2p.service import BaseService
 from p2p.utils import get_asyncio_executor, Timer
 
@@ -177,7 +177,7 @@ class StateDownloader(BaseService, PeerSubscriber):
             await self._process_nodes(zip(node_keys, msg))
         elif isinstance(cmd, eth.GetBlockHeaders):
             query = cast(Dict[Any, Union[bool, int]], msg)
-            request = HeaderRequest(
+            request = eth.HeaderRequest(
                 query['block_number_or_hash'],
                 query['max_headers'],
                 query['skip'],
@@ -199,7 +199,7 @@ class StateDownloader(BaseService, PeerSubscriber):
         else:
             self.logger.warn("%s not handled during StateSync, must be implemented", cmd)
 
-    async def _handle_get_block_headers(self, peer: ETHPeer, request: HeaderRequest) -> None:
+    async def _handle_get_block_headers(self, peer: ETHPeer, request: eth.HeaderRequest) -> None:
         headers = await self._handler.lookup_headers(request)
         peer.sub_proto.send_block_headers(headers)
 

--- a/tests/p2p/test_header_request_object.py
+++ b/tests/p2p/test_header_request_object.py
@@ -1,6 +1,7 @@
 import pytest
 
-from p2p.chain import HeaderRequest
+from p2p.exceptions import ValidationError
+from p2p.protocol import BaseHeaderRequest
 
 
 FORWARD_0_to_5 = (0, 6, 0, False)
@@ -11,6 +12,23 @@ REVERSE_5_to_0_SKIP_1 = (5, 3, 1, True)
 
 
 BLOCK_HASH = b'\x01' * 32
+
+
+class HeaderRequest(BaseHeaderRequest):
+    MAX_HEADERS_FETCH = 192
+
+    def __init__(self,
+                 block_number_or_hash,
+                 max_headers,
+                 skip,
+                 reverse):
+        self.block_number_or_hash = block_number_or_hash
+        self.max_headers = max_headers
+        self.skip = skip
+        self.reverse = reverse
+
+    def validate_response(self, response):
+        pass
 
 
 @pytest.mark.parametrize(
@@ -111,5 +129,5 @@ def test_header_request_sequence_matching(
     if is_match:
         request.validate_sequence(sequence)
     else:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             request.validate_sequence(sequence)

--- a/tests/p2p/test_header_request_object.py
+++ b/tests/p2p/test_header_request_object.py
@@ -15,7 +15,7 @@ BLOCK_HASH = b'\x01' * 32
 
 
 class HeaderRequest(BaseHeaderRequest):
-    MAX_HEADERS_FETCH = 192
+    max_size = 192
 
     def __init__(self,
                  block_number_or_hash,

--- a/tests/p2p/test_peer_block_header_request_and_response_api.py
+++ b/tests/p2p/test_peer_block_header_request_and_response_api.py
@@ -1,0 +1,153 @@
+import asyncio
+
+import pytest
+
+from eth_utils import to_tuple
+
+from eth.rlp.headers import BlockHeader
+
+from p2p.peer import ETHPeer, LESPeer
+from peer_helpers import (
+    get_directly_linked_peers,
+)
+
+
+@to_tuple
+def mk_header_chain(length):
+    assert length >= 1
+    genesis = BlockHeader(difficulty=100, block_number=0, gas_limit=3000000)
+    yield genesis
+    parent = genesis
+    if length == 1:
+        return
+
+    for i in range(length - 1):
+        header = BlockHeader(
+            difficulty=100,
+            block_number=parent.block_number + 1,
+            parent_hash=parent.hash,
+            gas_limit=3000000,
+        )
+        yield header
+        parent = header
+
+
+@pytest.fixture
+async def eth_peer_and_remote(request, event_loop):
+    peer, remote = await get_directly_linked_peers(
+        request,
+        event_loop,
+        peer1_class=ETHPeer,
+        peer2_class=ETHPeer,
+    )
+    return peer, remote
+
+
+@pytest.fixture
+async def les_peer_and_remote(request, event_loop):
+    peer, remote = await get_directly_linked_peers(
+        request,
+        event_loop,
+        peer1_class=LESPeer,
+        peer2_class=LESPeer,
+    )
+    return peer, remote
+
+
+@pytest.mark.parametrize(
+    'params,headers',
+    (
+        ((0, 1, 0, False), mk_header_chain(1)),
+        ((0, 10, 0, False), mk_header_chain(10)),
+        ((3, 5, 0, False), mk_header_chain(10)[3:8]),
+    )
+)
+@pytest.mark.asyncio
+async def test_eth_peer_get_headers_round_trip(eth_peer_and_remote,
+                                               params,
+                                               headers):
+    peer, remote = eth_peer_and_remote
+
+    async def send_headers():
+        remote.sub_proto.send_block_headers(headers)
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_headers())
+    response = await peer.get_block_headers(*params)
+
+    assert len(response) == len(headers)
+    for expected, actual in zip(headers, response):
+        assert expected == actual
+
+
+@pytest.mark.parametrize(
+    'params,headers',
+    (
+        ((0, 1, 0, False), mk_header_chain(1)),
+        ((0, 10, 0, False), mk_header_chain(10)),
+        ((3, 5, 0, False), mk_header_chain(10)[3:8]),
+    )
+)
+@pytest.mark.asyncio
+async def test_les_peer_get_headers_round_trip(les_peer_and_remote,
+                                               params,
+                                               headers):
+    peer, remote = les_peer_and_remote
+    request_id = 1234
+
+    peer.gen_request_id = lambda: request_id
+
+    async def send_headers():
+        remote.sub_proto.send_block_headers(headers, 0, request_id)
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_headers())
+    response = await peer.get_block_headers(*params)
+
+    assert len(response) == len(headers)
+    for expected, actual in zip(headers, response):
+        assert expected == actual
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_headers_round_trip_with_noise(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers = mk_header_chain(10)
+
+    async def send_responses():
+        remote.sub_proto.send_node_data([b'arst', b'tsra'])
+        await asyncio.sleep(0)
+        remote.sub_proto.send_block_headers(headers)
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_responses())
+    response = await peer.get_block_headers(0, 10, 0, False)
+
+    assert len(response) == len(headers)
+    for expected, actual in zip(headers, response):
+        assert expected == actual
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_headers_round_trip_does_not_match_invalid_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers = mk_header_chain(5)
+
+    wrong_headers = mk_header_chain(10)[3:8]
+
+    async def send_responses():
+        remote.sub_proto.send_node_data([b'arst', b'tsra'])
+        await asyncio.sleep(0)
+        remote.sub_proto.send_block_headers(wrong_headers)
+        await asyncio.sleep(0)
+        remote.sub_proto.send_block_headers(headers)
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_responses())
+    response = await peer.get_block_headers(0, 5, 0, False)
+
+    assert len(response) == len(headers)
+    for expected, actual in zip(headers, response):
+        assert expected == actual

--- a/trinity/utils/headers.py
+++ b/trinity/utils/headers.py
@@ -1,14 +1,10 @@
 from typing import (
     Iterator,
-    TYPE_CHECKING,
 )
 
 from eth_utils import to_tuple
 
 from eth.constants import UINT_256_MAX
-
-if TYPE_CHECKING:
-    from p2p.peer import HeaderRequest  # noqa: F401
 
 
 @to_tuple


### PR DESCRIPTION
### What was wrong?

Still too much manual work to be done for round trip requests for block headers.

### How was it fixed?

- established base class for p2p requests for data in `p2p.peer.BaseRequest`
- setup data structure on `ETHPeer` which houses a mapping between `Command -> Future`.
- In the `handle_sub_process_msg`, if there is a waiting future for a given command, it will set the future result.
- New API `ETHPeer.get_block_headers` which does the full request/response round trip.

This has a really nice side effect of not needing the chain syncers to handle the `BlockHeaders` response, and instead can just `await peer.get_block_headers(...)`, removing a decent amount of complexity from the class.  If we continue this pattern for the rest of the block body parts I think the chain syncer is going to look a lot cleaner and easier to grok.


#### Cute Animal Picture

![ab6jyf-1](https://user-images.githubusercontent.com/824194/43472910-e2f879a8-94ab-11e8-9728-2c71c544e22e.jpg)

