### PR TITLE
[WIP] add chain.get_transaction_result and rpc eth_call

### DIFF
--- a/eth/utils/spoof.py
+++ b/eth/utils/spoof.py
@@ -1,3 +1,7 @@
+from cytoolz import (
+    merge,
+)
+
 from eth.constants import (
     DEFAULT_SPOOF_V,
     DEFAULT_SPOOF_R,
@@ -44,6 +48,11 @@ class SpoofAttributes:
             return self.overrides[attr]
         else:
             return getattr(self.spoof_target, attr)
+
+    def copy(self, **kwargs):
+        new_target = self.spoof_target.copy(**kwargs)
+        new_overrides = merge(self.overrides, kwargs)
+        return type(self)(new_target, **new_overrides)
 
 
 class SpoofTransaction(SpoofAttributes):

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -163,6 +163,15 @@ class BaseComputation(Configurable, ABC):
         """
         return not self.is_success
 
+    def raise_if_error(self) -> None:
+        """
+        If there was an error during computation, raise it as an exception immediately.
+
+        :raise VMError:
+        """
+        if self._error is not None:
+            raise self._error
+
     @property
     def should_burn_gas(self) -> bool:
         """

--- a/eth/vm/forks/frontier/state.py
+++ b/eth/vm/forks/frontier/state.py
@@ -46,8 +46,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
 
     def build_evm_message(self, transaction):
 
-        transaction_context = self.get_transaction_context(transaction)
-        gas_fee = transaction.gas * transaction_context.gas_price
+        gas_fee = transaction.gas * transaction.gas_price
 
         # Buy Gas
         self.vm_state.account_db.delta_balance(transaction.sender, -1 * gas_fee)
@@ -99,7 +98,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
 
     def build_computation(self, message, transaction):
         """Apply the message to the VM."""
-        transaction_context = self.get_transaction_context(transaction)
+        transaction_context = self.vm_state.get_transaction_context(transaction)
         if message.is_create:
             is_collision = self.vm_state.account_db.account_has_code_or_nonce(
                 message.storage_address

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ deps = {
         "lru-dict>=1.1.6",
         "py-ecc>=1.4.2,<2.0.0",
         "pyethash>=0.1.27,<1.0.0",
-        "rlp>=1.0.1,<2.0.0",
+        "rlp>=1.0.2,<2.0.0",
         "trie>=1.3.5,<2.0.0",
     ],
     # The eth-extra sections is for libraries that the evm does not

--- a/tests/core/chain-object/test_contract_call.py
+++ b/tests/core/chain-object/test_contract_call.py
@@ -1,0 +1,149 @@
+from cytoolz import (
+    assoc,
+)
+from tests.core.helpers import (
+    new_transaction,
+)
+
+from eth_utils import (
+    decode_hex,
+    function_signature_to_4byte_selector,
+    to_bytes,
+)
+import pytest
+
+from eth.exceptions import (
+    InvalidInstruction,
+    OutOfGas,
+)
+
+
+@pytest.fixture
+def chain(chain_with_block_validation):
+    return chain_with_block_validation
+
+
+@pytest.fixture
+def simple_contract_address():
+    return b'\x88' * 20
+
+
+@pytest.fixture
+def genesis_state(base_genesis_state, simple_contract_address):
+    """
+    Includes runtime bytecode of compiled Solidity:
+
+        pragma solidity ^0.4.24;
+
+        contract GetValues {
+            function getMeaningOfLife() public pure returns (uint256) {
+                return 42;
+            }
+            function getGasPrice() public view returns (uint256) {
+                return tx.gasprice;
+            }
+            function getBalance() public view returns (uint256) {
+                return msg.sender.balance;
+            }
+            function doRevert() public pure {
+                revert("always reverts");
+            }
+            function useLotsOfGas() public view {
+                uint size;
+                for (uint i = 0; i < 2**255; i++){
+                    assembly {
+                        size := extcodesize(0)
+                    }
+                }
+            }
+        }
+    """
+    return assoc(
+        base_genesis_state,
+        simple_contract_address,
+        {
+            'balance': 0,
+            'nonce': 0,
+            'code': decode_hex('60806040526004361061006c5763ffffffff7c010000000000000000000000000000000000000000000000000000000060003504166312065fe08114610071578063455259cb14610098578063858af522146100ad57806395dd7a55146100c2578063afc874d2146100d9575b600080fd5b34801561007d57600080fd5b506100866100ee565b60408051918252519081900360200190f35b3480156100a457600080fd5b506100866100f3565b3480156100b957600080fd5b506100866100f7565b3480156100ce57600080fd5b506100d76100fc565b005b3480156100e557600080fd5b506100d7610139565b333190565b3a90565b602a90565b6000805b7f80000000000000000000000000000000000000000000000000000000000000008110156101355760003b9150600101610100565b5050565b604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152600e60248201527f616c776179732072657665727473000000000000000000000000000000000000604482015290519081900360640190fd00a165627a7a72305820645df686b4a16d5a69fc6d841fc9ad700528c14b35ca5629e11b154a9d3dff890029'),  # noqa: E501
+            'storage': {},
+        },
+    )
+
+
+def uint256_to_bytes(uint):
+    return to_bytes(uint).rjust(32, b'\0')
+
+
+@pytest.mark.parametrize(
+    'signature, gas_price, expected',
+    (
+        (
+            'getMeaningOfLife()',
+            0,
+            uint256_to_bytes(42),
+        ),
+        (
+            'getGasPrice()',
+            0,
+            uint256_to_bytes(0),
+        ),
+        (
+            'getGasPrice()',
+            9,
+            uint256_to_bytes(9),
+        ),
+        (
+            # make sure that whatever voodoo is used to execute a call, the balance is not inflated
+            'getBalance()',
+            1,
+            uint256_to_bytes(0),
+        ),
+    ),
+)
+def test_get_transaction_result(
+        chain,
+        simple_contract_address,
+        signature,
+        gas_price,
+        expected):
+
+    function_selector = function_signature_to_4byte_selector(signature)
+    call_txn = new_transaction(
+        chain.get_vm(),
+        b'\xff' * 20,
+        simple_contract_address,
+        gas_price=gas_price,
+        data=function_selector,
+    )
+    result_bytes = chain.get_transaction_result(call_txn, chain.get_canonical_head())
+    assert result_bytes == expected
+
+
+@pytest.mark.parametrize(
+    'signature, expected',
+    (
+        (
+            'doRevert()',
+            InvalidInstruction,
+        ),
+        (
+            'useLotsOfGas()',
+            OutOfGas,
+        ),
+    ),
+)
+def test_get_transaction_result_revert(
+        chain,
+        simple_contract_address,
+        signature,
+        expected):
+
+    function_selector = function_signature_to_4byte_selector(signature)
+    call_txn = new_transaction(
+        chain.get_vm(),
+        b'\xff' * 20,
+        simple_contract_address,
+        data=function_selector,
+    )
+    with pytest.raises(expected):
+        chain.get_transaction_result(call_txn, chain.get_canonical_head())

--- a/tests/trinity/core/json-rpc/test_ipc.py
+++ b/tests/trinity/core/json-rpc/test_ipc.py
@@ -4,6 +4,15 @@ import os
 import pytest
 import time
 
+from cytoolz import (
+    assoc,
+)
+from eth_utils import (
+    decode_hex,
+    function_signature_to_4byte_selector,
+    to_bytes,
+    to_hex,
+)
 
 from trinity.utils.version import construct_trinity_client_identifier
 
@@ -71,6 +80,62 @@ async def get_ipc_response(
 
     writer.close()
     return json.loads(result_bytes.decode())
+
+
+@pytest.fixture
+def chain(chain_with_block_validation):
+    return chain_with_block_validation
+
+
+@pytest.fixture
+def simple_contract_address():
+    return b'\x88' * 20
+
+
+@pytest.fixture
+def genesis_state(base_genesis_state, simple_contract_address):
+    """
+    Includes runtime bytecode of compiled Solidity:
+
+        pragma solidity ^0.4.24;
+
+        contract GetValues {
+            function getMeaningOfLife() public pure returns (uint256) {
+                return 42;
+            }
+            function getGasPrice() public view returns (uint256) {
+                return tx.gasprice;
+            }
+            function getBalance() public view returns (uint256) {
+                return msg.sender.balance;
+            }
+            function doRevert() public pure {
+                revert("always reverts");
+            }
+            function useLotsOfGas() public view {
+                uint size;
+                for (uint i = 0; i < 2**255; i++){
+                    assembly {
+                        size := extcodesize(0)
+                    }
+                }
+            }
+        }
+    """
+    return assoc(
+        base_genesis_state,
+        simple_contract_address,
+        {
+            'balance': 0,
+            'nonce': 0,
+            'code': decode_hex('60806040526004361061006c5763ffffffff7c010000000000000000000000000000000000000000000000000000000060003504166312065fe08114610071578063455259cb14610098578063858af522146100ad57806395dd7a55146100c2578063afc874d2146100d9575b600080fd5b34801561007d57600080fd5b506100866100ee565b60408051918252519081900360200190f35b3480156100a457600080fd5b506100866100f3565b3480156100b957600080fd5b506100866100f7565b3480156100ce57600080fd5b506100d76100fc565b005b3480156100e557600080fd5b506100d7610139565b333190565b3a90565b602a90565b6000805b7f80000000000000000000000000000000000000000000000000000000000000008110156101355760003b9150600101610100565b5050565b604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152600e60248201527f616c776179732072657665727473000000000000000000000000000000000000604482015290519081900360640190fd00a165627a7a72305820645df686b4a16d5a69fc6d841fc9ad700528c14b35ca5629e11b154a9d3dff890029'),  # noqa: E501
+            'storage': {},
+        },
+    )
+
+
+def uint256_to_bytes(uint):
+    return to_bytes(uint).rjust(32, b'\0')
 
 
 @pytest.mark.asyncio
@@ -220,6 +285,116 @@ async def test_estimate_gas_on_ipc(
         expected,
         event_loop,
         ipc_server):
+    result = await get_ipc_response(jsonrpc_ipc_pipe_path, request_msg, event_loop)
+    assert result == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'request_msg, expected',
+    (
+        (
+            build_request('eth_call', params=[{'to': '0x' + '99' * 20}, 'latest']),
+            {'result': '0x', 'id': 3, 'jsonrpc': '2.0'},
+        ),
+        (
+            build_request('eth_call', params=[{
+                'to': '0x' + '00' * 19 + '04',  # the 'identity' precompile
+                'data': '0x123456',
+            }, 'latest']),
+            {'result': '0x123456', 'id': 3, 'jsonrpc': '2.0'},
+        ),
+    ),
+    ids=id_from_rpc_request,
+)
+async def test_eth_call_on_ipc(
+        jsonrpc_ipc_pipe_path,
+        request_msg,
+        expected,
+        event_loop,
+        ipc_server):
+    result = await get_ipc_response(jsonrpc_ipc_pipe_path, request_msg, event_loop)
+    assert result == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'signature, gas_price, expected',
+    (
+        (
+            'getMeaningOfLife()',
+            0,
+            {
+                'result': '0x000000000000000000000000000000000000000000000000000000000000002a',
+                'id': 3,
+                'jsonrpc': '2.0',
+            },
+        ),
+        (
+            'getGasPrice()',
+            0,
+            {
+                'result': '0x0000000000000000000000000000000000000000000000000000000000000000',
+                'id': 3,
+                'jsonrpc': '2.0',
+            },
+        ),
+        (
+            'getGasPrice()',
+            9,
+            {
+                'result': '0x0000000000000000000000000000000000000000000000000000000000000009',
+                'id': 3,
+                'jsonrpc': '2.0',
+            },
+        ),
+        (
+            'doRevert()',
+            0,
+            {
+                'error': 'Invalid opcode 0xfd @ 415',
+                'id': 3,
+                'jsonrpc': '2.0',
+            },
+        ),
+        (
+            'useLotsOfGas()',
+            0,
+            {
+                'error': 'Out of gas: Needed 700 - Remaining 444 - Reason: EXTCODESIZE',
+                'id': 3,
+                'jsonrpc': '2.0',
+            },
+        ),
+        (
+            # make sure that whatever voodoo is used to execute a call, the balance is not inflated
+            'getBalance()',
+            1,
+            {
+                'result': '0x0000000000000000000000000000000000000000000000000000000000000000',
+                'id': 3,
+                'jsonrpc': '2.0',
+            },
+        ),
+    ),
+)
+async def test_eth_call_with_contract_on_ipc(
+        chain,
+        jsonrpc_ipc_pipe_path,
+        simple_contract_address,
+        signature,
+        gas_price,
+        event_loop,
+        ipc_server,
+        expected):
+    function_selector = function_signature_to_4byte_selector(signature)
+    transaction = {
+        'from': '0x' + 'ff' * 20,  # unfunded address
+        'to': to_hex(simple_contract_address),
+        'gasPrice': to_hex(gas_price),
+        'data': to_hex(function_selector),
+    }
+    request_msg = build_request('eth_call', params=[transaction, 'latest'])
     result = await get_ipc_response(jsonrpc_ipc_pipe_path, request_msg, event_loop)
     assert result == expected
 

--- a/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -15,6 +15,9 @@ from eth_utils import (
     is_string,
 )
 
+from eth.chains.base import (
+    MiningChain,
+)
 from eth.tools.fixture_tests import (
     filter_fixtures,
     generate_fixture_tests,
@@ -341,7 +344,16 @@ def chain_fixture(fixture_data):
     return fixture
 
 
-def test_rpc_against_fixtures(ipc_server, chain_fixture, fixture_data):
+@pytest.fixture
+def chain(chain_without_block_validation):
+    if isinstance(chain_without_block_validation, MiningChain):
+        # These tests are long. For RPC state tests, there shouldn't be any
+        # significant difference between a mining chain and a basic chain.
+        pytest.skip("Only need to test basic chain")
+        return
+
+
+def test_rpc_against_fixtures(chain, ipc_server, chain_fixture, fixture_data):
     rpc = RPCServer(None)
 
     setup_result, setup_error = call_rpc(rpc, 'evm_resetToGenesisFixture', [chain_fixture])

--- a/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -67,6 +67,7 @@ SLOW_TESTS = (
     'static_Call50000_d0g0v0_Byzantium',
     'static_Call50000_ecrec_d0g0v0_Byzantium',
     'static_Call50000_identity2_d0g0v0_Byzantium',
+    'static_Call50000_identity2_d1g0v0_Byzantium',
     'static_Call50000_identity_d1g0v0_Byzantium',
     'static_Call50000_identity_d0g0v0_Byzantium',
     'static_Call50000bytesContract50_1_d1g0v0_Byzantium',

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -192,6 +192,12 @@ class LightDispatchChain(BaseChain):
             transaction: BaseTransaction) -> Tuple[BaseBlock, Receipt, BaseComputation]:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
+    def get_transaction_result(
+            self,
+            transaction: Union[BaseTransaction, SpoofTransaction],
+            at_header: BlockHeader) -> bytes:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
     def estimate_gas(
             self,
             transaction: Union[BaseTransaction, SpoofTransaction],

--- a/trinity/utils/validation.py
+++ b/trinity/utils/validation.py
@@ -3,6 +3,10 @@ from typing import (
     Dict,
 )
 
+from eth_utils import (
+    is_address,
+)
+
 from eth.vm.base import (
     BaseVM,
 )
@@ -13,7 +17,7 @@ DERIVED_KEYS = {'from'}
 RENAMED_KEYS = {'gas_price': 'gasPrice'}
 
 
-def validate_transaction_call_dict(transaction_dict: Dict[str, Any], vm: BaseVM) -> None:
+def validate_transaction_gas_estimation_dict(transaction_dict: Dict[str, Any], vm: BaseVM) -> None:
     """Validate a transaction dictionary supplied for an RPC method call"""
     transaction_class = vm.get_transaction_class()
 
@@ -30,3 +34,11 @@ def validate_transaction_call_dict(transaction_dict: Dict[str, Any], vm: BaseVM)
                 list(sorted(spec_keys)),
             )
         )
+
+
+def validate_transaction_call_dict(transaction_dict: Dict[str, Any], vm: BaseVM) -> None:
+    validate_transaction_gas_estimation_dict(transaction_dict, vm)
+
+    # 'to' is required in a call, but not a gas estimation
+    if not is_address(transaction_dict.get('to', None)):
+        raise ValueError("The 'to' field must be supplied when getting the result of a transaction")


### PR DESCRIPTION
### What was wrong?

Need an eth_call endpoint, according to #1061 

### How was it fixed?

Add a new `Chain.get_transaction_result()` method. Test that method and the identity precompile.

TODO:
- [x] test calling a contract over RPC
- test calling a contract with a few error conditions:
  - [x] out of gas
  - [x] solidity revert
- [x] figure out how to handle non-zero gas price calls from accounts without funds. Current ideas:
  - [x] **Current Winner** Monkey-patch the execution context to use the original gas price, cut price to 0 for everything else
  - We could try to monkey-patch validation
  - If we force the gas price to 0, it could affect execution
  - If we add balance to the sending account, it could affect execution
  - We could force the gas to 0, then inspect the trace for any `GASPRICE` opcodes, and bail if found
  - We could add to the user balance, then inspect the trace for any `BALANCE` opcodes, and bail if found
  - we could try each of the previous two in succession, then bail if BOTH fail.

~~I'll probably bail on this last todo and put it in an issue to handle later.~~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://c1.staticflickr.com/9/8425/7544780858_812dbe1e9e_b.jpg)
