### PR TITLE
PoC: Use event bus to retrieve PeerCount from PeerPool by another process

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -51,6 +51,10 @@ from eth_keys import (
 
 from cancel_token import CancelToken, OperationCancelled
 
+from lahja import (
+    Endpoint,
+)
+
 from eth.chains.mainnet import MAINNET_NETWORK_ID
 from eth.chains.ropsten import ROPSTEN_NETWORK_ID
 from eth.constants import GENESIS_BLOCK_NUMBER
@@ -90,6 +94,11 @@ from p2p.p2p_proto import (
     P2PProtocol,
     Ping,
     Pong,
+)
+
+from trinity.events import (
+    PeerCountRequest,
+    PeerCountResponse
 )
 
 from .constants import (
@@ -682,6 +691,7 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
                  vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...],
                  max_peers: int = DEFAULT_MAX_PEERS,
                  token: CancelToken = None,
+                 event_bus: Endpoint = None
                  ) -> None:
         super().__init__(token)
         self.peer_class = peer_class
@@ -692,6 +702,16 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
         self.max_peers = max_peers
         self.connected_nodes: Dict[Node, BasePeer] = {}
         self._subscribers: List[PeerSubscriber] = []
+        self.event_bus = event_bus
+        self.run_task(self.answer_peer_count_requests())
+
+    async def answer_peer_count_requests(self):
+        async for req in self.event_bus.stream(PeerCountRequest):
+            # We are listening for all `PeerCountRequest` events but we ensure to
+            # only send a `PeerCountResponse` to the callsite that made the request.
+            # We do that by retrieving a `BroadcastConfig` from the request via the
+            # `event.broadcast_config()` API.
+            self.event_bus.broadcast(PeerCountResponse(len(self)), req.broadcast_config())
 
     def __len__(self) -> int:
         return len(self.connected_nodes)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ deps = {
         "ipython>=6.2.1,<7.0.0",
         "plyvel==1.0.5",
         "web3==4.4.1",
+        "lahja==0.4.0",
     ],
     'test': [
         "hypothesis==3.44.26",

--- a/trinity/events.py
+++ b/trinity/events.py
@@ -1,0 +1,12 @@
+from lahja import (
+    BaseEvent
+)
+
+
+class PeerCountRequest(BaseEvent):
+
+    def __init__(self) -> None:
+        super().__init__(None)
+
+class PeerCountResponse(BaseEvent):
+    pass

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -11,12 +11,19 @@ from typing import (
     Any
 )
 
+from lahja import (
+    Endpoint
+)
+
 from trinity.extensibility.events import (
     BaseEvent
 )
 
-# TODO: we spec this out later
-PluginContext = Any
+
+class PluginContext:
+
+    def __init__(self, endpoint: Endpoint):
+        self.eventbus = endpoint
 
 
 class BasePlugin(ABC):

--- a/trinity/extensibility/plugin_manager.py
+++ b/trinity/extensibility/plugin_manager.py
@@ -15,6 +15,7 @@ from trinity.extensibility.events import (
 )
 from trinity.extensibility.plugin import (
     BasePlugin,
+    PluginContext,
 )
 
 
@@ -28,9 +29,10 @@ class PluginManager:
         This API is very much in flux and is expected to change heavily.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, context: PluginContext) -> None:
         self._plugin_store: List[BasePlugin] = []
         self._started_plugins: List[BasePlugin] = []
+        self._plugin_context = context
         self._logger = logging.getLogger("trinity.extensibility.plugin_manager.PluginManager")
 
     def register(self, plugins: Union[BasePlugin, Iterable[BasePlugin]]) -> None:

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -47,6 +47,7 @@ class FullNode(Node):
                 bootstrap_nodes=self._bootstrap_nodes,
                 preferred_nodes=self._preferred_nodes,
                 token=self.cancel_token,
+                event_bus=self._plugin_manager._plugin_context.eventbus
             )
         return self._p2p_server
 

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -13,6 +13,10 @@ from eth_utils import big_endian_to_int
 
 from cancel_token import CancelToken, OperationCancelled
 
+from lahja import (
+    Endpoint
+)
+
 from eth.chains import AsyncChain
 
 from p2p.auth import (
@@ -78,9 +82,11 @@ class Server(BaseService):
                  peer_class: Type[BasePeer] = ETHPeer,
                  bootstrap_nodes: Tuple[Node, ...] = None,
                  preferred_nodes: Sequence[Node] = None,
+                 event_bus: Endpoint = None,
                  token: CancelToken = None,
                  ) -> None:
         super().__init__(token)
+        self.event_bus = event_bus
         self.headerdb = headerdb
         self.chaindb = chaindb
         self.chain = chain
@@ -128,6 +134,7 @@ class Server(BaseService):
             self.chain.get_vm_configuration(),
             max_peers=self.max_peers,
             token=self.cancel_token,
+            event_bus=self.event_bus,
         )
 
     async def _run(self) -> None:

--- a/trinity/test_proc.py
+++ b/trinity/test_proc.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from lahja import (
+    Endpoint
+)
+
+from trinity.events import (
+    PeerCountRequest,
+    PeerCountResponse,
+)
+
+def run_test_proc(event_bus: Endpoint):
+    print("hello from test proc")
+    loop = asyncio.get_event_loop()
+    event_bus.connect()
+
+    asyncio.ensure_future(request_receive_peer_count(event_bus))
+    loop.run_forever()
+    loop.close()
+
+
+async def request_receive_peer_count(event_bus):
+    while True:
+        response = await event_bus.request(PeerCountRequest())
+        print("Peer Count: " + str(response.payload))
+        await asyncio.sleep(1)
+


### PR DESCRIPTION
### What is this?

This is another PoC to demonstrate the concept of using an event bus for inter process communication. This time, a new independent process is interacting with the event bus to receive the current peer count from the `PeerPool`.

**Keep in mind this is a PoC. It is full of bugs and poor ergonomics**

### What happens:

1. There's a new independent dummy process being started

```python
test_proc = multiprocessing.Process(
        target=run_test_proc,
        args=(
            test_proc_endpoint,
        ),
    )
test_proc.start()
```

2. This process broadcasts a `PeerCountRequest` on the event bus **every second**

```Python
async def request_peer_count(event_bus: Endpoint):
    while True:
        await asyncio.sleep(1)
        event_bus.broadcast(PeerCountRequest())
```

3. It also streams all incoming `PeerCountResponse` objects

```Python
async def receive_peer_count(event_bus: Endpoint):
    async for resp in event_bus.stream(PeerCountResponse):
        print("Peer Count: " + str(resp.payload))
```

4. The `PeerPool` on the other hand listens for `PeerCountRequest` and answers them with `PeerCountResponse`

```Python
    async def answer_peer_count_requests(self):
        async for req in self.event_bus.stream(PeerCountRequest):
            print("answering!" + str(len(self)))
            self.event_bus.broadcast(PeerCountResponse(len(self)))
```

### Known issues

1. There's seems to be something wrong with the event loop. I could only get things to work if we don't `spawn` but rather `fork` processes. However, while that makes things work *somehow* I'm seeing duplicate log entries with that.

2. The communication could be much much more efficient. Currently, the event bus just fans out each and every event to every participating process. In practice, we will want to limit the direction and flow of events to not waste resources

3. I anticipate the event bus being used a lot for loose async communication with one sender and many receivers. However, as demoed in this PoC, the event bus can also be used for classical request / response type of work. That said, currently the API for that simply doesn't exist and combining `broadcast` and `stream` is both unergonomic and wasteful. It wouldn't be too hard to build the following API that would enable a simple request/response pattern between only two actors (without broadcasting to each and every participating actor)

```Python
response = await event_bus.request(PeerCountRequest())
```