### PR TITLE
Quiet down the missing SyncRequest messages

### DIFF
--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -98,6 +98,7 @@ def setup_queue_logging(log_queue: 'Queue[str]', level: int) -> None:
     logging.getLogger('p2p.kademlia').setLevel(logging.INFO)
     logging.getLogger('p2p.discovery').setLevel(logging.INFO)
     logging.getLogger('p2p.state.StateSync').setLevel(logging.INFO)
+    logging.getLogger('trie').setLevel(logging.ERROR)
     logger.debug('Logging initialized: PID=%s', os.getpid())
 
 


### PR DESCRIPTION
### What was wrong?

fixes https://github.com/ethereum/py-evm/issues/1085

### How was it fixed?

Reduce the logging level for the `trie` namespaced logger to `ERROR`

#### Cute Animal Picture

![96754](https://user-images.githubusercontent.com/824194/43417768-26fb4350-93f9-11e8-8fb4-c0f7c0107c06.jpg)
