### PR TITLE
PoC: Communication between PeerPool and other process via event bus

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -52,6 +52,10 @@ from eth_keys import (
 
 from cancel_token import CancelToken, OperationCancelled
 
+from lahja import (
+    Endpoint,
+)
+
 from eth.chains.mainnet import MAINNET_NETWORK_ID
 from eth.chains.ropsten import ROPSTEN_NETWORK_ID
 from eth.constants import GENESIS_BLOCK_NUMBER
@@ -91,6 +95,11 @@ from p2p.p2p_proto import (
     P2PProtocol,
     Ping,
     Pong,
+)
+
+from trinity.events import (
+    PeerCountRequest,
+    PeerCountResponse
 )
 
 from .constants import (
@@ -692,6 +701,7 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
                  vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...],
                  max_peers: int = DEFAULT_MAX_PEERS,
                  token: CancelToken = None,
+                 event_bus: Endpoint = None
                  ) -> None:
         super().__init__(token)
         self.peer_class = peer_class
@@ -702,6 +712,16 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
         self.max_peers = max_peers
         self.connected_nodes: Dict[Node, BasePeer] = {}
         self._subscribers: List[PeerSubscriber] = []
+        self.event_bus = event_bus
+        self.run_task(self.answer_peer_count_requests())
+
+    async def answer_peer_count_requests(self) -> None:
+        async for req in self.event_bus.stream(PeerCountRequest):
+            # We are listening for all `PeerCountRequest` events but we ensure to
+            # only send a `PeerCountResponse` to the callsite that made the request.
+            # We do that by retrieving a `BroadcastConfig` from the request via the
+            # `event.broadcast_config()` API.
+            self.event_bus.broadcast(PeerCountResponse(len(self)), req.broadcast_config())
 
     def __len__(self) -> int:
         return len(self.connected_nodes)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ deps = {
         "ipython>=6.2.1,<7.0.0",
         "plyvel==1.0.5",
         "web3==4.4.1",
+        "lahja==0.4.0",
     ],
     'test': [
         "hypothesis==3.44.26",

--- a/trinity/events.py
+++ b/trinity/events.py
@@ -1,0 +1,13 @@
+from lahja import (
+    BaseEvent
+)
+
+
+class PeerCountRequest(BaseEvent):
+
+    def __init__(self) -> None:
+        super().__init__(None)
+
+
+class PeerCountResponse(BaseEvent):
+    pass

--- a/trinity/extensibility/__init__.py
+++ b/trinity/extensibility/__init__.py
@@ -3,9 +3,14 @@ from trinity.extensibility.events import (  # noqa: F401
 )
 from trinity.extensibility.plugin import (  # noqa: F401
     BasePlugin,
+    BaseOwnProcessPlugin,
     DebugPlugin,
     PluginContext,
+    PluginProcessScope,
 )
 from trinity.extensibility.plugin_manager import (  # noqa: F401
+    MainAndOwnProcessScope,
     PluginManager,
+    ManagerProcessScope,
+    SharedProcessScope,
 )

--- a/trinity/extensibility/plugin_manager.py
+++ b/trinity/extensibility/plugin_manager.py
@@ -4,9 +4,16 @@ from argparse import (
 )
 import logging
 from typing import (
+    Any,
+    Dict,
     Iterable,
     List,
     Union,
+)
+
+from lahja import (
+    Endpoint,
+    EventBus,
 )
 
 from trinity.extensibility.events import (
@@ -15,7 +22,25 @@ from trinity.extensibility.events import (
 )
 from trinity.extensibility.plugin import (
     BasePlugin,
+    PluginContext,
+    PluginProcessScope,
 )
+
+
+class MainAndOwnProcessScope():
+
+    def __init__(self, event_bus: EventBus, main_proc_endpoint: Endpoint) -> None:
+        self.event_bus = event_bus
+        self.endpoint = main_proc_endpoint
+
+
+class SharedProcessScope():
+
+    def __init__(self, shared_proc_endpoint: Endpoint) -> None:
+        self.endpoint = shared_proc_endpoint
+
+
+ManagerProcessScope = Union[SharedProcessScope, MainAndOwnProcessScope]
 
 
 class PluginManager:
@@ -28,10 +53,18 @@ class PluginManager:
         This API is very much in flux and is expected to change heavily.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, scope: ManagerProcessScope) -> None:
+        self._scope = scope
         self._plugin_store: List[BasePlugin] = []
         self._started_plugins: List[BasePlugin] = []
         self._logger = logging.getLogger("trinity.extensibility.plugin_manager.PluginManager")
+
+    @property
+    def event_bus_endpoint(self) -> Endpoint:
+        """
+        Return the ``Endpoint`` that the ``PluginManager`` uses to connect to the ``EventBus``
+        """
+        return self._scope.endpoint
 
     def register(self, plugins: Union[BasePlugin, Iterable[BasePlugin]]) -> None:
         """
@@ -63,7 +96,7 @@ class PluginManager:
         """
         for plugin in self._plugin_store:
 
-            if plugin is exclude:
+            if plugin is exclude or not self._is_responsible_for_plugin(plugin):
                 continue
 
             plugin.handle_event(event)
@@ -74,7 +107,53 @@ class PluginManager:
             if not plugin.should_start():
                 continue
 
-            plugin.start(None)
+            context = self._create_context_for_plugin(plugin)
+            plugin.start(context)
             self._started_plugins.append(plugin)
             self._logger.info("Plugin started: {}".format(plugin.name))
             self.broadcast(PluginStartedEvent(plugin), plugin)
+
+    # FIXME: This is a temporary API
+    def start(self, boot_kwargs: Dict[str, Any]) -> None:
+        for plugin in self._plugin_store:
+
+            # This whole API is going away so for now, we aren't caring about
+            # any of the other plugins
+
+            if plugin.process_scope is not PluginProcessScope.OWN:
+                continue
+
+            context = self._create_context_for_plugin(plugin, boot_kwargs)
+            plugin.start(context)
+
+    def _is_responsible_for_plugin(self, plugin: BasePlugin) -> bool:
+
+        main_and_own_scopes = [PluginProcessScope.MAIN, PluginProcessScope.OWN]
+        plugin_for_main_or_own = plugin.process_scope in main_and_own_scopes
+        plugin_for_shared = not plugin_for_main_or_own
+
+        manager_for_main_or_own = isinstance(self._scope, MainAndOwnProcessScope)
+        manager_for_shared = not manager_for_main_or_own
+
+        return (plugin_for_main_or_own and manager_for_main_or_own or
+                plugin_for_shared and manager_for_shared)
+
+    def _create_context_for_plugin(self,
+                                   plugin: BasePlugin,
+                                   boot_kwargs: Dict[str, Any] = None) -> PluginContext:
+
+        if plugin.process_scope is PluginProcessScope.SHARED:
+            # A plugin that runs in a shared process gets the endpoint of the PluginManager
+            # injected to communicate with the rest of the world
+            return PluginContext(self._scope.endpoint)
+        elif plugin.process_scope is PluginProcessScope.OWN:
+            # A plugin that runs in it's own process gets a new endpoint created to get
+            # passed into that new process
+
+            # mypy doesn't know it can only be that scope at this point. The `isinstance`
+            # check avoids adding an ignore
+            if isinstance(self._scope, MainAndOwnProcessScope):
+                endpoint = self._scope.event_bus.create_endpoint(plugin.name)
+                return PluginContext(endpoint, boot_kwargs)
+
+        raise Exception("Invariant: unreachable code path")

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -10,6 +10,11 @@ from typing import (
     Type,
 )
 
+from lahja import (
+    EventBus,
+    Endpoint,
+)
+
 from eth.chains.mainnet import (
     MAINNET_NETWORK_ID,
 )
@@ -39,6 +44,9 @@ from trinity.config import (
 )
 from trinity.extensibility import (
     PluginManager,
+    MainAndOwnProcessScope,
+    ManagerProcessScope,
+    SharedProcessScope,
 )
 from trinity.extensibility.events import (
     TrinityStartupEvent
@@ -95,7 +103,13 @@ TRINITY_AMBIGIOUS_FILESYSTEM_INFO = (
 
 
 def main() -> None:
-    plugin_manager = setup_plugins()
+    event_bus = EventBus(ctx)
+    main_endpoint = event_bus.create_endpoint('main')
+    main_endpoint.connect()
+
+    plugin_manager = setup_plugins(
+        MainAndOwnProcessScope(event_bus, main_endpoint)
+    )
     plugin_manager.amend_argparser_config(parser, subparser)
     args = parser.parse_args()
 
@@ -163,17 +177,22 @@ def main() -> None:
     if hasattr(args, 'func'):
         args.func(args, chain_config)
     else:
-        trinity_boot(args, chain_config, extra_kwargs, listener, logger)
+        plugin_manager.start(extra_kwargs)
+        trinity_boot(args, chain_config, extra_kwargs, listener, event_bus, logger)
 
 
 def trinity_boot(args: Namespace,
                  chain_config: ChainConfig,
                  extra_kwargs: Dict[str, Any],
                  listener: logging.handlers.QueueListener,
+                 event_bus: EventBus,
                  logger: logging.Logger) -> None:
     # start the listener thread to handle logs produced by other processes in
     # the local logger.
     listener.start()
+
+    networking_endpoint = event_bus.create_endpoint('networking')
+    event_bus.start()
 
     # First initialize the database process.
     database_server_process = ctx.Process(
@@ -187,7 +206,7 @@ def trinity_boot(args: Namespace,
 
     networking_process = ctx.Process(
         target=launch_node,
-        args=(args, chain_config, ),
+        args=(args, chain_config, networking_endpoint,),
         kwargs=extra_kwargs,
     )
 
@@ -207,7 +226,9 @@ def trinity_boot(args: Namespace,
     logger.info("Started networking process (pid=%d)", networking_process.pid)
 
     try:
-        networking_process.join()
+        loop = asyncio.get_event_loop()
+        loop.run_forever()
+        loop.close()
     except KeyboardInterrupt:
         # When a user hits Ctrl+C in the terminal, the SIGINT is sent to all processes in the
         # foreground *process group*, so both our networking and database processes will terminate
@@ -272,8 +293,11 @@ async def exit_on_signal(service_to_exit: BaseService) -> None:
 
 @setup_cprofiler('launch_node')
 @with_queued_logging
-def launch_node(args: Namespace, chain_config: ChainConfig) -> None:
+def launch_node(args: Namespace, chain_config: ChainConfig, endpoint: Endpoint) -> None:
     with chain_config.process_id_file('networking'):
+
+        endpoint.connect()
+
         NodeClass = chain_config.node_class
         # Temporary hack: We setup a second instance of the PluginManager.
         # The first instance was only to configure the ArgumentParser whereas
@@ -281,14 +305,14 @@ def launch_node(args: Namespace, chain_config: ChainConfig) -> None:
         # performs the bulk of the work. In the future, the PluginManager
         # should probably live in its own process and manage whether plugins
         # run in the shared plugin process or spawn their own.
-        plugin_manager = setup_plugins()
+
+        plugin_manager = setup_plugins(SharedProcessScope(endpoint))
         plugin_manager.broadcast(TrinityStartupEvent(
             args,
             chain_config
         ))
 
         node = NodeClass(plugin_manager, chain_config)
-
         run_service_until_quit(node)
 
 
@@ -307,8 +331,8 @@ def run_service_until_quit(service: BaseService) -> None:
     loop.close()
 
 
-def setup_plugins() -> PluginManager:
-    plugin_manager = PluginManager()
+def setup_plugins(scope: ManagerProcessScope) -> PluginManager:
+    plugin_manager = PluginManager(scope)
     # TODO: Implement auto-discovery of plugins based on some convention/configuration scheme
     plugin_manager.register(ENABLED_PLUGINS)
 

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -47,6 +47,7 @@ class FullNode(Node):
                 bootstrap_nodes=self._bootstrap_nodes,
                 preferred_nodes=self._preferred_nodes,
                 token=self.cancel_token,
+                event_bus=self._plugin_manager.event_bus_endpoint
             )
         return self._p2p_server
 

--- a/trinity/plugins/builtin/proc_test/plugin.py
+++ b/trinity/plugins/builtin/proc_test/plugin.py
@@ -1,0 +1,47 @@
+import asyncio
+import logging
+from typing import (
+    Any,
+    Dict,
+)
+from lahja import (
+    Endpoint
+)
+
+from trinity.events import (
+    PeerCountRequest,
+)
+from trinity.extensibility import (
+    BaseOwnProcessPlugin,
+)
+
+
+async def request_receive_peer_count(event_bus: Endpoint) -> None:
+    while True:
+        response = await event_bus.request(PeerCountRequest())
+        print("Peer Count: " + str(response.payload))
+        await asyncio.sleep(1)
+
+
+class ProcTest(BaseOwnProcessPlugin):
+
+    def __init__(self) -> None:
+        pass
+
+    @property
+    def name(self) -> str:
+        return "ProcTest"
+
+    def should_start(self) -> bool:
+        return True
+
+    @staticmethod
+    def launch_process(event_bus: Endpoint, **kwargs: Dict[str, Any]) -> None:
+        logger = logging.getLogger('FOOBAR')
+        logger.info('hello from test proc')
+        loop = asyncio.get_event_loop()
+        event_bus.connect()
+
+        asyncio.ensure_future(request_receive_peer_count(event_bus))
+        loop.run_forever()
+        loop.close()

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -9,6 +9,9 @@ from trinity.plugins.builtin.fix_unclean_shutdown.plugin import (
 from trinity.plugins.builtin.tx_pool.plugin import (
     TxPlugin,
 )
+from trinity.plugins.builtin.proc_test.plugin import (
+    ProcTest
+)
 
 
 def is_ipython_available() -> bool:
@@ -28,4 +31,5 @@ ENABLED_PLUGINS = [
     AttachPlugin() if is_ipython_available() else AttachPlugin(use_ipython=False),
     FixUncleanShutdownPlugin(),
     TxPlugin(),
+    ProcTest()
 ]

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -13,6 +13,10 @@ from eth_utils import big_endian_to_int
 
 from cancel_token import CancelToken, OperationCancelled
 
+from lahja import (
+    Endpoint
+)
+
 from eth.chains import AsyncChain
 
 from p2p.auth import (
@@ -78,9 +82,11 @@ class Server(BaseService):
                  peer_class: Type[BasePeer] = ETHPeer,
                  bootstrap_nodes: Tuple[Node, ...] = None,
                  preferred_nodes: Sequence[Node] = None,
+                 event_bus: Endpoint = None,
                  token: CancelToken = None,
                  ) -> None:
         super().__init__(token)
+        self.event_bus = event_bus
         self.headerdb = headerdb
         self.chaindb = chaindb
         self.chain = chain
@@ -128,6 +134,7 @@ class Server(BaseService):
             self.chain.get_vm_configuration(),
             max_peers=self.max_peers,
             token=self.cancel_token,
+            event_bus=self.event_bus,
         )
 
     async def _run(self) -> None:


### PR DESCRIPTION
### Abstract?

This is a follow up to the (now closed) #1202 PR. After substantial progress, the description became outdated so I decided to open up a new PR. 

This is a PoC to show case how we can communicate between processes with the following properties.

- Messaging rather than RPC ([related article](http://www.inspirel.com/articles/RPC_vs_Messaging.html), [related comment](https://github.com/ethereum/py-evm/issues/1075#issuecomment-413489849))
- no `Proxy` or `Manager` classes were used. Only `Queue`
- all APIs are non-blocking and are built on top of `asyncio`

### What does this do?

1. The `PeerPool` got a handle to the event bus and is listening to `PeerCountRequest`s and answers them with a `PeerCountResponse`

```python
async for req in self.event_bus.stream(PeerCountRequest):
    self.event_bus.broadcast(PeerCountResponse(len(self)), req.broadcast_config())
```
Notice that while the event bus enables us to raise events to be consumed by many independent players, in this case the `broadcast` is done in a fashion to only broadcast an answer to the call site that raised the event we are listening for. This is done by passing a `BroadcastConfig` as a second parameter which we derive from the *incoming* event by calling `broadcast_config()` on it.

2. We set up another process to communicate with the `PeerPool` via these events.

```
test_proc = ctx.Process(
        target=run_test_proc,
        args=(
            test_proc_endpoint,
        ),
    )
     test_proc.start()
```

Notice that the process gets a handle to the event bus injected (similar to how we inject a handle in the networking process that hosts the `PeerPool`)

Then, inside that process we are raising a `PeerCountRequest` on the event bus every second.

```python
async def request_receive_peer_count(event_bus):
    while True:
        response = await event_bus.request(PeerCountRequest())
        print("Peer Count: " + str(response.payload))
        await asyncio.sleep(1)
```

### Where to go from here?

There are many things we can do in the event bus to improve ergonomics and efficiency. However, I feel we are nearing a state where this can actually be used for real. I see the next steps as follows:

#### Support plugins to run in their own process

Here's roughly what I think needs to be done:

1. ~~Allow plugins to express that they want to run in their own process. That in turn will cause the plugin manger that lives in the main process (not  to be confused with the instance that lives in the network process) to setup an eventbus endpoint for the plugin. This *needs* to happen in the main process for now.~~ This is now done.

2. Let the plugin handle the launch of the process (not sure, needs more thought)

3. Let the plugin do it's thing and communicate with the rest of Trinity via the event bus. This also means, depending on the first use case to spearhead this, that probably the `PeerPool` needs to expose some APIs built on top of the eventbus (similar to the demoed `PeerCountRequest` / `PeerCountResponse` in this PR)

I think that the `TxPool` is a great candidate to spearhead this.