### PR TITLE
Expand round trip api to block bodies

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -1067,8 +1067,8 @@ def _test() -> None:
         hashes = [header.hash for header in headers]
         if peer_class == ETHPeer:
             peer = cast(ETHPeer, peer)
-            peer.sub_proto.send_get_block_bodies(hashes)
-            peer.sub_proto.send_get_receipts(hashes)
+            peer.sub_proto._send_get_block_bodies(hashes)
+            peer.sub_proto._send_get_receipts(hashes)
         else:
             peer = cast(LESPeer, peer)
             request_id = 1

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -1063,7 +1063,7 @@ def _test() -> None:
             peer_pool.logger.info("Waiting for peer connection...")
             await asyncio.sleep(0.2)
         peer = peer_pool.highest_td_peer
-        headers = await peer.requests.get_block_headers(2440319, max_headers=100)  # type: ignore
+        headers = await peer.requests.get_block_headers(2440319, max_headers=100)
         hashes = [header.hash for header in headers]
         if peer_class == ETHPeer:
             peer = cast(ETHPeer, peer)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -1063,8 +1063,8 @@ def _test() -> None:
             peer_pool.logger.info("Waiting for peer connection...")
             await asyncio.sleep(0.2)
         peer = peer_pool.highest_td_peer
-        headers = await peer.requests.get_block_headers(2440319, max_headers=100)
-        hashes = [header.hash for header in headers]
+        headers = await cast(ETHPeer, peer).requests.get_block_headers(2440319, max_headers=100)
+        hashes = tuple(header.hash for header in headers)
         if peer_class == ETHPeer:
             peer = cast(ETHPeer, peer)
             peer.sub_proto._send_get_block_bodies(hashes)
@@ -1072,7 +1072,7 @@ def _test() -> None:
         else:
             peer = cast(LESPeer, peer)
             request_id = 1
-            peer.sub_proto.send_get_block_bodies(hashes, request_id + 1)
+            peer.sub_proto.send_get_block_bodies(list(hashes), request_id + 1)
             peer.sub_proto.send_get_receipts(hashes[0], request_id + 2)
 
     sigint_received = asyncio.Event()

--- a/tests/trinity/core/p2p-proto/test_block_bodies_request_object.py
+++ b/tests/trinity/core/p2p-proto/test_block_bodies_request_object.py
@@ -1,0 +1,143 @@
+import os
+import random
+import time
+
+import pytest
+
+import rlp
+
+from eth_hash.auto import keccak
+
+from eth_utils import (
+    to_tuple,
+    big_endian_to_int,
+)
+
+from eth.db.trie import make_trie_root_and_nodes
+from eth.rlp.headers import BlockHeader
+from eth.rlp.transactions import BaseTransactionFields
+
+from p2p.exceptions import ValidationError
+
+from trinity.rlp.block_body import BlockBody
+from trinity.protocol.eth.requests import BlockBodiesRequest
+
+
+def mk_uncle(block_number):
+    return BlockHeader(
+        state_root=os.urandom(32),
+        difficulty=1000000,
+        block_number=block_number,
+        gas_limit=3141592,
+        timestamp=int(time.time()),
+    )
+
+
+def mk_transaction():
+    return BaseTransactionFields(
+        nonce=0,
+        gas=21000,
+        gas_price=1,
+        to=os.urandom(20),
+        value=random.randint(0, 100),
+        data=b'',
+        v=27,
+        r=big_endian_to_int(os.urandom(32)),
+        s=big_endian_to_int(os.urandom(32)),
+    )
+
+
+def mk_header_and_body(block_number, num_transactions, num_uncles):
+    transactions = tuple(mk_transaction() for _ in range(num_transactions))
+    uncles = tuple(mk_uncle(block_number - 1) for _ in range(num_uncles))
+
+    transaction_root, trie_data = make_trie_root_and_nodes(transactions)
+    uncles_hash = keccak(rlp.encode(uncles))
+
+    body = BlockBody(transactions=transactions, uncles=uncles)
+
+    header = BlockHeader(
+        difficulty=1000000,
+        block_number=block_number,
+        gas_limit=3141592,
+        timestamp=int(time.time()),
+        transaction_root=transaction_root,
+        uncles_hash=uncles_hash,
+    )
+
+    return header, body, transaction_root, trie_data, uncles_hash
+
+
+@to_tuple
+def mk_headers(*counts):
+    for idx, (num_transactions, num_uncles) in enumerate(counts, 1):
+        yield mk_header_and_body(idx, num_transactions, num_uncles)
+
+
+def test_block_bodies_request_empty_response_is_valid():
+    headers_bundle = mk_headers((2, 3), (8, 4), (0, 1), (0, 0))
+    headers, _, _, _, _ = zip(*headers_bundle)
+    request = BlockBodiesRequest(headers)
+    request.validate_response(tuple(), tuple())
+
+
+def test_block_bodies_request_valid_with_full_response():
+    headers_bundle = mk_headers((2, 3), (8, 4), (0, 1), (0, 0))
+    headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
+    transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
+    bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
+    request = BlockBodiesRequest(headers)
+    request.validate_response(bodies, bodies_bundle)
+
+
+def test_block_bodies_request_valid_with_partial_response():
+    headers_bundle = mk_headers((2, 3), (8, 4), (0, 1), (0, 0))
+    headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
+    transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
+    bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
+    request = BlockBodiesRequest(headers)
+
+    request.validate_response(bodies[:2], bodies_bundle[:2])
+    request.validate_response(bodies[2:], bodies_bundle[2:])
+    request.validate_response(
+        (bodies[0], bodies[2], bodies[3]),
+        (bodies_bundle[0], bodies_bundle[2], bodies_bundle[3]),
+    )
+
+
+def test_block_bodies_request_with_fully_invalid_response():
+    headers_bundle = mk_headers((2, 3), (8, 4), (0, 1), (0, 0))
+    headers, _, _, _, _ = zip(*headers_bundle)
+
+    wrong_headers_bundle = mk_headers((3, 2), (4, 8), (1, 0), (0, 0))
+    w_headers, w_bodies, w_transactions_roots, w_trie_data_dicts, w_uncles_hashes = zip(
+        *wrong_headers_bundle
+    )
+    w_transactions_bundles = tuple(zip(w_transactions_roots, w_trie_data_dicts))
+    w_bodies_bundle = tuple(zip(w_bodies, w_transactions_bundles, w_uncles_hashes))
+
+    request = BlockBodiesRequest(headers)
+    with pytest.raises(ValidationError):
+        request.validate_response(w_bodies, w_bodies_bundle)
+
+
+def test_block_bodies_request_with_extra_unrequested_bodies():
+    headers_bundle = mk_headers((2, 3), (8, 4), (0, 1), (0, 0))
+    headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
+    transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
+    bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
+    request = BlockBodiesRequest(headers)
+
+    wrong_headers_bundle = mk_headers((3, 2), (4, 8), (1, 0), (0, 0))
+    w_headers, w_bodies, w_transactions_roots, w_trie_data_dicts, w_uncles_hashes = zip(
+        *wrong_headers_bundle
+    )
+    w_transactions_bundles = tuple(zip(w_transactions_roots, w_trie_data_dicts))
+    w_bodies_bundle = tuple(zip(w_bodies, w_transactions_bundles, w_uncles_hashes))
+
+    request = BlockBodiesRequest(headers)
+    with pytest.raises(ValidationError):
+        request.validate_response(
+            bodies + w_bodies,
+            bodies_bundle + w_bodies_bundle,
+        )

--- a/tests/trinity/core/p2p-proto/test_node_data_request_object.py
+++ b/tests/trinity/core/p2p-proto/test_node_data_request_object.py
@@ -28,7 +28,7 @@ def test_node_data_request_empty_response_is_valid():
     node_keys, _ = mk_node_data(10)
     request = NodeDataRequest(node_keys)
 
-    request.validate_response(tuple())
+    request.validate_response(tuple(), tuple())
 
 
 def test_node_data_request_with_full_response():
@@ -36,7 +36,7 @@ def test_node_data_request_with_full_response():
     request = NodeDataRequest(node_keys)
     node_data = tuple(zip(node_keys, nodes))
 
-    request.validate_response(node_data)
+    request.validate_response(nodes, node_data)
 
 
 def test_node_data_request_with_partial_response():
@@ -44,9 +44,12 @@ def test_node_data_request_with_partial_response():
     request = NodeDataRequest(node_keys)
     node_data = tuple(zip(node_keys, nodes))
 
-    request.validate_response(node_data[3:])
-    request.validate_response(node_data[:3])
-    request.validate_response((node_data[1], node_data[8], node_data[4]))
+    request.validate_response(nodes[3:], node_data[3:])
+    request.validate_response(nodes[:3], node_data[:3])
+    request.validate_response(
+        (nodes[1], nodes[8], nodes[4]),
+        (node_data[1], node_data[8], node_data[4]),
+    )
 
 
 def test_node_data_request_with_fully_invalid_response():
@@ -58,7 +61,7 @@ def test_node_data_request_with_fully_invalid_response():
     other_node_data = tuple((keccak(node), node) for node in other_nodes)
 
     with pytest.raises(ValidationError):
-        request.validate_response(other_node_data)
+        request.validate_response(other_nodes, other_node_data)
 
 
 def test_node_data_request_with_extra_unrequested_nodes():
@@ -71,4 +74,7 @@ def test_node_data_request_with_extra_unrequested_nodes():
     other_node_data = tuple((keccak(node), node) for node in other_nodes)
 
     with pytest.raises(ValidationError):
-        request.validate_response(node_data + other_node_data)
+        request.validate_response(
+            nodes + other_nodes,
+            node_data + other_node_data,
+        )

--- a/tests/trinity/core/p2p-proto/test_peer_block_body_request_and_response_api.py
+++ b/tests/trinity/core/p2p-proto/test_peer_block_body_request_and_response_api.py
@@ -98,8 +98,10 @@ async def test_eth_peer_get_block_bodies_round_trip_with_empty_response(eth_peer
         remote.sub_proto.send_block_bodies([])
         await asyncio.sleep(0)
 
+    get_bodies_task = asyncio.ensure_future(peer.requests.get_block_bodies(headers))
     asyncio.ensure_future(send_block_bodies())
-    response = await peer.requests.get_block_bodies(headers)
+
+    response = await get_bodies_task
 
     assert len(response) == 0
 
@@ -118,8 +120,10 @@ async def test_eth_peer_get_block_bodies_round_trip_with_full_response(eth_peer_
     transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
     bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
 
+    get_bodies_task = asyncio.ensure_future(peer.requests.get_block_bodies(headers))
     asyncio.ensure_future(send_block_bodies())
-    response = await peer.requests.get_block_bodies(headers)
+
+    response = await get_bodies_task
 
     assert len(response) == 4
     assert response == bodies_bundle
@@ -139,8 +143,10 @@ async def test_eth_peer_get_block_bodies_round_trip_with_partial_response(eth_pe
     transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
     bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
 
+    get_bodies_task = asyncio.ensure_future(peer.requests.get_block_bodies(headers))
     asyncio.ensure_future(send_block_bodies())
-    response = await peer.requests.get_block_bodies(headers)
+
+    response = await get_bodies_task
 
     assert len(response) == 3
     assert response == bodies_bundle[1:]
@@ -164,8 +170,10 @@ async def test_eth_peer_get_block_bodies_round_trip_with_noise(eth_peer_and_remo
     transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
     bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
 
+    get_bodies_task = asyncio.ensure_future(peer.requests.get_block_bodies(headers))
     asyncio.ensure_future(send_block_bodies())
-    response = await peer.requests.get_block_bodies(headers)
+
+    response = await get_bodies_task
 
     assert len(response) == 4
     assert response == bodies_bundle
@@ -190,8 +198,10 @@ async def test_eth_peer_get_block_bodies_round_trip_no_match_invalid_response(et
     transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
     bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
 
+    get_bodies_task = asyncio.ensure_future(peer.requests.get_block_bodies(headers))
     asyncio.ensure_future(send_block_bodies())
-    response = await peer.requests.get_block_bodies(headers)
+
+    response = await get_bodies_task
 
     assert len(response) == 4
     assert response == bodies_bundle

--- a/tests/trinity/core/p2p-proto/test_peer_block_body_request_and_response_api.py
+++ b/tests/trinity/core/p2p-proto/test_peer_block_body_request_and_response_api.py
@@ -1,0 +1,197 @@
+import asyncio
+import os
+import random
+import time
+
+import pytest
+
+import rlp
+
+from eth_utils import (
+    big_endian_to_int,
+    keccak,
+    to_tuple,
+)
+
+from eth.db.trie import make_trie_root_and_nodes
+from eth.rlp.headers import BlockHeader
+from eth.rlp.transactions import BaseTransactionFields
+
+from trinity.protocol.eth.peer import ETHPeer
+from trinity.rlp.block_body import BlockBody
+
+from tests.trinity.core.peer_helpers import (
+    get_directly_linked_peers,
+)
+
+
+def mk_uncle(block_number):
+    return BlockHeader(
+        state_root=os.urandom(32),
+        difficulty=1000000,
+        block_number=block_number,
+        gas_limit=3141592,
+        timestamp=int(time.time()),
+    )
+
+
+def mk_transaction():
+    return BaseTransactionFields(
+        nonce=0,
+        gas=21000,
+        gas_price=1,
+        to=os.urandom(20),
+        value=random.randint(0, 100),
+        data=b'',
+        v=27,
+        r=big_endian_to_int(os.urandom(32)),
+        s=big_endian_to_int(os.urandom(32)),
+    )
+
+
+def mk_header_and_body(block_number, num_transactions, num_uncles):
+    transactions = tuple(mk_transaction() for _ in range(num_transactions))
+    uncles = tuple(mk_uncle(block_number - 1) for _ in range(num_uncles))
+
+    transaction_root, trie_data = make_trie_root_and_nodes(transactions)
+    uncles_hash = keccak(rlp.encode(uncles))
+
+    body = BlockBody(transactions=transactions, uncles=uncles)
+
+    header = BlockHeader(
+        difficulty=1000000,
+        block_number=block_number,
+        gas_limit=3141592,
+        timestamp=int(time.time()),
+        transaction_root=transaction_root,
+        uncles_hash=uncles_hash,
+    )
+
+    return header, body, transaction_root, trie_data, uncles_hash
+
+
+@to_tuple
+def mk_headers(*counts):
+    for idx, (num_transactions, num_uncles) in enumerate(counts, 1):
+        yield mk_header_and_body(idx, num_transactions, num_uncles)
+
+
+@pytest.fixture
+async def eth_peer_and_remote(request, event_loop):
+    peer, remote = await get_directly_linked_peers(
+        request,
+        event_loop,
+        peer1_class=ETHPeer,
+        peer2_class=ETHPeer,
+    )
+    return peer, remote
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_block_bodies_round_trip_with_empty_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers((2, 3), (8, 4), (0, 1), (0, 0))
+    headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
+
+    async def send_block_bodies():
+        remote.sub_proto.send_block_bodies([])
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_block_bodies())
+    response = await peer.requests.get_block_bodies(headers)
+
+    assert len(response) == 0
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_block_bodies_round_trip_with_full_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers((2, 3), (8, 4), (0, 1), (0, 0))
+    headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
+
+    async def send_block_bodies():
+        remote.sub_proto.send_block_bodies(bodies)
+        await asyncio.sleep(0)
+
+    transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
+    bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
+
+    asyncio.ensure_future(send_block_bodies())
+    response = await peer.requests.get_block_bodies(headers)
+
+    assert len(response) == 4
+    assert response == bodies_bundle
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_block_bodies_round_trip_with_partial_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers((2, 3), (8, 4), (0, 1), (0, 0))
+    headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
+
+    async def send_block_bodies():
+        remote.sub_proto.send_block_bodies(bodies[1:])
+        await asyncio.sleep(0)
+
+    transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
+    bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
+
+    asyncio.ensure_future(send_block_bodies())
+    response = await peer.requests.get_block_bodies(headers)
+
+    assert len(response) == 3
+    assert response == bodies_bundle[1:]
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_block_bodies_round_trip_with_noise(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers((2, 3), (8, 4), (0, 1), (0, 0))
+    headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
+
+    async def send_block_bodies():
+        remote.sub_proto.send_node_data((b'', b'arst'))
+        await asyncio.sleep(0)
+        remote.sub_proto.send_block_bodies(bodies)
+        await asyncio.sleep(0)
+        remote.sub_proto.send_node_data((b'', b'arst'))
+        await asyncio.sleep(0)
+
+    transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
+    bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
+
+    asyncio.ensure_future(send_block_bodies())
+    response = await peer.requests.get_block_bodies(headers)
+
+    assert len(response) == 4
+    assert response == bodies_bundle
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_block_bodies_round_trip_no_match_invalid_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers((2, 3), (8, 4), (0, 1), (0, 0))
+    headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
+
+    wrong_headers_bundle = mk_headers((4, 1), (3, 5), (2, 0), (7, 3))
+    _, wrong_bodies, _, _, _ = zip(*wrong_headers_bundle)
+
+    async def send_block_bodies():
+        remote.sub_proto.send_block_bodies(wrong_bodies)
+        await asyncio.sleep(0)
+        remote.sub_proto.send_block_bodies(bodies)
+        await asyncio.sleep(0)
+
+    transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
+    bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
+
+    asyncio.ensure_future(send_block_bodies())
+    response = await peer.requests.get_block_bodies(headers)
+
+    assert len(response) == 4
+    assert response == bodies_bundle

--- a/tests/trinity/core/p2p-proto/test_peer_block_header_request_and_response_api.py
+++ b/tests/trinity/core/p2p-proto/test_peer_block_header_request_and_response_api.py
@@ -73,8 +73,10 @@ async def test_eth_peer_get_headers_round_trip(eth_peer_and_remote,
     async def send_headers():
         remote.sub_proto.send_block_headers(headers)
 
+    get_headers_task = asyncio.ensure_future(peer.requests.get_block_headers(*params))
     asyncio.ensure_future(send_headers())
-    response = await peer.requests.get_block_headers(*params)
+
+    response = await get_headers_task
 
     assert len(response) == len(headers)
     for expected, actual in zip(headers, response):
@@ -100,8 +102,10 @@ async def test_les_peer_get_headers_round_trip(les_peer_and_remote,
         remote.sub_proto.send_block_headers(headers, 0, request_id)
         await asyncio.sleep(0)
 
+    get_headers_task = asyncio.ensure_future(peer.requests.get_block_headers(*params))
     asyncio.ensure_future(send_headers())
-    response = await peer.requests.get_block_headers(*params)
+
+    response = await get_headers_task
 
     assert len(response) == len(headers)
     for expected, actual in zip(headers, response):
@@ -120,8 +124,10 @@ async def test_eth_peer_get_headers_round_trip_with_noise(eth_peer_and_remote):
         remote.sub_proto.send_block_headers(headers)
         await asyncio.sleep(0)
 
+    get_headers_task = asyncio.ensure_future(peer.requests.get_block_headers(0, 10, 0, False))
     asyncio.ensure_future(send_responses())
-    response = await peer.requests.get_block_headers(0, 10, 0, False)
+
+    response = await get_headers_task
 
     assert len(response) == len(headers)
     for expected, actual in zip(headers, response):
@@ -144,8 +150,10 @@ async def test_eth_peer_get_headers_round_trip_does_not_match_invalid_response(e
         remote.sub_proto.send_block_headers(headers)
         await asyncio.sleep(0)
 
+    get_headers_task = asyncio.ensure_future(peer.requests.get_block_headers(0, 5, 0, False))
     asyncio.ensure_future(send_responses())
-    response = await peer.requests.get_block_headers(0, 5, 0, False)
+
+    response = await get_headers_task
 
     assert len(response) == len(headers)
     for expected, actual in zip(headers, response):

--- a/tests/trinity/core/p2p-proto/test_peer_receipts_request_and_response_api.py
+++ b/tests/trinity/core/p2p-proto/test_peer_receipts_request_and_response_api.py
@@ -1,0 +1,143 @@
+import asyncio
+import os
+import time
+
+import pytest
+
+from eth_utils import to_tuple
+
+from eth.db.trie import make_trie_root_and_nodes
+from eth.rlp.headers import BlockHeader
+from eth.rlp.receipts import Receipt
+
+from trinity.protocol.eth.peer import ETHPeer
+
+from tests.trinity.core.peer_helpers import (
+    get_directly_linked_peers,
+)
+
+
+@pytest.fixture
+async def eth_peer_and_remote(request, event_loop):
+    peer, remote = await get_directly_linked_peers(
+        request,
+        event_loop,
+        peer1_class=ETHPeer,
+        peer2_class=ETHPeer,
+    )
+    return peer, remote
+
+
+@to_tuple
+def mk_receipts(num_receipts):
+    for _ in range(num_receipts):
+        yield Receipt(
+            state_root=os.urandom(32),
+            gas_used=21000,
+            bloom=0,
+            logs=[],
+        )
+
+
+def mk_header_and_receipts(block_number, num_receipts):
+    receipts = mk_receipts(num_receipts)
+    root_hash, trie_root_and_data = make_trie_root_and_nodes(receipts)
+    header = BlockHeader(
+        difficulty=1000000,
+        block_number=block_number,
+        gas_limit=3141592,
+        timestamp=int(time.time()),
+        receipt_root=root_hash,
+    )
+    return header, receipts, (root_hash, trie_root_and_data)
+
+
+@to_tuple
+def mk_headers(*counts):
+    for idx, num_receipts in enumerate(counts, 1):
+        yield mk_header_and_receipts(idx, num_receipts)
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_receipts_round_trip_with_full_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+
+    async def send_receipts():
+        remote.sub_proto.send_receipts(receipts)
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_receipts())
+    response = await peer.requests.get_receipts(headers)
+
+    assert len(response) == len(headers)
+    assert response == receipts_bundle
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_receipts_round_trip_with_partial_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+
+    async def send_receipts():
+        remote.sub_proto.send_receipts((receipts[2], receipts[1], receipts[4]))
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_receipts())
+    response = await peer.requests.get_receipts(headers)
+
+    assert len(response) == 3
+    assert response == (receipts_bundle[2], receipts_bundle[1], receipts_bundle[4])
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_receipts_round_trip_with_noise(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+
+    async def send_receipts():
+        remote.sub_proto.send_transactions([])
+        await asyncio.sleep(0)
+        remote.sub_proto.send_receipts(receipts)
+        await asyncio.sleep(0)
+        remote.sub_proto.send_transactions([])
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_receipts())
+    response = await peer.requests.get_receipts(headers)
+
+    assert len(response) == len(headers)
+    assert response == receipts_bundle
+
+
+@pytest.mark.asyncio
+async def test_eth_peer_get_receipts_round_trip_no_match_invalid_response(eth_peer_and_remote):
+    peer, remote = eth_peer_and_remote
+
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+
+    wrong_headers = mk_headers(4, 3, 8)
+    _, wrong_receipts, _ = zip(*wrong_headers)
+
+    async def send_receipts():
+        remote.sub_proto.send_receipts(wrong_receipts)
+        await asyncio.sleep(0)
+        remote.sub_proto.send_receipts(receipts)
+        await asyncio.sleep(0)
+
+    asyncio.ensure_future(send_receipts())
+    response = await peer.requests.get_receipts(headers)
+
+    assert len(response) == len(headers)
+    assert response == receipts_bundle

--- a/tests/trinity/core/p2p-proto/test_peer_receipts_request_and_response_api.py
+++ b/tests/trinity/core/p2p-proto/test_peer_receipts_request_and_response_api.py
@@ -70,8 +70,10 @@ async def test_eth_peer_get_receipts_round_trip_with_full_response(eth_peer_and_
         remote.sub_proto.send_receipts(receipts)
         await asyncio.sleep(0)
 
+    get_receipts_task = asyncio.ensure_future(peer.requests.get_receipts(headers))
     asyncio.ensure_future(send_receipts())
-    response = await peer.requests.get_receipts(headers)
+
+    response = await get_receipts_task
 
     assert len(response) == len(headers)
     assert response == receipts_bundle
@@ -89,8 +91,10 @@ async def test_eth_peer_get_receipts_round_trip_with_partial_response(eth_peer_a
         remote.sub_proto.send_receipts((receipts[2], receipts[1], receipts[4]))
         await asyncio.sleep(0)
 
+    get_receipts_task = asyncio.ensure_future(peer.requests.get_receipts(headers))
     asyncio.ensure_future(send_receipts())
-    response = await peer.requests.get_receipts(headers)
+
+    response = await get_receipts_task
 
     assert len(response) == 3
     assert response == (receipts_bundle[2], receipts_bundle[1], receipts_bundle[4])
@@ -112,8 +116,10 @@ async def test_eth_peer_get_receipts_round_trip_with_noise(eth_peer_and_remote):
         remote.sub_proto.send_transactions([])
         await asyncio.sleep(0)
 
+    get_receipts_task = asyncio.ensure_future(peer.requests.get_receipts(headers))
     asyncio.ensure_future(send_receipts())
-    response = await peer.requests.get_receipts(headers)
+
+    response = await get_receipts_task
 
     assert len(response) == len(headers)
     assert response == receipts_bundle
@@ -136,8 +142,10 @@ async def test_eth_peer_get_receipts_round_trip_no_match_invalid_response(eth_pe
         remote.sub_proto.send_receipts(receipts)
         await asyncio.sleep(0)
 
+    get_receipts_task = asyncio.ensure_future(peer.requests.get_receipts(headers))
     asyncio.ensure_future(send_receipts())
-    response = await peer.requests.get_receipts(headers)
+
+    response = await get_receipts_task
 
     assert len(response) == len(headers)
     assert response == receipts_bundle

--- a/tests/trinity/core/p2p-proto/test_receipts_request_object.py
+++ b/tests/trinity/core/p2p-proto/test_receipts_request_object.py
@@ -1,0 +1,105 @@
+import os
+import time
+
+import pytest
+
+from eth_utils import to_tuple
+
+from eth.db.trie import make_trie_root_and_nodes
+from eth.rlp.headers import BlockHeader
+from eth.rlp.receipts import Receipt
+
+from p2p.exceptions import ValidationError
+
+from trinity.protocol.eth.requests import ReceiptsRequest
+
+
+@to_tuple
+def mk_receipts(num_receipts):
+    for _ in range(num_receipts):
+        yield Receipt(
+            state_root=os.urandom(32),
+            gas_used=21000,
+            bloom=0,
+            logs=[],
+        )
+
+
+def mk_header_and_receipts(block_number, num_receipts):
+    receipts = mk_receipts(num_receipts)
+    root_hash, trie_root_and_data = make_trie_root_and_nodes(receipts)
+    header = BlockHeader(
+        difficulty=1000000,
+        block_number=block_number,
+        gas_limit=3141592,
+        timestamp=int(time.time()),
+        receipt_root=root_hash,
+    )
+    return header, receipts, (root_hash, trie_root_and_data)
+
+
+@to_tuple
+def mk_headers(*counts):
+    for idx, num_receipts in enumerate(counts, 1):
+        yield mk_header_and_receipts(idx, num_receipts)
+
+
+def test_receipts_request_empty_response_is_valid():
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, _, _ = zip(*headers_bundle)
+    request = ReceiptsRequest(headers)
+    request.validate_response(tuple(), tuple())
+
+
+def test_receipts_request_valid_with_full_response():
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+    request = ReceiptsRequest(headers)
+    request.validate_response(receipts, receipts_bundle)
+
+
+def test_receipts_request_valid_with_partial_response():
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+    request = ReceiptsRequest(headers)
+
+    request.validate_response(receipts[:3], receipts_bundle[:3])
+    request.validate_response(receipts[2:], receipts_bundle[2:])
+    request.validate_response(
+        (receipts[1], receipts[3], receipts[4]),
+        (receipts_bundle[1], receipts_bundle[3], receipts_bundle[4]),
+    )
+
+
+def test_receipts_request_with_fully_invalid_response():
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, _, _ = zip(*headers_bundle)
+
+    wrong_headers = mk_headers(4, 3, 8)
+    _, wrong_receipts, wrong_trie_roots_and_data = zip(*wrong_headers)
+    receipts_bundle = tuple(zip(wrong_receipts, wrong_trie_roots_and_data))
+
+    request = ReceiptsRequest(headers)
+
+    with pytest.raises(ValidationError):
+        request.validate_response(wrong_receipts, receipts_bundle)
+
+
+def test_receipts_request_with_extra_unrequested_receipts():
+    headers_bundle = mk_headers(1, 3, 2, 5, 4)
+    headers, receipts, trie_roots_and_data = zip(*headers_bundle)
+    receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
+
+    wrong_headers = mk_headers(4, 3, 8)
+    _, wrong_receipts, wrong_trie_roots_and_data = zip(*wrong_headers)
+    extra_receipts_bundle = tuple(zip(wrong_receipts, wrong_trie_roots_and_data))
+
+    request = ReceiptsRequest(headers)
+
+    with pytest.raises(ValidationError):
+        request.validate_response(
+            receipts + wrong_receipts,
+            receipts_bundle + extra_receipts_bundle,
+        )

--- a/trinity/p2p/handlers.py
+++ b/trinity/p2p/handlers.py
@@ -1,4 +1,5 @@
 from typing import (
+    Any,
     AsyncGenerator,
     List,
     Tuple,
@@ -80,7 +81,7 @@ class PeerRequestHandler(CancellableMixin):
         peer.sub_proto.send_node_data(tuple(nodes))
 
     async def lookup_headers(self,
-                             request: BaseHeaderRequest) -> Tuple[BlockHeader, ...]:
+                             request: BaseHeaderRequest[Any]) -> Tuple[BlockHeader, ...]:
         """
         Lookup :max_headers: headers starting at :block_number_or_hash:, skipping :skip: items
         between each, in reverse order if :reverse: is True.
@@ -101,7 +102,7 @@ class PeerRequestHandler(CancellableMixin):
         return headers
 
     async def _get_block_numbers_for_request(self,
-                                             request: BaseHeaderRequest
+                                             request: BaseHeaderRequest[Any],
                                              ) -> Tuple[BlockNumber, ...]:
         """
         Generate the block numbers for a given `HeaderRequest`.

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 import asyncio
 import time
 from typing import (
+    Any,
     cast,
     Generic,
     Set,
@@ -28,10 +29,14 @@ from trinity.exceptions import AlreadyWaiting
 from .requests import BaseRequest
 
 
+# The peer class that this will be connected to
 TPeer = TypeVar('TPeer', bound=BasePeer)
-TRequest = TypeVar('TRequest', bound=BaseRequest)
-TResponse = TypeVar('TResponse')
+# The `Request` class that will be used.
+TRequest = TypeVar('TRequest', bound=BaseRequest[Any, Any])
+# The type that will be returned to the caller
 TReturn = TypeVar('TReturn')
+# The type of the command payload
+TMsg = TypeVar('TMsg')
 
 
 class ResponseTimeTracker:
@@ -59,7 +64,7 @@ class ResponseTimeTracker:
         self.total_response_time += time
 
 
-class BaseRequestManager(PeerSubscriber, BaseService, Generic[TPeer, TRequest, TResponse, TReturn]):  # noqa: E501
+class BaseRequestManager(PeerSubscriber, BaseService, Generic[TPeer, TRequest, TMsg, TReturn]):
     #
     # PeerSubscriber
     #
@@ -93,14 +98,14 @@ class BaseRequestManager(PeerSubscriber, BaseService, Generic[TPeer, TRequest, T
                     self.logger.error("Unexpected peer: %s  expected: %s", peer, self._peer)
                     continue
                 elif isinstance(cmd, self._response_msg_type):
-                    await self._handle_msg(cast(TResponse, msg))
+                    await self._handle_msg(cast(TMsg, msg))
                 else:
                     self.logger.warning("Unexpected message type: %s", cmd.__class__.__name__)
 
     async def _cleanup(self) -> None:
         pass
 
-    async def _handle_msg(self, msg: TResponse) -> None:
+    async def _handle_msg(self, msg: TMsg) -> None:
         if self.pending_request is None:
             self.logger.debug(
                 "Got unexpected %s message from %", self.response_msg_name, self._peer
@@ -125,7 +130,7 @@ class BaseRequestManager(PeerSubscriber, BaseService, Generic[TPeer, TRequest, T
             return
 
         try:
-            request.validate_response(response)
+            request.validate_response(msg, response)
         except ValidationError as err:
             self.logger.debug(
                 "Response validation failed for pending %s request from peer %s: %s",
@@ -133,16 +138,17 @@ class BaseRequestManager(PeerSubscriber, BaseService, Generic[TPeer, TRequest, T
                 self._peer,
                 err,
             )
-        else:
-            future.set_result(response)
-            self.pending_request = None
+            return
+
+        future.set_result(response)
+        self.pending_request = None
 
     @abstractmethod
-    async def _normalize_response(self, msg: TResponse) -> TReturn:
+    async def _normalize_response(self, msg: TMsg) -> TReturn:
         pass
 
     @abstractmethod
-    def _get_item_count(self, msg: TResponse) -> int:
+    def _get_item_count(self, msg: TMsg) -> int:
         pass
 
     @abstractmethod

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -5,6 +5,7 @@ from trinity.protocol.common.handlers import (
 from .managers import (
     GetBlockHeadersRequestManager,
     GetNodeDataRequestManager,
+    GetReceiptsRequestManager,
 )
 
 
@@ -12,8 +13,10 @@ class ETHRequestResponseHandler(BaseRequestResponseHandler):
     _managers = {
         'get_block_headers': GetBlockHeadersRequestManager,
         'get_node_data': GetNodeDataRequestManager,
+        'get_receipts': GetReceiptsRequestManager,
     }
 
     # These are needed only to please mypy.
     get_block_headers: GetBlockHeadersRequestManager
     get_node_data: GetNodeDataRequestManager
+    get_receipts: GetReceiptsRequestManager

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -3,6 +3,7 @@ from trinity.protocol.common.handlers import (
 )
 
 from .managers import (
+    GetBlockBodiesRequestManager,
     GetBlockHeadersRequestManager,
     GetNodeDataRequestManager,
     GetReceiptsRequestManager,
@@ -11,12 +12,14 @@ from .managers import (
 
 class ETHRequestResponseHandler(BaseRequestResponseHandler):
     _managers = {
+        'get_block_bodies': GetBlockBodiesRequestManager,
         'get_block_headers': GetBlockHeadersRequestManager,
         'get_node_data': GetNodeDataRequestManager,
         'get_receipts': GetReceiptsRequestManager,
     }
 
     # These are needed only to please mypy.
+    get_block_bodies: GetBlockBodiesRequestManager
     get_block_headers: GetBlockHeadersRequestManager
     get_node_data: GetNodeDataRequestManager
     get_receipts: GetReceiptsRequestManager

--- a/trinity/protocol/eth/managers.py
+++ b/trinity/protocol/eth/managers.py
@@ -6,7 +6,6 @@ from typing import (
 )
 
 from cytoolz import (
-    concat,
     compose,
 )
 
@@ -178,7 +177,7 @@ class GetReceiptsRequestManager(BaseGetReceiptsRequestManager):
         return receipt_bundles
 
     def _get_item_count(self, msg: ReceiptsByBlock) -> int:
-        return len(concat(msg))
+        return sum(len(item) for item in msg)
 
 
 # (BlockBody, (txn_root, txn_trie_data), uncles_hash)

--- a/trinity/protocol/eth/managers.py
+++ b/trinity/protocol/eth/managers.py
@@ -1,8 +1,11 @@
 from typing import (
+    Dict,
     Tuple,
     Type,
     TYPE_CHECKING,
 )
+
+from cytoolz import concat
 
 from eth_typing import (
     BlockIdentifier,
@@ -11,7 +14,9 @@ from eth_typing import (
 
 from eth_hash.auto import keccak
 
+from eth.db.trie import make_trie_root_and_nodes
 from eth.rlp.headers import BlockHeader
+from eth.rlp.receipts import Receipt
 
 from p2p.exceptions import MalformedMessage
 from p2p.protocol import (
@@ -25,10 +30,12 @@ from trinity.protocol.common.managers import (
 from .commands import (
     BlockHeaders,
     NodeData,
+    Receipts,
 )
 from .requests import (
     HeaderRequest,
     NodeDataRequest,
+    ReceiptsRequest,
 )
 
 if TYPE_CHECKING:
@@ -69,7 +76,7 @@ class GetBlockHeadersRequestManager(BaseGetBlockHeadersRequestManager):
         self._peer.sub_proto.send_get_block_headers(request)
 
     async def _normalize_response(self,
-                                  msg: Tuple[BlockHeader, ...]
+                                  msg: Tuple[BlockHeader, ...],
                                   ) -> Tuple[BlockHeader, ...]:
         return msg
 
@@ -77,11 +84,12 @@ class GetBlockHeadersRequestManager(BaseGetBlockHeadersRequestManager):
         return len(msg)
 
 
+NodeDataBundles = Tuple[Tuple[Hash32, bytes], ...]
 BaseGetNodeDataRequestManager = BaseRequestManager[
     'ETHPeer',
     NodeDataRequest,
     Tuple[bytes, ...],
-    Tuple[Tuple[Hash32, bytes], ...],
+    NodeDataBundles,
 ]
 
 
@@ -92,7 +100,7 @@ class GetNodeDataRequestManager(BaseGetNodeDataRequestManager):
 
     async def __call__(self,  # type: ignore
                        node_hashes: Tuple[Hash32, ...],
-                       timeout: int = None) -> Tuple[Tuple[Hash32, bytes], ...]:
+                       timeout: int = None) -> NodeDataBundles:
         request = NodeDataRequest(node_hashes)
         return await self._request_and_wait(request, timeout)
 
@@ -101,7 +109,7 @@ class GetNodeDataRequestManager(BaseGetNodeDataRequestManager):
 
     async def _normalize_response(self,
                                   msg: Tuple[bytes, ...]
-                                  ) -> Tuple[Tuple[Hash32, bytes], ...]:
+                                  ) -> NodeDataBundles:
         if not isinstance(msg, tuple):
             raise MalformedMessage("Invalid msg, must be tuple of byte strings")
         elif not all(isinstance(item, bytes) for item in msg):
@@ -112,3 +120,54 @@ class GetNodeDataRequestManager(BaseGetNodeDataRequestManager):
 
     def _get_item_count(self, msg: Tuple[bytes, ...]) -> int:
         return len(msg)
+
+
+ReceiptsBundles = Tuple[Tuple[Tuple[Receipt, ...], Tuple[Hash32, Dict[Hash32, bytes]]], ...]
+ReceiptsByBlock = Tuple[Tuple[Receipt, ...], ...]
+BaseGetReceiptsRequestManager = BaseRequestManager[
+    'ETHPeer',
+    ReceiptsRequest,
+    ReceiptsByBlock,
+    ReceiptsBundles,
+]
+
+
+class GetReceiptsRequestManager(BaseGetReceiptsRequestManager):
+    msg_queue_maxsize = 100
+
+    _response_msg_type: Type[Command] = Receipts
+
+    async def __call__(self,  # type: ignore
+                       headers: Tuple[BlockHeader, ...],
+                       timeout: int = None) -> ReceiptsBundles:
+        request = ReceiptsRequest(headers)
+        return await self._request_and_wait(request, timeout)
+
+    def _send_sub_proto_request(self, request: ReceiptsRequest) -> None:
+        self._peer.sub_proto.send_get_receipts(request)
+
+    async def _normalize_response(self,
+                                  response: Tuple[Tuple[Receipt, ...], ...],
+                                  ) -> ReceiptsBundles:
+        if not isinstance(response, tuple):
+            raise MalformedMessage(
+                "`GetReceipts` response must be a tuple. Got: {0}".format(type(response))
+            )
+        elif not all(isinstance(item, tuple) for item in response):
+            raise MalformedMessage("`GetReceipts` response must be a tuple of tuples")
+
+        for item in response:
+            if not all(isinstance(value, Receipt) for value in item):
+                raise MalformedMessage(
+                    "Response must be a tuple of tuples of `BlockHeader` objects"
+                )
+
+        trie_roots_and_data = await self._run_in_executor(
+            tuple,
+            map(make_trie_root_and_nodes, response),
+        )
+        receipt_bundles = tuple(zip(response, trie_roots_and_data))
+        return receipt_bundles
+
+    def _get_item_count(self, msg: ReceiptsByBlock) -> int:
+        return len(concat(msg))

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -73,7 +73,7 @@ class ETHProtocol(Protocol):
     #
     # Node Data
     #
-    def send_get_node_data(self, request: Union[NodeDataRequest, Tuple[Hash32, ...]]) -> None:
+    def send_get_node_data(self, request: NodeDataRequest) -> None:
         self._send_get_node_data(request.node_hashes)
 
     def _send_get_node_data(self, node_hashes: Tuple[Hash32, ...]) -> None:

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -1,13 +1,15 @@
 import logging
 from typing import (
-    cast,
     List,
     Tuple,
     TYPE_CHECKING,
     Union,
 )
 
-from eth_typing import Hash32
+from eth_typing import (
+    Hash32,
+    BlockNumber,
+)
 
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
@@ -33,7 +35,6 @@ from .commands import (
     Status,
     Transactions,
 )
-from . import constants
 from .requests import (
     BlockBodiesRequest,
     HeaderRequest,
@@ -69,12 +70,14 @@ class ETHProtocol(Protocol):
         self.logger.debug("Sending ETH/Status msg: %s", resp)
         self.send(*cmd.encode(resp))
 
+    #
+    # Node Data
+    #
     def send_get_node_data(self, request: Union[NodeDataRequest, Tuple[Hash32, ...]]) -> None:
+        self._send_get_node_data(request.node_hashes)
+
+    def _send_get_node_data(self, node_hashes: Tuple[Hash32, ...]) -> None:
         cmd = GetNodeData(self.cmd_id_offset)
-        if isinstance(request, NodeDataRequest):
-            node_hashes = cast(NodeDataRequest, request).node_hashes
-        else:
-            node_hashes = cast(Tuple[Hash32, ...], request)
         header, body = cmd.encode(node_hashes)
         self.send(header, body)
 
@@ -83,6 +86,9 @@ class ETHProtocol(Protocol):
         header, body = cmd.encode(nodes)
         self.send(header, body)
 
+    #
+    # Block Headers
+    #
     def send_get_block_headers(self, request: HeaderRequest) -> None:
         """Send a GetBlockHeaders msg to the remote.
 
@@ -90,20 +96,24 @@ class ETHProtocol(Protocol):
         block_number_or_hash if reverse is False or ending at block_number_or_hash if reverse is
         True.
         """
-        if request.max_headers > constants.MAX_HEADERS_FETCH:
-            raise ValueError(
-                "Cannot ask for more than {} block headers in a single request. "
-                "Asked for {}".format(
-                    constants.MAX_HEADERS_FETCH,
-                    request.max_headers,
-                )
-            )
+        self._send_get_block_headers(
+            block_number_or_hash=request.block_number_or_hash,
+            max_headers=request.max_headers,
+            skip=request.skip,
+            reverse=request.reverse,
+        )
+
+    def _send_get_block_headers(self,
+                                block_number_or_hash: Union[BlockNumber, Hash32],
+                                max_headers: int,
+                                skip: int,
+                                reverse: bool) -> None:
         cmd = GetBlockHeaders(self.cmd_id_offset)
         data = {
-            'block_number_or_hash': request.block_number_or_hash,
-            'max_headers': request.max_headers,
-            'skip': request.skip,
-            'reverse': request.reverse
+            'block_number_or_hash': block_number_or_hash,
+            'max_headers': max_headers,
+            'skip': skip,
+            'reverse': reverse
         }
         header, body = cmd.encode(data)
         self.send(header, body)
@@ -113,13 +123,14 @@ class ETHProtocol(Protocol):
         header, body = cmd.encode(headers)
         self.send(header, body)
 
-    def send_get_block_bodies(self,
-                              request: Union[BlockBodiesRequest, Tuple[Hash32, ...]]) -> None:
+    #
+    # Block Bodies
+    #
+    def send_get_block_bodies(self, request: BlockBodiesRequest) -> None:
+        self._send_get_block_bodies(request.block_hashes)
+
+    def _send_get_block_bodies(self, block_hashes: Tuple[Hash32, ...]) -> None:
         cmd = GetBlockBodies(self.cmd_id_offset)
-        if isinstance(request, BlockBodiesRequest):
-            block_hashes = cast(BlockBodiesRequest, request).block_hashes
-        else:
-            block_hashes = cast(Tuple[Hash32, ...], request)
         header, body = cmd.encode(block_hashes)
         self.send(header, body)
 
@@ -128,12 +139,13 @@ class ETHProtocol(Protocol):
         header, body = cmd.encode(blocks)
         self.send(header, body)
 
-    def send_get_receipts(self,
-                          request: Union[ReceiptsRequest, Tuple[Hash32, ...]]) -> None:
-        if isinstance(request, ReceiptsRequest):
-            block_hashes = cast(ReceiptsRequest, request).block_hashes
-        else:
-            block_hashes = cast(Tuple[Hash32, ...], request)
+    #
+    # Receipts
+    #
+    def send_get_receipts(self, request: ReceiptsRequest) -> None:
+        self._send_get_receipts(request.block_hashes)
+
+    def _send_get_receipts(self, block_hashes: Tuple[Hash32, ...]) -> None:
         cmd = GetReceipts(self.cmd_id_offset)
         header, body = cmd.encode(block_hashes)
         self.send(header, body)
@@ -143,6 +155,9 @@ class ETHProtocol(Protocol):
         header, body = cmd.encode(receipts)
         self.send(header, body)
 
+    #
+    # Transactions
+    #
     def send_transactions(self, transactions: List[BaseTransactionFields]) -> None:
         cmd = Transactions(self.cmd_id_offset)
         header, body = cmd.encode(transactions)

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -35,6 +35,7 @@ from .commands import (
 )
 from . import constants
 from .requests import (
+    BlockBodiesRequest,
     HeaderRequest,
     NodeDataRequest,
     ReceiptsRequest,
@@ -112,8 +113,13 @@ class ETHProtocol(Protocol):
         header, body = cmd.encode(headers)
         self.send(header, body)
 
-    def send_get_block_bodies(self, block_hashes: List[Hash32]) -> None:
+    def send_get_block_bodies(self,
+                              request: Union[BlockBodiesRequest, Tuple[Hash32, ...]]) -> None:
         cmd = GetBlockBodies(self.cmd_id_offset)
+        if isinstance(request, BlockBodiesRequest):
+            block_hashes = cast(BlockBodiesRequest, request).block_hashes
+        else:
+            block_hashes = cast(Tuple[Hash32, ...], request)
         header, body = cmd.encode(block_hashes)
         self.send(header, body)
 

--- a/trinity/protocol/eth/requests.py
+++ b/trinity/protocol/eth/requests.py
@@ -1,4 +1,5 @@
 from typing import (
+    Dict,
     Tuple,
 )
 
@@ -6,6 +7,9 @@ from eth_typing import (
     BlockIdentifier,
     Hash32,
 )
+
+from eth.rlp.headers import BlockHeader
+from eth.rlp.receipts import Receipt
 
 from p2p.exceptions import ValidationError
 
@@ -17,7 +21,7 @@ from trinity.protocol.common.requests import (
 from . import constants
 
 
-class HeaderRequest(BaseHeaderRequest):
+class HeaderRequest(BaseHeaderRequest[Tuple[BlockHeader, ...]]):
     @property
     def max_size(self) -> int:
         return constants.MAX_HEADERS_FETCH
@@ -33,13 +37,16 @@ class HeaderRequest(BaseHeaderRequest):
         self.reverse = reverse
 
 
-class NodeDataRequest(BaseRequest):
-    node_keys_cache: Tuple[Hash32, ...]
+NodeDataBundles = Tuple[Tuple[Hash32, bytes], ...]
 
+
+class NodeDataRequest(BaseRequest[Tuple[bytes, ...], NodeDataBundles]):
     def __init__(self, node_hashes: Tuple[Hash32, ...]) -> None:
         self.node_hashes = node_hashes
 
-    def validate_response(self, response: Tuple[Tuple[Hash32, bytes], ...]) -> None:
+    def validate_response(self,
+                          msg: Tuple[bytes, ...],
+                          response: NodeDataBundles) -> None:
         if not response:
             # an empty response is always valid
             return
@@ -55,4 +62,38 @@ class NodeDataRequest(BaseRequest):
         if unexpected_keys:
             raise ValidationError(
                 "Response contains {0} unexpected nodes".format(len(unexpected_keys))
+            )
+
+
+ReceiptsBundles = Tuple[Tuple[Tuple[Receipt, ...], Tuple[Hash32, Dict[Hash32, bytes]]], ...]
+ReceiptsTuples = Tuple[Tuple[Receipt, ...], ...]
+
+
+class ReceiptsRequest(BaseRequest[ReceiptsTuples, ReceiptsBundles]):
+    def __init__(self, headers: Tuple[BlockHeader, ...]) -> None:
+        self.headers = headers
+
+    @property
+    def block_hashes(self) -> Tuple[Hash32, ...]:
+        return tuple(header.hash for header in self.headers)
+
+    def validate_response(self,
+                          msg: ReceiptsTuples,
+                          response: ReceiptsBundles) -> None:
+        if not response:
+            # empty response is always valid.
+            return
+
+        expected_receipt_roots = set(header.receipt_root for header in self.headers)
+        actual_receipt_roots = set(
+            root_hash
+            for receipt, (root_hash, trie_data)
+            in response
+        )
+
+        unexpected_roots = actual_receipt_roots.difference(expected_receipt_roots)
+
+        if unexpected_roots:
+            raise ValidationError(
+                "Got {0} unexpected receipt roots".format(len(unexpected_roots))
             )

--- a/trinity/protocol/les/managers.py
+++ b/trinity/protocol/les/managers.py
@@ -37,7 +37,7 @@ BaseRequestManager = _BaseRequestManager[
     'LESPeer',
     HeaderRequest,
     Dict[str, Any],
-    Tuple[BlockHeader, ...]
+    Tuple[BlockHeader, ...],
 ]
 
 

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -2,6 +2,12 @@ from typing import (
     List,
     Tuple,
     TYPE_CHECKING,
+    Union,
+)
+
+from eth_typing import (
+    BlockNumber,
+    Hash32,
 )
 
 from eth.rlp.headers import BlockHeader
@@ -81,19 +87,28 @@ class LESProtocol(Protocol):
         block_number_or_hash if reverse is False or ending at block_number_or_hash if reverse is
         True.
         """
-        if request.max_headers > constants.MAX_HEADERS_FETCH:
-            raise ValueError(
-                "Cannot ask for more than {} block headers in a single request".format(
-                    constants.MAX_HEADERS_FETCH))
+        self._send_get_block_headers(
+            request.block_number_or_hash,
+            request.max_headers,
+            request.skip,
+            request.reverse,
+            request.request_id,
+        )
+
+    def _send_get_block_headers(self,
+                                block_number_or_hash: Union[BlockNumber, Hash32],
+                                max_headers: int,
+                                skip: int,
+                                reverse: bool,
+                                request_id: int) -> None:
         cmd = GetBlockHeaders(self.cmd_id_offset)
-        # Number of block headers to skip between each item (i.e. step in python APIs).
         data = {
-            'request_id': request.request_id,
+            'request_id': request_id,
             'query': GetBlockHeadersQuery(
-                request.block_number_or_hash,
-                request.max_headers,
-                request.skip,
-                request.reverse,
+                block_number_or_hash,
+                max_headers,
+                skip,
+                reverse,
             ),
         }
         header, body = cmd.encode(data)

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -1,5 +1,14 @@
+from typing import (
+    Any,
+    Dict,
+    Tuple,
+)
+
 from eth_typing import BlockIdentifier
 
+from eth.rlp.headers import BlockHeader
+
+from p2p.exceptions import ValidationError
 
 from trinity.protocol.common.requests import (
     BaseHeaderRequest,
@@ -8,7 +17,10 @@ from trinity.protocol.common.requests import (
 from .constants import MAX_HEADERS_FETCH
 
 
-class HeaderRequest(BaseHeaderRequest):
+HeadersResponseDict = Dict[str, Any]
+
+
+class HeaderRequest(BaseHeaderRequest[HeadersResponseDict]):
     request_id: int
 
     max_size = MAX_HEADERS_FETCH
@@ -24,3 +36,10 @@ class HeaderRequest(BaseHeaderRequest):
         self.skip = skip
         self.reverse = reverse
         self.request_id = request_id
+
+    def validate_response(self,
+                          msg: HeadersResponseDict,
+                          response: Tuple[BlockHeader, ...]) -> None:
+        if msg['request_id'] != self.request_id:
+            raise ValidationError("Request `id` does not match")
+        super().validate_response(msg, response)

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -3,10 +3,8 @@ import math
 import operator
 from typing import (
     Any,
-    Callable,
     Dict,
     List,
-    NamedTuple,
     Set,
     Tuple,
     Type,
@@ -16,26 +14,21 @@ from typing import (
 
 from cytoolz import (
     concat,
+    merge,
     partition_all,
     unique,
 )
 
 from eth_typing import Hash32
 
-from cancel_token import CancelToken
-
 from eth.constants import (
     BLANK_ROOT_HASH, EMPTY_UNCLE_HASH, GENESIS_PARENT_HASH)
-from eth.chains import AsyncChain
-from eth.db.trie import make_trie_root_and_nodes
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransaction
 
 from p2p import protocol
 from p2p.exceptions import NoEligiblePeers
-from p2p.p2p_proto import DisconnectReason
-from p2p.peer import PeerPool
 from p2p.protocol import Command
 
 from trinity.db.chain import AsyncChainDB
@@ -52,7 +45,14 @@ from trinity.utils.timer import Timer
 
 
 HeaderRequestingPeer = Union[LESPeer, ETHPeer]
+# (ReceiptBundle, (Receipt, (root_hash, receipt_trie_data))
 ReceiptBundle = Tuple[Tuple[Receipt, ...], Tuple[Hash32, Dict[Hash32, bytes]]]
+# (BlockBody, (txn_root, txn_trie_data), uncles_hash)
+BlockBodyBundle = Tuple[
+    BlockBody,
+    Tuple[Hash32, Dict[Hash32, bytes]],
+    Hash32,
+]
 
 
 class FastChainSyncer(BaseHeaderChainSyncer):
@@ -66,29 +66,15 @@ class FastChainSyncer(BaseHeaderChainSyncer):
     db: AsyncChainDB
     _exit_on_sync_complete = True
 
-    def __init__(self,
-                 chain: AsyncChain,
-                 db: AsyncChainDB,
-                 peer_pool: PeerPool,
-                 token: CancelToken = None) -> None:
-        super().__init__(chain, db, peer_pool, token)
-        # Those are used by our msg handlers and _download_block_parts() in order to track missing
-        # bodies/receipts for a given chain segment.
-        self._downloaded_receipts: asyncio.Queue[Tuple[ETHPeer, List[DownloadedBlockPart]]] = asyncio.Queue()  # noqa: E501
-        self._downloaded_bodies: asyncio.Queue[Tuple[ETHPeer, List[DownloadedBlockPart]]] = asyncio.Queue()  # noqa: E501
-
     subscription_msg_types: Set[Type[Command]] = {
-        commands.BlockBodies,
         commands.NewBlock,
         commands.GetBlockHeaders,
         commands.GetBlockBodies,
         commands.GetReceipts,
         commands.GetNodeData,
-        commands.Transactions,
         # TODO: all of the following are here to quiet warning logging output
         # until the messages are properly handled.
         commands.Transactions,
-        commands.NewBlock,
         commands.NewBlockHashes,
     }
 
@@ -112,13 +98,7 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             self, peer: HeaderRequestingPeer, headers: Tuple[BlockHeader, ...]) -> int:
         timer = Timer()
         target_td = await self._calculate_td(headers)
-        bodies = await self._download_block_parts(
-            target_td,
-            [header for header in headers if not _is_body_empty(header)],
-            self.request_bodies,
-            self._downloaded_bodies,
-            _body_key,
-            'body')
+        bodies_by_key = await self._download_block_bodies(target_td, headers)
         self.logger.debug("Got block bodies for chain segment")
 
         await self._download_receipts(target_td, headers)
@@ -126,7 +106,8 @@ class FastChainSyncer(BaseHeaderChainSyncer):
 
         for header in headers:
             if header.uncles_hash != EMPTY_UNCLE_HASH:
-                body = cast(BlockBody, bodies[_body_key(header)])
+                key = (header.transaction_root, header.uncles_hash)
+                body = cast(BlockBody, bodies_by_key[key])
                 uncles = body.uncles
             else:
                 uncles = tuple()
@@ -138,11 +119,102 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             await self.wait(self.db.coro_persist_block(block))
 
         head = await self.wait(self.db.coro_get_canonical_head())
-        txs = sum(len(cast(BlockBody, body).transactions) for body in bodies.values())
+        txs = sum(len(cast(BlockBody, body).transactions) for body in bodies_by_key.values())
         self.logger.info(
             "Imported %d blocks (%d txs) in %0.2f seconds, new head: #%d",
             len(headers), txs, timer.elapsed, head.block_number)
         return head.block_number
+
+    async def _download_block_bodies(self,
+                                     target_td: int,
+                                     all_headers: Tuple[BlockHeader, ...]
+                                     ) -> Dict[Tuple[Hash32, Hash32], BlockBody]:
+        """
+        Downloads and persists the block bodies for the given set of block headers.
+        Block bodies are requested from all peers in equal sized batches.
+        """
+        headers = tuple(header for header in all_headers if not _is_body_empty(header))
+        block_bodies_by_key: Dict[Tuple[Hash32, Hash32], BlockBody] = {}
+
+        while headers:
+            # split the remaining headers into equal sized batches for each peer.
+            peers = cast(Tuple[ETHPeer, ...], self.peer_pool.get_peers(target_td))
+            if not peers:
+                raise NoEligiblePeers(
+                    "No connected peers have the block bodies we need for td={0}".format(target_td)
+                )
+            batch_size = math.ceil(len(headers) / len(peers))
+            batches = tuple(partition_all(batch_size, headers))
+
+            # issue requests to all of the peers and wait for all of them to respond.
+            requests = tuple(
+                self._get_block_bodies(peer, batch)
+                for peer, batch
+                in zip(peers, batches)
+            )
+            responses = await self.wait(asyncio.gather(
+                *requests,
+                loop=self.get_event_loop(),
+            ))
+
+            # extract the returned block body data and the headers for which we
+            # are still missing block bodies.
+            all_block_body_bundles, all_missing_headers = zip(*responses)
+
+            block_bodies_by_key = merge(block_bodies_by_key, {
+                (transaction_root, uncles_hash): block_body
+                for block_body, (transaction_root, trie_dict_data), uncles_hash
+                in concat(all_block_body_bundles)
+            })
+            headers = tuple(concat(all_missing_headers))
+        return block_bodies_by_key
+
+    async def _get_block_bodies(self,
+                                peer: ETHPeer,
+                                batch: Tuple[BlockHeader, ...],
+                                ) -> Tuple[Tuple[BlockBodyBundle, ...], Tuple[BlockHeader, ...]]:
+        """
+        Requests the batch of block bodies from the given peer, returning the
+        returned block bodies data and the headers for which block bodies were not
+        returned for.
+        """
+        self.logger.debug("Requesting block bodies for %d headers from %s", len(batch), peer)
+        try:
+            block_body_bundles = await peer.requests.get_block_bodies(batch)
+        except TimeoutError as err:
+            self.logger.debug(
+                "Timed out requesting block bodies for %d headers from %s", len(batch), peer,
+            )
+            return tuple(), batch
+        else:
+            self.logger.debug(
+                "Got block bodies for %d headers from %s", len(block_body_bundles), peer,
+            )
+
+        if not block_body_bundles:
+            return tuple(), batch
+
+        _, trie_roots_and_data_dicts, uncles_hashes = zip(*block_body_bundles)
+
+        # TODO: figure out why mypy is losing the type of the transactions_tries
+        # so we can get rid of the ignore
+        for (body, (tx_root, trie_data_dict), uncles_hash) in block_body_bundles:
+            await self.wait(self.db.coro_persist_trie_data_dict(trie_data_dict))
+
+        received_keys = {
+            (root_hash, uncles_hash)
+            for (root_hash, _), uncles_hash
+            in zip(trie_roots_and_data_dicts, uncles_hashes)
+        }
+
+        missing = tuple(
+            header
+            for header
+            in batch
+            if (header.transaction_root, header.uncles_hash) not in received_keys
+        )
+
+        return block_body_bundles, missing
 
     async def _download_receipts(self,
                                  target_td: int,
@@ -162,6 +234,10 @@ class FastChainSyncer(BaseHeaderChainSyncer):
         while headers:
             # split the remaining headers into equal sized batches for each peer.
             peers = cast(Tuple[ETHPeer, ...], self.peer_pool.get_peers(target_td))
+            if not peers:
+                raise NoEligiblePeers(
+                    "No connected peers have the receipts we need for td={0}".format(target_td)
+                )
             batch_size = math.ceil(len(headers) / len(peers))
             batches = tuple(partition_all(batch_size, headers))
 
@@ -213,6 +289,9 @@ class FastChainSyncer(BaseHeaderChainSyncer):
                 "Got receipts for %d headers from %s", len(receipt_bundles), peer,
             )
 
+        if not receipt_bundles:
+            return tuple(), batch
+
         receipts, trie_roots_and_data_dicts = zip(*receipt_bundles)
         receipt_roots, trie_data_dicts = zip(*trie_roots_and_data_dicts)
         receipt_roots_set = set(receipt_roots)
@@ -225,101 +304,15 @@ class FastChainSyncer(BaseHeaderChainSyncer):
 
         return receipt_bundles, missing
 
-    async def _download_block_parts(
-            self,
-            target_td: int,
-            headers: List[BlockHeader],
-            request_func: Callable[[int, List[BlockHeader]], int],
-            download_queue: 'asyncio.Queue[Tuple[ETHPeer, List[DownloadedBlockPart]]]',
-            key_func: Callable[[BlockHeader], Union[bytes, Tuple[bytes, bytes]]],
-            part_name: str
-    ) -> 'Dict[Union[bytes, Tuple[bytes, bytes]], Union[BlockBody, List[Receipt]]]':
-        """Download block parts for the given headers, using the given request_func.
-
-        Retry timed out parts until we have the parts for all headers.
-
-        Raises NoEligiblePeers if at any moment we have no connected peers that have the blocks
-        we want.
-        """
-        missing = headers.copy()
-        # The ETH protocol doesn't guarantee that we'll get all body parts requested, so we need
-        # to keep track of the number of pending replies and missing items to decide when to retry
-        # them. See request_receipts() for more info.
-        pending_replies = request_func(target_td, missing)
-        parts: List[DownloadedBlockPart] = []
-        while missing:
-            if pending_replies == 0:
-                pending_replies = request_func(target_td, missing)
-
-            try:
-                peer, received = await self.wait(
-                    download_queue.get(),
-                    timeout=self._reply_timeout)
-            except TimeoutError:
-                self.logger.info(
-                    "Timed out waiting for %d missing %s", len(missing), part_name)
-                pending_replies = request_func(target_td, missing)
-                continue
-
-            received_keys = set([part.unique_key for part in received])
-
-            duplicates = received_keys.intersection(part.unique_key for part in parts)
-            unexpected = received_keys.difference(key_func(header) for header in headers)
-
-            parts.extend(received)
-            pending_replies -= 1
-
-            if unexpected:
-                self.logger.debug("Got %d unexpected %s from %s", len(unexpected), part_name, peer)
-            if duplicates:
-                self.logger.debug("Got %d duplicate %s from %s", len(duplicates), part_name, peer)
-
-            missing = [
-                header
-                for header in missing
-                if key_func(header) not in received_keys
-            ]
-
-        return dict((part.unique_key, part.part) for part in parts)
-
-    def _request_block_parts(
-            self,
-            target_td: int,
-            headers: List[BlockHeader],
-            request_func: Callable[[ETHPeer, List[BlockHeader]], None]) -> int:
-        peers = self.peer_pool.get_peers(target_td)
-        if not peers:
-            raise NoEligiblePeers()
-        length = math.ceil(len(headers) / len(peers))
-        batches = list(partition_all(length, headers))
-        for peer, batch in zip(peers, batches):
-            request_func(cast(ETHPeer, peer), batch)
-        return len(batches)
-
-    def _send_get_block_bodies(self, peer: ETHPeer, headers: List[BlockHeader]) -> None:
-        block_numbers = ", ".join(str(h.block_number) for h in headers)
-        self.logger.debug(
-            "Requesting %d block bodies (%s) to %s", len(headers), block_numbers, peer)
-        peer.sub_proto.send_get_block_bodies([header.hash for header in headers])
-
-    def request_bodies(self, target_td: int, headers: List[BlockHeader]) -> int:
-        """Ask our peers for bodies for the given headers.
-
-        See request_receipts() for details of how this is done.
-        """
-        return self._request_block_parts(target_td, headers, self._send_get_block_bodies)
-
     async def _handle_msg(self, peer: HeaderRequestingPeer, cmd: protocol.Command,
                           msg: protocol._DecodedMsgType) -> None:
         peer = cast(ETHPeer, peer)
 
         # TODO: stop ignoring these once we have proper handling for these messages.
-        ignored_commands = (commands.Transactions, commands.NewBlock, commands.NewBlockHashes)
+        ignored_commands = (commands.Transactions, commands.NewBlockHashes)
 
         if isinstance(cmd, ignored_commands):
             pass
-        elif isinstance(cmd, commands.BlockBodies):
-            await self._handle_block_bodies(peer, list(cast(Tuple[BlockBody], msg)))
         elif isinstance(cmd, commands.NewBlock):
             await self._handle_new_block(peer, cast(Dict[str, Any], msg))
         elif isinstance(cmd, commands.GetBlockHeaders):
@@ -336,32 +329,11 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             # Only serve up to MAX_STATE_FETCH items in every request.
             node_hashes = cast(List[Hash32], msg)[:eth_constants.MAX_STATE_FETCH]
             await self._handler.handle_get_node_data(peer, node_hashes)
-        elif isinstance(cmd, commands.Transactions):
-            # Transactions msgs are handled by our TxPool service.
-            pass
         else:
             self.logger.debug("%s msg not handled yet, need to be implemented", cmd)
 
     async def _handle_new_block(self, peer: ETHPeer, msg: Dict[str, Any]) -> None:
         self._sync_requests.put_nowait(peer)
-
-    async def _handle_block_bodies(self,
-                                   peer: ETHPeer,
-                                   bodies: List[BlockBody]) -> None:
-        self.logger.debug("Got Bodies for %d blocks from %s", len(bodies), peer)
-        iterator = map(make_trie_root_and_nodes, [body.transactions for body in bodies])
-        # The map() call above is lazy (it returns an iterator! ;-), so it's only evaluated in
-        # the executor when the list() is applied to it.
-        transactions_tries = await self._run_in_executor(list, iterator)
-        downloaded: List[DownloadedBlockPart] = []
-
-        # TODO: figure out why mypy is losing the type of the transactions_tries
-        # so we can get rid of the ignore
-        for (body, (tx_root, trie_dict_data)) in zip(bodies, transactions_tries):  # type: ignore
-            await self.wait(self.db.coro_persist_trie_data_dict(trie_dict_data))
-            uncles_hash = await self.wait(self.db.coro_persist_uncles(body.uncles))
-            downloaded.append(DownloadedBlockPart(body, (tx_root, uncles_hash)))
-        self._downloaded_bodies.put_nowait((peer, downloaded))
 
     async def _handle_get_block_headers(
             self,
@@ -389,22 +361,10 @@ class RegularChainSyncer(FastChainSyncer):
     _exit_on_sync_complete = False
     _seal_check_random_sample_rate = 1
 
-    async def _handle_block_receipts(
-            self, peer: ETHPeer, receipts_by_block: List[List[Receipt]]) -> None:
-        # When doing a regular sync we never request receipts.
-        self.logger.warn("Unexpected BlockReceipts msg from %s, disconnecting", peer)
-        await peer.disconnect(DisconnectReason.bad_protocol)
-
     async def _process_headers(
             self, peer: HeaderRequestingPeer, headers: Tuple[BlockHeader, ...]) -> int:
         target_td = await self._calculate_td(headers)
-        downloaded_parts = await self._download_block_parts(
-            target_td,
-            [header for header in headers if not _is_body_empty(header)],
-            self.request_bodies,
-            self._downloaded_bodies,
-            _body_key,
-            'body')
+        bodies_by_key = await self._download_block_bodies(target_td, headers)
         self.logger.info("Got block bodies for chain segment")
 
         for header in headers:
@@ -415,7 +375,8 @@ class RegularChainSyncer(FastChainSyncer):
                 transactions: List[BaseTransaction] = []
                 uncles: List[BlockHeader] = []
             else:
-                body = cast(BlockBody, downloaded_parts[_body_key(header)])
+                key = (header.transaction_root, header.uncles_hash)
+                body = cast(BlockBody, bodies_by_key[key])
                 tx_class = block_class.get_transaction_class()
                 transactions = [tx_class.from_base_transaction(tx)
                                 for tx in body.transactions]
@@ -430,27 +391,6 @@ class RegularChainSyncer(FastChainSyncer):
         head = await self.wait(self.db.coro_get_canonical_head())
         self.logger.info("Imported chain segment, new head: #%d", head.block_number)
         return head.block_number
-
-
-class DownloadedBlockPart(NamedTuple):
-    part: Union[BlockBody, List[Receipt]]
-    unique_key: Union[bytes, Tuple[bytes, bytes]]
-
-
-def _body_key(header: BlockHeader) -> Tuple[bytes, bytes]:
-    """Return the unique key of the body for the given header.
-
-    i.e. a two-tuple with the transaction root and uncles hash.
-    """
-    return cast(Tuple[bytes, bytes], (header.transaction_root, header.uncles_hash))
-
-
-def _receipts_key(header: BlockHeader) -> bytes:
-    """Return the unique key of the list of receipts for the given header.
-
-    i.e. the header's receipt root.
-    """
-    return header.receipt_root
 
 
 def _is_body_empty(header: BlockHeader) -> bool:


### PR DESCRIPTION
Builds on https://github.com/ethereum/py-evm/pull/1159

### What was wrong?

Fixes https://github.com/ethereum/py-evm/issues/1131

### How was it fixed?

This finishes expanding the round trip API for the `eth` protocol to all of Headers, NodeData, Receipts, and BlockBodies request/response pairs.  The `FastChainSyncer` and `RegularChainSyncer` classes have been reworked to use this API.

#### Cute Animal Picture

![funny animals hugging_6](https://user-images.githubusercontent.com/824194/43973954-407e31d4-9c96-11e8-91b5-2e4f1081e168.jpg)
