### PR TITLE
quiet logging of No SyncRequest found messages durign state sync

### DIFF
--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -97,8 +97,7 @@ def setup_queue_logging(log_queue: 'Queue[str]', level: int) -> None:
     # the INFO level for it until https://github.com/ethereum/py-evm/issues/806 is fixed.
     logging.getLogger('p2p.kademlia').setLevel(logging.INFO)
     logging.getLogger('p2p.discovery').setLevel(logging.INFO)
-    logging.getLogger('p2p.state.StateSync').setLevel(logging.INFO)
-    logging.getLogger('trie').setLevel(logging.ERROR)
+    logging.getLogger('p2p.state.StateSync').setLevel(logging.ERROR)
     logger.debug('Logging initialized: PID=%s', os.getpid())
 
 


### PR DESCRIPTION
### What was wrong?

One of the logging statements during state sync drowns out all of the other messages.

### How was it fixed?

Adjust the logging level for that logger to only report `ERROR` level logs.

#### Cute Animal Picture

![karapaia_52183827_1](https://user-images.githubusercontent.com/824194/43478613-8f812062-94bb-11e8-8dbd-952caaccd6d4.jpg)

