### PR TITLE
Expand round trip to GetNodeData and NodeData commands

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ LOGGING_NAMESPACES = ('eth', 'p2p', 'trinity')
 
 
 @pytest.fixture(autouse=True, scope="session")
-def vm_logger(namespaces=LOGGING_NAMESPACES):
+def _stdout_logging(namespaces=LOGGING_NAMESPACES):
     for namespace in namespaces:
         logger = logging.getLogger(namespace)
 
@@ -43,14 +43,14 @@ def vm_logger(namespaces=LOGGING_NAMESPACES):
 
         logger.addHandler(handler)
 
-        return logger
+        logger.info('Set level for logger: %s', namespace)
 
 
 # Uncomment this to have logs from tests written to a file.  This is useful for
 # debugging when you need to dump the VM output from test runs.
 """
 @pytest.yield_fixture(autouse=True)
-def vm_file_logger(request):
+def _file_logging(request):
     import datetime
     import os
 

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pytest
@@ -51,8 +52,6 @@ from eth_typing.enums import (
     ForkName
 )
 
-from tests.conftest import vm_logger
-
 
 ROOT_PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
@@ -60,7 +59,7 @@ ROOT_PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 BASE_FIXTURE_PATH = os.path.join(ROOT_PROJECT_DIR, 'fixtures', 'GeneralStateTests')
 
 
-LOGGER = vm_logger()
+logger = logging.getLogger('eth.tests.fixtures.GeneralStateTests')
 
 
 @to_tuple
@@ -314,7 +313,7 @@ def test_state_fixtures(fixture, fixture_vm_class):
     except ValidationError as err:
         block = vm.block
         transaction_error = err
-        LOGGER.warn("Got transaction error", exc_info=True)
+        logger.warn("Got transaction error", exc_info=True)
     else:
         transaction_error = False
 

--- a/tests/p2p/test_peer_collect_sub_proto_msgs.py
+++ b/tests/p2p/test_peer_collect_sub_proto_msgs.py
@@ -5,7 +5,10 @@ import pytest
 
 from trinity.protocol.eth.peer import ETHPeer
 from trinity.protocol.eth.commands import GetBlockHeaders, GetNodeData
-from trinity.protocol.eth.requests import HeaderRequest
+from trinity.protocol.eth.requests import (
+    HeaderRequest,
+    NodeDataRequest,
+)
 
 from tests.trinity.core.peer_helpers import (
     get_directly_linked_peers,
@@ -27,11 +30,11 @@ async def test_peer_subscriber_filters_messages(request, event_loop):
 
     with peer.collect_sub_proto_messages() as collector:
         assert collector in peer._subscribers
-        remote.sub_proto.send_get_node_data([b'\x00' * 32])
+        remote.sub_proto.send_get_node_data(NodeDataRequest([b'\x00' * 32]))
         remote.sub_proto.send_get_block_headers(HeaderRequest(0, 1, 0, False))
-        remote.sub_proto.send_get_node_data([b'\x00' * 32])
+        remote.sub_proto.send_get_node_data(NodeDataRequest([b'\x00' * 32]))
         remote.sub_proto.send_get_block_headers(HeaderRequest(1, 1, 0, False))
-        remote.sub_proto.send_get_node_data([b'\x00' * 32])
+        remote.sub_proto.send_get_node_data(NodeDataRequest([b'\x00' * 32]))
         await asyncio.sleep(0.01)
 
     assert collector not in peer._subscribers

--- a/tests/p2p/test_peer_subscriber.py
+++ b/tests/p2p/test_peer_subscriber.py
@@ -8,7 +8,10 @@ from p2p.protocol import Command
 
 from trinity.protocol.eth.peer import ETHPeer
 from trinity.protocol.eth.commands import GetBlockHeaders
-from trinity.protocol.eth.requests import HeaderRequest
+from trinity.protocol.eth.requests import (
+    HeaderRequest,
+    NodeDataRequest,
+)
 
 from tests.trinity.core.peer_helpers import (
     get_directly_linked_peers,
@@ -45,11 +48,11 @@ async def test_peer_subscriber_filters_messages(request, event_loop):
     peer.add_subscriber(header_subscriber)
     peer.add_subscriber(all_subscriber)
 
-    remote.sub_proto.send_get_node_data([b'\x00' * 32])
+    remote.sub_proto.send_get_node_data(NodeDataRequest([b'\x00' * 32]))
     remote.sub_proto.send_get_block_headers(HeaderRequest(0, 1, 0, False))
-    remote.sub_proto.send_get_node_data([b'\x00' * 32])
+    remote.sub_proto.send_get_node_data(NodeDataRequest([b'\x00' * 32]))
     remote.sub_proto.send_get_block_headers(HeaderRequest(1, 1, 0, False))
-    remote.sub_proto.send_get_node_data([b'\x00' * 32])
+    remote.sub_proto.send_get_node_data(NodeDataRequest([b'\x00' * 32]))
 
     # yeild to let remote and peer transmit.
     await asyncio.sleep(0.01)

--- a/tests/trinity/core/p2p-proto/test_node_data_request_object.py
+++ b/tests/trinity/core/p2p-proto/test_node_data_request_object.py
@@ -1,0 +1,74 @@
+import os
+import random
+
+import pytest
+
+from eth_utils import keccak
+
+from p2p.exceptions import ValidationError
+
+from trinity.protocol.eth.requests import NodeDataRequest
+
+
+def mk_node():
+    node_length = random.randint(0, 2048)
+    node = os.urandom(node_length)
+    return node
+
+
+def mk_node_data(n):
+    if n == 0:
+        return tuple(), tuple()
+    nodes = tuple(set(mk_node() for _ in range(n)))
+    node_keys = tuple(keccak(node) for node in nodes)
+    return node_keys, nodes
+
+
+def test_node_data_request_empty_response_is_valid():
+    node_keys, _ = mk_node_data(10)
+    request = NodeDataRequest(node_keys)
+
+    request.validate_response(tuple())
+
+
+def test_node_data_request_with_full_response():
+    node_keys, nodes = mk_node_data(10)
+    request = NodeDataRequest(node_keys)
+    node_data = tuple(zip(node_keys, nodes))
+
+    request.validate_response(node_data)
+
+
+def test_node_data_request_with_partial_response():
+    node_keys, nodes = mk_node_data(10)
+    request = NodeDataRequest(node_keys)
+    node_data = tuple(zip(node_keys, nodes))
+
+    request.validate_response(node_data[3:])
+    request.validate_response(node_data[:3])
+    request.validate_response((node_data[1], node_data[8], node_data[4]))
+
+
+def test_node_data_request_with_fully_invalid_response():
+    node_keys, nodes = mk_node_data(10)
+    request = NodeDataRequest(node_keys)
+
+    # construct a unique set of other nodes
+    other_nodes = tuple(set(mk_node() for _ in range(10)).difference(nodes))
+    other_node_data = tuple((keccak(node), node) for node in other_nodes)
+
+    with pytest.raises(ValidationError):
+        request.validate_response(other_node_data)
+
+
+def test_node_data_request_with_extra_unrequested_nodes():
+    node_keys, nodes = mk_node_data(10)
+    request = NodeDataRequest(node_keys)
+    node_data = tuple(zip(node_keys, nodes))
+
+    # construct a unique set of other nodes
+    other_nodes = tuple(set(mk_node() for _ in range(10)).difference(nodes))
+    other_node_data = tuple((keccak(node), node) for node in other_nodes)
+
+    with pytest.raises(ValidationError):
+        request.validate_response(node_data + other_node_data)

--- a/tests/trinity/core/p2p-proto/test_peer_node_data_request_and_response_api.py
+++ b/tests/trinity/core/p2p-proto/test_peer_node_data_request_and_response_api.py
@@ -1,0 +1,133 @@
+import asyncio
+import os
+import random
+
+import pytest
+
+from eth_utils import (
+    keccak,
+)
+
+from trinity.protocol.eth.peer import ETHPeer
+
+from tests.trinity.core.peer_helpers import (
+    get_directly_linked_peers,
+)
+
+
+@pytest.fixture
+async def eth_peer_and_remote(request, event_loop):
+    peer, remote = await get_directly_linked_peers(
+        request,
+        event_loop,
+        peer1_class=ETHPeer,
+        peer2_class=ETHPeer,
+    )
+    return peer, remote
+
+
+def mk_node():
+    node_length = random.randint(0, 2048)
+    node = os.urandom(node_length)
+    return node
+
+
+def mk_node_data(n):
+    if n == 0:
+        return tuple(), tuple()
+    nodes = tuple(set(mk_node() for _ in range(n)))
+    node_keys = tuple(keccak(node) for node in nodes)
+    return node_keys, nodes
+
+
+@pytest.mark.parametrize(
+    'node_keys,nodes',
+    (
+        (
+            (keccak(b''),),
+            (b'',),
+        ),
+        mk_node_data(1),
+        mk_node_data(4),
+        mk_node_data(20),
+        mk_node_data(128),
+        mk_node_data(384),
+    )
+)
+@pytest.mark.asyncio
+async def test_eth_peer_get_node_data_round_trip(eth_peer_and_remote, node_keys, nodes):
+    peer, remote = eth_peer_and_remote
+    node_data = tuple(zip(node_keys, nodes))
+
+    async def send_node_data():
+        remote.sub_proto.send_node_data(nodes)
+
+    asyncio.ensure_future(send_node_data())
+    response = await peer.requests.get_node_data(node_keys)
+
+    assert len(response) == len(node_keys)
+    assert response == node_data
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_headers_round_trip_partial_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    node_keys, nodes = mk_node_data(32)
+    node_data = tuple(zip(node_keys, nodes))
+
+    async def send_responses():
+        remote.sub_proto.send_transactions([])
+        await asyncio.sleep(0)
+        remote.sub_proto.send_node_data(nodes[:10])
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_responses())
+    response = await peer.requests.get_node_data(node_keys)
+
+    assert len(response) == 10
+    assert response[:10] == node_data[:10]
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_headers_round_trip_with_noise(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    node_keys, nodes = mk_node_data(32)
+    node_data = tuple(zip(node_keys, nodes))
+
+    async def send_responses():
+        remote.sub_proto.send_transactions([])
+        await asyncio.sleep(0)
+        remote.sub_proto.send_node_data(nodes)
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_responses())
+    response = await peer.requests.get_node_data(node_keys)
+
+    assert len(response) == len(nodes)
+    assert response == node_data
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_headers_round_trip_does_not_match_invalid_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    node_keys, nodes = mk_node_data(32)
+    node_data = tuple(zip(node_keys, nodes))
+
+    wrong_nodes = tuple(set(mk_node() for _ in range(32)).difference(nodes))
+
+    async def send_responses():
+        remote.sub_proto.send_node_data(wrong_nodes)
+        await asyncio.sleep(0)
+        remote.sub_proto.send_transactions([])
+        await asyncio.sleep(0)
+        remote.sub_proto.send_node_data(nodes)
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_responses())
+    response = await peer.requests.get_node_data(node_keys)
+
+    assert len(response) == len(nodes)
+    assert response == node_data

--- a/tests/trinity/core/p2p-proto/test_server.py
+++ b/tests/trinity/core/p2p-proto/test_server.py
@@ -130,7 +130,7 @@ async def test_server_authenticates_incoming_connections(monkeypatch, server, ev
 async def test_peer_pool_connect(monkeypatch, event_loop, receiver_server_with_dumb_peer):
     started_peers = []
 
-    def mock_start_peer(peer):
+    async def mock_start_peer(peer):
         nonlocal started_peers
         started_peers.append(peer)
 

--- a/trinity/p2p/handlers.py
+++ b/trinity/p2p/handlers.py
@@ -77,7 +77,7 @@ class PeerRequestHandler(CancellableMixin):
                 continue
             nodes.append(node)
         self.logger.trace("Replying to %s with %d trie nodes", peer, len(nodes))
-        peer.sub_proto.send_node_data(nodes)
+        peer.sub_proto.send_node_data(tuple(nodes))
 
     async def lookup_headers(self,
                              request: BaseHeaderRequest) -> Tuple[BlockHeader, ...]:

--- a/trinity/protocol/common/requests.py
+++ b/trinity/protocol/common/requests.py
@@ -32,12 +32,6 @@ class BaseHeaderRequest(BaseRequest):
     skip: int
     reverse: bool
 
-    def validate_response(self, response: Tuple[BlockHeader, ...]) -> None:
-        """
-        Core `Request` API used for validation.
-        """
-        return self.validate_headers(response)
-
     @property
     @abstractmethod
     def max_size(self) -> int:
@@ -73,13 +67,12 @@ class BaseHeaderRequest(BaseRequest):
     def is_numbered(self) -> bool:
         return isinstance(self.block_number_or_hash, int)
 
-    def validate_headers(self,
-                         headers: Tuple[BlockHeader, ...]) -> None:
-        if not headers:
+    def validate_response(self, response: Tuple[BlockHeader, ...]) -> None:
+        if not response:
             # An empty response is always valid
             return
         elif not self.is_numbered:
-            first_header = headers[0]
+            first_header = response[0]
             if first_header.hash != self.block_number_or_hash:
                 raise ValidationError(
                     "Returned headers cannot be matched to header request. "
@@ -91,7 +84,7 @@ class BaseHeaderRequest(BaseRequest):
                 )
 
         block_numbers: Tuple[BlockNumber, ...] = tuple(
-            header.block_number for header in headers
+            header.block_number for header in response
         )
         return self.validate_sequence(block_numbers)
 

--- a/trinity/protocol/common/requests.py
+++ b/trinity/protocol/common/requests.py
@@ -32,6 +32,12 @@ class BaseHeaderRequest(BaseRequest):
     skip: int
     reverse: bool
 
+    def validate_response(self, response: Tuple[BlockHeader, ...]) -> None:
+        """
+        Core `Request` API used for validation.
+        """
+        return self.validate_headers(response)
+
     @property
     @abstractmethod
     def max_size(self) -> int:

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -2,12 +2,17 @@ from trinity.protocol.common.handlers import (
     BaseRequestResponseHandler,
 )
 
-from .managers import GetBlockHeadersRequestManager
+from .managers import (
+    GetBlockHeadersRequestManager,
+    GetNodeDataRequestManager,
+)
 
 
 class ETHRequestResponseHandler(BaseRequestResponseHandler):
     _managers = {
         'get_block_headers': GetBlockHeadersRequestManager,
+        'get_node_data': GetNodeDataRequestManager,
     }
 
     get_block_headers: GetBlockHeadersRequestManager
+    get_node_data: GetNodeDataRequestManager

--- a/trinity/protocol/eth/managers.py
+++ b/trinity/protocol/eth/managers.py
@@ -13,7 +13,7 @@ from eth_hash.auto import keccak
 
 from eth.rlp.headers import BlockHeader
 
-from p2p.exceptions import ValidationError
+from p2p.exceptions import MalformedMessage
 from p2p.protocol import (
     Command,
 )
@@ -100,9 +100,9 @@ class GetNodeDataRequestManager(BaseGetNodeDataRequestManager):
                                   msg: Tuple[bytes, ...]
                                   ) -> Tuple[Tuple[Hash32, bytes], ...]:
         if not isinstance(msg, tuple):
-            raise ValidationError("Invalid msg, must be tuple of byte strings")
+            raise MalformedMessage("Invalid msg, must be tuple of byte strings")
         elif not all(isinstance(item, bytes) for item in msg):
-            raise ValidationError("Invalid msg, must be tuple of byte strings")
+            raise MalformedMessage("Invalid msg, must be tuple of byte strings")
 
         node_keys = await self._run_in_executor(tuple, map(keccak, msg))
         return tuple(zip(node_keys, msg))

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -5,6 +5,8 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from eth_typing import Hash32
+
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransactionFields
@@ -32,6 +34,7 @@ from .commands import (
 from . import constants
 from .requests import (
     HeaderRequest,
+    NodeDataRequest,
 )
 
 if TYPE_CHECKING:
@@ -62,12 +65,12 @@ class ETHProtocol(Protocol):
         self.logger.debug("Sending ETH/Status msg: %s", resp)
         self.send(*cmd.encode(resp))
 
-    def send_get_node_data(self, node_hashes: List[bytes]) -> None:
+    def send_get_node_data(self, request: NodeDataRequest) -> None:
         cmd = GetNodeData(self.cmd_id_offset)
-        header, body = cmd.encode(node_hashes)
+        header, body = cmd.encode(request.node_hashes)
         self.send(header, body)
 
-    def send_node_data(self, nodes: List[bytes]) -> None:
+    def send_node_data(self, nodes: Tuple[bytes, ...]) -> None:
         cmd = NodeData(self.cmd_id_offset)
         header, body = cmd.encode(nodes)
         self.send(header, body)
@@ -102,7 +105,7 @@ class ETHProtocol(Protocol):
         header, body = cmd.encode(headers)
         self.send(header, body)
 
-    def send_get_block_bodies(self, block_hashes: List[bytes]) -> None:
+    def send_get_block_bodies(self, block_hashes: List[Hash32]) -> None:
         cmd = GetBlockBodies(self.cmd_id_offset)
         header, body = cmd.encode(block_hashes)
         self.send(header, body)
@@ -112,7 +115,7 @@ class ETHProtocol(Protocol):
         header, body = cmd.encode(blocks)
         self.send(header, body)
 
-    def send_get_receipts(self, block_hashes: List[bytes]) -> None:
+    def send_get_receipts(self, block_hashes: List[Hash32]) -> None:
         cmd = GetReceipts(self.cmd_id_offset)
         header, body = cmd.encode(block_hashes)
         self.send(header, body)

--- a/trinity/protocol/eth/requests.py
+++ b/trinity/protocol/eth/requests.py
@@ -40,17 +40,11 @@ class NodeDataRequest(BaseRequest):
         self.node_hashes = node_hashes
 
     def validate_response(self, response: Tuple[Tuple[Hash32, bytes], ...]) -> None:
-        """
-        Core `Request` API used for validation.
-        """
-        return self.validate_node_data(response)
-
-    def validate_node_data(self, node_data: Tuple[Tuple[Hash32, bytes], ...]) -> None:
-        if not node_data:
+        if not response:
             # an empty response is always valid
             return
 
-        node_keys = tuple(node_key for node_key, node in node_data)
+        node_keys = tuple(node_key for node_key, node in response)
         node_key_set = set(node_keys)
 
         if len(node_keys) != len(node_key_set):

--- a/trinity/protocol/eth/requests.py
+++ b/trinity/protocol/eth/requests.py
@@ -1,16 +1,18 @@
 from typing import (
-    Any,
-    cast,
     Tuple,
 )
 
-from eth_typing import BlockIdentifier
-
-from eth.rlp.headers import BlockHeader
+from eth_typing import (
+    BlockIdentifier,
+    Hash32,
+)
 
 from p2p.exceptions import ValidationError
 
-from trinity.protocol.common.requests import BaseHeaderRequest
+from trinity.protocol.common.requests import (
+    BaseRequest,
+    BaseHeaderRequest,
+)
 
 from . import constants
 
@@ -30,13 +32,33 @@ class HeaderRequest(BaseHeaderRequest):
         self.skip = skip
         self.reverse = reverse
 
-    def validate_response(self, response: Any) -> None:
+
+class NodeDataRequest(BaseRequest):
+    node_keys_cache: Tuple[Hash32, ...]
+
+    def __init__(self, node_hashes: Tuple[Hash32, ...]) -> None:
+        self.node_hashes = node_hashes
+
+    def validate_response(self, response: Tuple[Tuple[Hash32, bytes], ...]) -> None:
         """
         Core `Request` API used for validation.
         """
-        if not isinstance(response, tuple):
-            raise ValidationError("Response to `HeaderRequest` must be a tuple")
-        elif not all(isinstance(item, BlockHeader) for item in response):
-            raise ValidationError("Response must be a tuple of `BlockHeader` objects")
+        return self.validate_node_data(response)
 
-        return self.validate_headers(cast(Tuple[BlockHeader, ...], response))
+    def validate_node_data(self, node_data: Tuple[Tuple[Hash32, bytes], ...]) -> None:
+        if not node_data:
+            # an empty response is always valid
+            return
+
+        node_keys = tuple(node_key for node_key, node in node_data)
+        node_key_set = set(node_keys)
+
+        if len(node_keys) != len(node_key_set):
+            raise ValidationError("Response may not contain duplicate nodes")
+
+        unexpected_keys = node_key_set.difference(self.node_hashes)
+
+        if unexpected_keys:
+            raise ValidationError(
+                "Response contains {0} unexpected nodes".format(len(unexpected_keys))
+            )

--- a/trinity/protocol/les/managers.py
+++ b/trinity/protocol/les/managers.py
@@ -11,7 +11,7 @@ from eth_typing import BlockIdentifier
 from eth.rlp.headers import BlockHeader
 
 from p2p.exceptions import (
-    ValidationError,
+    MalformedMessage,
 )
 from p2p.protocol import (
     Command,
@@ -72,11 +72,11 @@ class GetBlockHeadersRequestManager(BaseRequestManager):
                                   msg: Dict[str, Any]
                                   ) -> Tuple[BlockHeader, ...]:
         if not isinstance(msg, dict):
-            raise ValidationError("msg must be a dictionary")
+            raise MalformedMessage("msg must be a dictionary")
         elif 'headers' not in msg:
-            raise ValidationError("No 'headers' key found in response")
+            raise MalformedMessage("No 'headers' key found in response")
         elif not all(isinstance(item, BlockHeader) for item in msg['headers']):
-            raise ValidationError(
+            raise MalformedMessage(
                 "`headers` key must be a tuple of `BlockHeader` instances"
             )
 

--- a/trinity/protocol/les/managers.py
+++ b/trinity/protocol/les/managers.py
@@ -10,6 +10,9 @@ from eth_typing import BlockIdentifier
 
 from eth.rlp.headers import BlockHeader
 
+from p2p.exceptions import (
+    ValidationError,
+)
 from p2p.protocol import (
     Command,
 )
@@ -65,5 +68,16 @@ class GetBlockHeadersRequestManager(BaseRequestManager):
     def _send_sub_proto_request(self, request: HeaderRequest) -> None:
         self._peer.sub_proto.send_get_block_headers(request)
 
-    def _normalize_response(self, response: Dict[str, Any]) -> Tuple[BlockHeader, ...]:
-        return response['headers']
+    async def _normalize_response(self,
+                                  msg: Dict[str, Any]
+                                  ) -> Tuple[BlockHeader, ...]:
+        if not isinstance(msg, dict):
+            raise ValidationError("msg must be a dictionary")
+        elif 'headers' not in msg:
+            raise ValidationError("No 'headers' key found in response")
+        elif not all(isinstance(item, BlockHeader) for item in msg['headers']):
+            raise ValidationError(
+                "`headers` key must be a tuple of `BlockHeader` instances"
+            )
+
+        return msg['headers']

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -1,6 +1,4 @@
 from typing import (
-    Any,
-    cast,
     Tuple,
 )
 
@@ -8,11 +6,14 @@ from eth_typing import BlockIdentifier
 
 from eth.rlp.headers import BlockHeader
 
-from p2p.exceptions import ValidationError
-
-from trinity.protocol.common.requests import BaseHeaderRequest
+from trinity.protocol.common.requests import (
+    BaseHeaderRequest,
+)
 
 from .constants import MAX_HEADERS_FETCH
+
+
+BlockHeaders_R = Tuple[BlockHeader, ...]
 
 
 class HeaderRequest(BaseHeaderRequest):
@@ -31,23 +32,3 @@ class HeaderRequest(BaseHeaderRequest):
         self.skip = skip
         self.reverse = reverse
         self.request_id = request_id
-
-    def validate_response(self, response: Any) -> None:
-        """
-        Core `Request` API used for validation.
-        """
-        if not isinstance(response, dict):
-            raise ValidationError("Response to `HeaderRequest` must be a dict")
-
-        request_id = response['request_id']
-        if request_id != self.request_id:
-            raise ValidationError(
-                "Response `request_id` does not match.  expected: %s | got: %s".format(
-                    self.request_id,
-                    request_id,
-                )
-            )
-        elif not all(isinstance(item, BlockHeader) for item in response['headers']):
-            raise ValidationError("Response must be a tuple of `BlockHeader` objects")
-
-        return self.validate_headers(cast(Tuple[BlockHeader, ...], response['headers']))

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -1,19 +1,11 @@
-from typing import (
-    Tuple,
-)
-
 from eth_typing import BlockIdentifier
 
-from eth.rlp.headers import BlockHeader
 
 from trinity.protocol.common.requests import (
     BaseHeaderRequest,
 )
 
 from .constants import MAX_HEADERS_FETCH
-
-
-BlockHeaders_R = Tuple[BlockHeader, ...]
 
 
 class HeaderRequest(BaseHeaderRequest):

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -23,8 +23,6 @@ from eth_utils import (
     encode_hex,
 )
 
-from eth_hash.auto import keccak
-
 from eth_typing import (
     Hash32
 )
@@ -91,7 +89,6 @@ class StateDownloader(BaseService, PeerSubscriber):
     # messages related to new blocks/transactions, but we must handle requests for data from
     # other peers or else they will disconnect from us.
     subscription_msg_types: Set[Type[Command]] = {
-        commands.NodeData,
         commands.GetBlockHeaders,
         commands.GetBlockBodies,
         commands.GetReceipts,
@@ -167,27 +164,6 @@ class StateDownloader(BaseService, PeerSubscriber):
 
         if isinstance(cmd, ignored_commands):
             pass
-        elif isinstance(cmd, commands.NodeData):
-            msg = cast(List[bytes], msg)
-            if peer not in self.request_tracker.active_requests:
-                # This is probably a batch that we retried after a timeout and ended up receiving
-                # more than once, so ignore but log as an INFO just in case.
-                self.logger.info(
-                    "Got %d NodeData entries from %s that were not expected, ignoring them",
-                    len(msg), peer)
-                return
-
-            self.logger.debug("Got %d NodeData entries from %s", len(msg), peer)
-            _, requested_node_keys = self.request_tracker.active_requests.pop(peer)
-
-            node_keys = await self._run_in_executor(list, map(keccak, msg))
-
-            missing = set(requested_node_keys).difference(node_keys)
-            self._peer_missing_nodes[peer].update(missing)
-            if missing:
-                await self.request_nodes(missing)
-
-            await self._process_nodes(zip(node_keys, msg))
         elif isinstance(cmd, commands.GetBlockHeaders):
             query = cast(Dict[Any, Union[bool, int]], msg)
             request = HeaderRequest(
@@ -245,11 +221,42 @@ class StateDownloader(BaseService, PeerSubscriber):
                 return
 
             candidates = list(not_yet_requested.difference(self._peer_missing_nodes[peer]))
-            batch = candidates[:eth_constants.MAX_STATE_FETCH]
+            batch = tuple(candidates[:eth_constants.MAX_STATE_FETCH])
             not_yet_requested = not_yet_requested.difference(batch)
             self.request_tracker.active_requests[peer] = (time.time(), batch)
-            self.logger.debug("Requesting %d trie nodes to %s", len(batch), peer)
-            peer.sub_proto.send_get_node_data(batch)
+            asyncio.ensure_future(self._request_and_process_nodes(peer, batch))
+
+    async def _request_and_process_nodes(self, peer: ETHPeer, batch: Tuple[Hash32, ...]) -> None:
+        self.logger.debug("Requesting %d trie nodes from %s", len(batch), peer)
+        node_data = await peer.requests.get_node_data(batch)
+        self.request_tracker.active_requests.pop(peer)
+
+        self.logger.debug("Got %d NodeData entries from %s", len(node_data), peer)
+
+        if node_data:
+            node_keys, _ = zip(*node_data)
+        else:
+            node_keys = tuple()
+
+        # check for missing nodes and re-schedule them
+        missing = set(batch).difference(node_keys)
+
+        # TODO: this doesn't actually mean the peer doesn't have them, just
+        # that they didn't respond with them this time.  We should explore
+        # alternate ways to do this since a false negative here will result in
+        # not requesting this node from this peer again.
+        if missing:
+            self._peer_missing_nodes[peer].update(missing)
+            self.logger.debug(
+                "Re-requesting %d/%d NodeData entries not returned by %s",
+                len(missing),
+                len(batch),
+                peer,
+            )
+            await self.request_nodes(missing)
+
+        if node_data:
+            await self._process_nodes(node_data)
 
     async def _periodically_retry_timedout_and_missing(self) -> None:
         while self.is_running:
@@ -331,7 +338,7 @@ class TrieNodeRequestTracker:
     def __init__(self, reply_timeout: int, logger: TraceLogger) -> None:
         self.reply_timeout = reply_timeout
         self.logger = logger
-        self.active_requests: Dict[ETHPeer, Tuple[float, List[Hash32]]] = {}
+        self.active_requests: Dict[ETHPeer, Tuple[float, Tuple[Hash32, ...]]] = {}
         self.missing: Dict[float, List[Hash32]] = {}
 
     def get_timed_out(self) -> List[Hash32]:


### PR DESCRIPTION
### What was wrong?

The `GetnodeData` and `NodeData` commands can be done as a singe awaitable round trip call using the new round trip peer request API

### How was it fixed?

Setup a new request manager for `NodeData` requests/response and integrated it into the `StateSyncer`

#### Cute Animal Picture

![wenn21648221_hejbmq](https://user-images.githubusercontent.com/824194/43736536-31561c58-997b-11e8-9193-f3cb01903599.jpg)
