### PR TITLE
Sync headers in queue instead of batch, add Peer types

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -295,7 +295,10 @@ class BaseChain(Configurable, ABC):
 
     @abstractmethod
     def validate_chain(
-            self, chain: Tuple[BlockHeader, ...], seal_check_random_sample_rate: int = 1) -> None:
+            self,
+            parent: BlockHeader,
+            chain: Tuple[BlockHeader, ...],
+            seal_check_random_sample_rate: int = 1) -> None:
         raise NotImplementedError("Chain classes must implement this method")
 
 
@@ -868,5 +871,8 @@ class AsyncChain(Chain):
         raise NotImplementedError()
 
     async def coro_validate_chain(
-            self, chain: Tuple[BlockHeader, ...], seal_check_random_sample_rate: int = 1) -> None:
+            self,
+            parent: BlockHeader,
+            chain: Tuple[BlockHeader, ...],
+            seal_check_random_sample_rate: int = 1) -> None:
         raise NotImplementedError()

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -763,8 +763,11 @@ class Chain(BaseChain):
             uncle_vm_class.validate_uncle(block, uncle, uncle_parent)
 
     def validate_chain(
-            self, chain: Tuple[BlockHeader, ...], seal_check_random_sample_rate: int = 1) -> None:
-        parent = self.chaindb.get_block_header_by_hash(chain[0].parent_hash)
+            self,
+            parent: BlockHeader,
+            chain: Tuple[BlockHeader, ...],
+            seal_check_random_sample_rate: int = 1) -> None:
+
         all_indices = list(range(len(chain)))
         if seal_check_random_sample_rate == 1:
             headers_to_check_seal = set(all_indices)

--- a/p2p/nat.py
+++ b/p2p/nat.py
@@ -160,6 +160,8 @@ class UPnPService(BaseService):
         except TimeoutError:
             self.logger.info("Timeout waiting for UPNP-enabled devices")
             return
+        else:
+            self.logger.debug("Found %d candidate NAT devices", len(devices))
 
         # If there are no UPNP devices we can exit early
         if not devices:

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -135,7 +135,7 @@ class BaseService(ABC, CancellableMixin):
                 pass
             except Exception as e:
                 self.logger.warning("Task %s finished unexpectedly: %s", awaitable, e)
-                self.logger.warning("Task failure traceback", exc_info=True)
+                self.logger.debug("Task failure traceback", exc_info=True)
             else:
                 self.logger.debug("Task %s finished with no errors", awaitable)
         self._tasks.add(asyncio.ensure_future(_run_task_wrapper()))

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -128,7 +128,7 @@ class BaseService(ABC, CancellableMixin):
         If it raises OperationCancelled, that is caught and ignored.
         """
         async def _run_task_wrapper() -> None:
-            self.logger.debug("Running task %s", awaitable)
+            self.logger.trace("Running task %s", awaitable)
             try:
                 await awaitable
             except OperationCancelled:
@@ -137,7 +137,7 @@ class BaseService(ABC, CancellableMixin):
                 self.logger.warning("Task %s finished unexpectedly: %s", awaitable, e)
                 self.logger.debug("Task failure traceback", exc_info=True)
             else:
-                self.logger.debug("Task %s finished with no errors", awaitable)
+                self.logger.trace("Task %s finished with no errors", awaitable)
         self._tasks.add(asyncio.ensure_future(_run_task_wrapper()))
 
     def run_child_service(self, child_service: 'BaseService') -> None:

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,11 @@ deps = {
         "web3==4.4.1",
     ],
     'test': [
-        "hypothesis==3.44.26",
+        "hypothesis==3.69.5",
         # pinned to <3.7 until async fixtures work again
         # https://github.com/pytest-dev/pytest-asyncio/issues/89
         "pytest>=3.6,<3.7",
-        "pytest-asyncio==0.8.0",
+        "pytest-asyncio==0.9.0",
         "pytest-cov==2.5.1",
         "pytest-watch>=4.1.0,<5",
         "pytest-xdist==1.18.1",

--- a/tests/p2p/test_service.py
+++ b/tests/p2p/test_service.py
@@ -26,11 +26,16 @@ class WaitService(BaseService):
 async def test_daemon_exit_causes_parent_cancellation():
     service = ParentService()
     asyncio.ensure_future(service.run())
+
     await asyncio.sleep(0.01)
+
     assert service.daemon.is_operational
     assert service.daemon.is_running
+
     await service.daemon.cancel()
     await asyncio.sleep(0.01)
+
     assert not service.is_operational
     assert not service.is_running
-    await service.events.cleaned_up.wait()
+
+    await asyncio.wait_for(service.events.cleaned_up.wait(), timeout=1)

--- a/tests/trinity/utils/test_task_queue.py
+++ b/tests/trinity/utils/test_task_queue.py
@@ -1,0 +1,197 @@
+import asyncio
+import pytest
+
+from eth_utils import ValidationError
+
+from trinity.utils.datastructures import TaskQueue
+
+
+async def wait(coro, timeout=0.05):
+    return await asyncio.wait_for(coro, timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_queue_size_reset_after_complete():
+    q = TaskQueue(maxsize=2)
+
+    await wait(q.add((1, 2)))
+
+    batch, tasks = await wait(q.get())
+
+    # there should not be room to add another task
+    try:
+        await wait(q.add((3, )))
+    except asyncio.TimeoutError:
+        pass
+    else:
+        assert False, "should not be able to add task past maxsize"
+
+    # do imaginary work here, then complete it all
+
+    q.complete(batch, tasks)
+
+    # there should be room to add more now
+    await wait(q.add((3, )))
+
+
+@pytest.mark.asyncio
+async def test_queue_contains_task_until_complete():
+    q = TaskQueue()
+
+    assert 2 not in q
+
+    await wait(q.add((2, )))
+
+    assert 2 in q
+
+    batch, tasks = await wait(q.get())
+
+    assert 2 in q
+
+    q.complete(batch, tasks)
+
+    assert 2 not in q
+
+
+@pytest.mark.asyncio
+async def test_default_priority_order():
+    q = TaskQueue(maxsize=4)
+    await wait(q.add((2, 1, 3)))
+    (batch, tasks) = await wait(q.get())
+    assert tasks == (1, 2, 3)
+
+
+@pytest.mark.asyncio
+async def test_custom_priority_order():
+    q = TaskQueue(maxsize=4, order_fn=lambda x: 0-x)
+
+    await wait(q.add((2, 1, 3)))
+    (batch, tasks) = await wait(q.get())
+    assert tasks == (3, 2, 1)
+
+
+@pytest.mark.asyncio
+async def test_cannot_add_single_non_tuple_task():
+    q = TaskQueue()
+    with pytest.raises(ValidationError):
+        await wait(q.add(1))
+
+
+@pytest.mark.asyncio
+async def test_unlimited_queue_by_default():
+    q = TaskQueue()
+    await wait(q.add(tuple(range(100001))))
+
+
+@pytest.mark.asyncio
+async def test_unfinished_tasks_readded():
+    q = TaskQueue()
+    await wait(q.add((2, 1, 3)))
+
+    batch, tasks = await wait(q.get())
+
+    q.complete(batch, (2, ))
+
+    batch, tasks = await wait(q.get())
+
+    assert tasks == (1, 3)
+
+
+@pytest.mark.asyncio
+async def test_wait_empty_queue():
+    q = TaskQueue()
+    try:
+        await wait(q.get())
+    except asyncio.TimeoutError:
+        pass
+    else:
+        assert False, "should not return from get() when nothing is available on queue"
+
+
+@pytest.mark.asyncio
+async def test_cannot_complete_batch_unless_pending():
+    q = TaskQueue()
+
+    await wait(q.add((1, 2)))
+
+    # cannot complete a valid task without a batch id
+    with pytest.raises(ValidationError):
+        q.complete(None, (1, 2))
+
+    assert 1 in q
+
+    batch, tasks = await wait(q.get())
+
+    # cannot complete a valid task with an invalid batch id
+    with pytest.raises(ValidationError):
+        q.complete(batch + 1, (1, 2))
+
+    assert 1 in q
+
+
+@pytest.mark.asyncio
+async def test_two_pending_adds_one_release():
+    q = TaskQueue(2)
+
+    asyncio.ensure_future(q.add((3, 1, 2)))
+
+    # wait for ^ to run and pause
+    await asyncio.sleep(0)
+    # note that the highest-priority items are queued first
+    assert 1 in q
+    assert 2 in q
+    assert 3 not in q
+
+    asyncio.ensure_future(q.add((0, 4)))
+    # wait for ^ to run and pause
+    await asyncio.sleep(0)
+
+    # task consumer 1 completes the first two pending
+    batch, tasks = await wait(q.get())
+    assert tasks == (1, 2)
+    q.complete(batch, tasks)
+
+    # task consumer 2 gets the next two, in priority order
+    batch, tasks = await wait(q.get())
+    assert len(tasks) in {0, 1}
+
+    if len(tasks) == 1:
+        batch2, tasks2 = await wait(q.get())
+        all_tasks = tuple(sorted(tasks + tasks2))
+    elif len(tasks) == 2:
+        batch2 = None
+        all_tasks = tasks
+
+    assert all_tasks == (0, 3)
+
+    # clean up, so the pending get() call can complete
+    q.complete(batch, tasks)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'start_tasks, get_max, expected, remainder',
+    (
+        ((4, 3, 2, 1), 5, (1, 2, 3, 4), None),
+        ((4, 3, 2, 1), 4, (1, 2, 3, 4), None),
+        ((4, 3, 2, 1), 3, (1, 2, 3), (4, )),
+    ),
+)
+async def test_queue_get_cap(start_tasks, get_max, expected, remainder):
+    q = TaskQueue()
+
+    await wait(q.add(start_tasks))
+
+    batch, tasks = await wait(q.get(get_max))
+    assert tasks == expected
+
+    if remainder:
+        batch2, tasks2 = await wait(q.get())
+        assert tasks2 == remainder
+    else:
+        try:
+            batch2, tasks2 = await wait(q.get())
+        except asyncio.TimeoutError:
+            pass
+        else:
+            assert False, f"No more tasks to get, but got {tasks2!r}"

--- a/tests/trinity/utils/test_task_queue.py
+++ b/tests/trinity/utils/test_task_queue.py
@@ -1,13 +1,130 @@
 import asyncio
+from asyncio import (
+    Event,
+)
+from contextlib import contextmanager
+import functools
 import pytest
+import random
 
+from cancel_token import CancelToken, OperationCancelled
 from eth_utils import ValidationError
+from hypothesis import (
+    example,
+    given,
+    strategies as st,
+)
 
 from trinity.utils.datastructures import TaskQueue
 
+DEFAULT_TIMEOUT = 0.05
 
-async def wait(coro, timeout=0.05):
+
+async def wait(coro, timeout=DEFAULT_TIMEOUT):
     return await asyncio.wait_for(coro, timeout=timeout)
+
+
+@contextmanager
+def trap_operation_cancelled():
+    try:
+        yield
+    except OperationCancelled:
+        pass
+
+
+def run_in_event_loop(async_func):
+    @functools.wraps(async_func)
+    def wrapped(operations, queue_size, add_size, get_size, event_loop):
+        event_loop.run_until_complete(asyncio.ensure_future(
+            async_func(operations, queue_size, add_size, get_size, event_loop),
+            loop=event_loop,
+        ))
+    return wrapped
+
+
+@given(
+    operations=st.lists(
+        elements=st.tuples(st.integers(min_value=0, max_value=5), st.booleans()),
+        min_size=10,
+        max_size=30,
+    ),
+    queue_size=st.integers(min_value=1, max_value=20),
+    add_size=st.integers(min_value=1, max_value=20),
+    get_size=st.integers(min_value=1, max_value=20),
+)
+@example(
+    # try having two adders alternate a couple times quickly
+    operations=[(0, False), (1, False), (0, False), (1, True), (2, False), (2, False), (2, False)],
+    queue_size=5,
+    add_size=2,
+    get_size=5,
+)
+@run_in_event_loop
+async def test_no_asyncio_exception_leaks(operations, queue_size, add_size, get_size, event_loop):
+    """
+    This could be made much more general, at the cost of simplicity.
+    For now, this mimics real usage enough to hopefully catch the big issues.
+
+    Some examples for more generality:
+
+    - different get sizes on each call
+    - complete varying amounts of tasks at each call
+    """
+
+    async def getter(queue, num_tasks, get_event, complete_event, cancel_token):
+        with trap_operation_cancelled():
+            # wait to run the get
+            await cancel_token.cancellable_wait(get_event.wait())
+
+            batch, tasks = await cancel_token.cancellable_wait(
+                queue.get(num_tasks)
+            )
+            get_event.clear()
+
+            # wait to run the completion
+            await cancel_token.cancellable_wait(complete_event.wait())
+
+            queue.complete(batch, tasks)
+            complete_event.clear()
+
+    async def adder(queue, add_size, add_event, cancel_token):
+        with trap_operation_cancelled():
+            # wait to run the add
+            await cancel_token.cancellable_wait(add_event.wait())
+
+            await cancel_token.cancellable_wait(
+                queue.add(tuple(random.randint(0, 2 ** 32) for _ in range(add_size)))
+            )
+            add_event.clear()
+
+    async def operation_order(operations, events, cancel_token):
+        for operation_id, pause in operations:
+            events[operation_id].set()
+            if pause:
+                await asyncio.sleep(0)
+
+        await asyncio.sleep(0)
+        cancel_token.trigger()
+
+    q = TaskQueue(queue_size)
+    events = tuple(Event() for _ in range(6))
+    add_event, add2_event, get_event, get2_event, complete_event, complete2_event = events
+    cancel_token = CancelToken('end test')
+
+    done, pending = await asyncio.wait([
+        getter(q, get_size, get_event, complete_event, cancel_token),
+        getter(q, get_size, get2_event, complete2_event, cancel_token),
+        adder(q, add_size, add_event, cancel_token),
+        adder(q, add_size, add2_event, cancel_token),
+        operation_order(operations, events, cancel_token),
+    ], return_when=asyncio.FIRST_EXCEPTION)
+
+    for task in done:
+        exc = task.exception()
+        if exc:
+            raise exc
+
+    assert not pending
 
 
 @pytest.mark.asyncio
@@ -63,7 +180,7 @@ async def test_default_priority_order():
 
 @pytest.mark.asyncio
 async def test_custom_priority_order():
-    q = TaskQueue(maxsize=4, order_fn=lambda x: 0-x)
+    q = TaskQueue(maxsize=4, order_fn=lambda x: 0 - x)
 
     await wait(q.add((2, 1, 3)))
     (batch, tasks) = await wait(q.get())
@@ -106,6 +223,25 @@ async def test_wait_empty_queue():
         pass
     else:
         assert False, "should not return from get() when nothing is available on queue"
+
+
+@pytest.mark.asyncio
+async def test_cannot_complete_batch_with_wrong_task():
+    q = TaskQueue()
+
+    await wait(q.add((1, 2)))
+
+    batch, tasks = await wait(q.get())
+
+    # cannot complete a valid task with a task it wasn't given
+    with pytest.raises(ValidationError):
+        q.complete(batch, (3, 4))
+
+    # partially invalid completion calls leave the valid task in an incomplete state
+    with pytest.raises(ValidationError):
+        q.complete(batch, (1, 3))
+
+    assert 1 in q
 
 
 @pytest.mark.asyncio
@@ -156,10 +292,9 @@ async def test_two_pending_adds_one_release():
     assert len(tasks) in {0, 1}
 
     if len(tasks) == 1:
-        batch2, tasks2 = await wait(q.get())
+        _, tasks2 = await wait(q.get())
         all_tasks = tuple(sorted(tasks + tasks2))
     elif len(tasks) == 2:
-        batch2 = None
         all_tasks = tasks
 
     assert all_tasks == (0, 3)
@@ -186,12 +321,20 @@ async def test_queue_get_cap(start_tasks, get_max, expected, remainder):
     assert tasks == expected
 
     if remainder:
-        batch2, tasks2 = await wait(q.get())
+        _, tasks2 = await wait(q.get())
         assert tasks2 == remainder
     else:
         try:
-            batch2, tasks2 = await wait(q.get())
+            _, tasks2 = await wait(q.get())
         except asyncio.TimeoutError:
             pass
         else:
             assert False, f"No more tasks to get, but got {tasks2!r}"
+
+
+@pytest.mark.asyncio
+async def test_cannot_readd_same_task():
+    q = TaskQueue()
+    await q.add((1, 2))
+    with pytest.raises(ValidationError):
+        await q.add((2,))

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -225,7 +225,11 @@ class LightDispatchChain(BaseChain):
     def validate_uncles(self, block: BaseBlock) -> None:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
-    def validate_chain(self, chain: Tuple[BlockHeader, ...], seal_check_frequency: int = 1) -> None:
+    def validate_chain(
+            self,
+            parent: BlockHeader,
+            chain: Tuple[BlockHeader, ...],
+            seal_check_random_sample_rate: int = 1) -> None:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
     #

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -73,7 +73,7 @@ class ResponseCandidateStream(
 
     msg_queue_maxsize = 100
 
-    response_timout: int = 60
+    response_timout: int = 20
 
     pending_request: Tuple[float, 'asyncio.Future[TResponsePayload]'] = None
 
@@ -92,13 +92,16 @@ class ResponseCandidateStream(
     async def payload_candidates(
             self,
             request: BaseRequest[TRequestPayload],
-            timeout: int) -> 'AsyncGenerator[TResponsePayload, None]':
+            timeout: int = None) -> 'AsyncGenerator[TResponsePayload, None]':
         """
         Make a request and iterate through candidates for a valid response.
 
         To mark a response as valid, use `complete_request`. After that call, payload
         candidates will stop arriving.
         """
+        if timeout is None:
+            timeout = self.response_timout
+
         self._request(request)
         while self._is_pending():
             yield await self._get_payload(timeout)
@@ -175,6 +178,12 @@ class ResponseCandidateStream(
 
     def _is_pending(self) -> bool:
         return self.pending_request is not None
+
+    def deregister_peer(self, peer: BasePeer) -> None:
+        if self.pending_request is not None:
+            self.logger.debug("Peer disconnected, trigger a timeout on the pending request")
+            _, future = self.pending_request
+            future.set_exception(TimeoutError("Peer disconnected, simulating inevitable timeout"))
 
     def get_stats(self) -> Tuple[str, str]:
         return (self.response_msg_name, self.response_times.get_stats())

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -25,6 +25,8 @@ from .handlers import ETHExchangeHandler
 
 
 class ETHPeer(BasePeer):
+    max_headers_fetch = constants.MAX_HEADERS_FETCH
+
     _supported_sub_protocols = [ETHProtocol]
     sub_proto: ETHProtocol = None
 
@@ -39,10 +41,6 @@ class ETHPeer(BasePeer):
         if self._requests is None:
             self._requests = ETHExchangeHandler(self)
         return self._requests
-
-    @property
-    def max_headers_fetch(self) -> int:
-        return constants.MAX_HEADERS_FETCH
 
     def handle_sub_proto_msg(self, cmd: Command, msg: _DecodedMsgType) -> None:
         if isinstance(cmd, NewBlock):

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -34,6 +34,8 @@ from .handlers import LESExchangeHandler
 
 
 class LESPeer(BasePeer):
+    max_headers_fetch = MAX_HEADERS_FETCH
+
     _supported_sub_protocols = [LESProtocol, LESProtocolV2]
     sub_proto: LESProtocol = None
     # TODO: This will no longer be needed once we've fixed #891, and then it should be removed.
@@ -50,10 +52,6 @@ class LESPeer(BasePeer):
         if self._requests is None:
             self._requests = LESExchangeHandler(self)
         return self._requests
-
-    @property
-    def max_headers_fetch(self) -> int:
-        return MAX_HEADERS_FETCH
 
     def handle_sub_proto_msg(self, cmd: Command, msg: _DecodedMsgType) -> None:
         if isinstance(cmd, Announce):

--- a/trinity/sync/light/chain.py
+++ b/trinity/sync/light/chain.py
@@ -63,7 +63,7 @@ class LightChainSyncer(BaseHeaderChainSyncer):
 
     async def _persist_headers(self) -> None:
         while self.is_operational:
-            batch, headers = await self.wait(self.header_queue.get())
+            batch_id, headers = await self.wait(self.header_queue.get())
 
             timer = Timer()
             for header in headers:
@@ -74,4 +74,4 @@ class LightChainSyncer(BaseHeaderChainSyncer):
                 "Imported %d headers in %0.2f seconds, new head: #%d",
                 len(headers), timer.elapsed, head.block_number)
 
-            self.header_queue.complete(batch, headers)
+            self.header_queue.complete(batch_id, headers)

--- a/trinity/sync/light/chain.py
+++ b/trinity/sync/light/chain.py
@@ -63,7 +63,7 @@ class LightChainSyncer(BaseHeaderChainSyncer):
 
     async def _persist_headers(self) -> None:
         while self.is_operational:
-            headers = await self.wait(self.pop_all_pending_headers())
+            batch, headers = await self.wait(self.header_queue.get())
 
             timer = Timer()
             for header in headers:
@@ -73,3 +73,5 @@ class LightChainSyncer(BaseHeaderChainSyncer):
             self.logger.info(
                 "Imported %d headers in %0.2f seconds, new head: #%d",
                 len(headers), timer.elapsed, head.block_number)
+
+            self.header_queue.complete(batch, headers)

--- a/trinity/utils/datastructures.py
+++ b/trinity/utils/datastructures.py
@@ -1,9 +1,8 @@
 from asyncio import (
+    AbstractEventLoop,
     Lock,
     PriorityQueue,
-    Queue,
     QueueFull,
-    BoundedSemaphore,
 )
 from itertools import count
 from typing import (
@@ -22,6 +21,19 @@ from eth_utils import (
 from eth_utils.toolz import identity
 
 TTask = TypeVar('TTask')
+TFunc = TypeVar('TFunc')
+
+
+class FunctionProperty(Generic[TFunc]):
+    """
+    A property class purely to convince mypy to let us assign a function to an
+    instance variable. See more at: https://github.com/python/mypy/issues/708#issuecomment-405812141
+    """
+    def __get__(self, oself: Any, owner: Any) -> TFunc:
+        return self._func
+
+    def __set__(self, oself: Any, value: TFunc) -> None:
+        self._func = value
 
 
 class TaskQueue(Generic[TTask]):
@@ -31,7 +43,7 @@ class TaskQueue(Generic[TTask]):
     A producer of tasks will insert pending tasks with await add(), which will not return until
     all tasks have been added to the queue.
 
-    A task consumer calls await get() to retrieve tasks to attempt. Tasks will be returned in
+    A task consumer calls await get() to retrieve tasks for processing. Tasks will be returned in
     priority order. If no tasks are pending, get()
     will pause until at least one is available. Only one consumer will have a task "checked out"
     from get() at a time.
@@ -42,7 +54,7 @@ class TaskQueue(Generic[TTask]):
     """
 
     # a function that determines the priority order (lower int is higher priority)
-    _order_fn: Callable[[TTask], Any]
+    _order_fn: FunctionProperty[Callable[[TTask], Any]]
 
     # batches of tasks that have been started but not completed
     _in_progress: Dict[int, Tuple[TTask, ...]]
@@ -58,7 +70,7 @@ class TaskQueue(Generic[TTask]):
             maxsize: int = 0,
             order_fn: Callable[[TTask], Any] = identity,
             *,
-            loop=None) -> None:
+            loop: AbstractEventLoop = None) -> None:
         self._maxsize = maxsize
         self._full_lock = Lock(loop=loop)
         self._open_queue = PriorityQueue(maxsize, loop=loop)
@@ -79,7 +91,7 @@ class TaskQueue(Generic[TTask]):
         already_pending = self._tasks.intersection(tasks)
         if already_pending:
             raise ValidationError(
-                f"Can't readd a task to queue. {already_pending!r} are already present"
+                f"Duplicate tasks detected: {already_pending!r} are already present in the queue"
             )
 
         # make sure to insert the highest-priority items first, in case queue fills up
@@ -124,43 +136,74 @@ class TaskQueue(Generic[TTask]):
             if self._full_lock.locked() and len(self._tasks) < self._maxsize:
                 self._full_lock.release()
 
+    def get_nowait(self, max_results: int = None) -> Tuple[int, Tuple[TTask, ...]]:
+        """
+        Get pending tasks. If no tasks are pending, raise an exception.
+
+        :param max_results: return up to this many pending tasks. If None, return all pending tasks.
+        :return: (batch_id, tasks to attempt)
+        :raise ~asyncio.QueueFull: if no tasks are available
+        """
+        if self._open_queue.empty():
+            raise QueueFull("No tasks are available to get")
+        else:
+            pending_tasks = self._get_nowait(max_results)
+
+            # Generate a pending batch of tasks, so uncompleted tasks can be inferred
+            next_id = next(self._id_generator)
+            self._in_progress[next_id] = pending_tasks
+
+            return (next_id, pending_tasks)
+
     async def get(self, max_results: int = None) -> Tuple[int, Tuple[TTask, ...]]:
-        """Get all the currently pending tasks. If no tasks pending, wait until one is"""
-        # TODO add argument to optionally limit the number of tasks retrieved
+        """
+        Get pending tasks. If no tasks are pending, wait until a task is added.
+
+        :param max_results: return up to this many pending tasks. If None, return all pending tasks.
+        :return: (batch_id, tasks to attempt)
+        """
         if max_results is not None and max_results < 1:
             raise ValidationError("Must request at least one task to process, not {max_results!r}")
 
         # if the queue is empty, wait until at least one item is available
         queue = self._open_queue
         if queue.empty():
-            first_task = await queue.get()
+            _rank, first_task = await queue.get()
         else:
-            first_task = queue.get_nowait()
-
-        available = queue.qsize()
+            _rank, first_task = queue.get_nowait()
 
         # In order to return from get() as soon as possible, never await again.
-        # Instead, take only the tasks that are already waiting.
-
-        # How many results past the first one do we want?
+        # Instead, take only the tasks that are already available.
         if max_results is None:
-            more_tasks_to_return = available
+            remaining_count = None
         else:
-            more_tasks_to_return = min((available, max_results - 1))
+            remaining_count = max_results - 1
+        remaining_tasks = self._get_nowait(remaining_count)
+
+        # Combine the first and remaining tasks
+        all_tasks = (first_task, ) + remaining_tasks
+
+        # Generate a pending batch of tasks, so uncompleted tasks can be inferred
+        next_id = next(self._id_generator)
+        self._in_progress[next_id] = all_tasks
+
+        return (next_id, all_tasks)
+
+    def _get_nowait(self, max_results: int = None) -> Tuple[TTask, ...]:
+        queue = self._open_queue
+
+        # How many results do we want?
+        available = queue.qsize()
+        if max_results is None:
+            num_tasks = available
+        else:
+            num_tasks = min((available, max_results))
 
         # Combine the remaining tasks with the first task we already pulled.
-        ranked_tasks = (first_task, ) + tuple(
-            queue.get_nowait() for _ in range(more_tasks_to_return)
-        )
+        ranked_tasks = tuple(queue.get_nowait() for _ in range(num_tasks))
 
-        # strip out the rank value used internally, for sorting in the priority queue
-        unranked_tasks = tuple(task for _rank, task in ranked_tasks)
-
-        # save the batch for later, so uncompleted tasks can be inferred
-        next_id = next(self._id_generator)
-        self._in_progress[next_id] = unranked_tasks
-
-        return (next_id, unranked_tasks)
+        # strip out the rank value used internally for sorting in the priority queue
+        return tuple(task for _rank, task in ranked_tasks)
 
     def complete(self, batch_id: int, completed: Tuple[TTask, ...]) -> None:
         if batch_id not in self._in_progress:

--- a/trinity/utils/datastructures.py
+++ b/trinity/utils/datastructures.py
@@ -1,0 +1,187 @@
+from asyncio import (
+    Lock,
+    PriorityQueue,
+    Queue,
+    QueueFull,
+    BoundedSemaphore,
+)
+from itertools import count
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Set,
+    Tuple,
+    TypeVar,
+)
+
+from eth_utils import (
+    ValidationError,
+)
+from eth_utils.toolz import identity
+
+TTask = TypeVar('TTask')
+
+
+class TaskQueue(Generic[TTask]):
+    """
+    TaskQueue keeps priority-order track of pending tasks, with a limit on number pending.
+
+    A producer of tasks will insert pending tasks with await add(), which will not return until
+    all tasks have been added to the queue.
+
+    A task consumer calls await get() to retrieve tasks to attempt. Tasks will be returned in
+    priority order. If no tasks are pending, get()
+    will pause until at least one is available. Only one consumer will have a task "checked out"
+    from get() at a time.
+
+    After tasks are successfully completed, the consumer will call complete() to remove them from
+    the queue. The consumer doesn't need to complete all tasks, but any uncompleted tasks will be
+    considered abandoned. Another consumer can pick it up at the next get() call.
+    """
+
+    # a function that determines the priority order (lower int is higher priority)
+    _order_fn: Callable[[TTask], Any]
+
+    # batches of tasks that have been started but not completed
+    _in_progress: Dict[int, Tuple[TTask, ...]]
+
+    # all tasks that have been placed in the queue and have not been started
+    _open_queue: 'PriorityQueue[Tuple[Any, TTask]]'
+
+    # all tasks that have been placed in the queue and have not been completed
+    _tasks: Set[TTask]
+
+    def __init__(
+            self,
+            maxsize: int = 0,
+            order_fn: Callable[[TTask], Any] = identity,
+            *,
+            loop=None) -> None:
+        self._maxsize = maxsize
+        self._full_lock = Lock(loop=loop)
+        self._open_queue = PriorityQueue(maxsize, loop=loop)
+        self._order_fn = order_fn
+        self._id_generator = count()
+        self._tasks = set()
+        self._in_progress = {}
+
+    async def add(self, tasks: Tuple[TTask, ...]) -> None:
+        """
+        add() will insert as many tasks as can be inserted until the queue fills up.
+        Then it will pause until the queue is no longer full, and continue adding tasks.
+        It will finally return when all tasks have been inserted.
+        """
+        if not isinstance(tasks, tuple):
+            raise ValidationError(f"must pass a tuple of tasks to add(), but got {tasks!r}")
+
+        # make sure to insert the highest-priority items first, in case queue fills up
+        remaining = tuple(sorted((self._order_fn(task), task) for task in tasks))
+
+        while remaining:
+            num_tasks = len(self._tasks)
+
+            if self._maxsize <= 0:
+                # no cap at all, immediately insert all tasks
+                open_slots = len(remaining)
+            elif num_tasks < self._maxsize:
+                # there is room to add at least one more task
+                open_slots = self._maxsize - num_tasks
+            else:
+                # wait until there is room in the queue
+                await self._full_lock.acquire()
+
+                # the current number of tasks has changed, can't reuse num_tasks
+                num_tasks = len(self._tasks)
+                open_slots = self._maxsize - num_tasks
+
+            queueing, remaining = remaining[:open_slots], remaining[open_slots:]
+
+            for task in queueing:
+                # There will always be room in _open_queue until _maxsize is reached
+                try:
+                    self._open_queue.put_nowait(task)
+                except QueueFull:
+                    task_idx = queueing.index(task)
+                    # TODO remove once this bug is tracked down
+                    import logging; logging.error(
+                        'TaskQueue unsuccessful in adding task %r because qsize=%d, '
+                        'num_tasks=%d, _maxsize=%d, open_slots=%d, num queueing=%d, '
+                        'len(_tasks)=%d, task_idx=%d, queuing=%r',
+                        task,
+                        self._open_queue.qsize(),
+                        num_tasks,
+                        self._maxsize,
+                        open_slots,
+                        len(queueing),
+                        len(self._tasks),
+                        task_idx,
+                        queueing,
+                    )
+                    raise
+
+            unranked_queued = tuple(task for _rank, task in queueing)
+            self._tasks.update(unranked_queued)
+
+            if self._full_lock.locked() and len(self._tasks) < self._maxsize:
+                self._full_lock.release()
+
+    async def get(self, max_results: int = None) -> Tuple[int, Tuple[TTask, ...]]:
+        """Get all the currently pending tasks. If no tasks pending, wait until one is"""
+        # TODO add argument to optionally limit the number of tasks retrieved
+        if max_results is not None and max_results < 1:
+            raise ValidationError("Must request at least one task to process, not {max_results!r}")
+
+        # if the queue is empty, wait until at least one item is available
+        queue = self._open_queue
+        if queue.empty():
+            first_task = await queue.get()
+        else:
+            first_task = queue.get_nowait()
+
+        available = queue.qsize()
+
+        # In order to return from get() as soon as possible, never await again.
+        # Instead, take only the tasks that are already waiting.
+
+        # How many results past the first one do we want?
+        if max_results is None:
+            more_tasks_to_return = available
+        else:
+            more_tasks_to_return = min((available, max_results - 1))
+
+        # Combine the remaining tasks with the first task we already pulled.
+        ranked_tasks = (first_task, ) + tuple(
+            queue.get_nowait() for _ in range(more_tasks_to_return)
+        )
+
+        # strip out the rank value used internally, for sorting in the priority queue
+        unranked_tasks = tuple(task for _rank, task in ranked_tasks)
+
+        # save the batch for later, so uncompleted tasks can be inferred
+        next_id = next(self._id_generator)
+        self._in_progress[next_id] = unranked_tasks
+
+        return (next_id, unranked_tasks)
+
+    def complete(self, batch_id: int, completed: Tuple[TTask, ...]) -> None:
+        if batch_id not in self._in_progress:
+            raise ValidationError(f"batch id {batch_id} not recognized, with tasks {completed!r}")
+
+        attempted = self._in_progress.pop(batch_id)
+
+        remaining = set(attempted).difference(completed)
+
+        for task in remaining:
+            # These tasks are already counted in the total task count, so there will be room
+            self._open_queue.put_nowait((self._order_fn(task), task))
+
+        self._tasks.difference_update(completed)
+
+        if self._full_lock.locked() and len(self._tasks) < self._maxsize:
+            self._full_lock.release()
+
+    def __contains__(self, task: TTask) -> bool:
+        """Determine if a task has been added and not yet completed"""
+        return task in self._tasks


### PR DESCRIPTION
### What was wrong?

Step 1 of #868 -- queue headers instead of batching them

Fixes #1215 

### How was it fixed?

Main changes:
- Queue up headers for processing in later stages (instead of waiting for all post-processing to finish before requesting the next batch of headers)

Follow up work:
- Decouple the header sync from the post-processing stages. It doesn't really need to be a subclass I think
- Do the same queue processing for later steps, like downloading block bodies.
- Track one queue per peer, so that a peer is never waiting on another peer to do its own request.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.funnydogsite.com/pictures/Hooray_For_Play_Time.jpg)
