### PR TITLE
removed p2p and trinity dependencies from py-evm(eth)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,10 +90,8 @@ deps['dev'] = (
     deps['lint']
 )
 
-# As long as eth, p2p and trinity are managed together in the py-evm
-# package, someone running a `pip install py-evm` should expect all
-# dependencies for eth, p2p and trinity to get installed.
-install_requires = deps['eth'] + deps['p2p'] + deps['trinity']
+
+install_requires = deps['eth']
 
 setup(
     name='py-evm',

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands=
     native-state-metropolis: pytest {posargs:tests/json-fixtures/test_state.py -k Metropolis}
     lightchain_integration: pytest --integration {posargs:tests/trinity/integration/test_lightchain_integration.py}
 
-deps = .[eth-extras, test]
+deps = .[p2p, trinity, eth-extras, test]
 
 basepython =
     py35: python3.5
@@ -53,7 +53,7 @@ basepython =
 [testenv:py36-docs]
 whitelist_externals=
     make
-deps = .[doc]
+deps = .[p2p, trinity, doc]
 passenv =
     PYTEST_ADDOPTS
     TRAVIS_EVENT_TYPE
@@ -62,7 +62,7 @@ commands=
 
 
 [common-trinity-integration]
-deps = .[eth-extras, test]
+deps = .[p2p, trinity, eth-extras, test]
 passenv =
     PYTEST_ADDOPTS
     TRAVIS_EVENT_TYPE
@@ -83,7 +83,7 @@ commands = {[common-trinity-integration]commands}
 
 
 [testenv:py36-benchmark]
-deps = .[eth-extras, benchmark]
+deps = .[p2p, trinity, eth-extras, benchmark]
 commands=
     benchmark: {toxinidir}/scripts/benchmark/run.py
 


### PR DESCRIPTION
### What was wrong?

Installing `py-evm` installed `p2p` and `trinity`

### How was it fixed?
modified `install_requires` to only include `eth` dependencies. 
https://github.com/ethereum/py-evm/pull/1188#issuecomment-413697522


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.likecovers.com/covers/parrot-flying-facebook-covers.jpg?i)
