### PR TITLE
cleanup state sync logging round 2

### DIFF
--- a/p2p/state.py
+++ b/p2p/state.py
@@ -296,12 +296,12 @@ class StateDownloader(BaseService, PeerSubscriber):
         while self.is_running:
             requested_nodes = sum(
                 len(node_keys) for _, node_keys in self.request_tracker.active_requests.values())
-            msg = "processed: %d " % self._total_processed_nodes
-            msg += "tnps: %d " % (self._total_processed_nodes / self._timer.elapsed)
-            msg += "committed: %d " % self.scheduler.committed_nodes
-            msg += "requested: %d " % requested_nodes
-            msg += "scheduled: %d " % len(self.scheduler.requests)
-            msg += "timeouts: %d" % self._total_timeouts
+            msg = "processed=%d  " % self._total_processed_nodes
+            msg += "tnps=%d  " % (self._total_processed_nodes / self._timer.elapsed)
+            msg += "committed=%d  " % self.scheduler.committed_nodes
+            msg += "requested=%d  " % requested_nodes
+            msg += "scheduled=%d  " % len(self.scheduler.requests)
+            msg += "timeouts=%d" % self._total_timeouts
             self.logger.info("State-Sync: %s", msg)
             try:
                 await self.sleep(self._report_interval)


### PR DESCRIPTION
### What was wrong?

State syn clogging output was still confusing to read.

### How was it fixed?

Replaced separators between labels and values from `: ` to `=` (the same as geth does)

#### Cute Animal Picture

![animal-animals-babies-bird-birds-cute-favim com-40474](https://user-images.githubusercontent.com/824194/43419588-8504dd76-93fe-11e8-94b1-9545f3a23b8d.jpg)

