### PR TITLE
Reduce logging level of BaseService cancellation message

### DIFF
--- a/p2p/service.py
+++ b/p2p/service.py
@@ -94,7 +94,7 @@ class BaseService(ABC, CancellableMixin):
                 self.events.started.set()
                 await self._run()
         except OperationCancelled as e:
-            self.logger.info("%s finished: %s", self, e)
+            self.logger.debug("%s finished: %s", self, e)
         except Exception:
             self.logger.exception("Unexpected error in %r, exiting", self)
         finally:


### PR DESCRIPTION
### What was wrong?

The logging message the the `BaseService` emits on cancellation is now too noisy with the increased number of services being run.

### How was it fixed?

Reduced the logging level to `DEBUG`

#### Cute Animal Picture

![baby-deer-puppy-cute-animal-picture-588632](https://user-images.githubusercontent.com/824194/44045612-459b39a8-9ee6-11e8-988b-6db310edfc21.jpg)

