### PR TITLE
Workaround: wait longer for IPC socket file to appear

### DIFF
--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -53,13 +53,12 @@ def database_server_ipc_path():
         )
         chaindb_server_process.start()
 
-        logger = logging.getLogger()
-        wait_for_ipc(chain_config.database_ipc_path, logger)
+        wait_for_ipc(chain_config.database_ipc_path)
 
         try:
             yield chain_config.database_ipc_path
         finally:
-            kill_process_gracefully(chaindb_server_process, logger)
+            kill_process_gracefully(chaindb_server_process, logging.getLogger())
 
 
 @pytest.fixture

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -53,12 +53,13 @@ def database_server_ipc_path():
         )
         chaindb_server_process.start()
 
-        wait_for_ipc(chain_config.database_ipc_path)
+        logger = logging.getLogger()
+        wait_for_ipc(chain_config.database_ipc_path, logger)
 
         try:
             yield chain_config.database_ipc_path
         finally:
-            kill_process_gracefully(chaindb_server_process, logging.getLogger())
+            kill_process_gracefully(chaindb_server_process, logger)
 
 
 @pytest.fixture

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -194,8 +194,8 @@ def trinity_boot(args: Namespace,
     # start the processes
     database_server_process.start()
     logger.info("Started DB server process (pid=%d)", database_server_process.pid)
-    wait_for_ipc(chain_config.database_ipc_path, logger)
 
+    wait_for_ipc(chain_config.database_ipc_path, logger)
     networking_process.start()
     logger.info("Started networking process (pid=%d)", networking_process.pid)
 

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -194,7 +194,13 @@ def trinity_boot(args: Namespace,
     # start the processes
     database_server_process.start()
     logger.info("Started DB server process (pid=%d)", database_server_process.pid)
-    wait_for_ipc(chain_config.database_ipc_path)
+
+    # networking process needs the IPC socket file provided by the database process
+    try:
+        wait_for_ipc(chain_config.database_ipc_path)
+    except TimeoutError as e:
+        logger.error(e)
+        logger.warn("Networking process is likely to fail - proceeding optimistically...")
 
     networking_process.start()
     logger.info("Started networking process (pid=%d)", networking_process.pid)

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -194,8 +194,8 @@ def trinity_boot(args: Namespace,
     # start the processes
     database_server_process.start()
     logger.info("Started DB server process (pid=%d)", database_server_process.pid)
+    wait_for_ipc(chain_config.database_ipc_path)
 
-    wait_for_ipc(chain_config.database_ipc_path, logger)
     networking_process.start()
     logger.info("Started networking process (pid=%d)", networking_process.pid)
 

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -199,8 +199,9 @@ def trinity_boot(args: Namespace,
     try:
         wait_for_ipc(chain_config.database_ipc_path)
     except TimeoutError as e:
-        logger.error(e)
-        logger.warn("Networking process is likely to fail - proceeding optimistically...")
+        logger.error("Timeout waiting for database to start.  Exiting...")
+        kill_process_gracefully(database_server_process, logger)
+        sys.exit(1)
 
     networking_process.start()
     logger.info("Started networking process (pid=%d)", networking_process.pid)

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -194,7 +194,7 @@ def trinity_boot(args: Namespace,
     # start the processes
     database_server_process.start()
     logger.info("Started DB server process (pid=%d)", database_server_process.pid)
-    wait_for_ipc(chain_config.database_ipc_path)
+    wait_for_ipc(chain_config.database_ipc_path, logger)
 
     networking_process.start()
     logger.info("Started networking process (pid=%d)", networking_process.pid)

--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -14,9 +14,10 @@ def wait_for_ipc(ipc_path: pathlib.Path, logger: Logger, timeout: int=10) -> Non
     while not ipc_path.exists():
         wait_duration = time.time() - start_at
         if wait_duration > timeout:
-            break
+            logger.warn("IPC socket file has not appeared in %1.3f seconds!", wait_duration)
+            return
         time.sleep(0.05)
-    logger.info("Waited %1.3f seconds for IPC socket file to appear", wait_duration)
+    logger.debug("Waited %1.3f seconds for IPC socket file to appear", wait_duration)
 
 
 DEFAULT_SIGINT_TIMEOUT = 10

--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -8,12 +8,15 @@ import time
 from typing import Callable
 
 
-def wait_for_ipc(ipc_path: pathlib.Path, timeout: int=10) -> None:
+def wait_for_ipc(ipc_path: pathlib.Path, logger: Logger, timeout: int=10) -> None:
     start_at = time.time()
-    while time.time() - start_at < timeout:
-        if ipc_path.exists():
+    wait_duration = 0
+    while not ipc_path.exists():
+        wait_duration = time.time() - start_at
+        if wait_duration > timeout:
             break
         time.sleep(0.05)
+    logger.info("Waited %1.3f seconds for IPC socket file to appear", wait_duration)
 
 
 DEFAULT_SIGINT_TIMEOUT = 10

--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -8,7 +8,7 @@ import time
 from typing import Callable
 
 
-def wait_for_ipc(ipc_path: pathlib.Path, timeout: int=1) -> None:
+def wait_for_ipc(ipc_path: pathlib.Path, timeout: int=10) -> None:
     start_at = time.time()
     while time.time() - start_at < timeout:
         if ipc_path.exists():

--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -13,7 +13,7 @@ def wait_for_ipc(ipc_path: pathlib.Path, logger: Logger, timeout: int=10) -> Non
     wait_duration = 0
     while not ipc_path.exists():
         wait_duration = time.time() - start_at
-        if wait_duration > timeout:
+        if wait_duration >= timeout:
             logger.warn("IPC socket file has not appeared in %1.3f seconds!", wait_duration)
             return
         time.sleep(0.05)

--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -9,11 +9,18 @@ from typing import Callable
 
 
 def wait_for_ipc(ipc_path: pathlib.Path, timeout: int=10) -> None:
+    """
+    Waits up to ``timeout`` seconds for the IPC socket file to appear at path
+    ``ipc_path``, or raises a :exc:`TimeoutError` otherwise.
+    """
     start_at = time.time()
     while time.time() - start_at < timeout:
         if ipc_path.exists():
-            break
-        time.sleep(0.05)
+            return
+        else:
+            time.sleep(0.05)
+    # haven't `return`ed by now - raise unconditionally
+    raise TimeoutError("IPC socket file has not appeared in %d seconds!" % timeout)
 
 
 DEFAULT_SIGINT_TIMEOUT = 10

--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -8,16 +8,12 @@ import time
 from typing import Callable
 
 
-def wait_for_ipc(ipc_path: pathlib.Path, logger: Logger, timeout: int=10) -> None:
+def wait_for_ipc(ipc_path: pathlib.Path, timeout: int=10) -> None:
     start_at = time.time()
-    wait_duration = 0
-    while not ipc_path.exists():
-        wait_duration = time.time() - start_at
-        if wait_duration >= timeout:
-            logger.warn("IPC socket file has not appeared in %1.3f seconds!", wait_duration)
-            return
+    while time.time() - start_at < timeout:
+        if ipc_path.exists():
+            break
         time.sleep(0.05)
-    logger.debug("Waited %1.3f seconds for IPC socket file to appear", wait_duration)
 
 
 DEFAULT_SIGINT_TIMEOUT = 10


### PR DESCRIPTION
### What was wrong?

On slow systems, it may take a while before the IPC socket file is created.

We wait for this file for 1 second only; and, whether it's present or not, continue in the same manner.

The networking process wants this file to be present, fails if it's not, and effectively "hangs" the node.

### How was it fixed?

The timeout was increased, from 1 second to 10.

If the timeout is reached, an exception is raised, an attempt is made to shut down the DB process, and an exit with error code 1 (generic) is performed.

Closes #1168 - should perhaps open a more specific issue, taking the notes there into account?..


### Cute Animal Picture

Two processes, one is "too fast"...

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/474x/42/07/13/4207132c24e714d26b57cb79c1db2118--adorable-animals-funny-animals.jpg)

Source: not sure; found [on pinterest](https://www.pinterest.com/pin/162903711496032131/).