### PR TITLE
Handle AlreadyWaiting exception in state sync

### DIFF
--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -45,12 +45,18 @@ from p2p.protocol import (
     _DecodedMsgType,
 )
 
-from p2p.exceptions import NoEligiblePeers, NoIdlePeers
+from p2p.exceptions import (
+    NoEligiblePeers,
+    NoIdlePeers,
+)
 from p2p.peer import BasePeer, PeerPool, PeerSubscriber
 
 from trinity.db.base import AsyncBaseDB
 from trinity.db.chain import AsyncChainDB
-from trinity.exceptions import SyncRequestAlreadyProcessed
+from trinity.exceptions import (
+    AlreadyWaiting,
+    SyncRequestAlreadyProcessed,
+)
 from trinity.p2p.handlers import PeerRequestHandler
 from trinity.protocol.eth.peer import ETHPeer
 from trinity.protocol.eth.requests import HeaderRequest
@@ -236,6 +242,11 @@ class StateDownloader(BaseService, PeerSubscriber):
                 err,
             )
             node_data = tuple()
+        except AlreadyWaiting as err:
+            self.logger.warn(
+                "Already waiting for a NodeData response from %s", peer,
+            )
+            return
 
         try:
             self.request_tracker.active_requests.pop(peer)


### PR DESCRIPTION
### What was wrong?

Something is wrong with the peer request tracking in the state sync which causes us to request nodes from a peer which is still waiting for a response, and thus an `AlreadyWaiting` exception is escaping.

### How was it fixed?

Catch the exception and log a warning so we don't forget about it.

> FYI, this section of functionality is up for being refactored very soon so this is only intended to be a stop-gap fix.

#### Cute Animal Picture

![ww-animal-friendships-kitten-chick jpg adapt 945 1](https://user-images.githubusercontent.com/824194/44065123-2902e47c-9f26-11e8-9efc-6a62ff4ec3a7.jpg)

