### PR TITLE
Fix full sync service cancellation detection

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -336,7 +336,7 @@ class DiscoveryService(BaseService):
     async def _run(self) -> None:
         connect_loop_sleep = 2
         self.run_task(self.proto.bootstrap())
-        while self.is_running:
+        while not self.cancel_token.triggered:
             await self.maybe_connect_to_more_peers()
             await self.sleep(connect_loop_sleep)
 

--- a/p2p/nat.py
+++ b/p2p/nat.py
@@ -72,7 +72,7 @@ class UPnPService(BaseService):
         On every iteration we configure the port mapping with a lifetime of 30 minutes and then
         sleep for that long as well.
         """
-        while self.is_running:
+        while not self.cancel_token.triggered:
             try:
                 # Wait for the port mapping lifetime, and then try registering it again
                 await self.wait(asyncio.sleep(self._nat_portmap_lifetime))

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -765,7 +765,9 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
     async def stop_all_peers(self) -> None:
         self.logger.info("Stopping all peers ...")
         peers = self.connected_nodes.values()
-        await asyncio.gather(*[peer.disconnect(DisconnectReason.client_quitting) for peer in peers])
+        await asyncio.gather(*[
+            peer.disconnect(DisconnectReason.client_quitting) for peer in peers if peer.is_running
+        ])
 
     async def _cleanup(self) -> None:
         await self.stop_all_peers()

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -342,7 +342,7 @@ class BasePeer(BaseService):
         self.close()
 
     async def _run(self) -> None:
-        while self.is_running:
+        while not self.cancel_token.triggered:
             try:
                 cmd, msg = await self.read_msg()
             except (PeerConnectionLost, TimeoutError) as err:

--- a/trinity/plugins/builtin/tx_pool/pool.py
+++ b/trinity/plugins/builtin/tx_pool/pool.py
@@ -73,7 +73,7 @@ class TxPool(BaseService, PeerSubscriber):
         self.logger.info("Running Tx Pool")
 
         with self.subscribe(self._peer_pool):
-            while self.is_running:
+            while not self.cancel_token.triggered:
                 peer, cmd, msg = await self.wait(
                     self.msg_queue.get(), token=self.cancel_token)
                 peer = cast(ETHPeer, peer)

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -92,7 +92,7 @@ class BaseRequestManager(PeerSubscriber, BaseService, Generic[TPeer, TRequest, T
         self.logger.debug("Launching %s for peer %s", self.__class__.__name__, self._peer)
 
         with self.subscribe_peer(self._peer):
-            while self.is_running:
+            while not self.cancel_token.triggered:
                 peer, cmd, msg = await self.wait(self.msg_queue.get())
                 if peer != self._peer:
                     self.logger.error("Unexpected peer: %s  expected: %s", peer, self._peer)

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -96,7 +96,7 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
     async def _run(self) -> None:
         self.run_task(self._handle_msg_loop())
         with self.subscribe(self.peer_pool):
-            while self.is_running:
+            while not self.cancel_token.triggered:
                 peer_or_finished: Any = await self.wait_first(
                     self._sync_requests.get(),
                     self._sync_complete.wait()

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -47,6 +47,7 @@ class FullNodeSyncer(BaseService):
                 self.chain, self.chaindb, self.peer_pool, self.cancel_token)
             await chain_syncer.run()
 
+        await self.sleep(0)
         if not self.is_running:
             return
 
@@ -59,6 +60,7 @@ class FullNodeSyncer(BaseService):
                 self.chaindb, self.base_db, head.state_root, self.peer_pool, self.cancel_token)
             await downloader.run()
 
+        await self.sleep(0)
         if not self.is_running:
             return
 

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -47,7 +47,6 @@ class FullNodeSyncer(BaseService):
                 self.chain, self.chaindb, self.peer_pool, self.cancel_token)
             await chain_syncer.run()
 
-        await self.sleep(0)
         if self.cancel_token.triggered:
             return
 
@@ -60,7 +59,6 @@ class FullNodeSyncer(BaseService):
                 self.chaindb, self.base_db, head.state_root, self.peer_pool, self.cancel_token)
             await downloader.run()
 
-        await self.sleep(0)
         if self.cancel_token.triggered:
             return
 

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -48,7 +48,7 @@ class FullNodeSyncer(BaseService):
             await chain_syncer.run()
 
         await self.sleep(0)
-        if not self.is_running:
+        if self.cancel_token.triggered:
             return
 
         # Ensure we have the state for our current head.
@@ -61,7 +61,7 @@ class FullNodeSyncer(BaseService):
             await downloader.run()
 
         await self.sleep(0)
-        if not self.is_running:
+        if self.cancel_token.triggered:
             return
 
         # Now, loop forever, fetching missing blocks and applying them.

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -95,7 +95,7 @@ class LightPeerChain(PeerSubscriber, BaseService):
 
     async def _run(self) -> None:
         with self.subscribe(self.peer_pool):
-            while self.is_running:
+            while not self.cancel_token.triggered:
                 peer, cmd, msg = await self.wait(self.msg_queue.get())
                 if isinstance(msg, dict):
                     request_id = msg.get('request_id')

--- a/trinity/sync/sharding/service.py
+++ b/trinity/sync/sharding/service.py
@@ -115,7 +115,7 @@ class ShardSyncer(BaseService, PeerSubscriber):
     #
     async def _run(self) -> None:
         with self.subscribe(self.peer_pool):
-            while self.is_running:
+            while not self.cancel_token.triggered:
                 peer, cmd, msg = await self.cancel_token.cancellable_wait(
                     self.msg_queue.get())
 


### PR DESCRIPTION
### What was wrong?

The previous fix for this in #1177 did not take the async nature into account when detecting whether cancellation has been requested.

### How was it fixed?

Added a `self.sleep(0)` before the `self.is_running` check.

#### Cute Animal Picture

![android-animals-hed2-2015](https://user-images.githubusercontent.com/824194/44113615-e997d414-9fc5-11e8-8ad9-286e492f066a.png)
