### PR TITLE
Move handling of MalformedMessage to the main Peer._run

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -356,6 +356,9 @@ class BasePeer(BaseService):
                     exc_info=True,
                 )
                 return
+            except MalformedMessage as err:
+                await self.disconnect(DisconnectReason.bad_protocol)
+                return
 
             try:
                 self.process_msg(cmd, msg)
@@ -846,12 +849,6 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
             except (TimeoutError, PeerConnectionLost) as err:
                 raise DAOForkCheckFailure(
                     "Timed out waiting for DAO fork header from {}: {}".format(peer, err)
-                ) from err
-            except MalformedMessage as err:
-                raise DAOForkCheckFailure(
-                    "Malformed message while doing DAO fork check with {0}: {1}".format(
-                        peer, err,
-                    )
                 ) from err
             except ValidationError as err:
                 raise DAOForkCheckFailure(


### PR DESCRIPTION
### What was wrong?

Turns out we only handled `MalformedMessage` during DAO fork checks.  If a peer sends a malformed message outside of this context, it isn't caught.

### How was it fixed?

Moved the handling of `MalformedMessage` directly into the `Peer._run` loop.

#### Cute Animal Picture

![animal-odd-couples](https://user-images.githubusercontent.com/824194/44059973-48670e30-9f10-11e8-95fd-166d59f75cc5.jpg)

