### PR TITLE
Expand round trip api to ETH-protocol receipts

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -1018,7 +1018,9 @@ def _test() -> None:
     from eth.chains.ropsten import RopstenChain, ROPSTEN_GENESIS_HEADER, ROPSTEN_VM_CONFIGURATION
     from eth.db.backends.memory import MemoryDB
     from trinity.protocol.eth.peer import ETHPeer
-    from trinity.protocol.eth.requests import HeaderRequest as ETHHeaderRequest
+    from trinity.protocol.eth.requests import (
+        HeaderRequest as ETHHeaderRequest,
+    )
     from trinity.protocol.les.peer import LESPeer
     from trinity.protocol.les.requests import HeaderRequest as LESHeaderRequest
     from tests.trinity.core.integration_test_helpers import FakeAsyncHeaderDB, connect_to_peers_loop
@@ -1062,7 +1064,7 @@ def _test() -> None:
             peer = cast(ETHPeer, peer)
             peer.sub_proto.send_get_block_headers(ETHHeaderRequest(block_hash, 1, 0, False))
             peer.sub_proto.send_get_block_bodies([block_hash])
-            peer.sub_proto.send_get_receipts([block_hash])
+            peer.sub_proto.send_get_receipts((block_hash,))
         else:
             peer = cast(LESPeer, peer)
             request_id = 1

--- a/tests/trinity/core/p2p-proto/test_node_data_request_object.py
+++ b/tests/trinity/core/p2p-proto/test_node_data_request_object.py
@@ -28,7 +28,7 @@ def test_node_data_request_empty_response_is_valid():
     node_keys, _ = mk_node_data(10)
     request = NodeDataRequest(node_keys)
 
-    request.validate_response(tuple())
+    request.validate_response(tuple(), tuple())
 
 
 def test_node_data_request_with_full_response():
@@ -36,7 +36,7 @@ def test_node_data_request_with_full_response():
     request = NodeDataRequest(node_keys)
     node_data = tuple(zip(node_keys, nodes))
 
-    request.validate_response(node_data)
+    request.validate_response(nodes, node_data)
 
 
 def test_node_data_request_with_partial_response():
@@ -44,9 +44,12 @@ def test_node_data_request_with_partial_response():
     request = NodeDataRequest(node_keys)
     node_data = tuple(zip(node_keys, nodes))
 
-    request.validate_response(node_data[3:])
-    request.validate_response(node_data[:3])
-    request.validate_response((node_data[1], node_data[8], node_data[4]))
+    request.validate_response(nodes[3:], node_data[3:])
+    request.validate_response(nodes[:3], node_data[:3])
+    request.validate_response(
+        (nodes[1], nodes[8], nodes[4]),
+        (node_data[1], node_data[8], node_data[4]),
+    )
 
 
 def test_node_data_request_with_fully_invalid_response():
@@ -58,7 +61,7 @@ def test_node_data_request_with_fully_invalid_response():
     other_node_data = tuple((keccak(node), node) for node in other_nodes)
 
     with pytest.raises(ValidationError):
-        request.validate_response(other_node_data)
+        request.validate_response(other_nodes, other_node_data)
 
 
 def test_node_data_request_with_extra_unrequested_nodes():
@@ -71,4 +74,7 @@ def test_node_data_request_with_extra_unrequested_nodes():
     other_node_data = tuple((keccak(node), node) for node in other_nodes)
 
     with pytest.raises(ValidationError):
-        request.validate_response(node_data + other_node_data)
+        request.validate_response(
+            nodes + other_nodes,
+            node_data + other_node_data,
+        )

--- a/tests/trinity/core/p2p-proto/test_peer_receipts_request_and_response_api.py
+++ b/tests/trinity/core/p2p-proto/test_peer_receipts_request_and_response_api.py
@@ -1,0 +1,143 @@
+import asyncio
+import os
+import time
+
+import pytest
+
+from eth_utils import to_tuple
+
+from eth.db.trie import make_trie_root_and_nodes
+from eth.rlp.headers import BlockHeader
+from eth.rlp.receipts import Receipt
+
+from trinity.protocol.eth.peer import ETHPeer
+
+from tests.trinity.core.peer_helpers import (
+    get_directly_linked_peers,
+)
+
+
+@pytest.fixture
+async def eth_peer_and_remote(request, event_loop):
+    peer, remote = await get_directly_linked_peers(
+        request,
+        event_loop,
+        peer1_class=ETHPeer,
+        peer2_class=ETHPeer,
+    )
+    return peer, remote
+
+
+@to_tuple
+def mk_receipts(num_receipts):
+    for _ in range(num_receipts):
+        yield Receipt(
+            state_root=os.urandom(32),
+            gas_used=21000,
+            bloom=0,
+            logs=[],
+        )
+
+
+def mk_header_and_receipts(block_number, num_receipts):
+    receipts = mk_receipts(num_receipts)
+    root_hash, trie_root_and_data = make_trie_root_and_nodes(receipts)
+    header = BlockHeader(
+        difficulty=1000000,
+        block_number=block_number,
+        gas_limit=3141592,
+        timestamp=int(time.time()),
+        receipt_root=root_hash,
+    )
+    return header, receipts, (root_hash, trie_root_and_data)
+
+
+@to_tuple
+def mk_headers(*counts):
+    for idx, num_receipts in enumerate(counts, 1):
+        yield mk_header_and_receipts(idx, num_receipts)
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_receipts_round_trip_with_full_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+
+    async def send_receipts():
+        remote.sub_proto.send_receipts(receipts)
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_receipts())
+    response = await peer.requests.get_receipts(headers)
+
+    assert len(response) == len(headers)
+    assert response == receipts_bundle
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_receipts_round_trip_with_partial_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+
+    async def send_receipts():
+        remote.sub_proto.send_receipts((receipts[2], receipts[1], receipts[4]))
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_receipts())
+    response = await peer.requests.get_receipts(headers)
+
+    assert len(response) == 3
+    assert response == (receipts_bundle[2], receipts_bundle[1], receipts_bundle[4])
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_receipts_round_trip_with_noise(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+
+    async def send_receipts():
+        remote.sub_proto.send_transactions([])
+        await asyncio.sleep(0)
+        remote.sub_proto.send_receipts(receipts)
+        await asyncio.sleep(0)
+        remote.sub_proto.send_transactions([])
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_receipts())
+    response = await peer.requests.get_receipts(headers)
+
+    assert len(response) == len(headers)
+    assert response == receipts_bundle
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_receipts_round_trip_no_match_invalid_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+
+    wrong_headers = mk_headers(4, 3, 8)
+    _, wrong_receipts, _ = zip(*wrong_headers)
+
+    async def send_receipts():
+        remote.sub_proto.send_receipts(wrong_receipts)
+        await asyncio.sleep(0)
+        remote.sub_proto.send_receipts(receipts)
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_receipts())
+    response = await peer.requests.get_receipts(headers)
+
+    assert len(response) == len(headers)
+    assert response == receipts_bundle

--- a/tests/trinity/core/p2p-proto/test_receipts_request_object.py
+++ b/tests/trinity/core/p2p-proto/test_receipts_request_object.py
@@ -1,0 +1,105 @@
+import os
+import time
+
+import pytest
+
+from eth_utils import to_tuple
+
+from eth.db.trie import make_trie_root_and_nodes
+from eth.rlp.headers import BlockHeader
+from eth.rlp.receipts import Receipt
+
+from p2p.exceptions import ValidationError
+
+from trinity.protocol.eth.requests import ReceiptsRequest
+
+
+@to_tuple
+def mk_receipts(num_receipts):
+    for _ in range(num_receipts):
+        yield Receipt(
+            state_root=os.urandom(32),
+            gas_used=21000,
+            bloom=0,
+            logs=[],
+        )
+
+
+def mk_header_and_receipts(block_number, num_receipts):
+    receipts = mk_receipts(num_receipts)
+    root_hash, trie_root_and_data = make_trie_root_and_nodes(receipts)
+    header = BlockHeader(
+        difficulty=1000000,
+        block_number=block_number,
+        gas_limit=3141592,
+        timestamp=int(time.time()),
+        receipt_root=root_hash,
+    )
+    return header, receipts, (root_hash, trie_root_and_data)
+
+
+@to_tuple
+def mk_headers(*counts):
+    for idx, num_receipts in enumerate(counts, 1):
+        yield mk_header_and_receipts(idx, num_receipts)
+
+
+def test_receipts_request_empty_response_is_valid():
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, _, _ = zip(*headers_bundle)
+    request = ReceiptsRequest(headers)
+    request.validate_response(tuple(), tuple())
+
+
+def test_receipts_request_valid_with_full_response():
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+    request = ReceiptsRequest(headers)
+    request.validate_response(receipts, receipts_bundle)
+
+
+def test_receipts_request_valid_with_partial_response():
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+    request = ReceiptsRequest(headers)
+
+    request.validate_response(receipts[:3], receipts_bundle[:3])
+    request.validate_response(receipts[2:], receipts_bundle[2:])
+    request.validate_response(
+        (receipts[1], receipts[3], receipts[4]),
+        (receipts_bundle[1], receipts_bundle[3], receipts_bundle[4]),
+    )
+
+
+def test_receipts_request_with_fully_invalid_response():
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, _, _ = zip(*headers_bundle)
+
+    wrong_headers = mk_headers(4, 3, 8)
+    _, wrong_receipts, wrong_trie_roots_and_data = zip(*wrong_headers)
+    receipts_bundle = tuple(zip(wrong_receipts, wrong_trie_roots_and_data))
+
+    request = ReceiptsRequest(headers)
+
+    with pytest.raises(ValidationError):
+        request.validate_response(wrong_receipts, receipts_bundle)
+
+
+def test_receipts_request_with_extra_unrequested_receipts():
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+
+    wrong_headers = mk_headers(4, 3, 8)
+    _, wrong_receipts, wrong_trie_roots_and_data = zip(*wrong_headers)
+    extra_receipts_bundle = tuple(zip(wrong_receipts, wrong_trie_roots_and_data))
+
+    request = ReceiptsRequest(headers)
+
+    with pytest.raises(ValidationError):
+        request.validate_response(
+            receipts + wrong_receipts,
+            receipts_bundle + extra_receipts_bundle,
+        )

--- a/trinity/p2p/handlers.py
+++ b/trinity/p2p/handlers.py
@@ -1,4 +1,5 @@
 from typing import (
+    Any,
     AsyncGenerator,
     List,
     Tuple,
@@ -80,7 +81,7 @@ class PeerRequestHandler(CancellableMixin):
         peer.sub_proto.send_node_data(tuple(nodes))
 
     async def lookup_headers(self,
-                             request: BaseHeaderRequest) -> Tuple[BlockHeader, ...]:
+                             request: BaseHeaderRequest[Any]) -> Tuple[BlockHeader, ...]:
         """
         Lookup :max_headers: headers starting at :block_number_or_hash:, skipping :skip: items
         between each, in reverse order if :reverse: is True.
@@ -101,7 +102,7 @@ class PeerRequestHandler(CancellableMixin):
         return headers
 
     async def _get_block_numbers_for_request(self,
-                                             request: BaseHeaderRequest
+                                             request: BaseHeaderRequest[Any],
                                              ) -> Tuple[BlockNumber, ...]:
         """
         Generate the block numbers for a given `HeaderRequest`.

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -5,6 +5,7 @@ from trinity.protocol.common.handlers import (
 from .managers import (
     GetBlockHeadersRequestManager,
     GetNodeDataRequestManager,
+    GetReceiptsRequestManager,
 )
 
 
@@ -12,7 +13,9 @@ class ETHRequestResponseHandler(BaseRequestResponseHandler):
     _managers = {
         'get_block_headers': GetBlockHeadersRequestManager,
         'get_node_data': GetNodeDataRequestManager,
+        'get_receipts': GetReceiptsRequestManager,
     }
 
     get_block_headers: GetBlockHeadersRequestManager
     get_node_data: GetNodeDataRequestManager
+    get_receipts: GetReceiptsRequestManager

--- a/trinity/protocol/eth/managers.py
+++ b/trinity/protocol/eth/managers.py
@@ -1,4 +1,5 @@
 from typing import (
+    Dict,
     Tuple,
     Type,
     TYPE_CHECKING,
@@ -11,7 +12,9 @@ from eth_typing import (
 
 from eth_hash.auto import keccak
 
+from eth.db.trie import make_trie_root_and_nodes
 from eth.rlp.headers import BlockHeader
+from eth.rlp.receipts import Receipt
 
 from p2p.exceptions import MalformedMessage
 from p2p.protocol import (
@@ -25,10 +28,12 @@ from trinity.protocol.common.managers import (
 from .commands import (
     BlockHeaders,
     NodeData,
+    Receipts,
 )
 from .requests import (
     HeaderRequest,
     NodeDataRequest,
+    ReceiptsRequest,
 )
 
 if TYPE_CHECKING:
@@ -69,16 +74,17 @@ class GetBlockHeadersRequestManager(BaseGetBlockHeadersRequestManager):
         self._peer.sub_proto.send_get_block_headers(request)
 
     async def _normalize_response(self,
-                                  msg: Tuple[BlockHeader, ...]
+                                  msg: Tuple[BlockHeader, ...],
                                   ) -> Tuple[BlockHeader, ...]:
         return msg
 
 
+NodeDataBundles = Tuple[Tuple[Hash32, bytes], ...]
 BaseGetNodeDataRequestManager = BaseRequestManager[
     'ETHPeer',
     NodeDataRequest,
     Tuple[bytes, ...],
-    Tuple[Tuple[Hash32, bytes], ...],
+    NodeDataBundles,
 ]
 
 
@@ -89,7 +95,7 @@ class GetNodeDataRequestManager(BaseGetNodeDataRequestManager):
 
     async def __call__(self,  # type: ignore
                        node_hashes: Tuple[Hash32, ...],
-                       timeout: int = None) -> Tuple[Tuple[Hash32, bytes], ...]:
+                       timeout: int = None) -> NodeDataBundles:
         request = NodeDataRequest(node_hashes)
         return await self._request_and_wait(request, timeout)
 
@@ -98,7 +104,7 @@ class GetNodeDataRequestManager(BaseGetNodeDataRequestManager):
 
     async def _normalize_response(self,
                                   msg: Tuple[bytes, ...]
-                                  ) -> Tuple[Tuple[Hash32, bytes], ...]:
+                                  ) -> NodeDataBundles:
         if not isinstance(msg, tuple):
             raise MalformedMessage("Invalid msg, must be tuple of byte strings")
         elif not all(isinstance(item, bytes) for item in msg):
@@ -106,3 +112,50 @@ class GetNodeDataRequestManager(BaseGetNodeDataRequestManager):
 
         node_keys = await self._run_in_executor(tuple, map(keccak, msg))
         return tuple(zip(node_keys, msg))
+
+
+ReceiptsBundles = Tuple[Tuple[Tuple[Receipt, ...], Tuple[Hash32, Dict[Hash32, bytes]]], ...]
+BaseGetReceiptsRequestManager = BaseRequestManager[
+    'ETHPeer',
+    ReceiptsRequest,
+    Tuple[Tuple[Receipt, ...], ...],
+    ReceiptsBundles,
+]
+
+
+class GetReceiptsRequestManager(BaseGetReceiptsRequestManager):
+    msg_queue_maxsize = 100
+
+    _response_msg_type: Type[Command] = Receipts
+
+    async def __call__(self,  # type: ignore
+                       headers: Tuple[BlockHeader, ...],
+                       timeout: int = None) -> ReceiptsBundles:
+        request = ReceiptsRequest(headers)
+        return await self._request_and_wait(request, timeout)
+
+    def _send_sub_proto_request(self, request: ReceiptsRequest) -> None:
+        self._peer.sub_proto.send_get_receipts(request)
+
+    async def _normalize_response(self,
+                                  response: Tuple[Tuple[Receipt, ...], ...],
+                                  ) -> ReceiptsBundles:
+        if not isinstance(response, tuple):
+            raise MalformedMessage(
+                "`GetReceipts` response must be a tuple. Got: {0}".format(type(response))
+            )
+        elif not all(isinstance(item, tuple) for item in response):
+            raise MalformedMessage("`GetReceipts` response must be a tuple of tuples")
+
+        for item in response:
+            if not all(isinstance(value, Receipt) for value in item):
+                raise MalformedMessage(
+                    "Response must be a tuple of tuples of `BlockHeader` objects"
+                )
+
+        trie_roots_and_data = await self._run_in_executor(
+            tuple,
+            map(make_trie_root_and_nodes, response),
+        )
+        receipt_bundles = tuple(zip(response, trie_roots_and_data))
+        return receipt_bundles

--- a/trinity/protocol/eth/requests.py
+++ b/trinity/protocol/eth/requests.py
@@ -1,4 +1,5 @@
 from typing import (
+    Dict,
     Tuple,
 )
 
@@ -6,6 +7,9 @@ from eth_typing import (
     BlockIdentifier,
     Hash32,
 )
+
+from eth.rlp.headers import BlockHeader
+from eth.rlp.receipts import Receipt
 
 from p2p.exceptions import ValidationError
 
@@ -17,7 +21,7 @@ from trinity.protocol.common.requests import (
 from . import constants
 
 
-class HeaderRequest(BaseHeaderRequest):
+class HeaderRequest(BaseHeaderRequest[Tuple[BlockHeader, ...]]):
     @property
     def max_size(self) -> int:
         return constants.MAX_HEADERS_FETCH
@@ -33,13 +37,16 @@ class HeaderRequest(BaseHeaderRequest):
         self.reverse = reverse
 
 
-class NodeDataRequest(BaseRequest):
-    node_keys_cache: Tuple[Hash32, ...]
+NodeDataBundles = Tuple[Tuple[Hash32, bytes], ...]
 
+
+class NodeDataRequest(BaseRequest[Tuple[bytes, ...], NodeDataBundles]):
     def __init__(self, node_hashes: Tuple[Hash32, ...]) -> None:
         self.node_hashes = node_hashes
 
-    def validate_response(self, response: Tuple[Tuple[Hash32, bytes], ...]) -> None:
+    def validate_response(self,
+                          msg: Tuple[bytes, ...],
+                          response: NodeDataBundles) -> None:
         if not response:
             # an empty response is always valid
             return
@@ -55,4 +62,38 @@ class NodeDataRequest(BaseRequest):
         if unexpected_keys:
             raise ValidationError(
                 "Response contains {0} unexpected nodes".format(len(unexpected_keys))
+            )
+
+
+ReceiptsBundles = Tuple[Tuple[Tuple[Receipt, ...], Tuple[Hash32, Dict[Hash32, bytes]]], ...]
+ReceiptsTuples = Tuple[Tuple[Receipt, ...], ...]
+
+
+class ReceiptsRequest(BaseRequest[ReceiptsTuples, ReceiptsBundles]):
+    def __init__(self, headers: Tuple[BlockHeader, ...]) -> None:
+        self.headers = headers
+
+    @property
+    def block_hashes(self) -> Tuple[Hash32, ...]:
+        return tuple(header.hash for header in self.headers)
+
+    def validate_response(self,
+                          msg: ReceiptsTuples,
+                          response: ReceiptsBundles) -> None:
+        if not response:
+            # empty response is always valid.
+            return
+
+        expected_receipt_roots = set(header.receipt_root for header in self.headers)
+        actual_receipt_roots = set(
+            root_hash
+            for receipt, (root_hash, trie_data)
+            in response
+        )
+
+        unexpected_roots = actual_receipt_roots.difference(expected_receipt_roots)
+
+        if unexpected_roots:
+            raise ValidationError(
+                "Got {0} unexpected receipt roots".format(len(unexpected_roots))
             )

--- a/trinity/protocol/les/managers.py
+++ b/trinity/protocol/les/managers.py
@@ -37,7 +37,7 @@ BaseRequestManager = _BaseRequestManager[
     'LESPeer',
     HeaderRequest,
     Dict[str, Any],
-    Tuple[BlockHeader, ...]
+    Tuple[BlockHeader, ...],
 ]
 
 

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -1,5 +1,14 @@
+from typing import (
+    Any,
+    Dict,
+    Tuple,
+)
+
 from eth_typing import BlockIdentifier
 
+from eth.rlp.headers import BlockHeader
+
+from p2p.exceptions import ValidationError
 
 from trinity.protocol.common.requests import (
     BaseHeaderRequest,
@@ -8,7 +17,10 @@ from trinity.protocol.common.requests import (
 from .constants import MAX_HEADERS_FETCH
 
 
-class HeaderRequest(BaseHeaderRequest):
+HeadersResponseDict = Dict[str, Any]
+
+
+class HeaderRequest(BaseHeaderRequest[HeadersResponseDict]):
     request_id: int
 
     max_size = MAX_HEADERS_FETCH
@@ -24,3 +36,10 @@ class HeaderRequest(BaseHeaderRequest):
         self.skip = skip
         self.reverse = reverse
         self.request_id = request_id
+
+    def validate_response(self,
+                          msg: HeadersResponseDict,
+                          response: Tuple[BlockHeader, ...]) -> None:
+        if msg['request_id'] != self.request_id:
+            raise ValidationError("Request `id` does not match")
+        super().validate_response(msg, response)


### PR DESCRIPTION
Builds on https://github.com/ethereum/py-evm/pull/1149

### What was wrong?

The round trip API for peer request/responses had not been implemented for block receipts.

### How was it fixed?

Expanded the API to cover receipts and integrated the new api into the `FastChainSyncer`.

#### Cute Animal Picture

![cow-attacks-and-dogs-770x405](https://user-images.githubusercontent.com/824194/43864627-6e3952e0-9b1d-11e8-8e92-baa4d851a0a0.jpg)

