### PR TITLE
PeerSubscribers now specify what messages they are interested in

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -2,6 +2,7 @@ import asyncio
 import collections
 import contextlib
 import datetime
+import functools
 import logging
 import operator
 import random
@@ -20,6 +21,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Set,
     TYPE_CHECKING,
     Tuple,
     Type,
@@ -381,13 +383,22 @@ class BasePeer(BaseService):
             raise UnexpectedMessage("Unexpected msg: {} ({})".format(cmd, msg))
 
     def handle_sub_proto_msg(self, cmd: protocol.Command, msg: protocol._DecodedMsgType) -> None:
+        cmd_type = type(cmd)
+
         if self._subscribers:
-            for subscriber in self._subscribers:
+            was_added = tuple(
                 subscriber.add_msg((self, cmd, msg))
+                for subscriber
+                in self._subscribers
+            )
+            if not any(was_added):
+                self.logger.warn(
+                    "Peer %s has no subscribers for msg type %s",
+                    self,
+                    cmd_type.__name__,
+                )
         else:
             self.logger.warn("Peer %s has no subscribers, discarding %s msg", self, cmd)
-
-        cmd_type = type(cmd)
 
         if cmd_type in self.pending_requests:
             request, future = self.pending_requests[cmd_type]
@@ -549,8 +560,26 @@ class PeerSubscriber(ABC):
 
     @property
     @abstractmethod
+    def subscription_msg_types(self) -> Set[Type[protocol.Command]]:
+        """
+        The `p2p.protocol.Command` types that this class subscribes to.  Any
+        command which is not in this set will not be passed to this subscriber.
+
+        The base command class `p2p.protocol.Command` can be used to enable
+        **all** command types.
+        """
+        pass
+
+    @functools.lru_cache(maxsize=64)
+    def is_subscription_command(self, cmd_type: Type[protocol.Command]) -> bool:
+        return bool(self.subscription_msg_types.intersection(
+            {cmd_type, protocol.Command}
+        ))
+
+    @property
+    @abstractmethod
     def msg_queue_maxsize(self) -> int:
-        raise NotImplementedError("Must be implemented by subclasses")
+        pass
 
     def register_peer(self, peer: BasePeer) -> None:
         """
@@ -577,16 +606,30 @@ class PeerSubscriber(ABC):
     def queue_size(self) -> int:
         return self.msg_queue.qsize()
 
-    def add_msg(self, msg: 'PEER_MSG_TYPE') -> None:
+    def add_msg(self, msg: 'PEER_MSG_TYPE') -> bool:
         peer, cmd, _ = msg
+
+        if not self.is_subscription_command(type(cmd)):
+            if hasattr(self, 'logger'):
+                self.logger.trace(  # type: ignore
+                    "Discarding %s msg from %s; not subscribed to msg type; "
+                    "subscriptions: %s",
+                    cmd, peer, self.subscription_msg_types,
+                )
+            return False
+
         try:
-            self.logger.trace(  # type: ignore
-                "Adding %s msg from %s to queue; queue_size=%d", cmd, peer, self.queue_size)
+            if hasattr(self, 'logger'):
+                self.logger.trace(  # type: ignore
+                    "Adding %s msg from %s to queue; queue_size=%d", cmd, peer, self.queue_size)
             self.msg_queue.put_nowait(msg)
+            return True
         except asyncio.queues.QueueFull:
-            self.logger.warn(  # type: ignore
-                "%s msg queue is full; discarding %s msg from %s",
-                self.__class__.__name__, cmd, peer)
+            if hasattr(self, 'logger'):
+                self.logger.warn(  # type: ignore
+                    "%s msg queue is full; discarding %s msg from %s",
+                    self.__class__.__name__, cmd, peer)
+            return False
 
     @contextlib.contextmanager
     def subscribe(self, peer_pool: 'PeerPool') -> Iterator[None]:

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -567,6 +567,10 @@ class PeerSubscriber(ABC):
 
         The base command class `p2p.protocol.Command` can be used to enable
         **all** command types.
+
+        .. note: This API only applies to sub-protocol commands.  Base protocol
+        commands are handled exclusively at the peer level and cannot be
+        consumed with this API.
         """
         pass
 
@@ -610,25 +614,22 @@ class PeerSubscriber(ABC):
         peer, cmd, _ = msg
 
         if not self.is_subscription_command(type(cmd)):
-            if hasattr(self, 'logger'):
-                self.logger.trace(  # type: ignore
-                    "Discarding %s msg from %s; not subscribed to msg type; "
-                    "subscriptions: %s",
-                    cmd, peer, self.subscription_msg_types,
-                )
+            self.logger.trace(  # type: ignore
+                "Discarding %s msg from %s; not subscribed to msg type; "
+                "subscriptions: %s",
+                cmd, peer, self.subscription_msg_types,
+            )
             return False
 
         try:
-            if hasattr(self, 'logger'):
-                self.logger.trace(  # type: ignore
-                    "Adding %s msg from %s to queue; queue_size=%d", cmd, peer, self.queue_size)
+            self.logger.trace(  # type: ignore
+                "Adding %s msg from %s to queue; queue_size=%d", cmd, peer, self.queue_size)
             self.msg_queue.put_nowait(msg)
             return True
         except asyncio.queues.QueueFull:
-            if hasattr(self, 'logger'):
-                self.logger.warn(  # type: ignore
-                    "%s msg queue is full; discarding %s msg from %s",
-                    self.__class__.__name__, cmd, peer)
+            self.logger.warn(  # type: ignore
+                "%s msg queue is full; discarding %s msg from %s",
+                self.__class__.__name__, cmd, peer)
             return False
 
     @contextlib.contextmanager

--- a/tests/p2p/test_peer_subscriber.py
+++ b/tests/p2p/test_peer_subscriber.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import pytest
 
@@ -13,12 +14,17 @@ from tests.trinity.core.peer_helpers import (
 )
 
 
+logger = logging.getLogger('testing.p2p.PeerSubscriber')
+
+
 class HeadersSubscriber(PeerSubscriber):
+    logger = logger
     msg_queue_maxsize = 10
     subscription_msg_types = {GetBlockHeaders}
 
 
 class AllSubscriber(PeerSubscriber):
+    logger = logger
     msg_queue_maxsize = 10
     subscription_msg_types = {Command}
 

--- a/tests/p2p/test_peer_subscriber.py
+++ b/tests/p2p/test_peer_subscriber.py
@@ -1,0 +1,51 @@
+import asyncio
+
+import pytest
+
+from p2p.peer import PeerSubscriber
+from p2p.protocol import Command
+
+from trinity.protocol.eth.peer import ETHPeer
+from trinity.protocol.eth.commands import GetBlockHeaders
+
+from tests.trinity.core.peer_helpers import (
+    get_directly_linked_peers,
+)
+
+
+class HeadersSubscriber(PeerSubscriber):
+    msg_queue_maxsize = 10
+    subscription_msg_types = {GetBlockHeaders}
+
+
+class AllSubscriber(PeerSubscriber):
+    msg_queue_maxsize = 10
+    subscription_msg_types = {Command}
+
+
+@pytest.mark.asyncio
+async def test_peer_subscriber_filters_messages(request, event_loop):
+    peer, remote = await get_directly_linked_peers(
+        request,
+        event_loop,
+        peer1_class=ETHPeer,
+        peer2_class=ETHPeer,
+    )
+
+    header_subscriber = HeadersSubscriber()
+    all_subscriber = AllSubscriber()
+
+    peer.add_subscriber(header_subscriber)
+    peer.add_subscriber(all_subscriber)
+
+    remote.sub_proto.send_get_node_data([b'\x00' * 32])
+    remote.sub_proto.send_get_block_headers(0, 1, 0, False)
+    remote.sub_proto.send_get_node_data([b'\x00' * 32])
+    remote.sub_proto.send_get_block_headers(1, 1, 0, False)
+    remote.sub_proto.send_get_node_data([b'\x00' * 32])
+
+    # yeild to let remote and peer transmit.
+    await asyncio.sleep(0.01)
+
+    assert header_subscriber.queue_size == 2
+    assert all_subscriber.queue_size == 5

--- a/tests/trinity/core/peer_helpers.py
+++ b/tests/trinity/core/peer_helpers.py
@@ -1,6 +1,8 @@
 import asyncio
 import os
-from typing import List
+from typing import (
+    List,
+)
 
 from eth_hash.auto import keccak
 
@@ -16,6 +18,7 @@ from p2p import ecies
 from p2p import kademlia
 from p2p.auth import decode_authentication
 from p2p.peer import BasePeer, PeerPool, PeerSubscriber
+from p2p.protocol import Command
 
 
 from trinity.protocol.les.peer import LESPeer
@@ -173,6 +176,8 @@ class MockPeerPoolWithConnectedPeers(PeerPool):
 
 class SamplePeerSubscriber(PeerSubscriber):
     logger = TraceLogger("")
+
+    subscription_msg_types = {Command}
 
     @property
     def msg_queue_maxsize(self) -> int:

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -85,6 +85,11 @@ class FastChainSyncer(BaseHeaderChainSyncer):
         commands.GetNodeData,
         commands.Transactions,
         commands.NodeData,
+        # TODO: all of the following are here to quiet warning logging output
+        # until the messages are properly handled.
+        commands.Transactions,
+        commands.NewBlock,
+        commands.NewBlockHashes,
     }
 
     async def _calculate_td(self, headers: Tuple[BlockHeader, ...]) -> int:
@@ -257,7 +262,12 @@ class FastChainSyncer(BaseHeaderChainSyncer):
                           msg: protocol._DecodedMsgType) -> None:
         peer = cast(ETHPeer, peer)
 
-        if isinstance(cmd, commands.BlockBodies):
+        # TODO: stop ignoring these once we have proper handling for these messages.
+        ignored_commands = (commands.Transactions, commands.NewBlock, commands.NewBlockHashes)
+
+        if isinstance(cmd, ignored_commands):
+            pass
+        elif isinstance(cmd, commands.BlockBodies):
             await self._handle_block_bodies(peer, list(cast(Tuple[BlockBody], msg)))
         elif isinstance(cmd, commands.Receipts):
             await self._handle_block_receipts(peer, cast(List[List[Receipt]], msg))

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -6,7 +6,9 @@ from typing import (
     Dict,
     List,
     NamedTuple,
+    Set,
     Tuple,
+    Type,
     Union,
     cast,
 )
@@ -32,9 +34,15 @@ from p2p import protocol
 from p2p.exceptions import NoEligiblePeers
 from p2p.p2p_proto import DisconnectReason
 from p2p.peer import PeerPool
+from p2p.protocol import Command
 
 from trinity.db.chain import AsyncChainDB
+from trinity.protocol.eth import commands
+from trinity.protocol.eth import (
+    constants as eth_constants,
+)
 from trinity.protocol.eth.peer import ETHPeer
+from trinity.protocol.eth.requests import HeaderRequest
 from trinity.protocol.les.peer import LESPeer
 from trinity.rlp.block_body import BlockBody
 from trinity.sync.base_chain_syncer import BaseHeaderChainSyncer
@@ -65,6 +73,19 @@ class FastChainSyncer(BaseHeaderChainSyncer):
         # bodies/receipts for a given chain segment.
         self._downloaded_receipts: asyncio.Queue[Tuple[ETHPeer, List[DownloadedBlockPart]]] = asyncio.Queue()  # noqa: E501
         self._downloaded_bodies: asyncio.Queue[Tuple[ETHPeer, List[DownloadedBlockPart]]] = asyncio.Queue()  # noqa: E501
+
+    subscription_msg_types: Set[Type[Command]] = {
+        commands.BlockBodies,
+        commands.Receipts,
+        commands.NewBlock,
+        commands.GetBlockHeaders,
+        commands.BlockHeaders,
+        commands.GetBlockBodies,
+        commands.GetReceipts,
+        commands.GetNodeData,
+        commands.Transactions,
+        commands.NodeData,
+    }
 
     async def _calculate_td(self, headers: Tuple[BlockHeader, ...]) -> int:
         """Return the score (total difficulty) of the last header in the given list.
@@ -191,7 +212,6 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             target_td: int,
             headers: List[BlockHeader],
             request_func: Callable[[ETHPeer, List[BlockHeader]], None]) -> int:
-        from trinity.protocol.eth.peer import ETHPeer  # noqa: F811
         peers = self.peer_pool.get_peers(target_td)
         if not peers:
             raise NoEligiblePeers()
@@ -235,12 +255,6 @@ class FastChainSyncer(BaseHeaderChainSyncer):
 
     async def _handle_msg(self, peer: HeaderRequestingPeer, cmd: protocol.Command,
                           msg: protocol._DecodedMsgType) -> None:
-        from trinity.protocol.eth.peer import ETHPeer  # noqa: F811
-        from trinity.protocol.eth import commands
-        from trinity.protocol.eth import (
-            constants as eth_constants,
-        )
-
         peer = cast(ETHPeer, peer)
 
         if isinstance(cmd, commands.BlockBodies):
@@ -318,8 +332,6 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             self,
             peer: ETHPeer,
             query: Dict[str, Any]) -> None:
-        from trinity.protocol.eth.requests import HeaderRequest  # noqa: F811
-
         self.logger.debug("Peer %s made header request: %s", peer, query)
         request = HeaderRequest(
             query['block_number_or_hash'],

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -98,6 +98,11 @@ class StateDownloader(BaseService, PeerSubscriber):
         commands.GetBlockBodies,
         commands.GetReceipts,
         commands.GetNodeData,
+        # TODO: all of the following are here to quiet warning logging output
+        # until the messages are properly handled.
+        commands.Transactions,
+        commands.NewBlock,
+        commands.NewBlockHashes,
     }
 
     # This is a rather arbitrary value, but when the sync is operating normally we never see
@@ -164,7 +169,12 @@ class StateDownloader(BaseService, PeerSubscriber):
 
     async def _handle_msg(
             self, peer: ETHPeer, cmd: Command, msg: _DecodedMsgType) -> None:
-        if isinstance(cmd, commands.NodeData):
+        # TODO: stop ignoring these once we have proper handling for these messages.
+        ignored_commands = (commands.Transactions, commands.NewBlock, commands.NewBlockHashes)
+
+        if isinstance(cmd, ignored_commands):
+            pass
+        elif isinstance(cmd, commands.NodeData):
             msg = cast(List[bytes], msg)
             if peer not in self.request_tracker.active_requests:
                 # This is probably a batch that we retried after a timeout and ended up receiving

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -8,6 +8,8 @@ from typing import (
     cast,
     Dict,
     List,
+    Set,
+    Type,
 )
 
 from async_lru import alru_cache
@@ -57,6 +59,7 @@ from p2p.peer import (
     PeerPool,
     PeerSubscriber,
 )
+from p2p.protocol import Command
 from p2p.service import (
     BaseService,
     service_timeout,
@@ -83,11 +86,12 @@ class LightPeerChain(PeerSubscriber, BaseService):
         self.peer_pool = peer_pool
         self._pending_replies: Dict[int, Callable[[protocol._DecodedMsgType], None]] = {}
 
-    @property
-    def msg_queue_maxsize(self) -> int:
-        # Here we only care about replies to our requests, ignoring most msgs (which are supposed
-        # to be handled by the chain syncer), so our queue should never grow too much.
-        return 500
+    # TODO: be more specific about what messages we want.
+    subscription_msg_types: Set[Type[Command]] = {Command}
+
+    # Here we only care about replies to our requests, ignoring most msgs (which are supposed
+    # to be handled by the chain syncer), so our queue should never grow too much.
+    msg_queue_maxsize = 500
 
     async def _run(self) -> None:
         with self.subscribe(self.peer_pool):

--- a/trinity/sync/sharding/service.py
+++ b/trinity/sync/sharding/service.py
@@ -7,6 +7,7 @@ from typing import (
     cast,
     Dict,
     Set,
+    Type,
 )
 
 from cytoolz import (
@@ -42,6 +43,7 @@ from eth.exceptions import (
     CollationBodyNotFound,
 )
 
+from p2p.protocol import Command
 from p2p.service import BaseService
 from p2p.peer import (
     PeerPool,
@@ -77,12 +79,12 @@ class ShardSyncer(BaseService, PeerSubscriber):
 
         self.start_time = time.time()
 
-    @property
-    def msg_queue_maxsize(self) -> int:
-        # This is a rather arbitrary value, but when the sync is operating normally we never see
-        # the msg queue grow past a few hundred items, so this should be a reasonable limit for
-        # now.
-        return 2000
+    subscription_msg_types: Set[Type[Command]] = {Collations, GetCollations, NewCollationHashes}
+
+    # This is a rather arbitrary value, but when the sync is operating normally we never see
+    # the msg queue grow past a few hundred items, so this should be a reasonable limit for
+    # now.
+    msg_queue_maxsize = 2000
 
     async def _cleanup(self) -> None:
         pass


### PR DESCRIPTION
### What was wrong?

fixes #1055

### How was it fixed?

All `PeerSubscriber` classes must now implement a `subscription_msg_types` which defines which types of messages it will add to it's queue.  Any message not the specified types is discarded.  Including the base `p2p.protocol.Command` in the list results in all messages being included in the queue.

#### Cute Animal Picture

![wenn21048138](https://user-images.githubusercontent.com/824194/43550214-15bfa5ec-95a0-11e8-84d2-984b030d0de0.jpg)
