### PR TITLE
Use trinity.Server in LightNode

### DIFF
--- a/tests/trinity/core/chain-management/test_initialize_data_dir.py
+++ b/tests/trinity/core/chain-management/test_initialize_data_dir.py
@@ -13,7 +13,7 @@ from trinity.config import (
 
 @pytest.fixture
 def chain_config():
-    return ChainConfig(network_id=1)
+    return ChainConfig(network_id=1, max_peers=1)
 
 
 @pytest.fixture

--- a/tests/trinity/core/chain-management/test_initialize_database.py
+++ b/tests/trinity/core/chain-management/test_initialize_database.py
@@ -16,7 +16,7 @@ from trinity.config import (
 
 @pytest.fixture
 def chain_config():
-    _chain_config = ChainConfig(network_id=1)
+    _chain_config = ChainConfig(network_id=1, max_peers=1)
     initialize_data_dir(_chain_config)
     return _chain_config
 

--- a/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
@@ -13,7 +13,7 @@ from trinity.config import (
 
 @pytest.fixture
 def chain_config():
-    return ChainConfig(network_id=1)
+    return ChainConfig(network_id=1, max_peers=1)
 
 
 @pytest.fixture
@@ -93,7 +93,7 @@ NODEKEY = decode_hex('0xd18445cc77139cd8e09110e99c9384f0601bd2dfa5b230cda917df7e
 
 
 def test_full_initialized_data_dir_with_custom_nodekey():
-    chain_config = ChainConfig(network_id=1, nodekey=NODEKEY)
+    chain_config = ChainConfig(network_id=1, max_peers=1, nodekey=NODEKEY)
 
     os.makedirs(chain_config.data_dir, exist_ok=True)
     os.makedirs(chain_config.database_dir, exist_ok=True)

--- a/tests/trinity/core/chain-management/test_is_database_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_database_initialized.py
@@ -16,7 +16,7 @@ from trinity.config import (
 
 @pytest.fixture
 def chain_config():
-    _chain_config = ChainConfig(network_id=1)
+    _chain_config = ChainConfig(network_id=1, max_peers=1)
     initialize_data_dir(_chain_config)
     return _chain_config
 

--- a/tests/trinity/core/chains-utils/test_chain_config_object.py
+++ b/tests/trinity/core/chains-utils/test_chain_config_object.py
@@ -21,7 +21,7 @@ from trinity.utils.filesystem import (
 
 def test_chain_config_computed_properties():
     data_dir = get_local_data_dir('muffin')
-    chain_config = ChainConfig(network_id=1234, data_dir=data_dir)
+    chain_config = ChainConfig(network_id=1234, max_peers=1, data_dir=data_dir)
 
     assert chain_config.network_id == 1234
     assert chain_config.data_dir == data_dir
@@ -32,6 +32,7 @@ def test_chain_config_computed_properties():
 def test_chain_config_explicit_properties():
     chain_config = ChainConfig(
         network_id=1,
+        max_peers=1,
         data_dir='./data-dir',
         nodekey_path='./nodekey'
     )
@@ -60,6 +61,7 @@ def nodekey_path(tmpdir, nodekey_bytes):
 def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
     chain_config = ChainConfig(
         network_id=1,
+        max_peers=1,
         nodekey_path=nodekey_path,
     )
 
@@ -70,6 +72,7 @@ def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
 def test_chain_config_explictely_provided_nodekey(nodekey_bytes, as_bytes):
     chain_config = ChainConfig(
         network_id=1,
+        max_peers=1,
         nodekey=nodekey_bytes if as_bytes else keys.PrivateKey(nodekey_bytes),
     )
 

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -39,7 +39,7 @@ def database_server_ipc_path():
     chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        chain_config = ChainConfig(network_id=ROPSTEN_NETWORK_ID, data_dir=temp_dir)
+        chain_config = ChainConfig(network_id=ROPSTEN_NETWORK_ID, max_peers=1, data_dir=temp_dir)
 
         chaindb_server_process = multiprocessing.Process(
             target=serve_chaindb,

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -18,7 +18,6 @@ from eth.chains.ropsten import (
 )
 from p2p.kademlia import Node as KademliaNode
 from p2p.constants import (
-    DEFAULT_MAX_PEERS,
     MAINNET_BOOTNODES,
     ROPSTEN_BOOTNODES,
 )
@@ -62,7 +61,7 @@ class ChainConfig:
 
     def __init__(self,
                  network_id: int,
-                 max_peers: int=DEFAULT_MAX_PEERS,
+                 max_peers: int,
                  data_dir: str=None,
                  nodekey_path: str=None,
                  logfile_path: str=None,

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -26,7 +26,7 @@ from trinity.chains.header import (
 from trinity.db.chain import ChainDBProxy
 from trinity.db.base import DBProxy
 from trinity.db.header import (
-    BaseAsyncHeaderDB,
+    AsyncHeaderDB,
     AsyncHeaderDBProxy
 )
 from trinity.rpc.main import (
@@ -86,7 +86,7 @@ class Node(BaseService):
         return self._db_manager
 
     @property
-    def headerdb(self) -> BaseAsyncHeaderDB:
+    def headerdb(self) -> AsyncHeaderDB:
         return self._headerdb
 
     def notify_resource_available(self) -> None:

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -1,10 +1,7 @@
-import asyncio
 from typing import Type
 
 from eth_keys.datatypes import PrivateKey
 
-from p2p.discovery import DiscoveryService, PreferredNodeDiscoveryProtocol
-from p2p.kademlia import Address
 from p2p.peer import (
     PeerPool,
 )
@@ -20,7 +17,7 @@ from trinity.extensibility import (
 )
 from trinity.nodes.base import Node
 from trinity.protocol.les.peer import LESPeer
-from trinity.sync.light.chain import LightChainSyncer
+from trinity.server import LightServer
 from trinity.sync.light.service import LightPeerChain
 
 
@@ -29,7 +26,7 @@ class LightNode(Node):
 
     _chain: LightDispatchChain = None
     _peer_chain: LightPeerChain = None
-    _p2p_server: LightChainSyncer = None
+    _p2p_server: LightServer = None
 
     network_id: int = None
     nodekey: PrivateKey = None
@@ -37,69 +34,46 @@ class LightNode(Node):
     def __init__(self, plugin_manager: PluginManager, chain_config: ChainConfig) -> None:
         super().__init__(plugin_manager, chain_config)
 
-        self.network_id = chain_config.network_id
-        self.nodekey = chain_config.nodekey
-
+        self._network_id = chain_config.network_id
+        self._nodekey = chain_config.nodekey
         self._port = chain_config.port
-        self._discovery_proto = PreferredNodeDiscoveryProtocol(
-            chain_config.nodekey,
-            Address('0.0.0.0', chain_config.port, chain_config.port),
-            bootstrap_nodes=chain_config.bootstrap_nodes,
-            preferred_nodes=chain_config.preferred_nodes,
-        )
-        self._peer_pool = self._create_peer_pool(chain_config)
-        self._discovery = DiscoveryService(
-            self._discovery_proto, self._peer_pool, self.cancel_token)
-        self._peer_chain = LightPeerChain(self.headerdb, self._peer_pool, self.cancel_token)
+        self._max_peers = chain_config.max_peers
+        self._bootstrap_nodes = chain_config.bootstrap_nodes
+        self._preferred_nodes = chain_config.preferred_nodes
+
+        self._peer_chain = LightPeerChain(self.headerdb, self.get_peer_pool(), self.cancel_token)
         self.notify_resource_available()
 
     async def _run(self) -> None:
-        self.run_child_service(self._discovery)
-        self.run_child_service(self._peer_pool)
         self.run_child_service(self._peer_chain)
-        # TODO add a datagram endpoint service that can be added with self.run_child_service
-        self.logger.info(
-            "enode://%s@%s:%s",
-            self.nodekey.public_key.to_hex()[2:],
-            '0.0.0.0',
-            self._port,
-        )
-        self.logger.info('network: %s', self.network_id)
-        self.logger.info('peers: max_peers=%s', self._peer_pool.max_peers)
-        transport, _ = await asyncio.get_event_loop().create_datagram_endpoint(
-            lambda: self._discovery_proto,
-            local_addr=('0.0.0.0', self._port)
-        )
         await super()._run()
 
     def get_chain(self) -> LightDispatchChain:
         if self._chain is None:
             if self.chain_class is None:
                 raise AttributeError("LightNode subclass must set chain_class")
-            self._chain = self.chain_class(self._headerdb, peer_chain=self._peer_chain)
+            self._chain = self.chain_class(self.headerdb, peer_chain=self._peer_chain)
 
         return self._chain
 
-    def get_p2p_server(self) -> LightChainSyncer:
+    def get_p2p_server(self) -> LightServer:
         if self._p2p_server is None:
-            if self.chain_class is None:
-                raise AttributeError("LightNode subclass must set chain_class")
-            self._p2p_server = LightChainSyncer(
-                self.db_manager.get_chain(),  # type: ignore
-                self._headerdb,
-                self._peer_pool,
-                self.cancel_token)
+            manager = self.db_manager
+            self._p2p_server = LightServer(
+                self._nodekey,
+                self._port,
+                manager.get_chain(),  # type: ignore
+                manager.get_chaindb(),  # type: ignore
+                self.headerdb,
+                manager.get_db(),  # type: ignore
+                self._network_id,
+                max_peers=self._max_peers,
+                peer_class=LESPeer,
+                bootstrap_nodes=self._bootstrap_nodes,
+                preferred_nodes=self._preferred_nodes,
+                token=self.cancel_token,
+            )
         return self._p2p_server
 
     def get_peer_pool(self) -> PeerPool:
-        return self._peer_pool
-
-    def _create_peer_pool(self, chain_config: ChainConfig) -> PeerPool:
-        return PeerPool(
-            LESPeer,
-            self.headerdb,
-            chain_config.network_id,
-            chain_config.nodekey,
-            self.chain_class.vm_configuration,
-            token=self.cancel_token,
-        )
+        return self.get_p2p_server().peer_pool

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -62,7 +62,8 @@ class LESProtocol(Protocol):
             'genesisHash': chain_info.genesis_hash,
             'serveHeaders': None,
             'serveChainSince': 0,
-            'txRelay': None,
+            # TODO: Uncomment once we start relaying transactions.
+            # 'txRelay': None,
         }
         cmd = Status(self.cmd_id_offset)
         self.send(*cmd.encode(resp))

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -54,9 +54,10 @@ from p2p.service import BaseService
 
 from trinity.db.base import AsyncBaseDB
 from trinity.db.chain import AsyncChainDB
-from trinity.db.header import BaseAsyncHeaderDB
+from trinity.db.header import AsyncHeaderDB
 from trinity.protocol.eth.peer import ETHPeer
 from trinity.sync.full.service import FullNodeSyncer
+from trinity.sync.light.chain import LightChainSyncer
 
 
 DIAL_IN_OUT_RATIO = 0.75
@@ -75,7 +76,7 @@ class Server(BaseService):
                  port: int,
                  chain: AsyncChain,
                  chaindb: AsyncChainDB,
-                 headerdb: BaseAsyncHeaderDB,
+                 headerdb: AsyncHeaderDB,
                  base_db: AsyncBaseDB,
                  network_id: int,
                  max_peers: int = DEFAULT_MAX_PEERS,
@@ -288,6 +289,12 @@ class Server(BaseService):
     async def _start_peer(self, peer: BasePeer) -> None:
         # This method exists only so that we can monkey-patch it in tests.
         await self.peer_pool.start_peer(peer)
+
+
+class LightServer(Server):
+
+    def _make_syncer(self, peer_pool: PeerPool) -> BaseService:
+        return LightChainSyncer(self.chain, self.headerdb, peer_pool, self.cancel_token)
 
 
 def _test() -> None:

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -22,6 +22,10 @@ from eth.chains.ropsten import (
     ROPSTEN_NETWORK_ID,
 )
 
+from p2p.constants import DEFAULT_MAX_PEERS
+
+from trinity.constants import SYNC_LIGHT
+
 from .xdg import (
     get_xdg_trinity_root,
 )
@@ -125,7 +129,7 @@ def load_nodekey(nodekey_path: Path) -> PrivateKey:
 
 @to_dict
 def construct_chain_config_params(
-        args: argparse.Namespace) -> Iterable[Tuple[str, Union[str, Tuple[str, ...]]]]:
+        args: argparse.Namespace) -> Iterable[Tuple[str, Union[int, str, Tuple[str, ...]]]]:
     """
     Helper function for constructing the kwargs to initialize a ChainConfig object.
     """
@@ -146,6 +150,8 @@ def construct_chain_config_params(
 
     if args.max_peers is not None:
         yield 'max_peers', args.max_peers
+    else:
+        yield 'max_peers', _default_max_peers(args.sync_mode)
 
     if args.port is not None:
         yield 'port', args.port
@@ -154,3 +160,10 @@ def construct_chain_config_params(
         yield 'preferred_nodes', tuple()
     else:
         yield 'preferred_nodes', tuple(args.preferred_nodes)
+
+
+def _default_max_peers(sync_mode: str) -> int:
+    if sync_mode == SYNC_LIGHT:
+        return DEFAULT_MAX_PEERS // 2
+    else:
+        return DEFAULT_MAX_PEERS


### PR DESCRIPTION
This avoids duplicating some logic to run a PeerPool/DiscoveryService,
but also causes LightNode to setup NAT port forwarding and accept
incoming peer connections.

Also changed the default peer limit when running in light mode to half
of the limit used when in full mode.

Closes: #1003