### PR TITLE
Reduce size of state sync status message

### DIFF
--- a/p2p/state.py
+++ b/p2p/state.py
@@ -296,13 +296,13 @@ class StateDownloader(BaseService, PeerSubscriber):
         while self.is_running:
             requested_nodes = sum(
                 len(node_keys) for _, node_keys in self.request_tracker.active_requests.values())
-            msg = "processed: %11d, " % self._total_processed_nodes
-            msg += "tnps: %5d, " % (self._total_processed_nodes / self._timer.elapsed)
-            msg += "committed: %11d, " % self.scheduler.committed_nodes
-            msg += "requested: %7d, " % requested_nodes
-            msg += "scheduled: %7d, " % len(self.scheduler.requests)
-            msg += "timeouts: %5d, " % self._total_timeouts
-            self.logger.info("State sync progress: %s", msg)
+            msg = "processed: %d " % self._total_processed_nodes
+            msg += "tnps: %d " % (self._total_processed_nodes / self._timer.elapsed)
+            msg += "committed: %d " % self.scheduler.committed_nodes
+            msg += "requested: %d " % requested_nodes
+            msg += "scheduled: %d " % len(self.scheduler.requests)
+            msg += "timeouts: %d" % self._total_timeouts
+            self.logger.info("State-Sync: %s", msg)
             try:
                 await self.sleep(self._report_interval)
             except OperationCancelled:


### PR DESCRIPTION
Reduces the size of the messages being logged during state sync.  My original approach of using fixed widths resulted in weird formatting as state sync starts.  As it turns out, the size of these numbers doesn't vary much between messages so allowing the width to organically grow with the width of the numbers seems aceptable.