### PR TITLE
Piper/fix cancellation error in full sync service

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -336,7 +336,7 @@ class DiscoveryService(BaseService):
     async def _run(self) -> None:
         connect_loop_sleep = 2
         self.run_task(self.proto.bootstrap())
-        while True:
+        while self.is_running:
             await self.maybe_connect_to_more_peers()
             await self.sleep(connect_loop_sleep)
 

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -241,13 +241,15 @@ class RoutingTable:
     logger = logging.getLogger("p2p.kademlia.RoutingTable")
 
     def __init__(self, node: Node) -> None:
+        self._initialized_at = time.time()
         self.this_node = node
         self.buckets = [KBucket(0, k_max_node_id)]
 
     def get_random_nodes(self, count: int) -> Iterator[Node]:
         if count > len(self):
-            self.logger.warn(
-                "Cannot get %d nodes as RoutingTable contains only %d nodes", count, len(self))
+            if time.time() - self._initialized_at > 30:
+                self.logger.warn(
+                    "Cannot get %d nodes as RoutingTable contains only %d nodes", count, len(self))
             count = len(self)
         seen: List[Node] = []
         # This is a rather inneficient way of randomizing nodes from all buckets, but even if we

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -342,7 +342,7 @@ class BasePeer(BaseService):
         self.close()
 
     async def _run(self) -> None:
-        while True:
+        while self.is_running:
             try:
                 cmd, msg = await self.read_msg()
             except (PeerConnectionLost, TimeoutError) as err:

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -158,6 +158,7 @@ class BaseService(ABC, CancellableMixin):
             *[task for task in self._tasks],
             self._cleanup()
         )
+
         self.events.cleaned_up.set()
 
     async def cancel(self) -> None:

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -75,11 +75,25 @@ def get_asyncio_executor(cpu_count: int=None) -> Executor:
                 cpu_count = 1
             else:
                 cpu_count = max(1, os_cpu_count - 1)
-        # we need the child processes to ignore `KeyboardInterrupt`
+        # The following block of code allows us to gracefully handle
+        # `KeyboardInterrupt` in the worker processes.  This is accomplished
+        # via two "hacks".
+        #
+        # First: We set the signal handler for SIGINT to the special case
+        # `SIG_IGN` which instructs the process to ignore SIGINT, while
+        # preserving the original signal handler.  We do this because child
+        # processes inherit the signal handlers of their parent processes.
+        #
+        # Second, we have to force the executor to initialize the worker
+        # processes, as they are not initialized on instantiation, but rather
+        # lazily when the first work is submitted.  We do this by calling the
+        # private method `_start_queue_management_thread`.
+        #
+        # Finally, we restore the original signal handler now that we know the
+        # child processes have been initialized to ensure that
+        # `KeyboardInterrupt` in the main process is still handled normally.
         original_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
         _executor = ProcessPoolExecutor(cpu_count)
-        # this is needed to force the `ProcessPoolExecutor` to start it's
-        # worker processes.
         _executor._start_queue_management_thread()  # type: ignore
         signal.signal(signal.SIGINT, original_handler)
     return _executor

--- a/p2p/utils.py
+++ b/p2p/utils.py
@@ -2,6 +2,7 @@ import datetime
 from concurrent.futures import Executor, ProcessPoolExecutor
 import logging
 import os
+import signal
 from typing import Tuple
 
 import rlp
@@ -74,5 +75,11 @@ def get_asyncio_executor(cpu_count: int=None) -> Executor:
                 cpu_count = 1
             else:
                 cpu_count = max(1, os_cpu_count - 1)
+        # we need the child processes to ignore `KeyboardInterrupt`
+        original_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
         _executor = ProcessPoolExecutor(cpu_count)
+        # this is needed to force the `ProcessPoolExecutor` to start it's
+        # worker processes.
+        _executor._start_queue_management_thread()  # type: ignore
+        signal.signal(signal.SIGINT, original_handler)
     return _executor

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -13,7 +13,7 @@ from eth.db.chain import (
 )
 
 from trinity.chains import (
-    serve_chaindb,
+    get_chaindb_manager,
 )
 from trinity.config import (
     ChainConfig,
@@ -29,6 +29,11 @@ from trinity.utils.ipc import (
 )
 
 
+def serve_chaindb(manager):
+    server = manager.get_server()
+    server.serve_forever()
+
+
 @pytest.fixture
 def database_server_ipc_path():
     core_db = MemoryDB()
@@ -41,9 +46,10 @@ def database_server_ipc_path():
     with tempfile.TemporaryDirectory() as temp_dir:
         chain_config = ChainConfig(network_id=ROPSTEN_NETWORK_ID, data_dir=temp_dir)
 
+        manager = get_chaindb_manager(chain_config, core_db)
         chaindb_server_process = multiprocessing.Process(
             target=serve_chaindb,
-            args=(chain_config, core_db),
+            args=(manager,),
         )
         chaindb_server_process.start()
 

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -209,7 +209,7 @@ def rebuild_exc(exc, tb):  # type: ignore
     return exc
 
 
-def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
+def get_chaindb_manager(chain_config: ChainConfig, base_db: BaseDB) -> BaseManager:
     chaindb = AsyncChainDB(base_db)
     chain_class: Type[BaseChain]
     if not is_database_initialized(chaindb):
@@ -255,9 +255,7 @@ def serve_chaindb(chain_config: ChainConfig, base_db: BaseDB) -> None:
     )
 
     manager = DBManager(address=str(chain_config.database_ipc_path))  # type: ignore
-    server = manager.get_server()  # type: ignore
-
-    server.serve_forever()
+    return manager
 
 
 class ChainProxy(BaseProxy):

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -277,11 +277,11 @@ def run_database_process(chain_config: ChainConfig, db_class: Type[BaseDB]) -> N
         base_db = db_class(db_path=chain_config.database_dir)
 
         manager = get_chaindb_manager(chain_config, base_db)
+        server = manager.get_server()  # type: ignore
 
         def _sigint_handler(*args: Any) -> None:
             server.stop_event.set()
 
-        server = manager.get_server()  # type: ignore
         signal.signal(signal.SIGINT, _sigint_handler)
 
         try:

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -28,7 +28,7 @@ from trinity.exceptions import (
 from trinity.chains import (
     initialize_data_dir,
     is_data_dir_initialized,
-    serve_chaindb,
+    get_chaindb_manager,
 )
 from trinity.cli_parser import (
     parser,
@@ -276,7 +276,19 @@ def run_database_process(chain_config: ChainConfig, db_class: Type[BaseDB]) -> N
     with chain_config.process_id_file('database'):
         base_db = db_class(db_path=chain_config.database_dir)
 
-        serve_chaindb(chain_config, base_db)
+        manager = get_chaindb_manager(chain_config, base_db)
+
+        def _sigint_handler(*args: Any) -> None:
+            server.stop_event.set()
+
+        server = manager.get_server()  # type: ignore
+        signal.signal(signal.SIGINT, _sigint_handler)
+
+        try:
+            server.serve_forever()
+        except SystemExit:
+            server.stop_event.set()
+            raise
 
 
 def exit_because_ambigious_filesystem(logger: logging.Logger) -> None:
@@ -294,6 +306,7 @@ async def exit_on_signal(service_to_exit: BaseService) -> None:
     await sigint_received.wait()
     try:
         await service_to_exit.cancel()
+        service_to_exit._executor.shutdown(wait=True)
     finally:
         loop.stop()
 

--- a/trinity/plugins/builtin/tx_pool/pool.py
+++ b/trinity/plugins/builtin/tx_pool/pool.py
@@ -73,7 +73,7 @@ class TxPool(BaseService, PeerSubscriber):
         self.logger.info("Running Tx Pool")
 
         with self.subscribe(self._peer_pool):
-            while True:
+            while self.is_running:
                 peer, cmd, msg = await self.wait(
                     self.msg_queue.get(), token=self.cancel_token)
                 peer = cast(ETHPeer, peer)

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -96,7 +96,7 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
     async def _run(self) -> None:
         self.run_task(self._handle_msg_loop())
         with self.subscribe(self.peer_pool):
-            while True:
+            while self.is_running:
                 peer_or_finished: Any = await self.wait_first(
                     self._sync_requests.get(),
                     self._sync_complete.wait()
@@ -154,7 +154,7 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
         # will be discarded by _fetch_missing_headers() so we don't unnecessarily process them
         # again.
         start_at = max(GENESIS_BLOCK_NUMBER + 1, head.block_number - MAX_REORG_DEPTH)
-        while True:
+        while self.is_running:
             if not peer.is_running:
                 self.logger.info("%s disconnected, aborting sync", peer)
                 break

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -47,6 +47,9 @@ class FullNodeSyncer(BaseService):
                 self.chain, self.chaindb, self.peer_pool, self.cancel_token)
             await chain_syncer.run()
 
+        if not self.is_running:
+            return
+
         # Ensure we have the state for our current head.
         head = await self.wait(self.chaindb.coro_get_canonical_head())
         if head.state_root != BLANK_ROOT_HASH and head.state_root not in self.base_db:
@@ -55,6 +58,9 @@ class FullNodeSyncer(BaseService):
             downloader = StateDownloader(
                 self.chaindb, self.base_db, head.state_root, self.peer_pool, self.cancel_token)
             await downloader.run()
+
+        if not self.is_running:
+            return
 
         # Now, loop forever, fetching missing blocks and applying them.
         self.logger.info("Starting regular sync; current head: #%d", head.block_number)

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -95,7 +95,7 @@ class LightPeerChain(PeerSubscriber, BaseService):
 
     async def _run(self) -> None:
         with self.subscribe(self.peer_pool):
-            while True:
+            while self.is_running:
                 peer, cmd, msg = await self.wait(self.msg_queue.get())
                 if isinstance(msg, dict):
                     request_id = msg.get('request_id')

--- a/trinity/sync/sharding/service.py
+++ b/trinity/sync/sharding/service.py
@@ -115,7 +115,7 @@ class ShardSyncer(BaseService, PeerSubscriber):
     #
     async def _run(self) -> None:
         with self.subscribe(self.peer_pool):
-            while True:
+            while self.is_running:
                 peer, cmd, msg = await self.cancel_token.cancellable_wait(
                     self.msg_queue.get())
 

--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -16,19 +16,23 @@ def wait_for_ipc(ipc_path: pathlib.Path, timeout: int=1) -> None:
         time.sleep(0.05)
 
 
+DEFAULT_SIGINT_TIMEOUT = 10
+DEFAULT_SIGTERM_TIMEOUT = 5
+
+
 def kill_process_gracefully(
         process: Process,
         logger: Logger,
-        SIGINT_timeout: int=5,
-        SIGTERM_timeout: int=3) -> None:
+        SIGINT_timeout: int=DEFAULT_SIGINT_TIMEOUT,
+        SIGTERM_timeout: int=DEFAULT_SIGTERM_TIMEOUT) -> None:
     kill_process_id_gracefully(process.pid, process.join, logger, SIGINT_timeout, SIGTERM_timeout)
 
 
 def kill_popen_gracefully(
         popen: subprocess.Popen,
         logger: Logger,
-        SIGINT_timeout: int=5,
-        SIGTERM_timeout: int=3) -> None:
+        SIGINT_timeout: int=DEFAULT_SIGINT_TIMEOUT,
+        SIGTERM_timeout: int=DEFAULT_SIGTERM_TIMEOUT) -> None:
 
     def silent_timeout(timeout_len: int) -> None:
         try:
@@ -43,8 +47,8 @@ def kill_process_id_gracefully(
         process_id: int,
         wait_for_completion: Callable[[int], None],
         logger: Logger,
-        SIGINT_timeout: int=5,
-        SIGTERM_timeout: int=3) -> None:
+        SIGINT_timeout: int=DEFAULT_SIGINT_TIMEOUT,
+        SIGTERM_timeout: int=DEFAULT_SIGTERM_TIMEOUT) -> None:
     try:
         try:
             os.kill(process_id, signal.SIGINT)


### PR DESCRIPTION
### What was wrong?

The `full` syncer service throws errors about not being able to restart a cancelled service.

Many of our services used `while True` in their `_run` loop.  

### How was it fixed?

The full syncer `_run` loop now has exit clauses between the different types of syncing to exit if cancellation has been triggered.

Also changed all of the `while True` statements to a more correct way to  `while self.is_running` so that the loop automatically exits upon cancellation.

#### Cute Animal Picture

![bb0949ad8ea8fcbe9c61a2267aa2993c](https://user-images.githubusercontent.com/824194/44064179-063b1ce8-9f21-11e8-9fd9-86707c7c2db6.jpg)

