### PR TITLE
Piper/fix validation error if new head uncle is current head v2

### DIFF
--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -562,7 +562,7 @@ class VM(BaseVM):
         """
         if 'uncles' in kwargs:
             uncles = kwargs.pop('uncles')
-            kwargs.setdefault('uncles_hash', keccak(rlp.encode(block.uncles)))
+            kwargs.setdefault('uncles_hash', keccak(rlp.encode(uncles)))
         else:
             uncles = block.uncles
 
@@ -710,7 +710,7 @@ class VM(BaseVM):
                 " - header uncle_hash: {2}".format(
                     len(block.uncles),
                     local_uncle_hash,
-                    block.header.uncle_hash,
+                    block.header.uncles_hash,
                 )
             )
 

--- a/tests/core/chain-object/test_chain_get_ancestors.py
+++ b/tests/core/chain-object/test_chain_get_ancestors.py
@@ -100,8 +100,10 @@ def test_chain_get_ancestors_for_fork_chains(chain, fork_chain):
     ) = [fork_chain.mine_block() for _ in range(3)]
 
     # import the fork blocks into the main chain (ensuring they don't cause a reorg)
-    assert not chain.import_block(f_block_4)[1]
-    assert not chain.import_block(f_block_5)[1]
+    _, new_chain, _ = chain.import_block(f_block_4)
+    assert new_chain == tuple()
+    _, new_chain, _ = chain.import_block(f_block_5)
+    assert new_chain == tuple()
 
     # check with a block that has been imported
     assert chain.get_ancestors(0, f_block_5.header) == tuple()

--- a/tests/core/chain-object/test_chain_get_ancestors.py
+++ b/tests/core/chain-object/test_chain_get_ancestors.py
@@ -1,0 +1,127 @@
+import pytest
+
+from eth.chains.base import MiningChain
+from eth.db.backends.memory import MemoryDB
+
+
+@pytest.fixture
+def chain(chain_without_block_validation):
+    if not isinstance(chain_without_block_validation, MiningChain):
+        pytest.skip('only valid on mining chains')
+    return chain_without_block_validation
+
+
+@pytest.fixture
+def fork_chain(chain):
+    # make a duplicate chain with no shared state
+    fork_db = MemoryDB(chain.chaindb.db.kv_store.copy())
+    fork_chain = type(chain)(fork_db, chain.header)
+
+    return fork_chain
+
+
+@pytest.mark.parametrize(
+    'limit',
+    (0, 1, 2, 5),
+)
+def test_chain_get_ancestors_from_genesis_block(chain, limit):
+    header = chain.get_canonical_head()
+    assert header.block_number == 0
+
+    ancestors = chain.get_ancestors(limit, header)
+    assert ancestors == tuple()
+
+
+def test_chain_get_ancestors_from_block_1(chain):
+    genesis = chain.get_canonical_block_by_number(0)
+    block_1 = chain.mine_block()
+    header = block_1.header
+    assert header.block_number == 1
+
+    assert chain.get_ancestors(0, header) == tuple()
+    assert chain.get_ancestors(1, header) == (genesis,)
+    assert chain.get_ancestors(2, header) == (genesis,)
+    assert chain.get_ancestors(5, header) == (genesis,)
+
+
+def test_chain_get_ancestors_from_block_5(chain):
+    genesis = chain.get_canonical_block_by_number(0)
+    (
+        block_1,
+        block_2,
+        block_3,
+        block_4,
+        block_5,
+    ) = [chain.mine_block() for _ in range(5)]
+
+    header = block_5.header
+    assert header.block_number == 5
+
+    assert chain.get_ancestors(0, header) == tuple()
+    assert chain.get_ancestors(1, header) == (block_4,)
+    assert chain.get_ancestors(2, header) == (block_4, block_3)
+    assert chain.get_ancestors(3, header) == (block_4, block_3, block_2)
+    assert chain.get_ancestors(4, header) == (block_4, block_3, block_2, block_1)
+    assert chain.get_ancestors(5, header) == (block_4, block_3, block_2, block_1, genesis)
+    assert chain.get_ancestors(6, header) == (block_4, block_3, block_2, block_1, genesis)
+    assert chain.get_ancestors(10, header) == (block_4, block_3, block_2, block_1, genesis)
+
+
+def test_chain_get_ancestors_for_fork_chains(chain, fork_chain):
+    genesis = chain.get_canonical_block_by_number(0)
+    (
+        block_1,
+        block_2,
+        block_3,
+    ) = [chain.mine_block() for _ in range(3)]
+    (
+        f_block_1,
+        f_block_2,
+        f_block_3,
+    ) = [fork_chain.mine_block() for _ in range(3)]
+
+    assert block_1 == f_block_1
+    assert block_2 == f_block_2
+    assert block_3 == f_block_3
+
+    # force the fork chain to diverge
+    fork_chain.header = fork_chain.header.copy(extra_data=b'fork-it!')
+
+    # mine ahead a bit further on both chains.
+    (
+        block_4,
+        block_5,
+        block_6,
+    ) = [chain.mine_block() for _ in range(3)]
+    (
+        f_block_4,
+        f_block_5,
+        f_block_6,
+    ) = [fork_chain.mine_block() for _ in range(3)]
+
+    # import the fork blocks into the main chain (ensuring they don't cause a reorg)
+    assert not chain.import_block(f_block_4)[1]
+    assert not chain.import_block(f_block_5)[1]
+
+    # check with a block that has been imported
+    assert chain.get_ancestors(0, f_block_5.header) == tuple()
+    assert chain.get_ancestors(1, f_block_5.header) == (f_block_4,)
+    assert chain.get_ancestors(2, f_block_5.header) == (f_block_4, block_3)
+    assert chain.get_ancestors(3, f_block_5.header) == (f_block_4, block_3, block_2)
+    assert chain.get_ancestors(4, f_block_5.header) == (f_block_4, block_3, block_2, block_1)
+    assert chain.get_ancestors(5, f_block_5.header) == (f_block_4, block_3, block_2, block_1, genesis)  # noqa: E501
+    # check that when we hit genesis it self limits
+    assert chain.get_ancestors(6, f_block_5.header) == (f_block_4, block_3, block_2, block_1, genesis)  # noqa: E501
+    assert chain.get_ancestors(20, f_block_5.header) == (f_block_4, block_3, block_2, block_1, genesis)  # noqa: E501
+
+    # check with a block that has NOT been imported
+    assert chain.get_ancestors(0, f_block_6.header) == tuple()
+    assert chain.get_ancestors(1, f_block_6.header) == (f_block_5,)
+    assert chain.get_ancestors(2, f_block_6.header) == (f_block_5, f_block_4)
+    assert chain.get_ancestors(3, f_block_6.header) == (f_block_5, f_block_4, block_3)
+    assert chain.get_ancestors(4, f_block_6.header) == (f_block_5, f_block_4, block_3, block_2)
+    assert chain.get_ancestors(5, f_block_6.header) == (f_block_5, f_block_4, block_3, block_2, block_1)  # noqa: E501
+    assert chain.get_ancestors(6, f_block_6.header) == (f_block_5, f_block_4, block_3, block_2, block_1, genesis)  # noqa: E501
+    # check that when we hit genesis it self limits
+    assert chain.get_ancestors(7, f_block_6.header) == (f_block_5, f_block_4, block_3, block_2, block_1, genesis)  # noqa: E501
+    assert chain.get_ancestors(20, f_block_6.header) == (f_block_5, f_block_4, block_3, block_2, block_1, genesis)  # noqa: E501

--- a/tests/core/chain-object/test_chain_reorganization.py
+++ b/tests/core/chain-object/test_chain_reorganization.py
@@ -14,7 +14,7 @@ VM_CLASSES = tuple(
 
 
 @pytest.fixture(params=VM_CLASSES)
-def chain(request, genesis_state):
+def base_chain(request, genesis_state):
     VMClass = request.param.configure(validate_seal=lambda block: None)
 
     class ChainForTest(MiningChain):
@@ -30,20 +30,23 @@ def chain(request, genesis_state):
     return chain
 
 
-ZERO_ADDRESS = b'\x00' * 20
-
-
-def test_import_block_with_reorg(chain, funded_address_private_key):
+@pytest.fixture
+def chain(base_chain):
     # mine 3 "common blocks"
-    block_0 = chain.get_canonical_block_by_number(0)
+    block_0 = base_chain.get_canonical_block_by_number(0)
     assert block_0.number == 0
-    block_1 = chain.mine_block()
+    block_1 = base_chain.mine_block()
     assert block_1.number == 1
-    block_2 = chain.mine_block()
+    block_2 = base_chain.mine_block()
     assert block_2.number == 2
-    block_3 = chain.mine_block()
+    block_3 = base_chain.mine_block()
     assert block_3.number == 3
 
+    return base_chain
+
+
+@pytest.fixture
+def fork_chain(chain):
     # make a duplicate chain with no shared state
     fork_db = MemoryDB(chain.chaindb.db.kv_store.copy())
     fork_chain = type(chain)(fork_db, chain.header)
@@ -56,12 +59,26 @@ def test_import_block_with_reorg(chain, funded_address_private_key):
 
     assert fork_chain.get_canonical_head() == chain.get_canonical_head()
 
+    block_0 = chain.get_canonical_block_by_number(0)
     assert fork_chain.get_canonical_block_by_number(0) == block_0
+
+    block_1 = chain.get_canonical_block_by_number(1)
     assert fork_chain.get_canonical_block_by_number(1) == block_1
+
+    block_2 = chain.get_canonical_block_by_number(2)
     assert fork_chain.get_canonical_block_by_number(2) == block_2
+
+    block_3 = chain.get_canonical_block_by_number(3)
     assert fork_chain.get_canonical_block_by_number(3) == block_3
 
-    # now cause the fork chain to diverge from the main chain
+    return fork_chain
+
+
+ZERO_ADDRESS = b'\x00' * 20
+
+
+def test_import_block_with_reorg(chain, fork_chain, funded_address_private_key):
+    # cause the fork chain to diverge from the main chain
     tx = fork_chain.create_unsigned_transaction(
         nonce=0,
         gas_price=1,
@@ -72,7 +89,7 @@ def test_import_block_with_reorg(chain, funded_address_private_key):
     )
     fork_chain.apply_transaction(tx.as_signed_transaction(funded_address_private_key))
 
-    # Mine 3 blocks, ensuring that the difficulty of the main chain remains
+    # Mine 2 blocks, ensuring that the difficulty of the main chain remains
     # equal or greater than the fork chain
     block_4 = chain.mine_block()
     f_block_4 = fork_chain.mine_block()
@@ -87,28 +104,50 @@ def test_import_block_with_reorg(chain, funded_address_private_key):
     assert f_block_5.number == 5
     assert f_block_5.header.difficulty <= block_5.header.difficulty
 
-    f_block_6, block_6 = fork_chain.mine_block(), chain.mine_block()
-    assert f_block_6 != block_6
-    assert block_6.number == 6
-    assert f_block_6.number == 6
-    assert f_block_6.header.difficulty <= block_6.header.difficulty
-
-    # now mine the 7th block which will outpace the main chain difficulty.
-    f_block_7 = fork_chain.mine_block()
+    # now mine the 6th block which will outpace the main chain difficulty.
+    f_block_6 = fork_chain.mine_block()
 
     pre_fork_chain_head = chain.header
 
     # now we proceed to import the blocks from the fork chain into the main
-    # chain.  Blocks 4, 5, and 6 should import resulting in no re-organization.
-    for block in (f_block_4, f_block_5, f_block_6):
+    # chain.  Blocks 4 and 5 should import resulting in no re-organization.
+    for block in (f_block_4, f_block_5):
         _, new_canonical_blocks, old_canonical_blocks = chain.import_block(block)
         assert not new_canonical_blocks
         assert not old_canonical_blocks
         assert chain.header == pre_fork_chain_head
 
-    # now we import block 7 from the fork chain.  This should cause a re-org.
-    _, new_canonical_blocks, old_canonical_blocks = chain.import_block(f_block_7)
-    assert new_canonical_blocks == (f_block_4, f_block_5, f_block_6, f_block_7)
-    assert old_canonical_blocks == (block_4, block_5, block_6)
+    # now we import block 6 from the fork chain.  This should cause a re-org.
+    _, new_canonical_blocks, old_canonical_blocks = chain.import_block(f_block_6)
+    assert new_canonical_blocks == (f_block_4, f_block_5, f_block_6)
+    assert old_canonical_blocks == (block_4, block_5)
 
-    assert chain.get_canonical_head() == f_block_7.header
+    assert chain.get_canonical_head() == f_block_6.header
+
+
+def test_import_block_with_reorg_with_current_head_as_uncle(
+        chain,
+        fork_chain,
+        funded_address_private_key):
+    """
+    https://github.com/ethereum/py-evm/issues/1185
+    """
+    # mine a block on the main chain which will eventually become an uncle on
+    # the main chain after a reorg.
+    block = chain.mine_block()
+
+    # Force the fork_chain to diverge from the main chain
+    fork_chain.header = fork_chain.header.copy(extra_data=b'fork-it!')
+    f_block_a = fork_chain.mine_block()
+
+    # now mine a block which has the current chain head as an uncle.
+    assert f_block_a != block
+    f_block_b = fork_chain.mine_block(uncles=(block.header,))
+
+    # ensure that we don't cause a re-org with our first import.
+    assert not chain.import_block(f_block_a)[1]
+
+    # import the block with the uncle, ensure that the chain did indeed re-org
+    chain.import_block(f_block_b)
+
+    assert chain.get_canonical_head() == f_block_b.header

--- a/tests/core/chain-object/test_chain_reorganization.py
+++ b/tests/core/chain-object/test_chain_reorganization.py
@@ -145,7 +145,8 @@ def test_import_block_with_reorg_with_current_head_as_uncle(
     f_block_b = fork_chain.mine_block(uncles=(block.header,))
 
     # ensure that we don't cause a re-org with our first import.
-    assert not chain.import_block(f_block_a)[1]
+    _, new_chain, _ = chain.import_block(f_block_a)
+    assert new_chain == tuple()
 
     # import the block with the uncle, ensure that the chain did indeed re-org
     chain.import_block(f_block_b)

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -128,7 +128,7 @@ class LightDispatchChain(BaseChain):
     #
     # Block API
     #
-    def get_ancestors(self, limit: int, header: BlockHeader=None) -> Iterator[BaseBlock]:
+    def get_ancestors(self, limit: int, header: BlockHeader) -> Tuple[BaseBlock, ...]:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
     def get_block(self) -> BaseBlock:


### PR DESCRIPTION
### What was wrong?

Fixes #1185 

### How was it fixed?

Change `Chain.get_ancestors()` to appropriately return the ancestor chain from the provided header rather than the canonical block numbers.

#### Cute Animal Picture

![m6vdgo](https://user-images.githubusercontent.com/824194/44431888-0d640380-a55d-11e8-9041-61211948ebeb.jpg)
