### PR TITLE
Run trinity integration tests with py3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,14 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: lint-py36
+
   py36-docs:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-docs
+
   py35-native-state-byzantium:
     <<: *common
     docker:
@@ -118,6 +120,7 @@ jobs:
       - image: circleci/python:3.5
         environment:
           TOXENV: py35-database
+
   py36-benchmark:
     <<: *common
     docker:
@@ -244,19 +247,36 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-rpc-state-quadratic
+
   py37-core:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py37-trinity:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-trinity
+  py37-trinity-integration:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-trinity-integration
 
 workflows:
   version: 2
   test:
     jobs:
-      - py37-core
       - py36-docs
+
+      - py37-core
+      - py37-trinity
+      - py37-trinity-integration
+
       - py36-native-state-byzantium
       - py36-native-state-frontier
       - py36-native-state-homestead
@@ -278,6 +298,7 @@ workflows:
       - py36-p2p
       - py36-database
       - py36-rpc-state-quadratic
+
       - py35-native-state-byzantium
       - py35-native-state-frontier
       - py35-native-state-homestead
@@ -288,5 +309,6 @@ workflows:
       - py35-core
       - py35-transactions
       - py35-database
+
       - lint-py35
       - lint-py36

--- a/tox.ini
+++ b/tox.ini
@@ -72,20 +72,17 @@ commands=
     py.test -n 1 {posargs:tests/trinity/integration/}
 
 [testenv:py36-trinity-integration]
-basepython=python3.6
 deps = {[common-trinity-integration]deps}
 passenv = {[common-trinity-integration]passenv}
 commands = {[common-trinity-integration]commands}
 
 [testenv:py37-trinity-integration]
-basepython=python3.7
 deps = {[common-trinity-integration]deps}
 passenv = {[common-trinity-integration]passenv}
 commands = {[common-trinity-integration]commands}
 
 
 [testenv:py36-benchmark]
-basepython=python3.6
 deps = .[eth-extras, benchmark]
 commands=
     benchmark: {toxinidir}/scripts/benchmark/run.py
@@ -98,7 +95,6 @@ commands=
     flake8 {toxinidir}/eth
 
 [testenv:lint-py35]
-basepython=python3.5
 deps = {[common-lint]deps}
 setenv = {[common-lint]setenv}
 commands=
@@ -108,7 +104,6 @@ commands=
     mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs -p eth
 
 [testenv:lint-py36]
-basepython=python3.6
 deps = {[common-lint]deps}
 setenv = {[common-lint]setenv}
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist=
-    py37-core
     py{35,36}-{core,database,transactions,vm,native-blockchain}
     py{36}-{benchmark,p2p,trinity}
     py{36}-rpc-blockchain
     py{36}-rpc-state-{frontier,homestead,eip150,eip158,byzantium,quadratic}
     py{35,36}-native-state-{frontier,homestead,eip150,eip158,byzantium,constantinople,metropolis}
+    py37-{core,trinity,trinity-integration}
     lint-py{35,36}
 
 [flake8]
@@ -61,9 +61,8 @@ commands=
     make validate-docs
 
 
-[testenv:py36-trinity-integration]
+[common-trinity-integration]
 deps = .[eth-extras, test]
-basepython=python3.6
 passenv =
     PYTEST_ADDOPTS
     TRAVIS_EVENT_TYPE
@@ -72,37 +71,52 @@ commands=
     # due to multiple Trinity instances competing for the same ports
     py.test -n 1 {posargs:tests/trinity/integration/}
 
+[testenv:py36-trinity-integration]
+basepython=python3.6
+deps = {[common-trinity-integration]deps}
+passenv = {[common-trinity-integration]passenv}
+commands = {[common-trinity-integration]commands}
+
+[testenv:py37-trinity-integration]
+basepython=python3.7
+deps = {[common-trinity-integration]deps}
+passenv = {[common-trinity-integration]passenv}
+commands = {[common-trinity-integration]commands}
+
 
 [testenv:py36-benchmark]
-deps = .[eth-extras, benchmark]
 basepython=python3.6
+deps = .[eth-extras, benchmark]
 commands=
     benchmark: {toxinidir}/scripts/benchmark/run.py
 
 
-[testenv:lint-py35]
+[common-lint]
 deps = .[lint]
-basepython=python3.5
 setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
 commands=
     flake8 {toxinidir}/eth
+
+[testenv:lint-py35]
+basepython=python3.5
+deps = {[common-lint]deps}
+setenv = {[common-lint]setenv}
+commands=
+    {[common-lint]commands}
     flake8 {toxinidir}/tests --exclude="trinity,p2p"
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
     mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs -p eth
 
-
 [testenv:lint-py36]
-deps = .[lint]
 basepython=python3.6
-setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
+deps = {[common-lint]deps}
+setenv = {[common-lint]setenv}
 commands=
-    flake8 {toxinidir}/eth
+    {[common-lint]commands}
+    flake8 {toxinidir}/tests
     flake8 {toxinidir}/p2p
     flake8 {toxinidir}/trinity
-    flake8 {toxinidir}/tests
     flake8 {toxinidir}/scripts
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
     mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics scripts/benchmark
     mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p p2p -p trinity
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,6 @@ basepython =
 whitelist_externals=
     make
 deps = .[doc]
-basepython=python3.6
 passenv =
     PYTEST_ADDOPTS
     TRAVIS_EVENT_TYPE


### PR DESCRIPTION
### What was wrong?

PR #1109 enabled testing with Python 3.7 for the `core` tests only. This is useful to show support by dependencies, but not much else.

### How was it fixed?

This PR enables `trinity{,-integration}` tests. As discussed in #1129, the rest aren't very useful (yet), and would prolong CI runs (by about 50%).

Closes #1129 as superceded. (This is a squashed/rebased version.)

### Note: two new `tox` configuration features used!

(Some [discussion below](https://github.com/ethereum/py-evm/pull/1135#discussion_r207134409) that urged me to add this, so the fact doesn't slip through.)

#### Factor-conditional settings

See [relevant `tox` doc section](https://tox.readthedocs.io/en/latest/config.html#factors-and-factor-conditional-settings).

**TL;DR:** a "factor" is a segment of a `testenv`'s name. E.g., `testenv:py37-trinity-integration` has 3 factors: `py37`, `trinity`, and `integration`. A factor can be used (e.g. by the "generic" `testenv`) to apply settings conditionally to other environments that have it in their name.

These were already being specified in the "generic" `testenv`, as:

https://github.com/veox/py-evm/blob/27ebdf83481540098413de90af54d98077a7e8ed/tox.ini#L46-L49

``` python
basepython =
    py35: python3.5  # factor `py35`: use `basepython=python3.5`
    py36: python3.6  # factor `py36`: use `basepython=python3.6`
    py37: python3.7  # factor `py37`: use `basepython=python3.7`
```

However, other `testenv`s still had their own `basepython` lines, effectively overriding what's set here.

This PR removes `basepython` from all `testenv`s but this one, meaning that the setting is picked up based on a factor.

#### Other-section substitutions

See [relevant `tox` doc section](https://tox.readthedocs.io/en/latest/config.html#substitution-for-values-from-other-sections).

**TL;DR:** curly-brackety syntax like `X = {[S]Y}` will substitute the value of var `Y` from section `S` to var `X`.

Otherwise, there would be some copy-paste repetition, e.g. in `py3{6,7}-trinity-integration`; so I moved the common part to a section called `common-trinity-integration` (_not_ `testenv:common-trinity-integration`, since it's not an actual `testenv` - just a helper).

This doesn't reduce the line count (actually, increases it!..), but I thought it's less error-prone than copy-paste sections.

The same could have been achieved using factor-conditional settings - for example, for the `lint`/`integration` `testenv`s touched in this PR, we could've had:

``` python
[testenv]
# ...
deps=
    integration: .[eth-extras, test]
    lint: .[lint]
setenv=
    lint: MYPYPATH={toxinidir}:{toxinidir}/stubs
passenv=
    integration: ACTUALLY NOT SURE ABOUT VALID SYNTAX WITHOUT NEWLINES
# ...
```

But that looks much less readable to me, and piles settings from various environments into the same spot...

### Cute Animal Picture

![baby black-footed ferret](https://d3el53au0d7w62.cloudfront.net/wp-content/uploads/2016/07/26/BC-US-Black-Footed-Ferrets-IMG-jpg-768x593.jpg)

([Image source](https://www.abqjournal.com/814838/black-footed-ferrets-return-to-where-they-held-out-in-wild.html))