### PR TITLE
state-sync: don't request trie nodes to peers known not to have them

### DIFF
--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -109,7 +109,14 @@ class NoConnectedPeers(BaseP2PError):
 
 class NoEligiblePeers(BaseP2PError):
     """
-    Raised when none of our peers have the blocks we want.
+    Raised when none of our peers have the data we want.
+    """
+    pass
+
+
+class NoIdlePeers(BaseP2PError):
+    """
+    Raised when none of our peers is idle and can be used for data requests.
     """
     pass
 

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -443,7 +443,7 @@ class KademliaProtocol:
         try:
             callback = self.pong_callbacks.get_callback(pingid)
         except KeyError:
-            self.logger.info('unexpected pong from %s (token == %s)', remote, encode_hex(token))
+            self.logger.debug('unexpected pong from %s (token == %s)', remote, encode_hex(token))
         else:
             callback()
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -760,6 +760,10 @@ class PeerSubscriber(ABC):
         """
         pass
 
+    def deregister_peer(self, peer: BasePeer) -> None:
+        """Called when a peer is removed from the pool."""
+        pass
+
     @property
     def msg_queue(self) -> 'asyncio.Queue[PEER_MSG_TYPE]':
         if self._msg_queue is None:
@@ -1010,6 +1014,8 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
         else:
             self.logger.warn(
                 "%s finished but was not found in connected_nodes (%s)", peer, self.connected_nodes)
+        for subscriber in self._subscribers:
+            subscriber.deregister_peer(peer)
 
     def __aiter__(self) -> AsyncIterator[BasePeer]:
         return ConnectedPeersIterator(tuple(self.connected_nodes.values()))

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -133,6 +133,10 @@ class BaseService(ABC, CancellableMixin):
         asyncio.run_coroutine_threadsafe(self.cancel(), loop=self.loop)
         await asyncio.wait_for(self.cleaned_up.wait(), timeout=self._wait_until_finished_timeout)
 
+    async def sleep(self, delay: float) -> None:
+        """Coroutine that completes after a given time (in seconds)."""
+        await self.wait(asyncio.sleep(delay))
+
     @abstractmethod
     async def _run(self) -> None:
         """Run the service's loop.

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -11,7 +11,7 @@ from typing import (
     Union,
 )
 
-from cytoolz.itertoolz import partition_all
+from cytoolz import dicttoolz, itertoolz
 
 import rlp
 
@@ -98,7 +98,7 @@ class StateDownloader(BaseService, PeerSubscriber):
     async def _handle_msg_loop(self) -> None:
         while self.is_running:
             try:
-                peer, cmd, msg = await self.wait_first(self.msg_queue.get())
+                peer, cmd, msg = await self.wait(self.msg_queue.get())
             except OperationCancelled:
                 break
 
@@ -125,7 +125,11 @@ class StateDownloader(BaseService, PeerSubscriber):
                 self._peers_with_pending_requests.pop(peer)
 
             node_keys = await loop.run_in_executor(self._executor, list, map(keccak, msg))
-            for node_key, node in zip(node_keys, msg):
+            # If we removed items from self._pending_nodes in the processing loop below, the retry
+            # coroutine could kick in before we've finished and retry the nodes we haven't gotten
+            # to yet, so we first pop all received node keys from self._pending_nodes.
+            self._pending_nodes = dicttoolz.dissoc(self._pending_nodes, *node_keys)
+            for idx, (node_key, node) in enumerate(zip(node_keys, msg)):
                 self._total_processed_nodes += 1
                 try:
                     self.scheduler.process([(node_key, node)])
@@ -133,8 +137,11 @@ class StateDownloader(BaseService, PeerSubscriber):
                     # This means we received a node more than once, which can happen when we
                     # retry after a timeout.
                     pass
-                # A node may be received more than once, so pop() with a default value.
-                self._pending_nodes.pop(node_key, None)
+                if idx % 10 == 0:
+                    # XXX: This is a quick workaround for
+                    # https://github.com/ethereum/py-evm/issues/1074, which will be replaced soon
+                    # with a proper fix.
+                    await self.wait(asyncio.sleep(0))
         elif isinstance(cmd, eth.GetBlockHeaders):
             query = cast(Dict[Any, Union[bool, int]], msg)
             request = HeaderRequest(
@@ -169,7 +176,7 @@ class StateDownloader(BaseService, PeerSubscriber):
         await asyncio.sleep(0)
 
     async def request_nodes(self, node_keys: List[bytes]) -> None:
-        batches = list(partition_all(eth.MAX_STATE_FETCH, node_keys))
+        batches = list(itertoolz.partition_all(eth.MAX_STATE_FETCH, node_keys))
         for batch in batches:
             peer = await self.get_idle_peer()
             now = time.time()
@@ -208,7 +215,7 @@ class StateDownloader(BaseService, PeerSubscriber):
             now = time.time()
             sleep_duration = (oldest_request_time + self._reply_timeout) - now
             try:
-                await self.wait_first(asyncio.sleep(sleep_duration))
+                await self.wait(asyncio.sleep(sleep_duration))
             except OperationCancelled:
                 break
 
@@ -227,7 +234,7 @@ class StateDownloader(BaseService, PeerSubscriber):
                 # This ensures we yield control and give _handle_msg() a chance to process any nodes
                 # we may have received already, also ensuring we exit when our cancel token is
                 # triggered.
-                await self.wait_first(asyncio.sleep(0))
+                await self.wait(asyncio.sleep(0))
 
                 requests = self.scheduler.next_batch(eth.MAX_STATE_FETCH)
                 if not requests:
@@ -236,7 +243,7 @@ class StateDownloader(BaseService, PeerSubscriber):
                     # pending nodes take a while to arrive thus causing the scheduler to run out
                     # of new requests for a while.
                     self.logger.debug("Scheduler queue is empty, sleeping a bit")
-                    await self.wait_first(asyncio.sleep(0.5))
+                    await self.wait(asyncio.sleep(0.5))
                     continue
 
                 await self.request_nodes([request.node_key for request in requests])
@@ -256,7 +263,7 @@ class StateDownloader(BaseService, PeerSubscriber):
                 "Nodes scheduled but not requested yet: %d", len(self.scheduler.requests))
             self.logger.info("Total nodes timed out: %d", self._total_timeouts)
             try:
-                await self.wait_first(asyncio.sleep(self._report_interval))
+                await self.wait(asyncio.sleep(self._report_interval))
             except OperationCancelled:
                 break
 

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -74,7 +74,7 @@ class StateDownloader(BaseService, PeerSubscriber):
         self.scheduler = StateSync(root_hash, account_db)
         self._handler = PeerRequestHandler(self.chaindb, self.logger, self.cancel_token)
         self._active_requests: Dict[ETHPeer, Tuple[float, List[Hash32]]] = {}
-        self._peer_missing_nodes: Dict[ETHPeer, List[Hash32]] = collections.defaultdict(list)
+        self._peer_missing_nodes: Dict[ETHPeer, Set[Hash32]] = collections.defaultdict(set)
         self._executor = get_asyncio_executor()
 
     @property
@@ -156,7 +156,7 @@ class StateDownloader(BaseService, PeerSubscriber):
             node_keys = await loop.run_in_executor(self._executor, list, map(keccak, msg))
 
             missing = set(requested_node_keys).difference(node_keys)
-            self._peer_missing_nodes[peer].extend(missing)
+            self._peer_missing_nodes[peer].update(missing)
             if missing:
                 await self.request_nodes(missing)
 

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -279,15 +279,13 @@ class StateDownloader(BaseService, PeerSubscriber):
         while self.is_running:
             requested_nodes = sum(
                 len(node_keys) for _, node_keys in self._active_requests.values())
-            self.logger.info("====== State sync progress ========")
-            self.logger.info("Nodes processed: %d", self._total_processed_nodes)
-            self.logger.info("Nodes processed per second (average): %d",
-                             self._total_processed_nodes / self._timer.elapsed)
-            self.logger.info("Nodes committed to DB: %d", self.scheduler.committed_nodes)
-            self.logger.info("Nodes requested but not received yet: %d", requested_nodes)
-            self.logger.info(
-                "Nodes scheduled but not requested yet: %d", len(self.scheduler.requests))
-            self.logger.info("Total nodes timed out: %d", self._total_timeouts)
+            msg = "processed: %11d, " % self._total_processed_nodes
+            msg += "tnps: %5d, " % (self._total_processed_nodes / self._timer.elapsed)
+            msg += "committed: %11d, " % self.scheduler.committed_nodes
+            msg += "requested: %7d, " % requested_nodes
+            msg += "scheduled: %7d, " % len(self.scheduler.requests)
+            msg += "timeouts: %5d, " % self._total_timeouts
+            self.logger.info("State sync progress: %s", msg)
             try:
                 await self.sleep(self._report_interval)
             except OperationCancelled:

--- a/tests/p2p/test_state_sync.py
+++ b/tests/p2p/test_state_sync.py
@@ -1,10 +1,12 @@
 import os
 import random
+import time
 
 from eth.db.backends.memory import MemoryDB
 from eth.db.account import AccountDB
+from eth.utils.logging import TraceLogger
 
-from p2p.state import StateSync
+from p2p.state import StateSync, TrieNodeRequestTracker
 
 
 def make_random_state(n):
@@ -46,3 +48,86 @@ def test_state_sync():
         assert result_account_db.get_nonce(addr) == nonce
         assert result_account_db.get_storage(addr, 0) == storage
         assert result_account_db.get_code(addr) == code
+
+
+REPLY_TIMEOUT = 5
+
+
+def test_node_request_tracker_get_timed_out():
+    tracker = TrieNodeRequestTracker(REPLY_TIMEOUT, TraceLogger('name'))
+    peer1, peer2, peer3, peer4 = object(), object(), object(), object()
+    peer_nodes = dict(
+        (peer, [os.urandom(32) for _ in range(3)])
+        for peer in [peer1, peer2, peer3, peer4])
+    now = time.time()
+    # Populate the tracker's active_requests with 4 requests, 2 of them made more than
+    # REPLY_TIMEOUT seconds in the past and 2 made less than REPLY_TIMEOUT seconds ago.
+    tracker.active_requests[peer1] = (now, peer_nodes[peer1])
+    tracker.active_requests[peer2] = (now - REPLY_TIMEOUT - 1, peer_nodes[peer2])
+    tracker.active_requests[peer3] = (now - REPLY_TIMEOUT - 2, peer_nodes[peer3])
+    tracker.active_requests[peer4] = (now - REPLY_TIMEOUT + 1, peer_nodes[peer4])
+
+    # get_timed_out() must return all node keys from requests made more than REPLY_TIMEOUT seconds
+    # in the past.
+    expected = set(peer_nodes[peer2] + peer_nodes[peer3])
+    timed_out = tracker.get_timed_out()
+    assert len(timed_out) == len(expected)
+    assert set(timed_out) == expected
+
+    # and it should remove the entries for those from the active_requests dict.
+    assert peer2 not in tracker.active_requests
+    assert peer3 not in tracker.active_requests
+    assert peer1 in tracker.active_requests
+    assert peer4 in tracker.active_requests
+
+
+def test_node_request_tracker_get_retriable_missing():
+    tracker = TrieNodeRequestTracker(REPLY_TIMEOUT, TraceLogger('name'))
+    now = time.time()
+    # Populate the tracker's missing dict with 4 requests, 2 of them made more than
+    # REPLY_TIMEOUT seconds in the past and 2 made less than REPLY_TIMEOUT seconds ago.
+    req1_time, req1_nodes = now, [os.urandom(32) for _ in range(3)]
+    req2_time, req2_nodes = (now - REPLY_TIMEOUT - 1), [os.urandom(32) for _ in range(3)]
+    req3_time, req3_nodes = (now - REPLY_TIMEOUT - 2), [os.urandom(32) for _ in range(3)]
+    req4_time, req4_nodes = (now - REPLY_TIMEOUT + 1), [os.urandom(32) for _ in range(3)]
+    tracker.missing[req1_time] = req1_nodes
+    tracker.missing[req2_time] = req2_nodes
+    tracker.missing[req3_time] = req3_nodes
+    tracker.missing[req4_time] = req4_nodes
+
+    expected = set(req2_nodes + req3_nodes)
+    retriable_missing = tracker.get_retriable_missing()
+    assert len(retriable_missing) == len(expected)
+    assert set(retriable_missing) == expected
+
+    assert req2_time not in tracker.missing
+    assert req3_time not in tracker.missing
+    assert req1_time in tracker.missing
+    assert req4_time in tracker.missing
+
+
+def test_node_request_tracker_get_next_timeout():
+    tracker = TrieNodeRequestTracker(REPLY_TIMEOUT, TraceLogger('name'))
+    oldest_req_time = 1234
+
+    # Populate the tracker with missing and active requests, one of each made at oldest_req_time
+    # and one of each made 1s after that.
+    peer1, peer2 = object(), object()
+    tracker.missing[oldest_req_time] = []
+    tracker.missing[oldest_req_time + 1] = []
+    tracker.active_requests[peer1] = (oldest_req_time, [])
+    tracker.active_requests[peer2] = (oldest_req_time + 1, [])
+
+    # Our next shcheduled timeout must be the oldest_req_time + REPLY_TIMEOUT
+    assert tracker.get_next_timeout() == oldest_req_time + REPLY_TIMEOUT
+
+    # Now, if we pop any of the requests made at oldest_req_time, but leave one behind, the next
+    # scheduled timeout will still be the same since we still have one request made at
+    # oldest_req_time.
+    tracker.missing.pop(oldest_req_time)
+    assert tracker.get_next_timeout() == oldest_req_time + REPLY_TIMEOUT
+
+    # Removing the last remaining request made at oldest_req_time will cause the next scheduled
+    # timeout to be (oldest_req_time + 1) + REPLY_TIMEOUT as expected.
+    tracker.active_requests.pop(peer1)
+    assert tracker.get_next_timeout() == oldest_req_time + 1 + REPLY_TIMEOUT


### PR DESCRIPTION
Keep track of which nodes we requested to every peer so that we know which
ones they're missing when they reply with just a subset of what was
requested. That way we can avoid re-requesting those missing nodes to peers
that don't have them. #1073

Also, when a reply from a peer contains only a subset of what was
requested, we immediately re-request the missing ones. Closes: #1077

And a quick workaround to avoid losing peers during state sync (#1074)