### PR TITLE
Make 'persist_header' accept batches

### DIFF
--- a/tests/trinity/core/integration_test_helpers.py
+++ b/tests/trinity/core/integration_test_helpers.py
@@ -52,6 +52,7 @@ class FakeAsyncHeaderDB(AsyncHeaderDB):
     coro_get_score = async_passthrough('get_score')
     coro_header_exists = async_passthrough('header_exists')
     coro_persist_header = async_passthrough('persist_header')
+    coro_persist_header_chain = async_passthrough('persist_header_chain')
 
 
 class FakeAsyncChainDB(FakeAsyncHeaderDB, AsyncChainDB):

--- a/trinity/db/header.py
+++ b/trinity/db/header.py
@@ -4,7 +4,10 @@ from abc import abstractmethod
 from multiprocessing.managers import (  # type: ignore
     BaseProxy,
 )
-from typing import Tuple
+from typing import (
+    Iterable,
+    Tuple,
+)
 
 from eth_typing import (
     Hash32,
@@ -58,6 +61,11 @@ class BaseAsyncHeaderDB(BaseHeaderDB):
     async def coro_persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    @abstractmethod
+    async def coro_persist_header_chain(self,
+                                        headers: Iterable[BlockHeader]) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
 
 class AsyncHeaderDB(HeaderDB, BaseAsyncHeaderDB):
     async def coro_get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
@@ -81,6 +89,10 @@ class AsyncHeaderDB(HeaderDB, BaseAsyncHeaderDB):
     async def coro_persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
         raise NotImplementedError("ChainDB classes must implement this method")
 
+    async def coro_persist_header_chain(self,
+                                        headers: Iterable[BlockHeader]) -> Tuple[BlockHeader, ...]:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
 
 class AsyncHeaderDBProxy(BaseProxy, BaseAsyncHeaderDB, BaseHeaderDB):
     coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
@@ -91,6 +103,7 @@ class AsyncHeaderDBProxy(BaseProxy, BaseAsyncHeaderDB, BaseHeaderDB):
     coro_header_exists = async_method('header_exists')
     coro_get_canonical_block_hash = async_method('get_canonical_block_hash')
     coro_persist_header = async_method('persist_header')
+    coro_persist_header_chain = async_method('persist_header_chain')
 
     get_block_header_by_hash = sync_method('get_block_header_by_hash')
     get_canonical_block_hash = sync_method('get_canonical_block_hash')
@@ -100,3 +113,4 @@ class AsyncHeaderDBProxy(BaseProxy, BaseAsyncHeaderDB, BaseHeaderDB):
     header_exists = sync_method('header_exists')
     get_canonical_block_hash = sync_method('get_canonical_block_hash')
     persist_header = sync_method('persist_header')
+    persist_header_chain = sync_method('persist_header_chain')

--- a/trinity/sync/light/chain.py
+++ b/trinity/sync/light/chain.py
@@ -66,8 +66,7 @@ class LightChainSyncer(BaseHeaderChainSyncer):
             batch_id, headers = await self.wait(self.header_queue.get())
 
             timer = Timer()
-            for header in headers:
-                await self.wait(self.db.coro_persist_header(header))
+            await self.wait(self.db.coro_persist_header_chain(headers))
 
             head = await self.wait(self.db.coro_get_canonical_head())
             self.logger.info(


### PR DESCRIPTION
### What was wrong?

Noticed [this comment](https://github.com/ethereum/py-evm/pull/1151#discussion_r210757360) and jumped on it.

The `persist_header` API did not allow updating batches. By doing so, we can save some time as there is some work inside that method that can be shared across multiple updates.

### How was it fixed?

- make the method accept a `Union[BlockHeader, Iterable[BlockHeader]]` and internally wrap single values in a list
- update call site in light change syncer to take advantage.

Btw, I think there's a further optimization that we could do. Here's a call site:

https://github.com/ethereum/py-evm/blob/cde40dbd953186aafc2832d915261089ec589002/trinity/sync/light/chain.py#L67-L70

Seems like we are fetching the canonical head right after the usage of `persist_header`. However, we know this internally and could change the return type from `Tuple[BlockHeader, ...]` to `Tuple[BlockHeader, Tuple[BlockHeader, ...]]` (or use a named tuple for readability). Then we could directly use the canonical head from the return instead of doing a second call. Thoughts?

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media1.giphy.com/media/2GrNmaGsI2ybu/giphy.gif)
