### PR TITLE
Handle OperationCancelled in state downloader background task

### DIFF
--- a/trinity/utils/cancellation.py
+++ b/trinity/utils/cancellation.py
@@ -1,0 +1,24 @@
+import functools
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    TypeVar,
+    Optional,
+)
+
+from cancel_token import OperationCancelled
+
+
+TReturn = TypeVar('TReturn')
+
+
+def async_handle_cancellation(awaitable_fn: Callable[..., Awaitable[TReturn]]
+                              ) -> Callable[..., Awaitable[Optional[TReturn]]]:
+    async def inner(*args: Any, **kwargs: Any) -> Optional[TReturn]:
+        try:
+            return await awaitable_fn(*args, **kwargs)
+        except OperationCancelled:
+            return None
+
+    return functools.update_wrapper(inner, awaitable_fn)


### PR DESCRIPTION
### What was wrong?

Fixes #1162 

### How was it fixed?

Created a new decorator `trinity.utils.cancellation.async_handle_cancellation` which can be used to handle the `OperationCancelled` exception for a full function.

#### Cute Animal Picture

![o-cute-animals-photos-facebook](https://user-images.githubusercontent.com/824194/43968730-36728782-9c85-11e8-8c2d-a3ce0da92b7b.jpg)

