### PR TITLE
Handle decryption error

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -332,9 +332,16 @@ class BasePeer(BaseService):
         while True:
             try:
                 cmd, msg = await self.read_msg()
-            except (PeerConnectionLost, TimeoutError) as e:
+            except (PeerConnectionLost, TimeoutError) as err:
                 self.logger.debug(
-                    "%s stopped responding (%s), disconnecting", self.remote, repr(e))
+                    "%s stopped responding (%r), disconnecting", self.remote, err)
+                return
+            except DecryptionError as err:
+                self.logger.warn(
+                    "Unable to decrypt message from %s, disconnecting: %r",
+                    self, err,
+                    exc_info=True,
+                )
                 return
 
             try:


### PR DESCRIPTION
### What was wrong?

`Peer.read_msg` can throw a decryption error.

```
Traceback (most recent call last):
  File "/home/piper/projects/py-evm/p2p/service.py", line 76, in run
    await self._run()
  File "/home/piper/projects/py-evm/p2p/peer.py", line 334, in _run
    cmd, msg = await self.read_msg()
  File "/home/piper/projects/py-evm/p2p/peer.py", line 348, in read_msg
    header = self.decrypt_header(header_data)
  File "/home/piper/projects/py-evm/p2p/peer.py", line 460, in decrypt_header
    expected_header_mac, header_mac))
```

### How was it fixed?

Handle it in the main `_run` loop.

#### Cute Animal Picture

