### PR TITLE
PoC: Using the lahja eventbus for event based inter process communication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ deps = {
         "ipython>=6.2.1,<7.0.0",
         "plyvel==1.0.5",
         "web3==4.4.1",
+        "lahja==0.1.0-alpha.0",
     ],
     'test': [
         "hypothesis==3.44.26",

--- a/tests/trinity/integration/test_trinity_cli.py
+++ b/tests/trinity/integration/test_trinity_cli.py
@@ -74,6 +74,24 @@ async def test_txpool_full_boot(async_process_runner, command):
 @pytest.mark.parametrize(
     'command',
     (
+        ('trinity', '--light', '--tx-pool',),
+        ('trinity', '--light', '--ropsten', '--tx-pool',),
+    )
+)
+@pytest.mark.asyncio
+async def test_txpool_deactivated(async_process_runner, command):
+    await async_process_runner.run(command)
+    assert await contains_all(async_process_runner.stderr, {
+        "Started DB server process",
+        "Started networking process",
+        "The transaction pool is not yet available in light mode",
+        "IPC started at",
+    })
+
+
+@pytest.mark.parametrize(
+    'command',
+    (
         ('trinity', '--light',),
         ('trinity', '--light', '--ropsten',),
     )

--- a/trinity/events.py
+++ b/trinity/events.py
@@ -1,0 +1,6 @@
+from lahja import (
+    BaseEvent
+)
+
+class ShutdownRequested(BaseEvent):
+    pass

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -9,6 +9,13 @@ from argparse import (
 import logging
 import sys
 
+from lahja import (
+    Endpoint
+)
+
+from trinity.events import (
+    ShutdownRequested
+)
 from trinity.extensibility.events import (
     BaseEvent
 )
@@ -16,8 +23,11 @@ from trinity.extensibility.events import (
 
 class PluginContext:
 
+    def __init__(self, endpoint: Endpoint):
+        self.eventbus = endpoint
+
     def shutdown_trinity(self, exit_code: int = 0) -> None:
-        sys.exit(exit_code)
+        self.eventbus.broadcast(ShutdownRequested('meh'))
 
 
 class BasePlugin(ABC):

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -7,16 +7,17 @@ from argparse import (
     _SubParsersAction,
 )
 import logging
-from typing import (
-    Any
-)
+import sys
 
 from trinity.extensibility.events import (
     BaseEvent
 )
 
-# TODO: we spec this out later
-PluginContext = Any
+
+class PluginContext:
+
+    def shutdown_trinity(self, exit_code: int = 0) -> None:
+        sys.exit(exit_code)
 
 
 class BasePlugin(ABC):
@@ -34,6 +35,13 @@ class BasePlugin(ABC):
     @property
     def logger(self) -> logging.Logger:
         return logging.getLogger('trinity.extensibility.plugin.BasePlugin#{0}'.format(self.name))
+
+    @property
+    def context(self) -> PluginContext:
+        return self._context
+
+    def __init__(self, context: PluginContext) -> None:
+        self._context = context
 
     def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         """
@@ -56,7 +64,7 @@ class BasePlugin(ABC):
 
         return False
 
-    def start(self, context: PluginContext) -> None:
+    def start(self) -> None:
         """
         The ``start`` method is called only once when the plugin is started
         """
@@ -89,5 +97,5 @@ class DebugPlugin(BasePlugin):
         self.logger.info("Debug plugin: should_start called")
         return True
 
-    def start(self, context: PluginContext) -> None:
+    def start(self) -> None:
         self.logger.info("Debug plugin: start called")

--- a/trinity/extensibility/plugin_manager.py
+++ b/trinity/extensibility/plugin_manager.py
@@ -30,11 +30,11 @@ class PluginManager:
         This API is very much in flux and is expected to change heavily.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, context: PluginContext) -> None:
         self._plugin_store: List[Type[BasePlugin]] = []
         self._initialized_plugins: List[BasePlugin] = []
         self._started_plugins: List[BasePlugin] = []
-        self._plugin_context = PluginContext()
+        self._plugin_context = context
         self._logger = logging.getLogger("trinity.extensibility.plugin_manager.PluginManager")
 
     def register(self, plugins: Union[Type[BasePlugin], Iterable[Type[BasePlugin]]]) -> None:

--- a/trinity/extensibility/plugin_manager.py
+++ b/trinity/extensibility/plugin_manager.py
@@ -7,6 +7,7 @@ from typing import (
     Iterable,
     List,
     Union,
+    Type,
 )
 
 from trinity.extensibility.events import (
@@ -15,6 +16,7 @@ from trinity.extensibility.events import (
 )
 from trinity.extensibility.plugin import (
     BasePlugin,
+    PluginContext,
 )
 
 
@@ -29,18 +31,25 @@ class PluginManager:
     """
 
     def __init__(self) -> None:
-        self._plugin_store: List[BasePlugin] = []
+        self._plugin_store: List[Type[BasePlugin]] = []
+        self._initialized_plugins: List[BasePlugin] = []
         self._started_plugins: List[BasePlugin] = []
+        self._plugin_context = PluginContext()
         self._logger = logging.getLogger("trinity.extensibility.plugin_manager.PluginManager")
 
-    def register(self, plugins: Union[BasePlugin, Iterable[BasePlugin]]) -> None:
+    def register(self, plugins: Union[Type[BasePlugin], Iterable[Type[BasePlugin]]]) -> None:
         """
         Register one or multiple instances of :class:`~trinity.extensibility.plugin.BasePlugin`
         with the plugin manager.
         """
 
-        new_plugins = [plugins] if isinstance(plugins, BasePlugin) else plugins
+        new_plugins = [plugins] if not isinstance(plugins, Iterable) else plugins
         self._plugin_store.extend(new_plugins)
+
+    def initialize_plugins(self) -> None:
+        for plugin in self._plugin_store:
+            initialized_plugin = plugin(self._plugin_context)
+            self._initialized_plugins.append(initialized_plugin)
 
     def amend_argparser_config(self,
                                arg_parser: ArgumentParser,
@@ -49,7 +58,7 @@ class PluginManager:
         Call :meth:`~trinity.extensibility.plugin.BasePlugin.configure_parser` for every registered
         plugin, giving them the option to amend the global parser setup.
         """
-        for plugin in self._plugin_store:
+        for plugin in self._initialized_plugins:
             plugin.configure_parser(arg_parser, subparser)
 
     def broadcast(self, event: BaseEvent, exclude: BasePlugin = None) -> None:
@@ -61,7 +70,7 @@ class PluginManager:
         :class:`~trinity.extensibility.events.PluginStartedEvent` to get
         broadcasted to all other plugins, giving them the chance to start based on that.
         """
-        for plugin in self._plugin_store:
+        for plugin in self._initialized_plugins:
 
             if plugin is exclude:
                 continue
@@ -74,7 +83,7 @@ class PluginManager:
             if not plugin.should_start():
                 continue
 
-            plugin.start(None)
+            plugin.start()
             self._started_plugins.append(plugin)
             self._logger.info("Plugin started: {}".format(plugin.name))
             self.broadcast(PluginStartedEvent(plugin), plugin)

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -1,6 +1,8 @@
 from argparse import Namespace
 import asyncio
 import logging
+import multiprocessing
+import os
 import signal
 import sys
 import time
@@ -8,6 +10,12 @@ from typing import (
     Any,
     Dict,
     Type,
+)
+
+from lahja import (
+    EventBus,
+    Endpoint,
+    BaseEvent
 )
 
 from eth.chains.mainnet import (
@@ -37,8 +45,12 @@ from trinity.cli_parser import (
 from trinity.config import (
     ChainConfig,
 )
+from trinity.events import (
+    ShutdownRequested,
+)
 from trinity.extensibility import (
     PluginManager,
+    PluginContext,
 )
 from trinity.extensibility.events import (
     TrinityStartupEvent
@@ -171,6 +183,12 @@ def trinity_boot(args: Namespace,
     # the local logger.
     listener.start()
 
+    event_bus = EventBus()
+    main_endpoint = event_bus.create_endpoint('main')
+    networking_endpoint = event_bus.create_endpoint('networking')
+    event_bus.start()
+    main_endpoint.connect()
+
     # First initialize the database process.
     database_server_process = ctx.Process(
         target=run_database_process,
@@ -181,10 +199,19 @@ def trinity_boot(args: Namespace,
         kwargs=extra_kwargs,
     )
 
-    networking_process = ctx.Process(
+    networking_process = multiprocessing.Process(
         target=launch_node,
-        args=(args, chain_config, ),
+        args=(args, chain_config, networking_endpoint,),
         kwargs=extra_kwargs,
+    )
+
+    main_endpoint.subscribe(
+        ShutdownRequested,
+        lambda event: kill_trinity_gracefully(
+            database_server_process,
+            networking_process,
+            logger
+        )
     )
 
     # start the processes
@@ -196,7 +223,9 @@ def trinity_boot(args: Namespace,
     logger.info("Started networking process (pid=%d)", networking_process.pid)
 
     try:
-        networking_process.join()
+        loop = asyncio.get_event_loop()
+        loop.run_forever()
+        loop.close()
     except KeyboardInterrupt:
         # When a user hits Ctrl+C in the terminal, the SIGINT is sent to all processes in the
         # foreground *process group*, so both our networking and database processes will terminate
@@ -209,13 +238,18 @@ def trinity_boot(args: Namespace,
         # simply uses 'kill' to send a signal to the main process, but also because they will
         # perform a non-gracefull shutdown if the process takes too long to terminate.
         logger.info('Keyboard Interrupt: Stopping')
-        kill_process_gracefully(database_server_process, logger)
-        logger.info('DB server process (pid=%d) terminated', database_server_process.pid)
-        # XXX: This short sleep here seems to avoid us hitting a deadlock when attempting to
-        # join() the networking subprocess: https://github.com/ethereum/py-evm/issues/940
-        time.sleep(0.2)
-        kill_process_gracefully(networking_process, logger)
-        logger.info('Networking process (pid=%d) terminated', networking_process.pid)
+        kill_trinity_gracefully(database_server_process, networking_process, logger)
+
+def kill_trinity_gracefully(database_server_process, networking_process, logger):
+    kill_process_gracefully(database_server_process, logger)
+    logger.info('DB server process (pid=%d) terminated', database_server_process.pid)
+    # XXX: This short sleep here seems to avoid us hitting a deadlock when attempting to
+    # join() the networking subprocess: https://github.com/ethereum/py-evm/issues/940
+    time.sleep(0.2)
+    kill_process_gracefully(networking_process, logger)
+    logger.info('Networking process (pid=%d) terminated', networking_process.pid)
+    # FIXME: This is just until I figured out why we can't have a clean, full, shutdown
+    os._exit(0)
 
 
 def fix_unclean_shutdown(chain_config: ChainConfig, logger: logging.Logger) -> None:
@@ -290,8 +324,11 @@ async def exit_on_signal(service_to_exit: BaseService) -> None:
 
 @setup_cprofiler('launch_node')
 @with_queued_logging
-def launch_node(args: Namespace, chain_config: ChainConfig) -> None:
+def launch_node(args: Namespace, chain_config: ChainConfig, endpoint: Endpoint) -> None:
     with chain_config.process_id_file('networking'):
+
+        endpoint.connect()
+
         NodeClass = chain_config.node_class
         # Temporary hack: We setup a second instance of the PluginManager.
         # The first instance was only to configure the ArgumentParser whereas
@@ -299,16 +336,15 @@ def launch_node(args: Namespace, chain_config: ChainConfig) -> None:
         # performs the bulk of the work. In the future, the PluginManager
         # should probably live in its own process and manage whether plugins
         # run in the shared plugin process or spawn their own.
-        plugin_manager = setup_plugins()
+        plugin_context = PluginContext(endpoint)
+        plugin_manager = setup_plugins(plugin_context)
         plugin_manager.broadcast(TrinityStartupEvent(
             args,
             chain_config
         ))
 
         node = NodeClass(plugin_manager, chain_config)
-
         run_service_until_quit(node)
-
 
 def display_launch_logs(chain_config: ChainConfig) -> None:
     logger = logging.getLogger('trinity')
@@ -325,8 +361,8 @@ def run_service_until_quit(service: BaseService) -> None:
     loop.close()
 
 
-def setup_plugins() -> PluginManager:
-    plugin_manager = PluginManager()
+def setup_plugins(plugin_context: PluginContext = None) -> PluginManager:
+    plugin_manager = PluginManager(plugin_context)
     # TODO: Implement auto-discovery of plugins based on some convention/configuration scheme
     plugin_manager.register(ENABLED_PLUGINS)
     plugin_manager.initialize_plugins()

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -329,5 +329,6 @@ def setup_plugins() -> PluginManager:
     plugin_manager = PluginManager()
     # TODO: Implement auto-discovery of plugins based on some convention/configuration scheme
     plugin_manager.register(ENABLED_PLUGINS)
+    plugin_manager.initialize_plugins()
 
     return plugin_manager

--- a/trinity/plugins/builtin/attach/plugin.py
+++ b/trinity/plugins/builtin/attach/plugin.py
@@ -1,3 +1,6 @@
+from abc import (
+    abstractmethod
+)
 from argparse import (
     ArgumentParser,
     Namespace,
@@ -19,10 +22,6 @@ from trinity.plugins.builtin.attach.console import (
 
 class AttachPlugin(BasePlugin):
 
-    def __init__(self, use_ipython: bool = True) -> None:
-        super().__init__()
-        self.use_ipython = use_ipython
-
     @property
     def name(self) -> str:
         return "Attach"
@@ -36,9 +35,25 @@ class AttachPlugin(BasePlugin):
 
         attach_parser.set_defaults(func=self.run_console)
 
+    @abstractmethod
+    def console(self, chain_config: ChainConfig) -> None:
+        raise NotImplementedError('Must be implemented in subclasses')
+
     def run_console(self, args: Namespace, chain_config: ChainConfig) -> None:
         try:
-            console(chain_config.jsonrpc_ipc_path, use_ipython=self.use_ipython)
+            self.console(chain_config)
         except FileNotFoundError as err:
             self.logger.error(str(err))
             sys.exit(1)
+
+
+class IPythonShellAttachPlugin(AttachPlugin):
+
+    def console(self, chain_config: ChainConfig) -> None:
+        console(chain_config.jsonrpc_ipc_path, use_ipython=True)
+
+
+class VanillaShellAttachPlugin(AttachPlugin):
+
+    def console(self, chain_config: ChainConfig) -> None:
+        console(chain_config.jsonrpc_ipc_path, use_ipython=False)

--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -41,7 +41,8 @@ from trinity.plugins.builtin.tx_pool.validators import (
 
 class TxPlugin(BasePlugin):
 
-    def __init__(self) -> None:
+    def __init__(self, context: PluginContext) -> None:
+        super().__init__(context)
         self.peer_pool: PeerPool = None
         self.cancel_token: CancelToken = None
         self.chain: BaseChain = None
@@ -70,7 +71,7 @@ class TxPlugin(BasePlugin):
     def should_start(self) -> bool:
         return all((self.peer_pool is not None, self.chain is not None, self.is_enabled))
 
-    def start(self, context: PluginContext) -> None:
+    def start(self) -> None:
         if isinstance(self.chain, BaseMainnetChain):
             validator = DefaultTransactionValidator(self.chain, BYZANTIUM_MAINNET_BLOCK)
         elif isinstance(self.chain, BaseRopstenChain):

--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -22,6 +22,9 @@ from p2p.peer import (
     PeerPool
 )
 
+from trinity.constants import (
+    SYNC_LIGHT
+)
 from trinity.extensibility import (
     BaseEvent,
     BasePlugin,
@@ -61,7 +64,11 @@ class TxPlugin(BasePlugin):
 
     def handle_event(self, activation_event: BaseEvent) -> None:
         if isinstance(activation_event, TrinityStartupEvent):
-            self.is_enabled = activation_event.args.tx_pool
+            light_mode = activation_event.args.sync_mode == SYNC_LIGHT
+            self.is_enabled = activation_event.args.tx_pool and not light_mode
+            if light_mode:
+                self.logger.warning('The transaction pool is not yet available in light mode')
+                self.context.shutdown_trinity(exit_code=1)
         if isinstance(activation_event, ResourceAvailableEvent):
             if activation_event.resource_type is PeerPool:
                 self.peer_pool, self.cancel_token = activation_event.resource

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -23,6 +23,6 @@ def is_ipython_available() -> bool:
 # config file which plugin is enabled or not
 
 ENABLED_PLUGINS = [
-    IPythonShellAttachPlugin() if is_ipython_available() else VanillaShellAttachPlugin,
-    TxPlugin(),
+    IPythonShellAttachPlugin if is_ipython_available() else VanillaShellAttachPlugin,
+    TxPlugin,
 ]

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -1,7 +1,8 @@
 import pkg_resources
 
 from trinity.plugins.builtin.attach.plugin import (
-    AttachPlugin
+    IPythonShellAttachPlugin,
+    VanillaShellAttachPlugin,
 )
 from trinity.plugins.builtin.tx_pool.plugin import (
     TxPlugin,
@@ -22,6 +23,6 @@ def is_ipython_available() -> bool:
 # config file which plugin is enabled or not
 
 ENABLED_PLUGINS = [
-    AttachPlugin() if is_ipython_available() else AttachPlugin(use_ipython=False),
+    IPythonShellAttachPlugin() if is_ipython_available() else VanillaShellAttachPlugin,
     TxPlugin(),
 ]


### PR DESCRIPTION
## DISCLAIMER

**This is not intended to get merged. This is a PROOF OF CONCEPT to demonstrate how to use the [lahja eventbus](https://github.com/cburgdorf/lahja/blob/master/README.md) for decoupled event-based inter process communication**

### What is this?

This is a PoC that is based on https://github.com/ethereum/py-evm/pull/1079 which means it also 
 contains some unrelated code. The reason this is based on https://github.com/ethereum/py-evm/pull/1079 is because that PR already lays out a potential use case for this event bus. That is, we want plugins to be able to tell the main process to gracefully shut down Trinity. This is really just one among many use cases that we will probably run into once we try to embrace the plugin infrastructure more.

**Notice that this code is full of bugs and unresolved issues so it is really just to demonstrate the potential approach**

### Keypoints

1. We setup an event bus in the main process

```Python
    event_bus = EventBus()
    main_endpoint = event_bus.create_endpoint('main')
    networking_endpoint = event_bus.create_endpoint('networking')
```

Notice, that we are creating two `Endpoints` to this eventbus. Each process is intended to hold one endpoint to the eventbus which can be used to `subscribe`, `stream` and `broadcast` events.

2. We pass the `networking_endpoint` into the networking process

```Python
networking_process = multiprocessing.Process(
        target=launch_node,
        args=(args, chain_config, networking_endpoint,),
        kwargs=extra_kwargs,
    )
```

3. In the main process, we subscribe to the `ShutdownRequested` event, which can be raised by any process that holds an endpoint to the eventbus.

```Python
    main_endpoint.subscribe(
        ShutdownRequested,
        lambda event: kill_trinity_gracefully(
            database_server_process,
            networking_process,
            logger
        )
    )

The main process listens to the event and causes a clean shutdown.
```

4. The `PluginContext` that each plugin has access to also holds one endpoint. Currently the `networking_endpoint` since all plugins run into that shared process.

```Python
class PluginContext:

    def __init__(self, endpoint: Endpoint):
        self.eventbus = endpoint

    def shutdown_trinity(self, exit_code: int = 0) -> None:
        self.eventbus.broadcast(ShutdownRequested('meh'))
```

5. The `TxPool` plugin calls `shutdown_trinity` on the plugin context

```Python
if light_mode:
    self.logger.warning('The transaction pool is not yet available in light mode')
    self.context.shutdown_trinity(exit_code=1)
```
(Theoretically plugins will most likely also hold a direct reference to the eventbus endpoint and only go through API calls on the context for "well defined" stuff such as a Trinity shutdown)

We can see this already working on this PR when running `trinity --tx-pool --light`. The networking process will broadcast the `ShutdownRequested` event, the main process will get it and shutdown Trinity.

