### PR TITLE
Reduce logging about no idle peers

### DIFF
--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -232,7 +232,7 @@ class StateDownloader(BaseService, PeerSubscriber):
             try:
                 peer = await self.get_peer_for_request(not_yet_requested)
             except NoIdlePeers:
-                self.logger.debug(
+                self.logger.trace(
                     "No idle peers have any of the %d trie nodes we want, sleeping a bit",
                     len(not_yet_requested),
                 )


### PR DESCRIPTION

### What was wrong?

Fixes #1133 

### How was it fixed?

Reduced the logging level to `TRACE`.  After running stat sync continuously for days now, these messages provide no useful information in the debug logs and merely serve as noise.

#### Cute Animal Picture


![unlikely-sleeping-buddies-animal-friendship-fb](https://user-images.githubusercontent.com/824194/43796311-219c5860-9a41-11e8-98b5-1d98fadad028.jpg)
