### PR TITLE
WIP: Start moving the ETH p2p protocol stuff into the trinity module

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -44,10 +44,6 @@ CHAIN_SPLIT_CHECK_TIMEOUT = 5 * REPLY_TIMEOUT
 # Default timeout before giving up on a caller-initiated interaction
 COMPLETION_TIMEOUT = 5
 
-# Types of LES Announce messages
-LES_ANNOUNCE_SIMPLE = 1
-LES_ANNOUNCE_SIGNED = 2
-
 MAINNET_BOOTNODES = (
     'enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303',  # noqa: E501
     'enode://aa36fdf33dd030378a0168efe6ed7d5cc587fafa3cdd375854fe735a2e11ea3650ba29644e2db48368c46e1f60e716300ba49396cd63778bf8a818c09bded46f@13.93.211.84:30303',  # noqa: E501

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -1,9 +1,7 @@
 import logging
 import struct
-from abc import ABC, abstractmethod
 from typing import (
     Any,
-    cast,
     Dict,
     List,
     Tuple,
@@ -15,16 +13,10 @@ from typing import (
 import rlp
 from rlp import sedes
 
-from eth_utils import encode_hex
-
-from eth_typing import BlockIdentifier, BlockNumber
-
 from eth.constants import NULL_BYTE
-from eth.rlp.headers import BlockHeader
 
 from p2p.exceptions import (
     MalformedMessage,
-    ValidationError,
 )
 from p2p.utils import get_devp2p_cmd_id
 
@@ -131,120 +123,6 @@ class Command:
         return header, body
 
 
-class BaseRequest(ABC):
-    """
-    Base representation of a *request* to a connected peer which has a matching
-    *response*.
-    """
-    @abstractmethod
-    def validate_response(self, response: Any) -> None:
-        pass
-
-
-class BaseHeaderRequest(BaseRequest):
-    block_number_or_hash: BlockIdentifier
-    max_headers: int
-    skip: int
-    reverse: bool
-
-    @property
-    @abstractmethod
-    def max_size(self) -> int:
-        pass
-
-    def generate_block_numbers(self,
-                               block_number: BlockNumber=None) -> Tuple[BlockNumber, ...]:
-        if block_number is None and not self.is_numbered:
-            raise TypeError(
-                "A `block_number` must be supplied to generate block numbers "
-                "for hash based header requests"
-            )
-        elif block_number is not None and self.is_numbered:
-            raise TypeError(
-                "The `block_number` parameter may not be used for number based "
-                "header requests"
-            )
-        elif block_number is None:
-            block_number = cast(BlockNumber, self.block_number_or_hash)
-
-        max_headers = min(self.max_size, self.max_headers)
-
-        # inline import until this module is moved to `trinity`
-        from trinity.utils.headers import sequence_builder
-        return sequence_builder(
-            block_number,
-            max_headers,
-            self.skip,
-            self.reverse,
-        )
-
-    @property
-    def is_numbered(self) -> bool:
-        return isinstance(self.block_number_or_hash, int)
-
-    def validate_headers(self,
-                         headers: Tuple[BlockHeader, ...]) -> None:
-        if not headers:
-            # An empty response is always valid
-            return
-        elif not self.is_numbered:
-            first_header = headers[0]
-            if first_header.hash != self.block_number_or_hash:
-                raise ValidationError(
-                    "Returned headers cannot be matched to header request. "
-                    "Expected first header to have hash of {0} but instead got "
-                    "{1}.".format(
-                        encode_hex(self.block_number_or_hash),
-                        encode_hex(first_header.hash),
-                    )
-                )
-
-        block_numbers: Tuple[BlockNumber, ...] = tuple(
-            header.block_number for header in headers
-        )
-        return self.validate_sequence(block_numbers)
-
-    def validate_sequence(self, block_numbers: Tuple[BlockNumber, ...]) -> None:
-        if not block_numbers:
-            return
-        elif self.is_numbered:
-            expected_numbers = self.generate_block_numbers()
-        else:
-            expected_numbers = self.generate_block_numbers(block_numbers[0])
-
-        # check for numbers that should not be present.
-        unexpected_numbers = set(block_numbers).difference(expected_numbers)
-        if unexpected_numbers:
-            raise ValidationError(
-                'Unexpected numbers: {0}'.format(unexpected_numbers))
-
-        # check that the numbers are correctly ordered.
-        expected_order = tuple(sorted(
-            block_numbers,
-            reverse=self.reverse,
-        ))
-        if block_numbers != expected_order:
-            raise ValidationError(
-                'Returned headers are not correctly ordered.\n'
-                'Expected: {0}\n'
-                'Got     : {1}\n'.format(expected_order, block_numbers)
-            )
-
-        # check that all provided numbers are an ordered subset of the master
-        # sequence.
-        iter_expected = iter(expected_numbers)
-        for number in block_numbers:
-            for value in iter_expected:
-                if value == number:
-                    break
-            else:
-                raise ValidationError(
-                    'Returned headers contain an unexpected block number.\n'
-                    'Unexpected Number: {0}\n'
-                    'Expected Numbers : {1}'.format(number, expected_numbers)
-                )
-
-
 class Protocol:
     logger = logging.getLogger("p2p.protocol.Protocol")
     name: str = None
@@ -264,13 +142,6 @@ class Protocol:
 
     def __repr__(self) -> str:
         return "(%s, %d)" % (self.name, self.version)
-
-
-class BaseBlockHeaders(ABC, Command):
-
-    @abstractmethod
-    def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
-        raise NotImplementedError("Must be implemented by subclasses")
 
 
 def _pad_to_16_byte_boundary(data: bytes) -> bytes:

--- a/p2p/server.py
+++ b/p2p/server.py
@@ -50,7 +50,6 @@ from p2p.p2p_proto import (
 from p2p.peer import (
     BasePeer,
     DEFAULT_PREFERRED_NODES,
-    ETHPeer,
     PeerPool,
 )
 from p2p.service import BaseService
@@ -59,6 +58,7 @@ from p2p.sync import FullNodeSyncer
 if TYPE_CHECKING:
     from trinity.db.chain import AsyncChainDB  # noqa: F401
     from trinity.db.header import BaseAsyncHeaderDB  # noqa: F401
+    from trinity.protocol.eth.peer import ETHPeer  # noqa: F401
 
 
 DIAL_IN_OUT_RATIO = 0.75
@@ -81,7 +81,7 @@ class Server(BaseService):
                  base_db: BaseDB,
                  network_id: int,
                  max_peers: int = DEFAULT_MAX_PEERS,
-                 peer_class: Type[BasePeer] = ETHPeer,
+                 peer_class: Type[BasePeer] = None,
                  bootstrap_nodes: Tuple[Node, ...] = None,
                  preferred_nodes: Sequence[Node] = None,
                  token: CancelToken = None,
@@ -94,6 +94,9 @@ class Server(BaseService):
         self.privkey = privkey
         self.port = port
         self.network_id = network_id
+        if peer_class is None:
+            from trinity.protocol.eth.peer import ETHPeer  # noqa: F811
+            peer_class = ETHPeer
         self.peer_class = peer_class
         self.max_peers = max_peers
         self.bootstrap_nodes = bootstrap_nodes
@@ -302,8 +305,8 @@ def _test() -> None:
 
     from p2p import ecies
     from p2p.constants import ROPSTEN_BOOTNODES
-    from p2p.peer import ETHPeer
 
+    from trinity.protocol.eth.peer import ETHPeer  # noqa: F811
     from trinity.utils.chains import load_nodekey
 
     from tests.p2p.integration_test_helpers import FakeAsyncHeaderDB

--- a/p2p/shard_syncer.py
+++ b/p2p/shard_syncer.py
@@ -54,10 +54,6 @@ from p2p.sharding_protocol import (
     NewCollationHashes,
 )
 
-from p2p.utils import (
-    gen_request_id,
-)
-
 from cytoolz import (
     excepts,
 )
@@ -192,6 +188,8 @@ class ShardSyncer(BaseService, PeerSubscriber):
         # to header existence at the moment. In the future we won't transfer collations anyway but
         # only collation bodies (headers are retrieved from the main chain), so there's no need to
         # add this at the moment.
+        from trinity.protocol.les.utils import gen_request_id
+
         collation_hashes = set(
             collation_hash for collation_hash, _ in msg["collation_hashes_and_periods"]
         )

--- a/p2p/sharding_peer.py
+++ b/p2p/sharding_peer.py
@@ -35,9 +35,6 @@ from p2p.sharding_protocol import (
     Status,
 )
 
-from p2p.utils import (
-    gen_request_id,
-)
 from p2p.exceptions import (
     HandshakeFailure,
     UnexpectedMessage,
@@ -92,6 +89,7 @@ class ShardingPeer(BasePeer):
     async def get_collations(self,
                              collation_hashes: List[Hash32],
                              cancel_token: CancelToken) -> Set[Collation]:
+        from trinity.protocol.les.utils import gen_request_id
         # Don't send empty request
         if len(collation_hashes) == 0:
             return set()

--- a/p2p/sync.py
+++ b/p2p/sync.py
@@ -77,11 +77,12 @@ def _test() -> None:
     import argparse
     import asyncio
     import signal
-    from p2p import ecies
-    from p2p.kademlia import Node
-    from p2p.peer import ETHPeer, DEFAULT_PREFERRED_NODES
     from eth.chains.ropsten import RopstenChain, ROPSTEN_VM_CONFIGURATION
     from eth.db.backends.level import LevelDB
+    from p2p import ecies
+    from p2p.kademlia import Node
+    from p2p.peer import DEFAULT_PREFERRED_NODES
+    from trinity.protocol.eth.peer import ETHPeer
     from tests.p2p.integration_test_helpers import (
         FakeAsyncChainDB, FakeAsyncRopstenChain, connect_to_peers_loop)
     logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s')

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -7,8 +7,6 @@ from typing import Tuple
 
 import rlp
 
-from eth.utils.numeric import big_endian_to_int
-
 
 def sxor(s1: bytes, s2: bytes) -> bytes:
     if len(s1) != len(s2):
@@ -22,10 +20,6 @@ def roundup_16(x: int) -> int:
     if remainder != 0:
         x += 16 - remainder
     return x
-
-
-def gen_request_id() -> int:
-    return big_endian_to_int(os.urandom(8))
 
 
 def get_devp2p_cmd_id(msg: bytes) -> int:

--- a/tests/p2p/dumb_peer.py
+++ b/tests/p2p/dumb_peer.py
@@ -1,5 +1,5 @@
 from p2p import protocol
-from p2p.peer import (
+from trinity.protocol.eth.peer import (
     ETHPeer,
 )
 

--- a/tests/p2p/peer_helpers.py
+++ b/tests/p2p/peer_helpers.py
@@ -14,10 +14,12 @@ from p2p import auth
 from p2p import constants
 from p2p import ecies
 from p2p import kademlia
-from p2p.peer import BasePeer, LESPeer, PeerPool, PeerSubscriber
+from p2p.peer import BasePeer, PeerPool, PeerSubscriber
 from p2p.server import decode_authentication
 
-from integration_test_helpers import FakeAsyncHeaderDB
+from trinity.protocol.les.peer import LESPeer
+
+from tests.p2p.integration_test_helpers import FakeAsyncHeaderDB
 
 
 def get_fresh_mainnet_headerdb():
@@ -146,7 +148,11 @@ async def get_directly_linked_peers(
     asyncio.ensure_future(peer2.run())
 
     def finalizer():
-        event_loop.run_until_complete(asyncio.gather(peer1.cancel(), peer2.cancel()))
+        event_loop.run_until_complete(asyncio.gather(
+            peer1.cancel(),
+            peer2.cancel(),
+            loop=event_loop,
+        ))
     request.addfinalizer(finalizer)
 
     return peer1, peer2

--- a/tests/p2p/test_lightchain_integration.py
+++ b/tests/p2p/test_lightchain_integration.py
@@ -21,7 +21,9 @@ from p2p import ecies
 from p2p.chain import LightChainSyncer
 from p2p.kademlia import Node
 from p2p.lightchain import LightPeerChain
-from p2p.peer import LESPeer, PeerPool
+from p2p.peer import PeerPool
+
+from trinity.protocol.les.peer import LESPeer
 
 from integration_test_helpers import (
     FakeAsyncChainDB,

--- a/tests/p2p/test_server.py
+++ b/tests/p2p/test_server.py
@@ -10,7 +10,6 @@ from eth.db.header import HeaderDB
 from eth.db.backends.memory import MemoryDB
 
 from p2p.peer import (
-    ETHPeer,
     PeerPool,
 )
 from p2p.kademlia import (
@@ -18,6 +17,8 @@ from p2p.kademlia import (
     Address,
 )
 from p2p.server import Server
+
+from trinity.protocol.eth.peer import ETHPeer
 
 from auth_constants import eip8_values
 from dumb_peer import DumbPeer

--- a/tests/p2p/test_sync.py
+++ b/tests/p2p/test_sync.py
@@ -9,10 +9,11 @@ from eth import constants
 from eth.db.backends.memory import MemoryDB
 from eth.vm.forks.frontier import FrontierVM, _PoWMiningVM
 
-from p2p import eth
-from p2p.peer import ETHPeer, LESPeer
 from p2p.chain import FastChainSyncer, LightChainSyncer, RegularChainSyncer
 from p2p.state import StateDownloader
+
+from trinity.protocol.eth.peer import ETHPeer
+from trinity.protocol.les.peer import LESPeer
 
 from integration_test_helpers import FakeAsyncChain, FakeAsyncChainDB, FakeAsyncHeaderDB
 from peer_helpers import get_directly_linked_peers, MockPeerPoolWithConnectedPeers
@@ -23,8 +24,9 @@ from peer_helpers import get_directly_linked_peers, MockPeerPoolWithConnectedPee
 # by requesting a single batch.
 @pytest.fixture(autouse=True)
 def small_header_batches(monkeypatch):
-    monkeypatch.setattr(eth, 'MAX_HEADERS_FETCH', 10)
-    monkeypatch.setattr(eth, 'MAX_BODIES_FETCH', 5)
+    from trinity.protocol.eth import constants
+    monkeypatch.setattr(constants, 'MAX_HEADERS_FETCH', 10)
+    monkeypatch.setattr(constants, 'MAX_BODIES_FETCH', 5)
 
 
 @pytest.mark.asyncio

--- a/tests/trinity/core/p2p-proto/test_header_request_object.py
+++ b/tests/trinity/core/p2p-proto/test_header_request_object.py
@@ -1,7 +1,8 @@
 import pytest
 
 from p2p.exceptions import ValidationError
-from p2p.protocol import BaseHeaderRequest
+
+from trinity.protocol.base_request import BaseHeaderRequest
 
 
 FORWARD_0_to_5 = (0, 6, 0, False)

--- a/tests/trinity/core/p2p-proto/test_peer.py
+++ b/tests/trinity/core/p2p-proto/test_peer.py
@@ -2,15 +2,16 @@ import asyncio
 
 import pytest
 
-from p2p.les import (
+from p2p.exceptions import NoMatchingPeerCapabilities
+from p2p.p2p_proto import DisconnectReason, P2PProtocol
+
+from trinity.protocol.les.peer import LESPeer
+from trinity.protocol.les.proto import (
     LESProtocol,
     LESProtocolV2,
 )
-from p2p.exceptions import NoMatchingPeerCapabilities
-from p2p.peer import LESPeer
-from p2p.p2p_proto import DisconnectReason, P2PProtocol
 
-from peer_helpers import (
+from tests.p2p.peer_helpers import (
     get_directly_linked_peers_without_handshake,
     get_directly_linked_peers,
     MockPeerPoolWithConnectedPeers,

--- a/tests/trinity/core/p2p-proto/test_peer_block_header_request_and_response_api.py
+++ b/tests/trinity/core/p2p-proto/test_peer_block_header_request_and_response_api.py
@@ -6,8 +6,10 @@ from eth_utils import to_tuple
 
 from eth.rlp.headers import BlockHeader
 
-from p2p.peer import ETHPeer, LESPeer
-from peer_helpers import (
+from trinity.protocol.eth.peer import ETHPeer
+from trinity.protocol.les.peer import LESPeer
+
+from tests.p2p.peer_helpers import (
     get_directly_linked_peers,
 )
 

--- a/tests/trinity/core/tx-pool/test_tx_pool.py
+++ b/tests/trinity/core/tx-pool/test_tx_pool.py
@@ -2,13 +2,6 @@ import asyncio
 import pytest
 import uuid
 
-from p2p.peer import (
-    ETHPeer,
-)
-from p2p.eth import (
-    Transactions
-)
-
 from eth.utils.address import (
     force_bytes_to_address
 )
@@ -19,6 +12,10 @@ from trinity.plugins.builtin.tx_pool.pool import (
 from trinity.plugins.builtin.tx_pool.validators import (
     DefaultTransactionValidator
 )
+from trinity.protocol.eth.commands import (
+    Transactions
+)
+from trinity.protocol.eth.peer import ETHPeer
 
 from tests.conftest import (
     funded_address_private_key

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -8,20 +8,20 @@ from p2p.discovery import DiscoveryService, PreferredNodeDiscoveryProtocol
 from p2p.kademlia import Address
 from p2p.lightchain import LightPeerChain
 from p2p.peer import (
-    LESPeer,
     PeerPool,
 )
 
 from trinity.chains.light import (
     LightDispatchChain,
 )
+from trinity.config import (
+    ChainConfig,
+)
 from trinity.extensibility import (
     PluginManager
 )
 from trinity.nodes.base import Node
-from trinity.config import (
-    ChainConfig,
-)
+from trinity.protocol.les.peer import LESPeer
 
 
 class LightNode(Node):

--- a/trinity/plugins/builtin/tx_pool/pool.py
+++ b/trinity/plugins/builtin/tx_pool/pool.py
@@ -15,17 +15,19 @@ from cancel_token import CancelToken
 from eth.rlp.transactions import (
     BaseTransactionFields
 )
-from p2p.eth import (
-    Transactions
-)
+
 from p2p.peer import (
     BasePeer,
-    ETHPeer,
     PeerPool,
     PeerSubscriber,
 )
 from p2p.service import (
     BaseService
+)
+
+from trinity.protocol.eth.peer import ETHPeer
+from trinity.protocol.eth.commands import (
+    Transactions
 )
 
 

--- a/trinity/protocol/base_block_headers.py
+++ b/trinity/protocol/base_block_headers.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import Tuple
+
+from eth.rlp.headers import BlockHeader
+
+from p2p.protocol import (
+    Command,
+    _DecodedMsgType,
+)
+
+
+class BaseBlockHeaders(ABC, Command):
+
+    @abstractmethod
+    def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("Must be implemented by subclasses")

--- a/trinity/protocol/base_request.py
+++ b/trinity/protocol/base_request.py
@@ -1,0 +1,130 @@
+from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    cast,
+    Tuple,
+)
+
+from eth_utils import encode_hex
+
+from eth_typing import BlockIdentifier, BlockNumber
+
+from eth.rlp.headers import BlockHeader
+
+from p2p.exceptions import (
+    ValidationError,
+)
+
+
+class BaseRequest(ABC):
+    """
+    Base representation of a *request* to a connected peer which has a matching
+    *response*.
+    """
+    @abstractmethod
+    def validate_response(self, response: Any) -> None:
+        pass
+
+
+class BaseHeaderRequest(BaseRequest):
+    block_number_or_hash: BlockIdentifier
+    max_headers: int
+    skip: int
+    reverse: bool
+
+    @property
+    @abstractmethod
+    def max_size(self) -> int:
+        pass
+
+    def generate_block_numbers(self,
+                               block_number: BlockNumber=None) -> Tuple[BlockNumber, ...]:
+        if block_number is None and not self.is_numbered:
+            raise TypeError(
+                "A `block_number` must be supplied to generate block numbers "
+                "for hash based header requests"
+            )
+        elif block_number is not None and self.is_numbered:
+            raise TypeError(
+                "The `block_number` parameter may not be used for number based "
+                "header requests"
+            )
+        elif block_number is None:
+            block_number = cast(BlockNumber, self.block_number_or_hash)
+
+        max_headers = min(self.max_size, self.max_headers)
+
+        # inline import until this module is moved to `trinity`
+        from trinity.utils.headers import sequence_builder
+        return sequence_builder(
+            block_number,
+            max_headers,
+            self.skip,
+            self.reverse,
+        )
+
+    @property
+    def is_numbered(self) -> bool:
+        return isinstance(self.block_number_or_hash, int)
+
+    def validate_headers(self,
+                         headers: Tuple[BlockHeader, ...]) -> None:
+        if not headers:
+            # An empty response is always valid
+            return
+        elif not self.is_numbered:
+            first_header = headers[0]
+            if first_header.hash != self.block_number_or_hash:
+                raise ValidationError(
+                    "Returned headers cannot be matched to header request. "
+                    "Expected first header to have hash of {0} but instead got "
+                    "{1}.".format(
+                        encode_hex(self.block_number_or_hash),
+                        encode_hex(first_header.hash),
+                    )
+                )
+
+        block_numbers: Tuple[BlockNumber, ...] = tuple(
+            header.block_number for header in headers
+        )
+        return self.validate_sequence(block_numbers)
+
+    def validate_sequence(self, block_numbers: Tuple[BlockNumber, ...]) -> None:
+        if not block_numbers:
+            return
+        elif self.is_numbered:
+            expected_numbers = self.generate_block_numbers()
+        else:
+            expected_numbers = self.generate_block_numbers(block_numbers[0])
+
+        # check for numbers that should not be present.
+        unexpected_numbers = set(block_numbers).difference(expected_numbers)
+        if unexpected_numbers:
+            raise ValidationError(
+                'Unexpected numbers: {0}'.format(unexpected_numbers))
+
+        # check that the numbers are correctly ordered.
+        expected_order = tuple(sorted(
+            block_numbers,
+            reverse=self.reverse,
+        ))
+        if block_numbers != expected_order:
+            raise ValidationError(
+                'Returned headers are not correctly ordered.\n'
+                'Expected: {0}\n'
+                'Got     : {1}\n'.format(expected_order, block_numbers)
+            )
+
+        # check that all provided numbers are an ordered subset of the master
+        # sequence.
+        iter_expected = iter(expected_numbers)
+        for number in block_numbers:
+            for value in iter_expected:
+                if value == number:
+                    break
+            else:
+                raise ValidationError(
+                    'Returned headers contain an unexpected block number.\n'
+                    'Unexpected Number: {0}\n'
+                    'Expected Numbers : {1}'.format(number, expected_numbers)
+                )

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -1,0 +1,103 @@
+from typing import (
+    cast,
+    Tuple,
+    TYPE_CHECKING
+)
+
+from rlp import sedes
+
+from eth.rlp.headers import BlockHeader
+from eth.rlp.receipts import Receipt
+from eth.rlp.transactions import BaseTransactionFields
+
+from p2p.protocol import (
+    Command,
+    _DecodedMsgType,
+)
+
+from trinity.protocol.base_block_headers import BaseBlockHeaders
+from trinity.rlp.block_body import BlockBody
+from trinity.rlp.sedes import HashOrNumber
+
+if TYPE_CHECKING:
+    from p2p.peer import (  # noqa: F401
+        ChainInfo
+    )
+
+
+class Status(Command):
+    _cmd_id = 0
+    structure = [
+        ('protocol_version', sedes.big_endian_int),
+        ('network_id', sedes.big_endian_int),
+        ('td', sedes.big_endian_int),
+        ('best_hash', sedes.binary),
+        ('genesis_hash', sedes.binary),
+    ]
+
+
+class NewBlockHashes(Command):
+    _cmd_id = 1
+    structure = sedes.CountableList(sedes.List([sedes.binary, sedes.big_endian_int]))
+
+
+class Transactions(Command):
+    _cmd_id = 2
+    structure = sedes.CountableList(BaseTransactionFields)
+
+
+class GetBlockHeaders(Command):
+    _cmd_id = 3
+    structure = [
+        ('block_number_or_hash', HashOrNumber()),
+        ('max_headers', sedes.big_endian_int),
+        ('skip', sedes.big_endian_int),
+        ('reverse', sedes.boolean),
+    ]
+
+
+class BlockHeaders(BaseBlockHeaders):
+    _cmd_id = 4
+    structure = sedes.CountableList(BlockHeader)
+
+    def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
+        return cast(Tuple[BlockHeader, ...], tuple(msg))
+
+
+class GetBlockBodies(Command):
+    _cmd_id = 5
+    structure = sedes.CountableList(sedes.binary)
+
+
+class BlockBodies(Command):
+    _cmd_id = 6
+    structure = sedes.CountableList(BlockBody)
+
+
+class NewBlock(Command):
+    _cmd_id = 7
+    structure = [
+        ('block', sedes.List([BlockHeader,
+                              sedes.CountableList(BaseTransactionFields),
+                              sedes.CountableList(BlockHeader)])),
+        ('total_difficulty', sedes.big_endian_int)]
+
+
+class GetNodeData(Command):
+    _cmd_id = 13
+    structure = sedes.CountableList(sedes.binary)
+
+
+class NodeData(Command):
+    _cmd_id = 14
+    structure = sedes.CountableList(sedes.binary)
+
+
+class GetReceipts(Command):
+    _cmd_id = 15
+    structure = sedes.CountableList(sedes.binary)
+
+
+class Receipts(Command):
+    _cmd_id = 16
+    structure = sedes.CountableList(sedes.CountableList(Receipt))

--- a/trinity/protocol/eth/constants.py
+++ b/trinity/protocol/eth/constants.py
@@ -1,0 +1,6 @@
+# Max number of items we can ask for in ETH requests. These are the values used
+# in geth and if we ask for more than this the peers will disconnect from us.
+MAX_STATE_FETCH = 384
+MAX_BODIES_FETCH = 128
+MAX_RECEIPTS_FETCH = 256
+MAX_HEADERS_FETCH = 192

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -1,0 +1,114 @@
+import asyncio
+from typing import (
+    Any,
+    cast,
+    Dict,
+    Tuple,
+)
+
+from eth_utils import encode_hex
+
+from eth_typing import BlockIdentifier
+
+from eth.rlp.headers import BlockHeader
+
+from p2p.exceptions import HandshakeFailure
+from p2p.p2p_proto import DisconnectReason
+from p2p.peer import BasePeer
+from p2p.protocol import (
+    Command,
+    _DecodedMsgType,
+)
+
+from trinity.protocol.base_request import BaseRequest
+from .commands import (
+    BlockHeaders,
+    NewBlock,
+    Status,
+)
+from . import constants
+from .requests import HeaderRequest
+from .proto import ETHProtocol
+
+
+class ETHPeer(BasePeer):
+    _supported_sub_protocols = [ETHProtocol]
+    sub_proto: ETHProtocol = None
+
+    @property
+    def max_headers_fetch(self) -> int:
+        return constants.MAX_HEADERS_FETCH
+
+    def handle_sub_proto_msg(self, cmd: Command, msg: _DecodedMsgType) -> None:
+        if isinstance(cmd, NewBlock):
+            msg = cast(Dict[str, Any], msg)
+            header, _, _ = msg['block']
+            actual_head = header.parent_hash
+            actual_td = msg['total_difficulty'] - header.difficulty
+            if actual_td > self.head_td:
+                self.head_hash = actual_head
+                self.head_td = actual_td
+
+        super().handle_sub_proto_msg(cmd, msg)
+
+    async def send_sub_proto_handshake(self) -> None:
+        self.sub_proto.send_handshake(await self._local_chain_info)
+
+    async def process_sub_proto_handshake(
+            self, cmd: Command, msg: _DecodedMsgType) -> None:
+        if not isinstance(cmd, Status):
+            await self.disconnect(DisconnectReason.subprotocol_error)
+            raise HandshakeFailure(
+                "Expected a ETH Status msg, got {}, disconnecting".format(cmd))
+        msg = cast(Dict[str, Any], msg)
+        if msg['network_id'] != self.network_id:
+            await self.disconnect(DisconnectReason.useless_peer)
+            raise HandshakeFailure(
+                "{} network ({}) does not match ours ({}), disconnecting".format(
+                    self, msg['network_id'], self.network_id))
+        genesis = await self.genesis
+        if msg['genesis_hash'] != genesis.hash:
+            await self.disconnect(DisconnectReason.useless_peer)
+            raise HandshakeFailure(
+                "{} genesis ({}) does not match ours ({}), disconnecting".format(
+                    self, encode_hex(msg['genesis_hash']), genesis.hex_hash))
+        self.head_td = msg['td']
+        self.head_hash = msg['best_hash']
+
+    def request_block_headers(self,
+                              block_number_or_hash: BlockIdentifier,
+                              max_headers: int = None,
+                              skip: int = 0,
+                              reverse: bool = True) -> HeaderRequest:
+        if max_headers is None:
+            max_headers = self.max_headers_fetch
+        request = HeaderRequest(
+            block_number_or_hash,
+            max_headers,
+            skip,
+            reverse,
+        )
+        self.sub_proto.send_get_block_headers(
+            request.block_number_or_hash,
+            request.max_headers,
+            request.skip,
+            request.reverse,
+        )
+        return request
+
+    async def wait_for_block_headers(self, request: HeaderRequest) -> Tuple[BlockHeader, ...]:
+        future: 'asyncio.Future[Tuple[BlockHeader, ...]]' = asyncio.Future()
+        self.pending_requests[BlockHeaders] = cast(
+            Tuple[BaseRequest, 'asyncio.Future[_DecodedMsgType]'],
+            (request, future),
+        )
+        response = await self.wait(future, timeout=self._response_timeout)
+        return response
+
+    async def get_block_headers(self,
+                                block_number_or_hash: BlockIdentifier,
+                                max_headers: int = None,
+                                skip: int = 0,
+                                reverse: bool = True) -> Tuple[BlockHeader, ...]:
+        request = self.request_block_headers(block_number_or_hash, max_headers, skip, reverse)
+        return await self.wait_for_block_headers(request)

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -1,32 +1,36 @@
 import logging
 from typing import (
-    Any,
-    cast,
     List,
     Tuple,
-    TYPE_CHECKING
+    TYPE_CHECKING,
 )
 
-from rlp import sedes
-
-from eth_typing import (
-    BlockIdentifier,
-)
+from eth_typing import BlockIdentifier
 
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransactionFields
 
-from p2p.exceptions import ValidationError
 from p2p.protocol import (
-    BaseBlockHeaders,
-    BaseHeaderRequest,
-    Command,
     Protocol,
-    _DecodedMsgType,
 )
 from p2p.rlp import BlockBody
-from p2p.sedes import HashOrNumber
+
+from .commands import (
+    BlockBodies,
+    BlockHeaders,
+    GetBlockBodies,
+    GetBlockHeaders,
+    GetNodeData,
+    GetReceipts,
+    NewBlock,
+    NewBlockHashes,
+    NodeData,
+    Receipts,
+    Status,
+    Transactions,
+)
+from . import constants
 
 if TYPE_CHECKING:
     from p2p.peer import (  # noqa: F401
@@ -34,122 +38,11 @@ if TYPE_CHECKING:
     )
 
 
-# Max number of items we can ask for in ETH requests. These are the values used in geth and if we
-# ask for more than this the peers will disconnect from us.
-MAX_STATE_FETCH = 384
-MAX_BODIES_FETCH = 128
-MAX_RECEIPTS_FETCH = 256
-MAX_HEADERS_FETCH = 192
-
-
-class Status(Command):
-    _cmd_id = 0
-    structure = [
-        ('protocol_version', sedes.big_endian_int),
-        ('network_id', sedes.big_endian_int),
-        ('td', sedes.big_endian_int),
-        ('best_hash', sedes.binary),
-        ('genesis_hash', sedes.binary),
-    ]
-
-
-class NewBlockHashes(Command):
-    _cmd_id = 1
-    structure = sedes.CountableList(sedes.List([sedes.binary, sedes.big_endian_int]))
-
-
-class Transactions(Command):
-    _cmd_id = 2
-    structure = sedes.CountableList(BaseTransactionFields)
-
-
-class GetBlockHeaders(Command):
-    _cmd_id = 3
-    structure = [
-        ('block_number_or_hash', HashOrNumber()),
-        ('max_headers', sedes.big_endian_int),
-        ('skip', sedes.big_endian_int),
-        ('reverse', sedes.boolean),
-    ]
-
-
-class HeaderRequest(BaseHeaderRequest):
-    max_size = MAX_HEADERS_FETCH
-
-    def __init__(self,
-                 block_number_or_hash: BlockIdentifier,
-                 max_headers: int,
-                 skip: int,
-                 reverse: bool) -> None:
-        self.block_number_or_hash = block_number_or_hash
-        self.max_headers = max_headers
-        self.skip = skip
-        self.reverse = reverse
-
-    def validate_response(self, response: Any) -> None:
-        """
-        Core `Request` API used for validation.
-        """
-        if not isinstance(response, tuple):
-            raise ValidationError("Response to `HeaderRequest` must be a tuple")
-        elif not all(isinstance(item, BlockHeader) for item in response):
-            raise ValidationError("Response must be a tuple of `BlockHeader` objects")
-
-        return self.validate_headers(cast(Tuple[BlockHeader, ...], response))
-
-
-class BlockHeaders(BaseBlockHeaders):
-    _cmd_id = 4
-    structure = sedes.CountableList(BlockHeader)
-
-    def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
-        return cast(Tuple[BlockHeader, ...], tuple(msg))
-
-
-class GetBlockBodies(Command):
-    _cmd_id = 5
-    structure = sedes.CountableList(sedes.binary)
-
-
-class BlockBodies(Command):
-    _cmd_id = 6
-    structure = sedes.CountableList(BlockBody)
-
-
-class NewBlock(Command):
-    _cmd_id = 7
-    structure = [
-        ('block', sedes.List([BlockHeader,
-                              sedes.CountableList(BaseTransactionFields),
-                              sedes.CountableList(BlockHeader)])),
-        ('total_difficulty', sedes.big_endian_int)]
-
-
-class GetNodeData(Command):
-    _cmd_id = 13
-    structure = sedes.CountableList(sedes.binary)
-
-
-class NodeData(Command):
-    _cmd_id = 14
-    structure = sedes.CountableList(sedes.binary)
-
-
-class GetReceipts(Command):
-    _cmd_id = 15
-    structure = sedes.CountableList(sedes.binary)
-
-
-class Receipts(Command):
-    _cmd_id = 16
-    structure = sedes.CountableList(sedes.CountableList(Receipt))
-
-
 class ETHProtocol(Protocol):
     name = 'eth'
     version = 63
     _commands = [
-        Status, NewBlockHashes, Transactions, GetBlockHeaders, BlockHeaders, BlockHeaders,
+        Status, NewBlockHashes, Transactions, GetBlockHeaders, BlockHeaders,
         GetBlockBodies, BlockBodies, NewBlock, GetNodeData, NodeData,
         GetReceipts, Receipts]
     cmd_length = 17
@@ -189,10 +82,10 @@ class ETHProtocol(Protocol):
         block_number_or_hash if reverse is False or ending at block_number_or_hash if reverse is
         True.
         """
-        if max_headers > MAX_HEADERS_FETCH:
+        if max_headers > constants.MAX_HEADERS_FETCH:
             raise ValueError(
                 "Cannot ask for more than {} block headers in a single request".format(
-                    MAX_HEADERS_FETCH))
+                    constants.MAX_HEADERS_FETCH))
         cmd = GetBlockHeaders(self.cmd_id_offset)
         data = {
             'block_number_or_hash': block_number_or_hash,

--- a/trinity/protocol/eth/requests.py
+++ b/trinity/protocol/eth/requests.py
@@ -1,0 +1,42 @@
+from typing import (
+    Any,
+    cast,
+    Tuple,
+)
+
+from eth_typing import BlockIdentifier
+
+from eth.rlp.headers import BlockHeader
+
+from p2p.exceptions import ValidationError
+
+from trinity.protocol.base_request import BaseHeaderRequest
+
+from . import constants
+
+
+class HeaderRequest(BaseHeaderRequest):
+    @property
+    def max_size(self) -> int:
+        return constants.MAX_HEADERS_FETCH
+
+    def __init__(self,
+                 block_number_or_hash: BlockIdentifier,
+                 max_headers: int,
+                 skip: int,
+                 reverse: bool) -> None:
+        self.block_number_or_hash = block_number_or_hash
+        self.max_headers = max_headers
+        self.skip = skip
+        self.reverse = reverse
+
+    def validate_response(self, response: Any) -> None:
+        """
+        Core `Request` API used for validation.
+        """
+        if not isinstance(response, tuple):
+            raise ValidationError("Response to `HeaderRequest` must be a tuple")
+        elif not all(isinstance(item, BlockHeader) for item in response):
+            raise ValidationError("Response must be a tuple of `BlockHeader` objects")
+
+        return self.validate_headers(cast(Tuple[BlockHeader, ...], response))

--- a/trinity/protocol/les/commands.py
+++ b/trinity/protocol/les/commands.py
@@ -1,49 +1,34 @@
-from typing import Any, cast, Dict, Iterator, List, Tuple, TYPE_CHECKING, Union
+from typing import (
+    Any,
+    cast,
+    Dict,
+    Iterator,
+    List,
+    Tuple,
+    Union,
+)
 
-import rlp
-from rlp import sedes
+from eth_typing import Hash32
 
 from eth_utils import (
     encode_hex,
     to_dict,
 )
 
-from eth_typing import (
-    BlockIdentifier,
-    Hash32
-)
+import rlp
+from rlp import sedes
 
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 
-from p2p.exceptions import (
-    ValidationError,
-)
 from p2p.protocol import (
-    BaseBlockHeaders,
-    BaseHeaderRequest,
     Command,
-    Protocol,
     _DecodedMsgType,
 )
-from p2p.rlp import BlockBody
-from p2p.sedes import HashOrNumber
 
-from .constants import LES_ANNOUNCE_SIMPLE
-
-if TYPE_CHECKING:
-    from p2p.peer import (  # noqa: F401
-        ChainInfo
-    )
-
-# Max number of items we can ask for in LES requests. These are the values used in geth and if we
-# ask for more than this the peers will disconnect from us.
-MAX_HEADERS_FETCH = 192
-MAX_BODIES_FETCH = 32
-MAX_RECEIPTS_FETCH = 128
-MAX_CODE_FETCH = 64
-MAX_PROOFS_FETCH = 64
-MAX_HEADER_PROOFS_FETCH = 64
+from trinity.protocol.base_block_headers import BaseBlockHeaders
+from trinity.rlp.block_body import BlockBody
+from trinity.rlp.sedes import HashOrNumber
 
 
 class HeadInfo:
@@ -167,44 +152,6 @@ class GetBlockHeadersQuery(rlp.Serializable):
     ]
 
 
-class HeaderRequest(BaseHeaderRequest):
-    request_id: int
-
-    max_size = MAX_HEADERS_FETCH
-
-    def __init__(self,
-                 block_number_or_hash: BlockIdentifier,
-                 max_headers: int,
-                 skip: int,
-                 reverse: bool,
-                 request_id: int) -> None:
-        self.block_number_or_hash = block_number_or_hash
-        self.max_headers = max_headers
-        self.skip = skip
-        self.reverse = reverse
-        self.request_id = request_id
-
-    def validate_response(self, response: Any) -> None:
-        """
-        Core `Request` API used for validation.
-        """
-        if not isinstance(response, dict):
-            raise ValidationError("Response to `HeaderRequest` must be a dict")
-
-        request_id = response['request_id']
-        if request_id != self.request_id:
-            raise ValidationError(
-                "Response `request_id` does not match.  expected: %s | got: %s".format(
-                    self.request_id,
-                    request_id,
-                )
-            )
-        elif not all(isinstance(item, BlockHeader) for item in response['headers']):
-            raise ValidationError("Response must be a tuple of `BlockHeader` objects")
-
-        return self.validate_headers(cast(Tuple[BlockHeader, ...], response['headers']))
-
-
 class GetBlockHeaders(Command):
     _cmd_id = 2
     structure = [
@@ -322,104 +269,6 @@ class ContractCodes(Command):
     ]
 
 
-class LESProtocol(Protocol):
-    name = 'les'
-    version = 1
-    _commands = [Status, Announce, BlockHeaders, GetBlockHeaders, BlockBodies, Receipts, Proofs,
-                 ContractCodes]
-    cmd_length = 15
-
-    def send_handshake(self, chain_info: 'ChainInfo') -> None:
-        resp = {
-            'protocolVersion': self.version,
-            'networkId': self.peer.network_id,
-            'headTd': chain_info.total_difficulty,
-            'headHash': chain_info.block_hash,
-            'headNum': chain_info.block_number,
-            'genesisHash': chain_info.genesis_hash,
-            'serveHeaders': None,
-            'serveChainSince': 0,
-            'txRelay': None,
-        }
-        cmd = Status(self.cmd_id_offset)
-        self.send(*cmd.encode(resp))
-        self.logger.debug("Sending LES/Status msg: %s", resp)
-
-    def send_get_block_bodies(self, block_hashes: List[bytes], request_id: int) -> None:
-        if len(block_hashes) > MAX_BODIES_FETCH:
-            raise ValueError(
-                "Cannot ask for more than {} blocks in a single request".format(
-                    MAX_BODIES_FETCH))
-        data = {
-            'request_id': request_id,
-            'block_hashes': block_hashes,
-        }
-        header, body = GetBlockBodies(self.cmd_id_offset).encode(data)
-        self.send(header, body)
-
-    def send_get_block_headers(self,
-                               block_number_or_hash: BlockIdentifier,
-                               max_headers: int,
-                               skip: int,
-                               reverse: bool,
-                               request_id: int,
-                               ) -> None:
-        """Send a GetBlockHeaders msg to the remote.
-
-        This requests that the remote send us up to max_headers, starting from
-        block_number_or_hash if reverse is False or ending at block_number_or_hash if reverse is
-        True.
-        """
-        if max_headers > MAX_HEADERS_FETCH:
-            raise ValueError(
-                "Cannot ask for more than {} block headers in a single request".format(
-                    MAX_HEADERS_FETCH))
-        cmd = GetBlockHeaders(self.cmd_id_offset)
-        # Number of block headers to skip between each item (i.e. step in python APIs).
-        skip = 0
-        data = {
-            'request_id': request_id,
-            'query': GetBlockHeadersQuery(block_number_or_hash, max_headers, skip, reverse),
-        }
-        header, body = cmd.encode(data)
-        self.send(header, body)
-
-    def send_block_headers(
-            self, headers: Tuple[BlockHeader, ...], buffer_value: int, request_id: int) -> None:
-        data = {
-            'request_id': request_id,
-            'headers': headers,
-            'buffer_value': buffer_value,
-        }
-        header, body = BlockHeaders(self.cmd_id_offset).encode(data)
-        self.send(header, body)
-
-    def send_get_receipts(self, block_hash: bytes, request_id: int) -> None:
-        data = {
-            'request_id': request_id,
-            'block_hashes': [block_hash],
-        }
-        header, body = GetReceipts(self.cmd_id_offset).encode(data)
-        self.send(header, body)
-
-    def send_get_proof(self, block_hash: bytes, account_key: bytes, key: bytes, from_level: int,
-                       request_id: int) -> None:
-        data = {
-            'request_id': request_id,
-            'proof_requests': [ProofRequest(block_hash, account_key, key, from_level)],
-        }
-        header, body = GetProofs(self.cmd_id_offset).encode(data)
-        self.send(header, body)
-
-    def send_get_contract_code(self, block_hash: bytes, key: bytes, request_id: int) -> None:
-        data = {
-            'request_id': request_id,
-            'code_requests': [ContractCodeRequest(block_hash, key)],
-        }
-        header, body = GetContractCodes(self.cmd_id_offset).encode(data)
-        self.send(header, body)
-
-
 class StatusV2(Status):
     _cmd_id = 0
 
@@ -439,40 +288,3 @@ class ProofsV2(Command):
         ('buffer_value', sedes.big_endian_int),
         ('proof', sedes.CountableList(sedes.raw)),
     ]
-
-
-class LESProtocolV2(LESProtocol):
-    version = 2
-    _commands = [StatusV2, Announce, BlockHeaders, GetBlockHeaders, BlockBodies, Receipts,
-                 ProofsV2, ContractCodes]
-    cmd_length = 21
-
-    def send_handshake(self, chain_info: 'ChainInfo') -> None:
-        resp = {
-            'announceType': LES_ANNOUNCE_SIMPLE,
-            'protocolVersion': self.version,
-            'networkId': self.peer.network_id,
-            'headTd': chain_info.total_difficulty,
-            'headHash': chain_info.block_hash,
-            'headNum': chain_info.block_number,
-            'genesisHash': chain_info.genesis_hash,
-            'serveHeaders': None,
-            'serveChainSince': 0,
-            'txRelay': None,
-        }
-        cmd = StatusV2(self.cmd_id_offset)
-        self.logger.debug("Sending LES/Status msg: %s", resp)
-        self.send(*cmd.encode(resp))
-
-    def send_get_proof(self,
-                       block_hash: bytes,
-                       account_key: bytes,
-                       key: bytes,
-                       from_level: int,
-                       request_id: int) -> None:
-        data = {
-            'request_id': request_id,
-            'proof_requests': [ProofRequest(block_hash, account_key, key, from_level)],
-        }
-        header, body = GetProofsV2(self.cmd_id_offset).encode(data)
-        self.send(header, body)

--- a/trinity/protocol/les/constants.py
+++ b/trinity/protocol/les/constants.py
@@ -1,0 +1,12 @@
+# Max number of items we can ask for in LES requests. These are the values used in geth and if we
+# ask for more than this the peers will disconnect from us.
+MAX_HEADERS_FETCH = 192
+MAX_BODIES_FETCH = 32
+MAX_RECEIPTS_FETCH = 128
+MAX_CODE_FETCH = 64
+MAX_PROOFS_FETCH = 64
+MAX_HEADER_PROOFS_FETCH = 64
+
+# Types of LES Announce messages
+LES_ANNOUNCE_SIMPLE = 1
+LES_ANNOUNCE_SIGNED = 2

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -1,0 +1,150 @@
+import asyncio
+from typing import (
+    Any,
+    cast,
+    Dict,
+    Tuple,
+)
+
+from eth_utils import encode_hex
+
+from eth_typing import BlockIdentifier
+
+from eth.rlp.headers import BlockHeader
+
+from p2p.exceptions import (
+    HandshakeFailure,
+)
+from p2p.p2p_proto import DisconnectReason
+from p2p.peer import BasePeer
+from p2p.protocol import (
+    Command,
+    _DecodedMsgType,
+)
+
+from trinity.protocol.base_request import BaseHeaderRequest
+
+from .commands import (
+    Announce,
+    BlockHeaders,
+    HeadInfo,
+    Status,
+    StatusV2,
+)
+from .constants import (
+    MAX_HEADERS_FETCH,
+)
+from .proto import (
+    LESProtocol,
+    LESProtocolV2,
+)
+from .requests import (
+    HeaderRequest,
+)
+from .utils import (
+    gen_request_id as _gen_request_id,
+)
+
+
+class LESPeer(BasePeer):
+    _supported_sub_protocols = [LESProtocol, LESProtocolV2]
+    sub_proto: LESProtocol = None
+    # TODO: This will no longer be needed once we've fixed #891, and then it should be removed.
+    head_info: HeadInfo = None
+
+    @property
+    def max_headers_fetch(self) -> int:
+        return MAX_HEADERS_FETCH
+
+    def handle_sub_proto_msg(self, cmd: Command, msg: _DecodedMsgType) -> None:
+        if isinstance(cmd, Announce):
+            self.head_info = cmd.as_head_info(msg)
+            self.head_td = self.head_info.total_difficulty
+            self.head_hash = self.head_info.block_hash
+
+        super().handle_sub_proto_msg(cmd, msg)
+
+    async def send_sub_proto_handshake(self) -> None:
+        self.sub_proto.send_handshake(await self._local_chain_info)
+
+    async def process_sub_proto_handshake(
+            self, cmd: Command, msg: _DecodedMsgType) -> None:
+        if not isinstance(cmd, (Status, StatusV2)):
+            await self.disconnect(DisconnectReason.subprotocol_error)
+            raise HandshakeFailure(
+                "Expected a LES Status msg, got {}, disconnecting".format(cmd))
+        msg = cast(Dict[str, Any], msg)
+        if msg['networkId'] != self.network_id:
+            await self.disconnect(DisconnectReason.useless_peer)
+            raise HandshakeFailure(
+                "{} network ({}) does not match ours ({}), disconnecting".format(
+                    self, msg['networkId'], self.network_id))
+        genesis = await self.genesis
+        if msg['genesisHash'] != genesis.hash:
+            await self.disconnect(DisconnectReason.useless_peer)
+            raise HandshakeFailure(
+                "{} genesis ({}) does not match ours ({}), disconnecting".format(
+                    self, encode_hex(msg['genesisHash']), genesis.hex_hash))
+        # TODO: Disconnect if the remote doesn't serve headers.
+        self.head_info = cmd.as_head_info(msg)
+        self.head_td = self.head_info.total_difficulty
+        self.head_hash = self.head_info.block_hash
+
+    def gen_request_id(self) -> int:
+        return _gen_request_id()
+
+    def request_block_headers(self,
+                              block_number_or_hash: BlockIdentifier,
+                              max_headers: int = None,
+                              skip: int = 0,
+                              reverse: bool = False) -> HeaderRequest:
+        if max_headers is None:
+            max_headers = self.max_headers_fetch
+        request_id = self.gen_request_id()
+        request = HeaderRequest(
+            block_number_or_hash,
+            max_headers,
+            skip,
+            reverse,
+            request_id,
+        )
+        self.sub_proto.send_get_block_headers(
+            request.block_number_or_hash,
+            request.max_headers,
+            request.skip,
+            request.reverse,
+            request_id,
+        )
+        return request
+
+    async def wait_for_block_headers(self, request: HeaderRequest) -> Tuple[BlockHeader, ...]:
+        future: 'asyncio.Future[_DecodedMsgType]' = asyncio.Future()
+        if BlockHeaders in self.pending_requests:
+            # the `finally` block below should prevent this from happening, but
+            # were two requests to the same peer to be fired off at the same
+            # time, this will prevent us from overwriting the first one.
+            raise ValueError(
+                "There is already a pending `BlockHeaders` request for peer {0}".format(self)
+            )
+        self.pending_requests[BlockHeaders] = cast(
+            Tuple[BaseHeaderRequest, 'asyncio.Future[_DecodedMsgType]'],
+            (request, future),
+        )
+        try:
+            response = cast(
+                Dict[str, Any],
+                await self.wait(future, timeout=self._response_timeout),
+            )
+        finally:
+            # We always want to be sure that this method cleans up the
+            # `pending_requests` so that we don't end up in a situation.
+            self.pending_requests.pop(BlockHeaders, None)
+        return cast(Tuple[BlockHeader, ...], response['headers'])
+
+    async def get_block_headers(self,
+                                block_number_or_hash: BlockIdentifier,
+                                max_headers: int = None,
+                                skip: int = 0,
+                                reverse: bool = True) -> Tuple[BlockHeader, ...]:
+        request = self.request_block_headers(block_number_or_hash, max_headers, skip, reverse)
+        return await self.wait_for_block_headers(request)

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -1,0 +1,177 @@
+from typing import (
+    List,
+    Tuple,
+    TYPE_CHECKING,
+)
+
+from eth_typing import (
+    BlockIdentifier,
+)
+
+from eth.rlp.headers import BlockHeader
+
+from p2p.protocol import (
+    Protocol,
+)
+
+from .commands import (
+    Status,
+    StatusV2,
+    Announce,
+    BlockHeaders,
+    GetBlockBodies,
+    GetBlockHeaders,
+    GetBlockHeadersQuery,
+    GetContractCodes,
+    GetProofs,
+    GetProofsV2,
+    GetReceipts,
+    BlockBodies,
+    Receipts,
+    Proofs,
+    ProofsV2,
+    ProofRequest,
+    ContractCodeRequest,
+    ContractCodes,
+)
+from . import constants
+
+if TYPE_CHECKING:
+    from p2p.peer import (  # noqa: F401
+        ChainInfo
+    )
+
+
+class LESProtocol(Protocol):
+    name = 'les'
+    version = 1
+    _commands = [Status, Announce, BlockHeaders, GetBlockHeaders, BlockBodies, Receipts, Proofs,
+                 ContractCodes]
+    cmd_length = 15
+
+    def send_handshake(self, chain_info: 'ChainInfo') -> None:
+        resp = {
+            'protocolVersion': self.version,
+            'networkId': self.peer.network_id,
+            'headTd': chain_info.total_difficulty,
+            'headHash': chain_info.block_hash,
+            'headNum': chain_info.block_number,
+            'genesisHash': chain_info.genesis_hash,
+            'serveHeaders': None,
+            'serveChainSince': 0,
+            'txRelay': None,
+        }
+        cmd = Status(self.cmd_id_offset)
+        self.send(*cmd.encode(resp))
+        self.logger.debug("Sending LES/Status msg: %s", resp)
+
+    def send_get_block_bodies(self, block_hashes: List[bytes], request_id: int) -> None:
+        if len(block_hashes) > constants.MAX_BODIES_FETCH:
+            raise ValueError(
+                "Cannot ask for more than {} blocks in a single request".format(
+                    constants.MAX_BODIES_FETCH))
+        data = {
+            'request_id': request_id,
+            'block_hashes': block_hashes,
+        }
+        header, body = GetBlockBodies(self.cmd_id_offset).encode(data)
+        self.send(header, body)
+
+    def send_get_block_headers(self,
+                               block_number_or_hash: BlockIdentifier,
+                               max_headers: int,
+                               skip: int,
+                               reverse: bool,
+                               request_id: int,
+                               ) -> None:
+        """Send a GetBlockHeaders msg to the remote.
+
+        This requests that the remote send us up to max_headers, starting from
+        block_number_or_hash if reverse is False or ending at block_number_or_hash if reverse is
+        True.
+        """
+        if max_headers > constants.MAX_HEADERS_FETCH:
+            raise ValueError(
+                "Cannot ask for more than {} block headers in a single request".format(
+                    constants.MAX_HEADERS_FETCH))
+        cmd = GetBlockHeaders(self.cmd_id_offset)
+        # Number of block headers to skip between each item (i.e. step in python APIs).
+        skip = 0
+        data = {
+            'request_id': request_id,
+            'query': GetBlockHeadersQuery(block_number_or_hash, max_headers, skip, reverse),
+        }
+        header, body = cmd.encode(data)
+        self.send(header, body)
+
+    def send_block_headers(
+            self, headers: Tuple[BlockHeader, ...], buffer_value: int, request_id: int) -> None:
+        data = {
+            'request_id': request_id,
+            'headers': headers,
+            'buffer_value': buffer_value,
+        }
+        header, body = BlockHeaders(self.cmd_id_offset).encode(data)
+        self.send(header, body)
+
+    def send_get_receipts(self, block_hash: bytes, request_id: int) -> None:
+        data = {
+            'request_id': request_id,
+            'block_hashes': [block_hash],
+        }
+        header, body = GetReceipts(self.cmd_id_offset).encode(data)
+        self.send(header, body)
+
+    def send_get_proof(self, block_hash: bytes, account_key: bytes, key: bytes, from_level: int,
+                       request_id: int) -> None:
+        data = {
+            'request_id': request_id,
+            'proof_requests': [ProofRequest(block_hash, account_key, key, from_level)],
+        }
+        header, body = GetProofs(self.cmd_id_offset).encode(data)
+        self.send(header, body)
+
+    def send_get_contract_code(self, block_hash: bytes, key: bytes, request_id: int) -> None:
+        data = {
+            'request_id': request_id,
+            'code_requests': [ContractCodeRequest(block_hash, key)],
+        }
+        header, body = GetContractCodes(self.cmd_id_offset).encode(data)
+        self.send(header, body)
+
+
+class LESProtocolV2(LESProtocol):
+    version = 2
+    _commands = [StatusV2, Announce, BlockHeaders, GetBlockHeaders, BlockBodies, Receipts,
+                 ProofsV2, ContractCodes]
+    cmd_length = 21
+
+    def send_handshake(self, chain_info: 'ChainInfo') -> None:
+        resp = {
+            'announceType': constants.LES_ANNOUNCE_SIMPLE,
+            'protocolVersion': self.version,
+            'networkId': self.peer.network_id,
+            'headTd': chain_info.total_difficulty,
+            'headHash': chain_info.block_hash,
+            'headNum': chain_info.block_number,
+            'genesisHash': chain_info.genesis_hash,
+            'serveHeaders': None,
+            'serveChainSince': 0,
+            'txRelay': None,
+        }
+        cmd = StatusV2(self.cmd_id_offset)
+        self.logger.debug("Sending LES/Status msg: %s", resp)
+        self.send(*cmd.encode(resp))
+
+    def send_get_proof(self,
+                       block_hash: bytes,
+                       account_key: bytes,
+                       key: bytes,
+                       from_level: int,
+                       request_id: int) -> None:
+        data = {
+            'request_id': request_id,
+            'proof_requests': [ProofRequest(block_hash, account_key, key, from_level)],
+        }
+        header, body = GetProofsV2(self.cmd_id_offset).encode(data)
+        self.send(header, body)

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -1,0 +1,53 @@
+from typing import (
+    Any,
+    cast,
+    Tuple,
+)
+
+from eth_typing import BlockIdentifier
+
+from eth.rlp.headers import BlockHeader
+
+from p2p.exceptions import ValidationError
+
+from trinity.protocol.base_request import BaseHeaderRequest
+
+from .constants import MAX_HEADERS_FETCH
+
+
+class HeaderRequest(BaseHeaderRequest):
+    request_id: int
+
+    max_size = MAX_HEADERS_FETCH
+
+    def __init__(self,
+                 block_number_or_hash: BlockIdentifier,
+                 max_headers: int,
+                 skip: int,
+                 reverse: bool,
+                 request_id: int) -> None:
+        self.block_number_or_hash = block_number_or_hash
+        self.max_headers = max_headers
+        self.skip = skip
+        self.reverse = reverse
+        self.request_id = request_id
+
+    def validate_response(self, response: Any) -> None:
+        """
+        Core `Request` API used for validation.
+        """
+        if not isinstance(response, dict):
+            raise ValidationError("Response to `HeaderRequest` must be a dict")
+
+        request_id = response['request_id']
+        if request_id != self.request_id:
+            raise ValidationError(
+                "Response `request_id` does not match.  expected: %s | got: %s".format(
+                    self.request_id,
+                    request_id,
+                )
+            )
+        elif not all(isinstance(item, BlockHeader) for item in response['headers']):
+            raise ValidationError("Response must be a tuple of `BlockHeader` objects")
+
+        return self.validate_headers(cast(Tuple[BlockHeader, ...], response['headers']))

--- a/trinity/protocol/les/utils.py
+++ b/trinity/protocol/les/utils.py
@@ -1,0 +1,7 @@
+import os
+
+from eth_utils import big_endian_to_int
+
+
+def gen_request_id() -> int:
+    return big_endian_to_int(os.urandom(8))

--- a/trinity/rlp/block_body.py
+++ b/trinity/rlp/block_body.py
@@ -1,0 +1,13 @@
+import rlp
+from rlp import sedes
+
+
+from eth.rlp.headers import BlockHeader
+from eth.rlp.transactions import BaseTransactionFields
+
+
+class BlockBody(rlp.Serializable):
+    fields = [
+        ('transactions', sedes.CountableList(BaseTransactionFields)),
+        ('uncles', sedes.CountableList(BlockHeader))
+    ]

--- a/trinity/rlp/sedes.py
+++ b/trinity/rlp/sedes.py
@@ -1,0 +1,14 @@
+from rlp import sedes
+
+
+class HashOrNumber:
+
+    def serialize(self, obj: int) -> bytes:
+        if isinstance(obj, int):
+            return sedes.big_endian_int.serialize(obj)
+        return sedes.binary.serialize(obj)
+
+    def deserialize(self, serial: bytes) -> int:
+        if len(serial) == 32:
+            return sedes.binary.deserialize(serial)
+        return sedes.big_endian_int.deserialize(serial)


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/py-evm/issues/1060

### How was it fixed?

- duplicated `p2p.rlp` and `p2p.sedes` into `trinity.rlp.block_body` and `p2p.rlp.sedes` respectively.
- setup new trinity module `trinity.protocols.eth`
- moved `p2p.peer.ETHPeer` -> `trinity.protocols.eth.peer`
- moved `p2p.eth`:
  - `trinity.protocols.eth.commands`
  - `trinity.protocols.eth.proto`
  - `trinity.protocols.eth.constants`
  - `trinity.protocols.eth.requests` (contains the `HeaderRequest`) object.
- same moves happened for `p2p.les -> trinity.protocol.les`

For `p2p` modules that still need access to these the following was done:

- for type hints, used `if TYPE_CHECKING` and used string version of value.
- for module level use, inlined imports within function bodies.

#### Cute Animal Picture

![cute-animals-my-favorite-snuggle-buddy](https://user-images.githubusercontent.com/824194/43490384-a59dd422-94dd-11e8-8dac-c2e98bfa5235.jpg)

