### PR TITLE
Use new network simulator library in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ deps = {
         "pytest-cov==2.5.1",
         "pytest-watch>=4.1.0,<5",
         "pytest-xdist==1.18.1",
+        # only needed for p2p
+        "pytest-asyncio-network-simulator==0.1.0a1;python_version>='3.6'",
     ],
     'lint': [
         "flake8==3.5.0",

--- a/tests/p2p/conftest.py
+++ b/tests/p2p/conftest.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def pytest_addoption(parser):
     parser.addoption("--enode", type=str, required=False)
     parser.addoption("--integration", action="store_true", default=False)
@@ -30,3 +33,10 @@ def p2p_logger():
 
     return logger
 """
+
+
+@pytest.fixture
+def _network_sim(router):
+    network = router.get_network(name='simulated')
+    with network.patch_asyncio():
+        yield network

--- a/tests/p2p/conftest.py
+++ b/tests/p2p/conftest.py
@@ -35,7 +35,7 @@ def p2p_logger():
 """
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def _network_sim(router):
     network = router.get_network(name='simulated')
     with network.patch_asyncio():


### PR DESCRIPTION
### What was wrong?

Some of our `p2p` tests use real networking.

### How was it fixed?

Change to use the new library `pytest-asyncio-network-simulator` which mocks out the networking.

#### Cute Animal Picture

![cat-monkey-shutterstock-76988095-webonly](https://user-images.githubusercontent.com/824194/43285446-291e0142-90dc-11e8-954b-a371e06da60b.jpg)

