### PR TITLE
Add an async sleep to the trie node processing loop

### DIFF
--- a/p2p/state.py
+++ b/p2p/state.py
@@ -132,6 +132,8 @@ class StateDownloader(BaseService, PeerSubscriber):
                     # This means we received a node more than once, which can happen when we
                     # retry after a timeout.
                     pass
+                else:
+                    await asyncio.sleep(0)
                 # A node may be received more than once, so pop() with a default value.
                 self._pending_nodes.pop(node_key, None)
         elif isinstance(cmd, eth.GetBlockHeaders):


### PR DESCRIPTION
### What was wrong?

The loop which processes trie nodes can take a long time and none of the loop internals yield control to the event loop.

### How was it fixed?

Added an `asyncio.sleep(0)` to the loop.  Local testing of this did not appear to have any significant effect on sync performance.

#### Cute Animal Picture

![4 3 15-dogs-and-baby-animals0](https://user-images.githubusercontent.com/824194/43236659-9948309e-9043-11e8-9411-c053834e27e1.jpg)
