### PR TITLE
Cleanup known causes of stacktraces escaping during trinity shutdown.

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -241,13 +241,15 @@ class RoutingTable:
     logger = logging.getLogger("p2p.kademlia.RoutingTable")
 
     def __init__(self, node: Node) -> None:
+        self._initialized_at = time.time()
         self.this_node = node
         self.buckets = [KBucket(0, k_max_node_id)]
 
     def get_random_nodes(self, count: int) -> Iterator[Node]:
         if count > len(self):
-            self.logger.warn(
-                "Cannot get %d nodes as RoutingTable contains only %d nodes", count, len(self))
+            if time.time() - self._initialized_at > 30:
+                self.logger.warn(
+                    "Cannot get %d nodes as RoutingTable contains only %d nodes", count, len(self))
             count = len(self)
         seen: List[Node] = []
         # This is a rather inneficient way of randomizing nodes from all buckets, but even if we

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -158,6 +158,7 @@ class BaseService(ABC, CancellableMixin):
             *[task for task in self._tasks],
             self._cleanup()
         )
+
         self.events.cleaned_up.set()
 
     async def cancel(self) -> None:

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -2,6 +2,7 @@ import datetime
 from concurrent.futures import Executor, ProcessPoolExecutor
 import logging
 import os
+import signal
 from typing import Tuple
 
 import rlp
@@ -74,5 +75,11 @@ def get_asyncio_executor(cpu_count: int=None) -> Executor:
                 cpu_count = 1
             else:
                 cpu_count = max(1, os_cpu_count - 1)
+        # we need the child processes to ignore `KeyboardInterrupt`
+        original_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
         _executor = ProcessPoolExecutor(cpu_count)
+        # this is needed to force the `ProcessPoolExecutor` to start it's
+        # worker processes.
+        _executor._start_queue_management_thread()  # type: ignore
+        signal.signal(signal.SIGINT, original_handler)
     return _executor

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -13,7 +13,7 @@ from eth.db.chain import (
 )
 
 from trinity.chains import (
-    serve_chaindb,
+    get_chaindb_manager,
 )
 from trinity.config import (
     ChainConfig,
@@ -29,6 +29,11 @@ from trinity.utils.ipc import (
 )
 
 
+def serve_chaindb(manager):
+    server = manager.get_server()
+    server.serve_forever()
+
+
 @pytest.fixture
 def database_server_ipc_path():
     core_db = MemoryDB()
@@ -41,9 +46,10 @@ def database_server_ipc_path():
     with tempfile.TemporaryDirectory() as temp_dir:
         chain_config = ChainConfig(network_id=ROPSTEN_NETWORK_ID, data_dir=temp_dir)
 
+        manager = get_chaindb_manager(chain_config, core_db)
         chaindb_server_process = multiprocessing.Process(
             target=serve_chaindb,
-            args=(chain_config, core_db),
+            args=(manager,),
         )
         chaindb_server_process.start()
 

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -209,7 +209,7 @@ def rebuild_exc(exc, tb):  # type: ignore
     return exc
 
 
-def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
+def get_chaindb_manager(chain_config: ChainConfig, base_db: BaseDB) -> BaseManager:
     chaindb = AsyncChainDB(base_db)
     chain_class: Type[BaseChain]
     if not is_database_initialized(chaindb):
@@ -255,9 +255,7 @@ def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
     )
 
     manager = DBManager(address=str(chain_config.database_ipc_path))  # type: ignore
-    server = manager.get_server()  # type: ignore
-
-    server.serve_forever()
+    return manager
 
 
 class ChainProxy(BaseProxy):

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -28,7 +28,7 @@ from trinity.exceptions import (
 from trinity.chains import (
     initialize_data_dir,
     is_data_dir_initialized,
-    serve_chaindb,
+    get_chaindb_manager,
 )
 from trinity.cli_parser import (
     parser,
@@ -276,7 +276,19 @@ def run_database_process(chain_config: ChainConfig, db_class: Type[BaseDB]) -> N
     with chain_config.process_id_file('database'):
         base_db = db_class(db_path=chain_config.database_dir)
 
-        serve_chaindb(chain_config, base_db)
+        manager = get_chaindb_manager(chain_config, base_db)
+
+        def _sigint_handler(*args: Any) -> None:
+            server.stop_event.set()
+
+        server = manager.get_server()  # type: ignore
+        signal.signal(signal.SIGINT, _sigint_handler)
+
+        try:
+            server.serve_forever()
+        except SystemExit:
+            server.stop_event.set()
+            raise
 
 
 def exit_because_ambigious_filesystem(logger: logging.Logger) -> None:
@@ -294,6 +306,7 @@ async def exit_on_signal(service_to_exit: BaseService) -> None:
     await sigint_received.wait()
     try:
         await service_to_exit.cancel()
+        service_to_exit._executor.shutdown(wait=True)
     finally:
         loop.stop()
 


### PR DESCRIPTION
### What was wrong?

fixes https://github.com/ethereum/py-evm/issues/863

### How was it fixed?

- Added shutting down the worker pool to the shutdown sequence for the trinity node.
- Initializing the worker pool such that the worker processes ignore `KeyboardInterrupt`
- Adds handler for `SIGINT` to the database process (previously unhandled)

This also contains a fix for a logging warning that the `kademlia.RoutingTable` emits regularly during startup before it has been populated.  That warning will now only be fired if the routing table has existed for at least 30 seconds.

#### Cute Animal Picture

![mixed-species-cat-raccoon](https://user-images.githubusercontent.com/824194/44057183-95a15eb6-9f07-11e8-8e92-3d48d59c9ace.jpg)
