### PR TITLE
Enable state tests for Constantinople

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,12 @@ jobs:
       - image: circleci/python:3.5
         environment:
           TOXENV: py35-native-state-byzantium
+  py35-native-state-constantinople:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-native-state-constantinople
   py35-native-state-frontier:
     <<: *common
     docker:
@@ -175,6 +181,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-native-state-byzantium
+  py36-native-state-constantinople:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-native-state-constantinople
   py36-native-state-frontier:
     <<: *common
     docker:
@@ -205,6 +217,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-rpc-state-byzantium
+  py36-rpc-state-constantinople:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-rpc-state-constantinople
   py36-rpc-state-frontier:
     <<: *common
     docker:
@@ -340,11 +358,13 @@ workflows:
       - py37-beacon
 
       - py36-native-state-byzantium
+      - py36-native-state-constantinople
       - py36-native-state-frontier
       - py36-native-state-homestead
       - py36-native-state-eip150
       - py36-native-state-eip158
       - py36-rpc-state-byzantium
+      - py36-rpc-state-constantinople
       - py36-rpc-state-frontier
       - py36-rpc-state-homestead
       - py36-rpc-state-eip150
@@ -364,6 +384,7 @@ workflows:
       - py36-beacon
 
       - py35-native-state-byzantium
+      - py35-native-state-constantinople
       - py35-native-state-frontier
       - py35-native-state-homestead
       - py35-native-state-eip150

--- a/eth/__init__.py
+++ b/eth/__init__.py
@@ -21,7 +21,7 @@ from eth.chains import (  # noqa: F401
 #
 #  Ensure we can reach 1024 frames of recursion
 #
-EVM_RECURSION_LIMIT = 1024 * 10
+EVM_RECURSION_LIMIT = 1024 * 12
 sys.setrecursionlimit(max(EVM_RECURSION_LIMIT, sys.getrecursionlimit()))
 
 

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -40,6 +40,7 @@ from eth.vm.base import (
     BaseVM,
 )
 from eth.vm.forks import (
+    ConstantinopleVM,
     ByzantiumVM,
     TangerineWhistleVM,
     FrontierVM,
@@ -122,6 +123,10 @@ def chain_vm_configuration(fixture: Dict[str, Any]) -> Iterable[Tuple[int, Type[
     elif network == 'Byzantium':
         return (
             (0, ByzantiumVM),
+        )
+    elif network == 'Constantinople':
+        return (
+            (0, ConstantinopleVM),
         )
     elif network == 'FrontierToHomesteadAt5':
         HomesteadVM = BaseHomesteadVM.configure(support_dao_fork=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,10 +23,13 @@ from eth.vm.forks.spurious_dragon import SpuriousDragonVM
 # Uncomment this to have logs from tests written to a file.  This is useful for
 # debugging when you need to dump the VM output from test runs.
 """
+import datetime
+import logging
+import os
+from eth.tools.logging import TRACE_LEVEL_NUM
+
 @pytest.yield_fixture(autouse=True)
 def _file_logging(request):
-    import datetime
-    import os
 
     logger = logging.getLogger('eth')
 

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -45,6 +45,11 @@ INCORRECT_UPSTREAM_TESTS = {
     # The result is in conflict with the yellow-paper:
     # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418800369
     ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_Byzantium'),  # noqa: E501
+    ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_Constantinople'),  # noqa: E501
+    # The CREATE2 variant seems to have been derived from the one above - it, too,
+    # has a "synthetic" state, on which py-evm flips.
+    # * https://github.com/ethereum/py-evm/pull/1181#issuecomment-446330609
+    ('GeneralStateTests/stCreate2/RevertInCreateInInitCreate2_d0g0v0.json', 'RevertInCreateInInitCreate2_d0g0v0_Constantinople'),  # noqa: E501
 }
 
 
@@ -84,8 +89,6 @@ def fixture(fixture_data):
         fixture_key,
         normalize_blockchain_fixtures,
     )
-    if fixture['network'] == 'Constantinople':
-        pytest.skip('Constantinople VM rules not yet supported')
     return fixture
 
 

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -28,12 +28,14 @@ from eth.vm.forks import (
     HomesteadVM,
     SpuriousDragonVM,
     ByzantiumVM,
+    ConstantinopleVM,
 )
 from eth.vm.forks.tangerine_whistle.state import TangerineWhistleState
 from eth.vm.forks.frontier.state import FrontierState
 from eth.vm.forks.homestead.state import HomesteadState
 from eth.vm.forks.spurious_dragon.state import SpuriousDragonState
 from eth.vm.forks.byzantium.state import ByzantiumState
+from eth.vm.forks.constantinople.state import ConstantinopleState
 
 from eth.rlp.headers import (
     BlockHeader,
@@ -245,6 +247,10 @@ ByzantiumStateForTesting = ByzantiumState.configure(
     __name__='ByzantiumStateForTesting',
     get_ancestor_hash=get_block_hash_for_testing,
 )
+ConstantinopleStateForTesting = ConstantinopleState.configure(
+    __name__='ConstantinopleStateForTesting',
+    get_ancestor_hash=get_block_hash_for_testing,
+)
 
 FrontierVMForTesting = FrontierVM.configure(
     __name__='FrontierVMForTesting',
@@ -271,6 +277,11 @@ ByzantiumVMForTesting = ByzantiumVM.configure(
     _state_class=ByzantiumStateForTesting,
     get_prev_hashes=get_prev_hashes_testing,
 )
+ConstantinopleVMForTesting = ConstantinopleVM.configure(
+    __name__='ConstantinopleVMForTesting',
+    _state_class=ConstantinopleStateForTesting,
+    get_prev_hashes=get_prev_hashes_testing,
+)
 
 
 @pytest.fixture
@@ -287,7 +298,7 @@ def fixture_vm_class(fixture_data):
     elif fork_name == ForkName.Byzantium:
         return ByzantiumVMForTesting
     elif fork_name == ForkName.Constantinople:
-        pytest.skip("Constantinople VM has not been implemented")
+        return ConstantinopleVMForTesting
     elif fork_name == ForkName.Metropolis:
         pytest.skip("Metropolis VM has not been implemented")
     else:

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -146,6 +146,7 @@ INCORRECT_UPSTREAM_TESTS = {
     # The result is in conflict with the yellow-paper:
     # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418800369
     ('stRevertTest/RevertInCreateInInit.json', 'RevertInCreateInInit', 'Byzantium', 0),
+    ('stRevertTest/RevertInCreateInInit.json', 'RevertInCreateInInit', 'Constantinople', 0),
 }
 
 

--- a/tests/json-fixtures/test_transactions.py
+++ b/tests/json-fixtures/test_transactions.py
@@ -28,6 +28,9 @@ from eth.vm.forks.spurious_dragon.transactions import (
 from eth.vm.forks.byzantium.transactions import (
     ByzantiumTransaction
 )
+from eth.vm.forks.constantinople.transactions import (
+    ConstantinopleTransaction
+)
 
 from eth_typing.enums import (
     ForkName
@@ -92,7 +95,7 @@ def fixture_transaction_class(fixture_data):
     elif fork_name == ForkName.Byzantium:
         return ByzantiumTransaction
     elif fork_name == ForkName.Constantinople:
-        pytest.skip("Constantinople Transaction class has not been implemented")
+        return ConstantinopleTransaction
     elif fork_name == ForkName.Metropolis:
         pytest.skip("Metropolis Transaction class has not been implemented")
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist=
     py{35,36}-{core,database,transactions,vm,native-blockchain}
     py{36}-{benchmark,p2p,trinity,lightchain_integration,beacon}
     py{36}-rpc-blockchain
-    py{36}-rpc-state-{frontier,homestead,eip150,eip158,byzantium,quadratic}
+    py{36}-rpc-state-{frontier,homestead,eip150,eip158,byzantium,constantinople,quadratic}
     py{35,36}-native-state-{frontier,homestead,eip150,eip158,byzantium,constantinople,metropolis}
     py37-{core,trinity,trinity-integration,beacon}
     py{35,36}-lint
@@ -32,6 +32,8 @@ commands=
     beacon: pytest {posargs:tests/beacon/}
     # The following test seems to consume a lot of memory. Restricting to 3 processes reduces crashes
     rpc-state-byzantium: pytest -n3 {posargs:tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Byzantium'}
+    # Uncomment the next line + modify test_rpc_fixtures.py when Constantinople is included in the mainnet config
+    # rpc-state-constantinople: pytest -n3 {posargs:tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Constantinople'}
     rpc-state-quadratic: pytest {posargs:tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
     transactions: pytest {posargs:tests/json-fixtures/test_transactions.py}
     vm: pytest {posargs:tests/json-fixtures/test_virtual_machine.py}


### PR DESCRIPTION
### What was wrong?

We need to run the global state tests from `ethereum/test` for the upcoming constantinople fork

### How was it fixed?

- updated `fixtures` against https://github.com/ethereum/tests/commit/10ab37c095bb87d2e781bcf112b6104912fccb44 which is a WIP branch containing some of the new constantinople tests. We'll most likely have to update this to a different version prior to merge
- configured `test_state.py` to handle Constantinople tests

We need to keep this PR open and continue to rebase it until we get all tests passing. Also notice that there are some tests failing for other forks as well which either means, we have some evm bugs or just need to adjust the test setup somehow.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
