### PR TITLE
WIP changes chain.import_block to return new blocks and blocks evicte…

### DIFF
--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -96,7 +96,7 @@ class BaseChainDB(BaseHeaderDB):
     @abstractmethod
     def persist_block(self,
                       block: 'BaseBlock'
-                      ) -> Tuple[Tuple[BlockHeader, ...], Tuple[BlockHeader, ...]]:
+                      ) -> Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]:
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
@@ -218,15 +218,21 @@ class ChainDB(HeaderDB, BaseChainDB):
         try:
             head_score = self.get_score(self.get_canonical_head().hash)
         except CanonicalHeadNotFound:
-            new_headers, old_headers = self._set_as_canonical_chain_head(header)
+            (
+                new_canonical_headers,
+                orphaned_canonical_headers
+            ) = self._set_as_canonical_chain_head(header)
         else:
             if score > head_score:
-                new_headers, old_headers = self._set_as_canonical_chain_head(header)
+                (
+                    new_canonical_headers,
+                    orphaned_canonical_headers
+                ) = self._set_as_canonical_chain_head(header)
             else:
-                new_headers = tuple()
-                old_headers = tuple()
+                new_canonical_headers = tuple()
+                orphaned_canonical_headers = tuple()
 
-        return new_headers, old_headers
+        return new_canonical_headers, orphaned_canonical_headers
 
     # TODO: update this to take a `hash` rather than a full header object.
     def _set_as_canonical_chain_head(self,
@@ -242,7 +248,7 @@ class ChainDB(HeaderDB, BaseChainDB):
                 header.hash))
 
         new_canonical_headers = tuple(reversed(self._find_new_ancestors(header)))
-        old_headers = []
+        orphaned_canonical_headers = []
         # remove transaction lookups for blocks that are no longer canonical
         for h in new_canonical_headers:
             try:
@@ -251,32 +257,30 @@ class ChainDB(HeaderDB, BaseChainDB):
                 # no old block, and no more possible
                 break
             else:
-                old_header = self.get_block_header_by_hash(old_hash)
-                old_headers.append(old_header)
-                for transaction_hash in self.get_block_transaction_hashes(old_header):
+                orphaned_header = self.get_block_header_by_hash(old_hash)
+                orphaned_canonical_headers.append(orphaned_header)
+                for transaction_hash in self.get_block_transaction_hashes(orphaned_header):
                     self._remove_transaction_from_canonical_chain(transaction_hash)
-                    # TODO re-add txn to internal pending pool (only if local sender)
-                    pass
 
         for h in new_canonical_headers:
             self._add_block_number_to_hash_lookup(h)
 
         self.db.set(SchemaV1.make_canonical_head_hash_lookup_key(), header.hash)
 
-        return new_canonical_headers, tuple(old_headers)
+        return new_canonical_headers, tuple(orphaned_canonical_headers)
 
     #
     # Block API
     #
     def persist_block(self,
                       block: 'BaseBlock'
-                      ) -> Tuple[Tuple[BlockHeader, ...], Tuple[BlockHeader, ...]]:
+                      ) -> Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]:
         '''
         Persist the given block's header and uncles.
 
         Assumes all block transactions have been persisted already.
         '''
-        new_canonical_headers, old_headers = self.persist_header(block.header)
+        new_canonical_headers, orphaned_canonical_headers = self.persist_header(block.header)
 
         for header in new_canonical_headers:
             if header.hash == block.hash:
@@ -298,8 +302,11 @@ class ChainDB(HeaderDB, BaseChainDB):
             raise ValidationError(
                 "Block's uncles_hash (%s) does not match actual uncles' hash (%s)",
                 block.header.uncles_hash, uncles_hash)
+        new_canonical_header_hashes = tuple(header.hash for header in new_canonical_headers)
+        orphaned_canonical_header_hashes = tuple(
+            header.hash for header in orphaned_canonical_headers)
 
-        return new_canonical_headers, old_headers
+        return new_canonical_header_hashes, orphaned_canonical_header_hashes
 
     def persist_uncles(self, uncles: Tuple[BlockHeader]) -> Hash32:
         """

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -94,7 +94,9 @@ class BaseChainDB(BaseHeaderDB):
     # Block API
     #
     @abstractmethod
-    def persist_block(self, block: 'BaseBlock') -> None:
+    def persist_block(self,
+                      block: 'BaseBlock'
+                      ) -> Tuple[Tuple[BlockHeader, ...], Tuple[BlockHeader, ...]]:
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
@@ -186,7 +188,9 @@ class ChainDB(HeaderDB, BaseChainDB):
 
     # TODO: This method should take a chain of headers as that's the most common use case
     # and it'd be much faster than inserting each header individually.
-    def persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+    def persist_header(self,
+                       header: BlockHeader
+                       ) -> Tuple[Tuple[BlockHeader, ...], Tuple[BlockHeader, ...]]:
         """
         Returns iterable of headers newly on the canonical chain
         """
@@ -214,17 +218,20 @@ class ChainDB(HeaderDB, BaseChainDB):
         try:
             head_score = self.get_score(self.get_canonical_head().hash)
         except CanonicalHeadNotFound:
-            new_headers = self._set_as_canonical_chain_head(header)
+            new_headers, old_headers = self._set_as_canonical_chain_head(header)
         else:
             if score > head_score:
-                new_headers = self._set_as_canonical_chain_head(header)
+                new_headers, old_headers = self._set_as_canonical_chain_head(header)
             else:
                 new_headers = tuple()
+                old_headers = tuple()
 
-        return new_headers
+        return new_headers, old_headers
 
     # TODO: update this to take a `hash` rather than a full header object.
-    def _set_as_canonical_chain_head(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+    def _set_as_canonical_chain_head(self,
+                                     header: BlockHeader
+                                     ) -> Tuple[Tuple[BlockHeader, ...], Tuple[BlockHeader, ...]]:
         """
         Returns iterable of headers newly on the canonical head
         """
@@ -235,7 +242,7 @@ class ChainDB(HeaderDB, BaseChainDB):
                 header.hash))
 
         new_canonical_headers = tuple(reversed(self._find_new_ancestors(header)))
-
+        old_headers = []
         # remove transaction lookups for blocks that are no longer canonical
         for h in new_canonical_headers:
             try:
@@ -245,6 +252,7 @@ class ChainDB(HeaderDB, BaseChainDB):
                 break
             else:
                 old_header = self.get_block_header_by_hash(old_hash)
+                old_headers.append(old_header)
                 for transaction_hash in self.get_block_transaction_hashes(old_header):
                     self._remove_transaction_from_canonical_chain(transaction_hash)
                     # TODO re-add txn to internal pending pool (only if local sender)
@@ -255,18 +263,20 @@ class ChainDB(HeaderDB, BaseChainDB):
 
         self.db.set(SchemaV1.make_canonical_head_hash_lookup_key(), header.hash)
 
-        return new_canonical_headers
+        return new_canonical_headers, tuple(old_headers)
 
     #
     # Block API
     #
-    def persist_block(self, block: 'BaseBlock') -> None:
+    def persist_block(self,
+                      block: 'BaseBlock'
+                      ) -> Tuple[Tuple[BlockHeader, ...], Tuple[BlockHeader, ...]]:
         '''
         Persist the given block's header and uncles.
 
         Assumes all block transactions have been persisted already.
         '''
-        new_canonical_headers = self.persist_header(block.header)
+        new_canonical_headers, old_headers = self.persist_header(block.header)
 
         for header in new_canonical_headers:
             if header.hash == block.hash:
@@ -288,6 +298,8 @@ class ChainDB(HeaderDB, BaseChainDB):
             raise ValidationError(
                 "Block's uncles_hash (%s) does not match actual uncles' hash (%s)",
                 block.header.uncles_hash, uncles_hash)
+
+        return new_canonical_headers, old_headers
 
     def persist_uncles(self, uncles: Tuple[BlockHeader]) -> Hash32:
         """

--- a/eth/db/header.py
+++ b/eth/db/header.py
@@ -68,7 +68,9 @@ class BaseHeaderDB(ABC):
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
-    def persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+    def persist_header(self,
+                       header: BlockHeader
+                       ) -> Tuple[Tuple[BlockHeader, ...], Tuple[BlockHeader, ...]]:
         raise NotImplementedError("ChainDB classes must implement this method")
 
 
@@ -144,7 +146,9 @@ class HeaderDB(BaseHeaderDB):
         validate_word(block_hash, title="Block Hash")
         return block_hash in self.db
 
-    def persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
+    def persist_header(self,
+                       header: BlockHeader
+                       ) -> Tuple[Tuple[BlockHeader, ...], Tuple[BlockHeader, ...]]:
         """
         :returns: iterable of headers newly on the canonical chain
         """
@@ -174,16 +178,18 @@ class HeaderDB(BaseHeaderDB):
         try:
             head_score = self.get_score(self.get_canonical_head().hash)
         except CanonicalHeadNotFound:
-            new_canonical_headers = self._set_as_canonical_chain_head(header.hash)
+            new_canonical_headers, old_headers = self._set_as_canonical_chain_head(header.hash)
         else:
             if score > head_score:
-                new_canonical_headers = self._set_as_canonical_chain_head(header.hash)
+                new_canonical_headers, old_headers = self._set_as_canonical_chain_head(header.hash)
             else:
                 new_canonical_headers = tuple()
+                old_headers = tuple()
 
-        return new_canonical_headers
+        return new_canonical_headers, old_headers
 
-    def _set_as_canonical_chain_head(self, block_hash: Hash32) -> Tuple[BlockHeader, ...]:
+    def _set_as_canonical_chain_head(self, block_hash: Hash32
+                                     ) -> Tuple[Tuple[BlockHeader, ...], Tuple[BlockHeader, ...]]:
         """
         Sets the canonical chain HEAD to the block header as specified by the
         given block hash.
@@ -198,13 +204,24 @@ class HeaderDB(BaseHeaderDB):
             )
 
         new_canonical_headers = tuple(reversed(self._find_new_ancestors(header)))
+        old_headers = []
+
+        for h in new_canonical_headers:
+            try:
+                old_hash = self.get_canonical_block_hash(h.block_number)
+            except HeaderNotFound:
+                # no old block, and no more possible
+                break
+            else:
+                old_header = self.get_block_header_by_hash(old_hash)
+                old_headers.append(old_header)
 
         for h in new_canonical_headers:
             self._add_block_number_to_hash_lookup(h)
 
         self.db.set(SchemaV1.make_canonical_head_hash_lookup_key(), header.hash)
 
-        return new_canonical_headers
+        return new_canonical_headers, tuple(old_headers)
 
     @to_tuple
     def _find_new_ancestors(self, header: BlockHeader) -> Iterable[BlockHeader]:

--- a/eth/db/header.py
+++ b/eth/db/header.py
@@ -204,24 +204,24 @@ class HeaderDB(BaseHeaderDB):
             )
 
         new_canonical_headers = tuple(reversed(self._find_new_ancestors(header)))
-        old_headers = []
+        orphaned_headers = []
 
         for h in new_canonical_headers:
             try:
-                old_hash = self.get_canonical_block_hash(h.block_number)
+                orphaned_hash = self.get_canonical_block_hash(h.block_number)
             except HeaderNotFound:
-                # no old block, and no more possible
+                # no orphaned block, and no more possible
                 break
             else:
-                old_header = self.get_block_header_by_hash(old_hash)
-                old_headers.append(old_header)
+                orphaned_header = self.get_block_header_by_hash(orphaned_hash)
+                orphaned_headers.append(orphaned_header)
 
         for h in new_canonical_headers:
             self._add_block_number_to_hash_lookup(h)
 
         self.db.set(SchemaV1.make_canonical_head_hash_lookup_key(), header.hash)
 
-        return new_canonical_headers, tuple(old_headers)
+        return new_canonical_headers, tuple(orphaned_headers)
 
     @to_tuple
     def _find_new_ancestors(self, header: BlockHeader) -> Iterable[BlockHeader]:

--- a/eth/tools/fixture_tests.py
+++ b/eth/tools/fixture_tests.py
@@ -641,7 +641,8 @@ def apply_fixture_block_to_chain(block_fixture, chain):
 
     block = rlp.decode(block_fixture['rlp'], sedes=block_class)
 
-    mined_block = chain.import_block(block)
+    imported_blocks, _, import_success = chain.import_block(block)
+    mined_block = imported_blocks[-1]
 
     rlp_encoded_mined_block = rlp.encode(mined_block, sedes=block_class)
 

--- a/eth/tools/fixture_tests.py
+++ b/eth/tools/fixture_tests.py
@@ -641,7 +641,7 @@ def apply_fixture_block_to_chain(block_fixture, chain):
 
     block = rlp.decode(block_fixture['rlp'], sedes=block_class)
 
-    imported_blocks, _, import_success = chain.import_block(block)
+    imported_blocks, _ = chain.import_block(block)
     mined_block = imported_blocks[-1]
 
     rlp_encoded_mined_block = rlp.encode(mined_block, sedes=block_class)

--- a/scripts/benchmark/checks/import_empty_blocks.py
+++ b/scripts/benchmark/checks/import_empty_blocks.py
@@ -47,7 +47,7 @@ class ImportEmptyBlocksBenchmark(BaseBenchmark):
 
         total_gas_used = 0
         for _ in range(1, number_blocks + 1):
-            imported_blocks, _, import_success = chain.import_block(chain.get_vm().block, False)
+            imported_blocks, _ = chain.import_block(chain.get_vm().block, False)
             block = imported_blocks[-1]
 
             total_gas_used = total_gas_used + block.header.gas_used

--- a/scripts/benchmark/checks/import_empty_blocks.py
+++ b/scripts/benchmark/checks/import_empty_blocks.py
@@ -47,7 +47,9 @@ class ImportEmptyBlocksBenchmark(BaseBenchmark):
 
         total_gas_used = 0
         for _ in range(1, number_blocks + 1):
-            block = chain.import_block(chain.get_vm().block, False)
+            imported_blocks, _, import_success = chain.import_block(chain.get_vm().block, False)
+            block = imported_blocks[-1]
+
             total_gas_used = total_gas_used + block.header.gas_used
             logging.debug(format_block(block))
 

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -41,7 +41,7 @@ def tx(chain, funded_address, funded_address_private_key):
 @pytest.mark.xfail(reason="modification to initial allocation made the block fixture invalid")
 def test_import_block_validation(valid_chain, funded_address, funded_address_initial_balance):
     block = rlp.decode(valid_block_rlp, sedes=FrontierBlock)
-    imported_blocks, _, import_success = valid_chain.import_block(block)
+    imported_blocks, _ = valid_chain.import_block(block)
     imported_block = imported_blocks[-1]
 
     assert len(imported_block.transactions) == 1
@@ -66,7 +66,7 @@ def test_import_block(chain, tx):
         new_block, receipts, computations = chain.build_block_with_transactions([tx])
         assert computations[0].is_success
 
-    imported_blocks, _, import_success = chain.import_block(new_block)
+    imported_blocks, _ = chain.import_block(new_block)
     block = imported_blocks[-1]
 
     assert block.transactions == (tx,)

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -41,7 +41,9 @@ def tx(chain, funded_address, funded_address_private_key):
 @pytest.mark.xfail(reason="modification to initial allocation made the block fixture invalid")
 def test_import_block_validation(valid_chain, funded_address, funded_address_initial_balance):
     block = rlp.decode(valid_block_rlp, sedes=FrontierBlock)
-    imported_block = valid_chain.import_block(block)
+    imported_blocks, _, import_success = valid_chain.import_block(block)
+    imported_block = imported_blocks[-1]
+
     assert len(imported_block.transactions) == 1
     tx = imported_block.transactions[0]
     assert tx.value == 10
@@ -64,7 +66,9 @@ def test_import_block(chain, tx):
         new_block, receipts, computations = chain.build_block_with_transactions([tx])
         assert computations[0].is_success
 
-    block = chain.import_block(new_block)
+    imported_blocks, _, import_success = chain.import_block(new_block)
+    block = imported_blocks[-1]
+
     assert block.transactions == (tx,)
     assert chain.get_block_by_hash(block.hash) == block
     assert chain.get_canonical_block_by_number(block.number) == block

--- a/tests/core/chain-object/test_header_chain.py
+++ b/tests/core/chain-object/test_header_chain.py
@@ -106,17 +106,17 @@ def test_header_chain_import_block(header_chain, genesis_header):
     chain_c = mk_header_chain(genesis_header, 5)
 
     for header in chain_a:
-        res = header_chain.import_header(header)
+        res, _ = header_chain.import_header(header)
         assert res == (header,)
         assert_headers_eq(header_chain.header, header)
 
     for header in chain_b:
-        res = header_chain.import_header(header)
+        res, _ = header_chain.import_header(header)
         assert res == tuple()
         assert_headers_eq(header_chain.header, chain_a[-1])
 
     for idx, header in enumerate(chain_c, 1):
-        res = header_chain.import_header(header)
+        res, _ = header_chain.import_header(header)
         if idx <= 3:
             # prior to passing up `chain_a` each import should not return new
             # canonical headers.

--- a/tests/core/chain-object/test_import_block.py
+++ b/tests/core/chain-object/test_import_block.py
@@ -1,0 +1,105 @@
+from eth_keys import keys
+from eth_utils import decode_hex
+
+from eth import constants
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.db.backends.memory import MemoryDB
+from eth.vm.forks.frontier import _PoWMiningVM
+
+
+class PowMiningChain(MiningChain):
+    vm_configuration = ((0, _PoWMiningVM),)
+    network_id = 999
+
+
+def test_import_block():
+    sender = keys.PrivateKey(
+        decode_hex("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee"))
+    receiver = keys.PrivateKey(
+        decode_hex("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"))
+    genesis_params = {
+        'parent_hash': constants.GENESIS_PARENT_HASH,
+        'uncles_hash': constants.EMPTY_UNCLE_HASH,
+        'coinbase': constants.ZERO_ADDRESS,
+        'transaction_root': constants.BLANK_ROOT_HASH,
+        'receipt_root': constants.BLANK_ROOT_HASH,
+        'bloom': 0,
+        'difficulty': 5,
+        'block_number': constants.GENESIS_BLOCK_NUMBER,
+        'gas_limit': constants.GENESIS_GAS_LIMIT,
+        'gas_used': 0,
+        'timestamp': 1514764800,
+        'extra_data': constants.GENESIS_EXTRA_DATA,
+        'nonce': constants.GENESIS_NONCE
+    }
+    state = {
+        sender.public_key.to_canonical_address(): {
+            "balance": 100000000000000000,
+            "code": b"",
+            "nonce": 0,
+            "storage": {}
+        }
+    }
+    chain_a = PowMiningChain.from_genesis(MemoryDB(), genesis_params, state)
+    chain_b = PowMiningChain.from_genesis(MemoryDB(), genesis_params, state)
+    for i in range(3):
+        block_a = chain_a.mine_block()
+        block_b = chain_b.mine_block()
+
+        assert block_a.number == i + 1
+        assert block_b.number == i + 1
+        assert chain_a.header.block_number == i + 2
+        assert chain_b.header.block_number == i + 2
+        assert block_a == block_b
+
+    for i in range(3):
+        block_a = chain_a.mine_block()
+
+        assert block_a.number == i + 4
+        assert chain_a.header.block_number == i + 5
+
+    for i in range(3):
+        tx = chain_b.create_unsigned_transaction(
+            nonce=i,
+            gas_price=1234,
+            gas=1234000,
+            to=receiver.public_key.to_canonical_address(),
+            value=i,
+            data=b'',
+        )
+        chain_b.apply_transaction(tx.as_signed_transaction(sender))
+        block_b = chain_b.mine_block()
+
+        assert block_b.number == i + 4
+        assert chain_b.header.block_number == i + 5
+        assert chain_a.get_canonical_block_by_number(i + 4) != block_b
+
+    for i in range(3):
+        tx = chain_b.create_unsigned_transaction(
+            nonce=i + 3,
+            gas_price=1234,
+            gas=1234000,
+            to=receiver.public_key.to_canonical_address(),
+            value=i,
+            data=b'',
+        )
+        chain_b.apply_transaction(tx.as_signed_transaction(sender))
+        block_b = chain_b.mine_block()
+
+        assert block_b.number == i + 7
+        assert chain_b.header.block_number == i + 8
+
+    for i in range(4, 9):
+        block = chain_b.get_canonical_block_by_number(i)
+        new_blocks, orphaned_canonical_blocks = chain_a.import_block(block)
+        assert block in new_blocks
+
+        if i == 7:
+            assert len(new_blocks) == 4
+            assert len(new_blocks) - 1 == len(orphaned_canonical_blocks)
+            assert new_blocks[0] != orphaned_canonical_blocks[0]
+        else:
+            assert len(orphaned_canonical_blocks) == 0
+            assert len(new_blocks) == 1

--- a/tests/core/chain-object/test_mining.py
+++ b/tests/core/chain-object/test_mining.py
@@ -43,6 +43,7 @@ def test_pow_mining():
         }
     }
     chain = PowMiningChain.from_genesis(MemoryDB(), genesis_params, state)
+    # import ipdb; ipdb.set_trace()
     for i in range(10):
         tx = chain.create_unsigned_transaction(
             nonce=i,

--- a/tests/core/vm/test_vm_state.py
+++ b/tests/core/vm/test_vm_state.py
@@ -13,7 +13,7 @@ def state(chain_without_block_validation):
 def test_block_properties(chain_without_block_validation):
     chain = chain_without_block_validation
     vm = chain.get_vm()
-    imported_blocks, _, import_success = chain.import_block(vm.mine_block())
+    imported_blocks, _ = chain.import_block(vm.mine_block())
     block = imported_blocks[-1]
 
     assert vm.state.coinbase == block.header.coinbase

--- a/tests/core/vm/test_vm_state.py
+++ b/tests/core/vm/test_vm_state.py
@@ -13,7 +13,8 @@ def state(chain_without_block_validation):
 def test_block_properties(chain_without_block_validation):
     chain = chain_without_block_validation
     vm = chain.get_vm()
-    block = chain.import_block(vm.mine_block())
+    imported_blocks, _, import_success = chain.import_block(vm.mine_block())
+    block = imported_blocks[-1]
 
     assert vm.state.coinbase == block.header.coinbase
     assert vm.state.timestamp == block.header.timestamp

--- a/tests/database/test_header_db.py
+++ b/tests/database/test_header_db.py
@@ -102,7 +102,7 @@ def test_headerdb_persist_header_disallows_unknown_parent(headerdb):
 
 
 def test_headerdb_persist_header_returns_new_canonical_chain(headerdb, genesis_header):
-    gen_result = headerdb.persist_header(genesis_header)
+    gen_result, _ = headerdb.persist_header(genesis_header)
     assert gen_result == (genesis_header,)
 
     chain_a = mk_header_chain(genesis_header, 3)
@@ -110,15 +110,15 @@ def test_headerdb_persist_header_returns_new_canonical_chain(headerdb, genesis_h
     chain_c = mk_header_chain(genesis_header, 5)
 
     for header in chain_a:
-        res = headerdb.persist_header(header)
+        res, _ = headerdb.persist_header(header)
         assert res == (header,)
 
     for header in chain_b:
-        res = headerdb.persist_header(header)
+        res, _ = headerdb.persist_header(header)
         assert res == tuple()
 
     for idx, header in enumerate(chain_c, 1):
-        res = headerdb.persist_header(header)
+        res, _ = headerdb.persist_header(header)
         if idx <= 3:
             # prior to passing up `chain_a` each import should not return new
             # canonical headers.


### PR DESCRIPTION
…d issue #772

### What was wrong?
evicted blocks were not being returned 


### How was it fixed?
created a list that holds old blocks inside _set_as_canonical_chain_head() and returns both new and evicted blocks. 
one thing that was unclear was why the tests required the imported block even if it wasn't added to the chain, so I added a bool import_success to track this, but not sure if this is best practice.   


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.critterbabies.com/wp-content/gallery/alligators/baby-alligator.jpg)
