### PR TITLE
Test core with py3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,37 +256,37 @@ workflows:
   test:
     jobs:
       - py37-core
-      # - py36-docs
-      # - py36-native-state-byzantium
-      # - py36-native-state-frontier
-      # - py36-native-state-homestead
-      # - py36-native-state-eip150
-      # - py36-native-state-eip158
-      # - py36-rpc-state-byzantium
-      # - py36-rpc-state-frontier
-      # - py36-rpc-state-homestead
-      # - py36-rpc-state-eip150
-      # - py36-rpc-state-eip158
-      # - py36-native-blockchain
-      # - py36-rpc-blockchain
-      # - py36-vm
-      # - py36-benchmark
-      # - py36-core
-      # - py36-trinity
-      # - py36-trinity-integration
-      # - py36-transactions
-      # - py36-p2p
-      # - py36-database
-      # - py36-rpc-state-quadratic
-      # - py35-native-state-byzantium
-      # - py35-native-state-frontier
-      # - py35-native-state-homestead
-      # - py35-native-state-eip150
-      # - py35-native-state-eip158
-      # - py35-native-blockchain
-      # - py35-vm
-      # - py35-core
-      # - py35-transactions
-      # - py35-database
-      # - lint-py35
-      # - lint-py36
+      - py36-docs
+      - py36-native-state-byzantium
+      - py36-native-state-frontier
+      - py36-native-state-homestead
+      - py36-native-state-eip150
+      - py36-native-state-eip158
+      - py36-rpc-state-byzantium
+      - py36-rpc-state-frontier
+      - py36-rpc-state-homestead
+      - py36-rpc-state-eip150
+      - py36-rpc-state-eip158
+      - py36-native-blockchain
+      - py36-rpc-blockchain
+      - py36-vm
+      - py36-benchmark
+      - py36-core
+      - py36-trinity
+      - py36-trinity-integration
+      - py36-transactions
+      - py36-p2p
+      - py36-database
+      - py36-rpc-state-quadratic
+      - py35-native-state-byzantium
+      - py35-native-state-frontier
+      - py35-native-state-homestead
+      - py35-native-state-eip150
+      - py35-native-state-eip158
+      - py35-native-blockchain
+      - py35-vm
+      - py35-core
+      - py35-transactions
+      - py35-database
+      - lint-py35
+      - lint-py36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,37 +256,37 @@ workflows:
   test:
     jobs:
       - py37-core
-      - py36-docs
-      - py36-native-state-byzantium
-      - py36-native-state-frontier
-      - py36-native-state-homestead
-      - py36-native-state-eip150
-      - py36-native-state-eip158
-      - py36-rpc-state-byzantium
-      - py36-rpc-state-frontier
-      - py36-rpc-state-homestead
-      - py36-rpc-state-eip150
-      - py36-rpc-state-eip158
-      - py36-native-blockchain
-      - py36-rpc-blockchain
-      - py36-vm
-      - py36-benchmark
-      - py36-core
-      - py36-trinity
-      - py36-trinity-integration
-      - py36-transactions
-      - py36-p2p
-      - py36-database
-      - py36-rpc-state-quadratic
-      - py35-native-state-byzantium
-      - py35-native-state-frontier
-      - py35-native-state-homestead
-      - py35-native-state-eip150
-      - py35-native-state-eip158
-      - py35-native-blockchain
-      - py35-vm
-      - py35-core
-      - py35-transactions
-      - py35-database
-      - lint-py35
-      - lint-py36
+      # - py36-docs
+      # - py36-native-state-byzantium
+      # - py36-native-state-frontier
+      # - py36-native-state-homestead
+      # - py36-native-state-eip150
+      # - py36-native-state-eip158
+      # - py36-rpc-state-byzantium
+      # - py36-rpc-state-frontier
+      # - py36-rpc-state-homestead
+      # - py36-rpc-state-eip150
+      # - py36-rpc-state-eip158
+      # - py36-native-blockchain
+      # - py36-rpc-blockchain
+      # - py36-vm
+      # - py36-benchmark
+      # - py36-core
+      # - py36-trinity
+      # - py36-trinity-integration
+      # - py36-transactions
+      # - py36-p2p
+      # - py36-database
+      # - py36-rpc-state-quadratic
+      # - py35-native-state-byzantium
+      # - py35-native-state-frontier
+      # - py35-native-state-homestead
+      # - py35-native-state-eip150
+      # - py35-native-state-eip158
+      # - py35-native-blockchain
+      # - py35-vm
+      # - py35-core
+      # - py35-transactions
+      # - py35-database
+      # - lint-py35
+      # - lint-py36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,11 +244,18 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-rpc-state-quadratic
+  py37-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-core
 
 workflows:
   version: 2
   test:
     jobs:
+      - py37-core
       - py36-docs
       - py36-native-state-byzantium
       - py36-native-state-frontier

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     # trinity
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ deps = {
     # Installing these libraries may make the evm perform better than
     # using the default fallbacks though.
     'eth-extra': [
-        "coincurve>=7.0.0,<8.0.0",
+        "coincurve>=8.0.0,<9.0.0",
         "eth-hash[pysha3];implementation_name=='cpython'",
         "eth-hash[pycryptodome];implementation_name=='pypy'",
-        "plyvel==1.0.4",
+        "plyvel==1.0.5",
     ],
     'p2p': [
         "asyncio-cancel-token==0.1.0a2",
@@ -38,9 +38,9 @@ deps = {
     'trinity': [
         "bloom-filter==1.3",
         "cachetools>=2.1.0,<3.0.0",
-        "coincurve>=7.0.0,<8.0.0",
+        "coincurve>=8.0.0,<9.0.0",
         "ipython>=6.2.1,<7.0.0",
-        "plyvel==1.0.4",
+        "plyvel==1.0.5",
         "web3==4.4.1",
     ],
     'test': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist=
+    py37-core
     py{35,36}-{core,database,transactions,vm,native-blockchain}
     py{36}-{benchmark,p2p,trinity}
     py{36}-rpc-blockchain
@@ -45,6 +46,7 @@ deps = .[eth-extras, test]
 basepython =
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 
 
 [testenv:py36-docs]


### PR DESCRIPTION
### What was wrong?

Nothing; Python 3.7 is out, and it would be nice to start testing for compatibility.

### How was it fixed?

~~Implements~~ Closes #970.

The most basic set of tests, `core`, is now also run with a `circleci/python:3.7` image.

The image lacks some dependencies to build wheels locally (`gmp`, `leveldb`, likely others); so some packages are bumped to versions where wheels have Python 3.7 support. These are:

* `plyvel` - https://plyvel.readthedocs.io/en/latest/news.html#plyvel-1-0-5
* `coincurve` - https://pypi.org/project/coincurve/#id4

### Cute Animal Picture

Source: [friendlyferret](https://www.friendlyferret.com/how-many-types-of-ferrets-are-there/)

![put a cute animal picture link inside the parentheses](https://www.friendlyferret.com/wp-content/uploads/2016/11/1214webferretinsidepic.jpg)