### PR TITLE
Switch to cancel-token library exception class

### DIFF
--- a/p2p/chain.py
+++ b/p2p/chain.py
@@ -23,7 +23,7 @@ from cytoolz import (
 
 from eth_typing import BlockNumber, Hash32
 
-from cancel_token import CancelToken
+from cancel_token import CancelToken, OperationCancelled
 
 from eth.constants import (
     BLANK_ROOT_HASH, EMPTY_UNCLE_HASH, GENESIS_BLOCK_NUMBER, GENESIS_PARENT_HASH)
@@ -43,7 +43,7 @@ from p2p import eth
 from p2p import les
 from p2p.cancellable import CancellableMixin
 from p2p.constants import MAX_REORG_DEPTH, SEAL_CHECK_RANDOM_SAMPLE_RATE
-from p2p.exceptions import NoEligiblePeers, OperationCancelled
+from p2p.exceptions import NoEligiblePeers
 from p2p.p2p_proto import DisconnectReason
 from p2p.peer import BasePeer, ETHPeer, LESPeer, HeaderRequest, PeerPool, PeerSubscriber
 from p2p.rlp import BlockBody

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -42,9 +42,9 @@ from eth_keys import datatypes
 
 from eth_hash.auto import keccak
 
-from cancel_token import CancelToken
+from cancel_token import CancelToken, OperationCancelled
 
-from p2p.exceptions import NoEligibleNodes, OperationCancelled
+from p2p.exceptions import NoEligibleNodes
 from p2p import kademlia
 from p2p.peer import PeerPool
 from p2p.service import BaseService

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -86,13 +86,6 @@ class TooManyTimeouts(BaseP2PError):
     pass
 
 
-class OperationCancelled(BaseP2PError):
-    """
-    Raised when an operation was cancelled.
-    """
-    pass
-
-
 class NoMatchingPeerCapabilities(BaseP2PError):
     """
     Raised when no matching protocol between peers was found.

--- a/p2p/nat.py
+++ b/p2p/nat.py
@@ -11,10 +11,10 @@ from urllib.parse import urlparse
 
 from cancel_token import (
     CancelToken,
+    OperationCancelled,
 )
 from p2p.exceptions import (
     NoInternalAddressMatchesDevice,
-    OperationCancelled,
 )
 import netifaces
 from p2p.service import BaseService

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -48,7 +48,7 @@ from eth_keys import (
     keys,
 )
 
-from cancel_token import CancelToken
+from cancel_token import CancelToken, OperationCancelled
 
 from eth.chains.mainnet import MAINNET_NETWORK_ID
 from eth.chains.ropsten import ROPSTEN_NETWORK_ID
@@ -70,7 +70,6 @@ from p2p.exceptions import (
     MalformedMessage,
     NoConnectedPeers,
     NoMatchingPeerCapabilities,
-    OperationCancelled,
     PeerConnectionLost,
     RemoteDisconnected,
     UnexpectedMessage,

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -14,7 +14,7 @@ from eth_keys import datatypes
 
 from eth_utils import big_endian_to_int
 
-from cancel_token import CancelToken
+from cancel_token import CancelToken, OperationCancelled
 
 from eth.chains import AsyncChain
 from eth.db.backends.base import BaseDB
@@ -37,7 +37,6 @@ from p2p.discovery import (
 from p2p.exceptions import (
     DecryptionError,
     HandshakeFailure,
-    OperationCancelled,
     PeerConnectionLost,
 )
 from p2p.kademlia import (

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -12,10 +12,9 @@ from typing import (
 
 from eth.utils.logging import TraceLogger
 
-from cancel_token import CancelToken
+from cancel_token import CancelToken, OperationCancelled
 
 from p2p.cancellable import CancellableMixin
-from p2p.exceptions import OperationCancelled
 
 
 class BaseService(ABC, CancellableMixin):

--- a/p2p/state.py
+++ b/p2p/state.py
@@ -31,7 +31,7 @@ from eth_typing import (
     Hash32
 )
 
-from cancel_token import CancelToken
+from cancel_token import CancelToken, OperationCancelled
 
 from eth.constants import (
     BLANK_ROOT_HASH,
@@ -43,7 +43,6 @@ from eth.rlp.accounts import Account
 from p2p import eth
 from p2p import protocol
 from p2p.chain import PeerRequestHandler
-from p2p.exceptions import OperationCancelled
 from p2p.peer import ETHPeer, HeaderRequest, PeerPool, PeerSubscriber
 from p2p.service import BaseService
 from p2p.utils import get_asyncio_executor, Timer

--- a/tests/p2p/integration_test_helpers.py
+++ b/tests/p2p/integration_test_helpers.py
@@ -1,11 +1,11 @@
 import asyncio
 
+from cancel_token import OperationCancelled
+
 from eth import MainnetChain, RopstenChain
 from eth.chains.base import (
     MiningChain,
 )
-
-from p2p.exceptions import OperationCancelled
 
 from trinity.db.chain import AsyncChainDB
 from trinity.db.header import AsyncHeaderDB

--- a/trinity/rpc/ipc.py
+++ b/trinity/rpc/ipc.py
@@ -12,11 +12,9 @@ from cytoolz import curry
 
 from cancel_token import (
     CancelToken,
-)
-
-from p2p.exceptions import (
     OperationCancelled,
 )
+
 from p2p.service import (
     BaseService,
 )


### PR DESCRIPTION
### What was wrong?

We were still using the `OperationCancelled` exception from the local `p2p` library and so `OperationCancelled` requests were not being correctly handled

### How was it fixed?

Switched to use new one from the new cancel token library

#### Cute Animal Picture


![cute-baby-animals1](https://user-images.githubusercontent.com/824194/43407250-6d855c48-93db-11e8-98c1-76052f302884.jpeg)
