### PR TITLE
Prepare base ConstantinopleVM structure

### DIFF
--- a/eth/vm/forks/__init__.py
+++ b/eth/vm/forks/__init__.py
@@ -13,3 +13,6 @@ from .spurious_dragon import (  # noqa: F401
 from .byzantium import (  # noqa: F401
     ByzantiumVM,
 )
+from .constantinople import (  # noqa: F401
+    ConstantinopleVM
+)

--- a/eth/vm/forks/constantinople/__init__.py
+++ b/eth/vm/forks/constantinople/__init__.py
@@ -1,0 +1,19 @@
+from typing import (  # noqa: F401
+    Type,
+)
+
+from eth.rlp.blocks import BaseBlock  # noqa: F401
+from eth.vm.forks.byzantium import ByzantiumVM
+from eth.vm.state import BaseState  # noqa: F401
+
+from .blocks import ConstantinopleBlock
+from .state import ConstantinopleState
+
+
+class ConstantinopleVM(ByzantiumVM):
+    # fork name
+    fork = 'constantinople'
+
+    # classes
+    block_class = ConstantinopleBlock  # type: Type[BaseBlock]
+    _state_class = ConstantinopleState  # type: Type[BaseState]

--- a/eth/vm/forks/constantinople/blocks.py
+++ b/eth/vm/forks/constantinople/blocks.py
@@ -1,0 +1,22 @@
+from rlp.sedes import (
+    CountableList,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
+from eth.vm.forks.byzantium.blocks import (
+    ByzantiumBlock,
+)
+
+from .transactions import (
+    ConstantinopleTransaction,
+)
+
+
+class ConstantinopleBlock(ByzantiumBlock):
+    transaction_class = ConstantinopleTransaction
+    fields = [
+        ('header', BlockHeader),
+        ('transactions', CountableList(transaction_class)),
+        ('uncles', CountableList(BlockHeader))
+    ]

--- a/eth/vm/forks/constantinople/computation.py
+++ b/eth/vm/forks/constantinople/computation.py
@@ -1,0 +1,29 @@
+from cytoolz import (
+    merge,
+)
+
+from eth.vm.forks.byzantium.computation import (
+    BYZANTIUM_PRECOMPILES
+)
+from eth.vm.forks.byzantium.computation import (
+    ByzantiumComputation
+)
+
+from .opcodes import CONSTANTINOPLE_OPCODES
+
+CONSTANTINOPLE_PRECOMPILES = merge(
+    BYZANTIUM_PRECOMPILES,
+    {
+        # TODO: add new precompiles
+    },
+)
+
+
+class ConstantinopleComputation(ByzantiumComputation):
+    """
+    A class for all execution computations in the ``Constantinople`` fork.
+    Inherits from :class:`~eth.vm.forks.byzantium.computation.ByzantiumComputation`
+    """
+    # Override
+    opcodes = CONSTANTINOPLE_OPCODES
+    _precompiles = CONSTANTINOPLE_PRECOMPILES

--- a/eth/vm/forks/constantinople/opcodes.py
+++ b/eth/vm/forks/constantinople/opcodes.py
@@ -1,0 +1,8 @@
+import copy
+
+from eth.vm.forks.byzantium.opcodes import (
+    BYZANTIUM_OPCODES
+)
+
+
+CONSTANTINOPLE_OPCODES = copy.deepcopy(BYZANTIUM_OPCODES)

--- a/eth/vm/forks/constantinople/state.py
+++ b/eth/vm/forks/constantinople/state.py
@@ -1,0 +1,9 @@
+from eth.vm.forks.byzantium.state import (
+    ByzantiumState
+)
+
+from .computation import ConstantinopleComputation
+
+
+class ConstantinopleState(ByzantiumState):
+    computation_class = ConstantinopleComputation

--- a/eth/vm/forks/constantinople/transactions.py
+++ b/eth/vm/forks/constantinople/transactions.py
@@ -1,0 +1,30 @@
+from eth.vm.forks.byzantium.transactions import (
+    ByzantiumTransaction,
+    ByzantiumUnsignedTransaction,
+)
+
+from eth.utils.transactions import (
+    create_transaction_signature,
+)
+
+
+class ConstantinopleTransaction(ByzantiumTransaction):
+    @classmethod
+    def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):
+        return ConstantinopleUnsignedTransaction(nonce, gas_price, gas, to, value, data)
+
+
+class ConstantinopleUnsignedTransaction(ByzantiumUnsignedTransaction):
+    def as_signed_transaction(self, private_key, chain_id=None):
+        v, r, s = create_transaction_signature(self, private_key, chain_id=chain_id)
+        return ConstantinopleTransaction(
+            nonce=self.nonce,
+            gas_price=self.gas_price,
+            gas=self.gas,
+            to=self.to,
+            value=self.value,
+            data=self.data,
+            v=v,
+            r=r,
+            s=s,
+        )


### PR DESCRIPTION
### What was wrong?

As stated in #1107 we don't have the base structure for the Constantinople fork yet.

### How was it fixed?

Adds all the base structure to support the Constantinople fork. Notice that this doesn't yet add the `ConstantinopleVM` to any chain though.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.images.dailystar.co.uk/dynamic/1/photos/489000/620x/Sitting-camel-517821.jpg)
