### PR TITLE
Implementing --trinity-root-dir

### DIFF
--- a/tests/trinity/core/chain-management/test_initialize_data_dir.py
+++ b/tests/trinity/core/chain-management/test_initialize_data_dir.py
@@ -9,11 +9,14 @@ from trinity.chains import (
 from trinity.config import (
     ChainConfig,
 )
+from trinity.utils.xdg import (
+    get_xdg_trinity_root,
+)
 
 
 @pytest.fixture
 def chain_config():
-    return ChainConfig(network_id=1, max_peers=1)
+    return ChainConfig(network_id=1, max_peers=1, trinity_root_dir=get_xdg_trinity_root())
 
 
 @pytest.fixture

--- a/tests/trinity/core/chain-management/test_initialize_database.py
+++ b/tests/trinity/core/chain-management/test_initialize_database.py
@@ -12,11 +12,14 @@ from trinity.chains import (
 from trinity.config import (
     ChainConfig,
 )
+from trinity.utils.xdg import (
+    get_xdg_trinity_root,
+)
 
 
 @pytest.fixture
 def chain_config():
-    _chain_config = ChainConfig(network_id=1, max_peers=1)
+    _chain_config = ChainConfig(network_id=1, max_peers=1, trinity_root_dir=get_xdg_trinity_root())
     initialize_data_dir(_chain_config)
     return _chain_config
 

--- a/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
@@ -9,11 +9,14 @@ from trinity.chains import (
 from trinity.config import (
     ChainConfig,
 )
+from trinity.utils.xdg import (
+    get_xdg_trinity_root,
+)
 
 
 @pytest.fixture
 def chain_config():
-    return ChainConfig(network_id=1, max_peers=1)
+    return ChainConfig(network_id=1, max_peers=1, trinity_root_dir=get_xdg_trinity_root())
 
 
 @pytest.fixture
@@ -93,7 +96,12 @@ NODEKEY = decode_hex('0xd18445cc77139cd8e09110e99c9384f0601bd2dfa5b230cda917df7e
 
 
 def test_full_initialized_data_dir_with_custom_nodekey():
-    chain_config = ChainConfig(network_id=1, max_peers=1, nodekey=NODEKEY)
+    chain_config = ChainConfig(
+        network_id=1,
+        max_peers=1,
+        nodekey=NODEKEY,
+        trinity_root_dir=get_xdg_trinity_root()
+    )
 
     os.makedirs(chain_config.data_dir, exist_ok=True)
     os.makedirs(chain_config.database_dir, exist_ok=True)

--- a/tests/trinity/core/chain-management/test_is_database_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_database_initialized.py
@@ -12,11 +12,14 @@ from trinity.chains import (
 from trinity.config import (
     ChainConfig,
 )
+from trinity.utils.xdg import (
+    get_xdg_trinity_root,
+)
 
 
 @pytest.fixture
 def chain_config():
-    _chain_config = ChainConfig(network_id=1, max_peers=1)
+    _chain_config = ChainConfig(network_id=1, max_peers=1, trinity_root_dir=get_xdg_trinity_root())
     initialize_data_dir(_chain_config)
     return _chain_config
 

--- a/tests/trinity/core/chains-utils/test_chain_config_object.py
+++ b/tests/trinity/core/chains-utils/test_chain_config_object.py
@@ -5,6 +5,7 @@ from eth_utils import (
 )
 
 from eth_keys import keys
+from pathlib import Path
 
 from trinity.utils.chains import (
     get_local_data_dir,
@@ -17,11 +18,19 @@ from trinity.config import (
 from trinity.utils.filesystem import (
     is_same_path,
 )
+from trinity.utils.xdg import (
+    get_xdg_trinity_root,
+)
 
 
 def test_chain_config_computed_properties():
-    data_dir = get_local_data_dir('muffin')
-    chain_config = ChainConfig(network_id=1234, max_peers=1, data_dir=data_dir)
+    data_dir = get_local_data_dir('muffin', Path(get_xdg_trinity_root()))
+    chain_config = ChainConfig(
+        network_id=1234,
+        max_peers=1,
+        data_dir=data_dir,
+        trinity_root_dir=get_xdg_trinity_root()
+    )
 
     assert chain_config.network_id == 1234
     assert chain_config.data_dir == data_dir
@@ -34,7 +43,8 @@ def test_chain_config_explicit_properties():
         network_id=1,
         max_peers=1,
         data_dir='./data-dir',
-        nodekey_path='./nodekey'
+        nodekey_path='./nodekey',
+        trinity_root_dir=get_xdg_trinity_root()
     )
 
     assert is_same_path(chain_config.data_dir, './data-dir')
@@ -63,6 +73,7 @@ def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
         network_id=1,
         max_peers=1,
         nodekey_path=nodekey_path,
+        trinity_root_dir=get_xdg_trinity_root()
     )
 
     assert chain_config.nodekey.to_bytes() == nodekey_bytes
@@ -74,6 +85,7 @@ def test_chain_config_explictely_provided_nodekey(nodekey_bytes, as_bytes):
         network_id=1,
         max_peers=1,
         nodekey=nodekey_bytes if as_bytes else keys.PrivateKey(nodekey_bytes),
+        trinity_root_dir=get_xdg_trinity_root()
     )
 
     assert chain_config.nodekey.to_bytes() == nodekey_bytes

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -27,6 +27,9 @@ from trinity.utils.ipc import (
     wait_for_ipc,
     kill_process_gracefully,
 )
+from trinity.utils.xdg import (
+    get_xdg_trinity_root,
+)
 
 
 def serve_chaindb(manager):
@@ -44,7 +47,12 @@ def database_server_ipc_path():
     chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        chain_config = ChainConfig(network_id=ROPSTEN_NETWORK_ID, max_peers=1, data_dir=temp_dir)
+        chain_config = ChainConfig(
+            network_id=ROPSTEN_NETWORK_ID,
+            max_peers=1,
+            data_dir=temp_dir,
+            trinity_root_dir=get_xdg_trinity_root()
+        )
 
         manager = get_chaindb_manager(chain_config, core_db)
         chaindb_server_process = multiprocessing.Process(

--- a/tests/trinity/integration/test_trinity_cli.py
+++ b/tests/trinity/integration/test_trinity_cli.py
@@ -1,9 +1,31 @@
+import os
 import pytest
+import shutil
 
 from trinity.tools.async_process_runner import AsyncProcessRunner
 from trinity.utils.async_iter import (
-    contains_all
+    contains_all,
 )
+from trinity.utils.xdg import (
+    get_xdg_runtime_home,
+)
+
+
+XDG_RUNTIME_DIR = os.path.join(get_xdg_runtime_home(), '.test')
+
+
+@pytest.fixture(scope="function")
+def xdg_runtime_dir(monkeypatch):
+    assert not os.path.exists(XDG_RUNTIME_DIR)
+    os.makedirs(XDG_RUNTIME_DIR)
+    assert os.path.exists(XDG_RUNTIME_DIR)
+    monkeypatch.setenv('XDG_RUNTIME_DIR', XDG_RUNTIME_DIR)
+    try:
+        yield XDG_RUNTIME_DIR
+    finally:
+        assert os.path.exists(XDG_RUNTIME_DIR)
+        shutil.rmtree(XDG_RUNTIME_DIR)
+        assert not os.path.exists(XDG_RUNTIME_DIR)
 
 
 # IMPORTANT: Test names are intentionally short here because they end up
@@ -37,18 +59,32 @@ def async_process_runner():
     (
         ('trinity',),
         ('trinity', '--ropsten',),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR,),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR, '--ropsten',),
     )
 )
 @pytest.mark.asyncio
-async def test_full_boot(async_process_runner, command):
-    # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
-    await async_process_runner.run(command, timeout_sec=40)
-    assert await contains_all(async_process_runner.stderr, {
-        "Started DB server process",
-        "Started networking process",
-        "Running server",
-        "IPC started at",
-    })
+async def test_full_boot(async_process_runner, command, xdg_runtime_dir):
+    check_command = list(command)
+    try:
+        # If the --trinity-root-dir is defined, then trinity is expected to start
+        check_command.index('--trinity-root-dir')
+
+        # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
+        await async_process_runner.run(command, timeout_sec=40)
+        assert await contains_all(async_process_runner.stderr, {
+            "Started DB server process",
+            "Started networking process",
+            "Running server",
+            "IPC started at",
+        })
+    except ValueError:
+        # If the --trinity-root-dir is NOT defined, then trinity is expected to throw error
+        await async_process_runner.run(command, timeout_sec=40)
+        assert await contains_all(async_process_runner.stderr, {
+            "Please run trinity using --trinity-root-dir param: "
+            "trinity --trinity-root-dir <directory>",
+        })
 
 
 @pytest.mark.parametrize(
@@ -56,19 +92,33 @@ async def test_full_boot(async_process_runner, command):
     (
         ('trinity', '--tx-pool',),
         ('trinity', '--tx-pool', '--ropsten',),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR, '--tx-pool',),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR, '--tx-pool', '--ropsten',),
     )
 )
 @pytest.mark.asyncio
-async def test_txpool_full_boot(async_process_runner, command):
-    # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
-    await async_process_runner.run(command, timeout_sec=40)
-    assert await contains_all(async_process_runner.stderr, {
-        "Started DB server process",
-        "Started networking process",
-        "Running Tx Pool",
-        "Running server",
-        "IPC started at",
-    })
+async def test_txpool_full_boot(async_process_runner, command, xdg_runtime_dir):
+    check_command = list(command)
+    try:
+        # If the --trinity-root-dir is defined, then trinity is expected to start
+        check_command.index('--trinity-root-dir')
+
+        # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
+        await async_process_runner.run(command, timeout_sec=40)
+        assert await contains_all(async_process_runner.stderr, {
+            "Started DB server process",
+            "Started networking process",
+            "Running Tx Pool",
+            "Running server",
+            "IPC started at",
+        })
+    except ValueError:
+        # If the --trinity-root-dir is NOT defined, then trinity is expected to throw error
+        await async_process_runner.run(command, timeout_sec=40)
+        assert await contains_all(async_process_runner.stderr, {
+            "Please run trinity using --trinity-root-dir param: "
+            "trinity --trinity-root-dir <directory>",
+        })
 
 
 @pytest.mark.parametrize(
@@ -76,17 +126,31 @@ async def test_txpool_full_boot(async_process_runner, command):
     (
         ('trinity', '--light',),
         ('trinity', '--light', '--ropsten',),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR, '--light',),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR, '--light', '--ropsten',),
     )
 )
 @pytest.mark.asyncio
-async def test_light_boot(async_process_runner, command):
-    # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
-    await async_process_runner.run(command, timeout_sec=40)
-    assert await contains_all(async_process_runner.stderr, {
-        "Started DB server process",
-        "Started networking process",
-        "IPC started at",
-    })
+async def test_light_boot(async_process_runner, command, xdg_runtime_dir):
+    check_command = list(command)
+    try:
+        # If the --trinity-root-dir is defined, then trinity is expected to start
+        check_command.index('--trinity-root-dir')
+
+        # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
+        await async_process_runner.run(command, timeout_sec=40)
+        assert await contains_all(async_process_runner.stderr, {
+            "Started DB server process",
+            "Started networking process",
+            "IPC started at",
+        })
+    except ValueError:
+        # If the --trinity-root-dir is NOT defined, then trinity is expected to throw error
+        await async_process_runner.run(command, timeout_sec=40)
+        assert await contains_all(async_process_runner.stderr, {
+            "Please run trinity using --trinity-root-dir param: "
+            "trinity --trinity-root-dir <directory>",
+        })
 
 
 @pytest.mark.parametrize(
@@ -96,30 +160,48 @@ async def test_light_boot(async_process_runner, command):
         ('trinity',),
         ('trinity', '--tx-pool',),
         ('trinity', '--light',),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR,),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR, '--tx-pool',),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR, '--light',),
         # ropsten
         ('trinity', '--ropsten',),
         ('trinity', '--ropsten', '--tx-pool',),
         ('trinity', '--light', '--ropsten',),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR, '--ropsten',),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR, '--ropsten', '--tx-pool',),
+        ('trinity', '--trinity-root-dir', XDG_RUNTIME_DIR, '--light', '--ropsten',),
     )
 )
 @pytest.mark.asyncio
-async def test_does_not_throw(async_process_runner, command):
-    # This is our last line of defence. This test basically observes the first
-    # 20 seconds of the Trinity boot process and fails if Trinity logs any exceptions
-    lines_since_error = 0
-    await async_process_runner.run(command, timeout_sec=20)
-    async for line in async_process_runner.stderr:
+async def test_does_not_throw(async_process_runner, command, xdg_runtime_dir):
+    check_command = list(command)
+    try:
+        # If the --trinity-root-dir is defined, then trinity is expected to start
+        check_command.index('--trinity-root-dir')
 
-        # We detect errors by some string at the beginning of the Traceback and keep
-        # counting lines from there to be able to read and report more valuable info
-        if "Traceback (most recent call last)" in line and lines_since_error == 0:
-            lines_since_error = 1
-        elif lines_since_error > 0:
-            lines_since_error += 1
+        # This is our last line of defence. This test basically observes the first
+        # 20 seconds of the Trinity boot process and fails if Trinity logs any exceptions
+        lines_since_error = 0
+        await async_process_runner.run(command, timeout_sec=20)
+        async for line in async_process_runner.stderr:
 
-        # Keep on listening for output for a maxmimum of 100 lines after the error
-        if lines_since_error >= 100:
-            break
+            # We detect errors by some string at the beginning of the Traceback and keep
+            # counting lines from there to be able to read and report more valuable info
+            if "Traceback (most recent call last)" in line and lines_since_error == 0:
+                lines_since_error = 1
+            elif lines_since_error > 0:
+                lines_since_error += 1
 
-    if lines_since_error > 0:
-        raise Exception("Exception during Trinity boot detected")
+            # Keep on listening for output for a maxmimum of 100 lines after the error
+            if lines_since_error >= 100:
+                break
+
+        if lines_since_error > 0:
+            raise Exception("Exception during Trinity boot detected")
+    except ValueError:
+        # If the --trinity-root-dir is NOT defined, then trinity is expected to throw error
+        await async_process_runner.run(command, timeout_sec=40)
+        assert await contains_all(async_process_runner.stderr, {
+            "Please run trinity using --trinity-root-dir param: "
+            "trinity --trinity-root-dir <directory>",
+        })

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ passenv =
 commands=
     # We don't want to run these tests concurrently to avoid running into errors
     # due to multiple Trinity instances competing for the same ports
-    pytest -n 1 {posargs:tests/trinity/integration/ -k 'not lightchain_integration'}
+    pytest -n 1 {posargs:tests/trinity/integration/ -k "not lightchain_integration"}
 
 [testenv:py36-trinity-integration]
 deps = {[common-trinity-integration]deps}

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -49,6 +49,7 @@ DATABASE_DIR_NAME = 'chain'
 
 class ChainConfig:
     _data_dir: Path = None
+    _trinity_root_dir: Path = None
     _nodekey_path: Path = None
     _logfile_path: Path = None
     _nodekey = None
@@ -63,6 +64,7 @@ class ChainConfig:
                  network_id: int,
                  max_peers: int,
                  data_dir: str=None,
+                 trinity_root_dir: str=None,
                  nodekey_path: str=None,
                  logfile_path: str=None,
                  nodekey: PrivateKey=None,
@@ -97,10 +99,13 @@ class ChainConfig:
             raise ValueError("It is invalid to provide both a `nodekey` and a `nodekey_path`")
 
         # set values
+        if trinity_root_dir is not None:
+            self._trinity_root_dir = Path(trinity_root_dir).resolve()
+
         if data_dir is not None:
             self.data_dir = data_dir
         else:
-            self.data_dir = get_data_dir_for_network_id(self.network_id)
+            self.data_dir = get_data_dir_for_network_id(self.network_id, self.trinity_root_dir)
 
         if nodekey_path is not None:
             self.nodekey_path = nodekey_path
@@ -142,6 +147,10 @@ class ChainConfig:
     @data_dir.setter
     def data_dir(self, value: str) -> None:
         self._data_dir = Path(value).resolve()
+
+    @property
+    def trinity_root_dir(self) -> Path:
+        return self._trinity_root_dir
 
     @property
     def database_dir(self) -> Path:

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -28,6 +28,8 @@ from trinity.exceptions import (
 from trinity.chains import (
     initialize_data_dir,
     is_data_dir_initialized,
+    initialize_trinity_root_dir,
+    need_create_trinity_root_dir,
     get_chaindb_manager,
 )
 from trinity.cli_parser import (
@@ -134,6 +136,9 @@ def main() -> None:
             ).format(e.path)
             logger.error(msg)
             sys.exit(1)
+
+    if need_create_trinity_root_dir(chain_config):
+        initialize_trinity_root_dir(chain_config)
 
     logger, log_queue, listener = setup_trinity_file_and_queue_logging(
         logger,

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import signal
+import logging
 from typing import (
     AsyncIterable,
     Awaitable,
@@ -63,4 +64,8 @@ class AsyncProcessRunner():
         raise TimeoutError('Killed process after {} seconds'.format(timeout_sec))
 
     def kill(self) -> None:
-        os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+        logger = logging.getLogger("trinity.tools.AsyncProcessRunner")
+        try:
+            os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            logger.warning("Cannot kill the process PID %d because it is not found.", self.proc.pid)

--- a/trinity/utils/xdg.py
+++ b/trinity/utils/xdg.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 from pathlib import Path
 
@@ -37,6 +38,13 @@ def get_xdg_data_home() -> str:
         return os.environ['XDG_DATA_HOME']
     except KeyError:
         return os.path.join(get_home(), '.local', 'share')
+
+
+def get_xdg_runtime_home() -> str:
+    try:
+        return os.environ['XDG_RUNTIME_DIR']
+    except KeyError:
+        return os.path.join(tempfile.gettempdir(), 'trinity')
 
 
 def get_xdg_trinity_root() -> str:


### PR DESCRIPTION
### What was wrong?
Trinity promotes `--trinity-root-dir` to overwrite the trinity root dir but we actually don't pick that up anywhere. In other words, passing `--trinity-root-dir` is absolutely useless right now.

Issue Reference: https://github.com/ethereum/py-evm/issues/951, https://github.com/ethereum/py-evm/issues/922

### How was it fixed?
Implementing `--trinity-root-dir`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/opKg3fyqWt4/hqdefault.jpg)
