### PR TITLE
Move JSON-RPC server into an isolated plugin

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -904,3 +904,15 @@ class AsyncChain(Chain):
                                     receipt: Receipt,
                                     at_header: BlockHeader) -> None:
         raise NotImplementedError()
+
+    async def coro_get_block_by_hash(self,
+                                     block_hash: Hash32) -> BaseBlock:
+        raise NotImplementedError()
+
+    async def coro_get_block_by_header(self,
+                                       header: BlockHeader) -> BaseBlock:
+        raise NotImplementedError()
+
+    async def coro_get_canonical_block_by_number(self,
+                                                 block_number: BlockNumber) -> BaseBlock:
+        raise NotImplementedError()

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -146,12 +146,12 @@ def genesis_params_from_fixture(fixture):
     }
 
 
-def new_chain_from_fixture(fixture):
+def new_chain_from_fixture(fixture, chain_cls=MainnetChain):
     base_db = AtomicDB()
 
     vm_config = chain_vm_configuration(fixture)
 
-    ChainFromFixture = MainnetChain.configure(
+    ChainFromFixture = chain_cls.configure(
         'ChainFromFixture',
         vm_configuration=vm_config,
     )

--- a/p2p/events.py
+++ b/p2p/events.py
@@ -1,0 +1,21 @@
+from typing import (
+    Type,
+)
+
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+)
+
+
+class PeerCountResponse(BaseEvent):
+
+    def __init__(self, peer_count: int) -> None:
+        self.peer_count = peer_count
+
+
+class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
+
+    @staticmethod
+    def expected_response_type() -> Type[PeerCountResponse]:
+        return PeerCountResponse

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ deps = {
         "ipython>=6.2.1,<7.0.0",
         "plyvel==1.0.5",
         "web3==4.4.1",
-        "lahja==0.6.1",
+        "lahja==0.8.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin'",
     ],
     'test': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,8 +78,7 @@ def funded_address_initial_balance():
     return to_wei(1000, 'ether')
 
 
-@pytest.fixture
-def chain_with_block_validation(base_db, genesis_state):
+def _chain_with_block_validation(base_db, genesis_state, chain_cls=Chain):
     """
     Return a Chain object containing just the genesis block.
 
@@ -107,7 +106,8 @@ def chain_with_block_validation(base_db, genesis_state):
         "transaction_root": decode_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),  # noqa: E501
         "uncles_hash": decode_hex("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")  # noqa: E501
     }
-    klass = Chain.configure(
+
+    klass = chain_cls.configure(
         __name__='TestChain',
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVM),
@@ -116,6 +116,11 @@ def chain_with_block_validation(base_db, genesis_state):
     )
     chain = klass.from_genesis(base_db, genesis_params, genesis_state)
     return chain
+
+
+@pytest.fixture
+def chain_with_block_validation(base_db, genesis_state):
+    return _chain_with_block_validation(base_db, genesis_state)
 
 
 def import_block_without_validation(chain, block):

--- a/tests/trinity/core/chain-management/test_light_peer_chain.py
+++ b/tests/trinity/core/chain-management/test_light_peer_chain.py
@@ -1,0 +1,20 @@
+from trinity.sync.light.service import (
+    LightPeerChain
+)
+from trinity.plugins.builtin.light_peer_chain_bridge import (
+    EventBusLightPeerChain,
+)
+
+
+# These tests may seem obvious but they safe us from runtime errors where
+# changes are made to the `BaseLightPeerChain` that are then forgotton to
+# implement on both derived chains.
+
+def test_can_instantiate_eventbus_light_peer_chain():
+    chain = EventBusLightPeerChain(None)
+    assert chain is not None
+
+
+def test_can_instantiate_light_peer_chain():
+    chain = LightPeerChain(None, None)
+    assert chain is not None

--- a/tests/trinity/integration/test_lightchain_integration.py
+++ b/tests/trinity/integration/test_lightchain_integration.py
@@ -200,26 +200,26 @@ async def test_lightchain_integration(
 
     # https://ropsten.etherscan.io/block/11
     header = headerdb.get_canonical_block_header_by_number(n)
-    body = await peer_chain.get_block_body_by_hash(header.hash)
+    body = await peer_chain.coro_get_block_body_by_hash(header.hash)
     assert len(body['transactions']) == 15
 
-    receipts = await peer_chain.get_receipts(header.hash)
+    receipts = await peer_chain.coro_get_receipts(header.hash)
     assert len(receipts) == 15
     assert encode_hex(keccak(rlp.encode(receipts[0]))) == (
         '0xf709ed2c57efc18a1675e8c740f3294c9e2cb36ba7bb3b89d3ab4c8fef9d8860')
 
     assert len(peer_pool) == 1
     peer = peer_pool.highest_td_peer
-    head = await peer_chain.get_block_header_by_hash(peer.head_hash)
+    head = await peer_chain.coro_get_block_header_by_hash(peer.head_hash)
 
     # In order to answer queries for contract code, geth needs the state trie entry for the block
     # we specify in the query, but because of fast sync we can only assume it has that for recent
     # blocks, so we use the current head to lookup the code for the contract below.
     # https://ropsten.etherscan.io/address/0x95a48dca999c89e4e284930d9b9af973a7481287
     contract_addr = decode_hex('0x8B09D9ac6A4F7778fCb22852e879C7F3B2bEeF81')
-    contract_code = await peer_chain.get_contract_code(head.hash, contract_addr)
+    contract_code = await peer_chain.coro_get_contract_code(head.hash, contract_addr)
     assert encode_hex(contract_code) == '0x600060006000600060006000356000f1'
 
-    account = await peer_chain.get_account(head.hash, contract_addr)
+    account = await peer_chain.coro_get_account(head.hash, contract_addr)
     assert account.code_hash == keccak(contract_code)
     assert account.balance == 0

--- a/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -25,6 +25,9 @@ from eth.tools.fixtures import (
     should_run_slow_tests,
 )
 
+from trinity.chains.mainnet import (
+    MainnetFullChain
+)
 from trinity.rpc import RPCServer
 from trinity.rpc.format import (
     empty_to_0x,
@@ -383,7 +386,7 @@ def chain(chain_without_block_validation):
 
 @pytest.mark.asyncio
 async def test_rpc_against_fixtures(chain, ipc_server, chain_fixture, fixture_data):
-    rpc = RPCServer(None)
+    rpc = RPCServer(MainnetFullChain(None))
 
     setup_result, setup_error = await call_rpc(rpc, 'evm_resetToGenesisFixture', [chain_fixture])
     assert setup_error is None and setup_result is True, "cannot load chain for %r" % fixture_data

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ commands=
     rpc-state-homestead: pytest {posargs:tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Homestead'}
     rpc-state-eip150: pytest {posargs:tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP150'}
     rpc-state-eip158: pytest {posargs:tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP158'}
-    rpc-state-byzantium: pytest {posargs:tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Byzantium'}
+    # The following test seems to consume a lot of memory. Restricting to 3 processes reduces crashes
+    rpc-state-byzantium: pytest -n3 {posargs:tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Byzantium'}
     rpc-state-quadratic: pytest {posargs:tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
     transactions: pytest {posargs:tests/json-fixtures/test_transactions.py}
     vm: pytest {posargs:tests/json-fixtures/test_virtual_machine.py}

--- a/trinity/chains/coro.py
+++ b/trinity/chains/coro.py
@@ -1,0 +1,10 @@
+from trinity.utils.async_dispatch import (
+    async_method,
+)
+
+
+class AsyncChainMixin:
+
+    coro_get_canonical_block_by_number = async_method('get_canonical_block_by_number')
+    coro_get_block_by_hash = async_method('get_block_by_hash')
+    coro_get_block_by_header = async_method('get_block_by_header')

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -141,7 +141,7 @@ class LightDispatchChain(BaseChain):
     def get_block_by_header(self, header: BlockHeader) -> BaseBlock:
         # TODO check local cache, before hitting peer
         block_body = self._run_async(
-            self._peer_chain.get_block_body_by_hash(header.hash)
+            self._peer_chain.coro_get_block_body_by_hash(header.hash)
         )
 
         block_class = self.get_vm_class_for_block_number(header.block_number).get_block_class()

--- a/trinity/chains/mainnet.py
+++ b/trinity/chains/mainnet.py
@@ -1,8 +1,14 @@
 from eth.chains.mainnet import (
     BaseMainnetChain,
+    MainnetChain
 )
 
+from trinity.chains.coro import AsyncChainMixin
 from trinity.chains.light import LightDispatchChain
+
+
+class MainnetFullChain(MainnetChain, AsyncChainMixin):
+    pass
 
 
 class MainnetLightDispatchChain(BaseMainnetChain, LightDispatchChain):

--- a/trinity/chains/ropsten.py
+++ b/trinity/chains/ropsten.py
@@ -1,8 +1,14 @@
 from eth.chains.ropsten import (
     BaseRopstenChain,
+    RopstenChain
 )
 
+from trinity.chains.coro import AsyncChainMixin
 from trinity.chains.light import LightDispatchChain
+
+
+class RopstenFullChain(RopstenChain, AsyncChainMixin):
+    pass
 
 
 class RopstenLightDispatchChain(BaseRopstenChain, LightDispatchChain):

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -1,10 +1,8 @@
 from abc import abstractmethod
-import asyncio
 from pathlib import Path
 from multiprocessing.managers import (
     BaseManager,
 )
-from threading import Thread
 from typing import (
     Type,
 )
@@ -16,23 +14,8 @@ from p2p.service import (
     BaseService,
 )
 
-from trinity.chains import (
-    ChainProxy,
-)
-from trinity.chains.header import (
-    AsyncHeaderChainProxy,
-)
-from trinity.db.chain import ChainDBProxy
-from trinity.db.base import DBProxy
 from trinity.db.header import (
     AsyncHeaderDB,
-    AsyncHeaderDBProxy
-)
-from trinity.rpc.main import (
-    RPCServer,
-)
-from trinity.rpc.ipc import (
-    IPCServer,
 )
 from trinity.config import (
     ChainConfig,
@@ -42,6 +25,9 @@ from trinity.extensibility import (
 )
 from trinity.extensibility.events import (
     ResourceAvailableEvent
+)
+from trinity.utils.db_proxy import (
+    create_db_manager
 )
 
 
@@ -106,69 +92,5 @@ class Node(BaseService):
             resource_type=BaseChain
         ))
 
-    @property
-    def has_ipc_server(self) -> bool:
-        return bool(self._jsonrpc_ipc_path)
-
-    def make_ipc_server(self, loop: asyncio.AbstractEventLoop) -> BaseService:
-        if self.has_ipc_server:
-            rpc = RPCServer(self.get_chain(), self.get_peer_pool())
-            return IPCServer(rpc, self._jsonrpc_ipc_path, loop=loop)
-        else:
-            return None
-
     async def _run(self) -> None:
-        if self.has_ipc_server:
-            # The RPC server needs its own thread, because it provides a synchcronous
-            # API which might call into p2p async methods. These sync->async calls
-            # deadlock if they are run in the same Thread and loop.
-            ipc_loop = self._make_new_loop_thread()
-
-            self._ipc_server = self.make_ipc_server(ipc_loop)
-
-            # keep a copy on self, for later shutdown
-            self._ipc_loop = ipc_loop
-
-            asyncio.run_coroutine_threadsafe(self._ipc_server.run(), loop=ipc_loop)
-
         await self.get_p2p_server().run()
-
-    async def _cleanup(self) -> None:
-        # IPC Server requires special handling because it's running in its own loop & thread
-        if self.has_ipc_server:
-            await self._ipc_server.threadsafe_cancel()
-            # Stop the this IPCServer-specific event loop, so that the IPCServer thread will exit
-            self._ipc_loop.stop()
-
-    def _make_new_loop_thread(self) -> asyncio.AbstractEventLoop:
-        new_loop = asyncio.new_event_loop()
-
-        def start_loop(loop: asyncio.AbstractEventLoop) -> None:
-            asyncio.set_event_loop(loop)
-            loop.run_forever()
-            loop.close()
-
-        thread = Thread(target=start_loop, args=(new_loop, ))
-        thread.start()
-
-        return new_loop
-
-
-def create_db_manager(ipc_path: Path) -> BaseManager:
-    """
-    We're still using 'str' here on param ipc_path because an issue with
-    multi-processing not being able to interpret 'Path' objects correctly
-    """
-    class DBManager(BaseManager):
-        pass
-
-    # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
-    # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
-    DBManager.register('get_db', proxytype=DBProxy)  # type: ignore
-    DBManager.register('get_chaindb', proxytype=ChainDBProxy)  # type: ignore
-    DBManager.register('get_chain', proxytype=ChainProxy)  # type: ignore
-    DBManager.register('get_headerdb', proxytype=AsyncHeaderDBProxy)  # type: ignore
-    DBManager.register('get_header_chain', proxytype=AsyncHeaderChainProxy)  # type: ignore
-
-    manager = DBManager(address=str(ipc_path))  # type: ignore
-    return manager

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -46,6 +46,7 @@ class FullNode(Node):
                 bootstrap_nodes=self._bootstrap_nodes,
                 preferred_nodes=self._preferred_nodes,
                 token=self.cancel_token,
+                event_bus=self._plugin_manager.event_bus_endpoint
             )
         return self._p2p_server
 

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -78,6 +78,7 @@ class LightNode(Node):
                 preferred_nodes=self._preferred_nodes,
                 use_discv5=self._use_discv5,
                 token=self.cancel_token,
+                event_bus=self._plugin_manager.event_bus_endpoint,
             )
         return self._p2p_server
 

--- a/trinity/nodes/mainnet.py
+++ b/trinity/nodes/mainnet.py
@@ -1,8 +1,5 @@
-from eth.chains.mainnet import (
-    MainnetChain,
-)
-
 from trinity.chains.mainnet import (
+    MainnetFullChain,
     MainnetLightDispatchChain,
 )
 from trinity.nodes.light import LightNode
@@ -10,7 +7,7 @@ from trinity.nodes.full import FullNode
 
 
 class MainnetFullNode(FullNode):
-    chain_class = MainnetChain
+    chain_class = MainnetFullChain
 
 
 class MainnetLightNode(LightNode):

--- a/trinity/nodes/ropsten.py
+++ b/trinity/nodes/ropsten.py
@@ -1,8 +1,5 @@
-from eth.chains.ropsten import (
-    RopstenChain,
-)
-
 from trinity.chains.ropsten import (
+    RopstenFullChain,
     RopstenLightDispatchChain,
 )
 from trinity.nodes.light import LightNode
@@ -10,7 +7,7 @@ from trinity.nodes.full import FullNode
 
 
 class RopstenFullNode(FullNode):
-    chain_class = RopstenChain
+    chain_class = RopstenFullChain
 
 
 class RopstenLightNode(LightNode):

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -1,0 +1,70 @@
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction,
+)
+import asyncio
+
+from trinity.constants import (
+    SYNC_LIGHT
+)
+from trinity.extensibility import (
+    BaseIsolatedPlugin,
+)
+from trinity.plugins.builtin.light_peer_chain_bridge.light_peer_chain_bridge import (
+    EventBusLightPeerChain,
+)
+from trinity.rpc.main import (
+    RPCServer,
+)
+from trinity.rpc.ipc import (
+    IPCServer,
+)
+from trinity.utils.db_proxy import (
+    create_db_manager
+)
+from trinity.utils.shutdown import (
+    exit_on_signal
+)
+
+
+class JsonRpcServerPlugin(BaseIsolatedPlugin):
+
+    @property
+    def name(self) -> str:
+        return "JSON-RPC Server"
+
+    def should_start(self) -> bool:
+        return not self.context.args.disable_rpc
+
+    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+        arg_parser.add_argument(
+            "--disable-rpc",
+            action="store_true",
+            help="Disables the JSON-RPC Server",
+        )
+
+    def start(self) -> None:
+        self.logger.info('JSON-RPC Server started')
+        self.context.event_bus.connect()
+
+        db_manager = create_db_manager(self.context.chain_config.database_ipc_path)
+        db_manager.connect()
+
+        chain_class = self.context.chain_config.node_class.chain_class
+
+        if self.context.chain_config.sync_mode == SYNC_LIGHT:
+            header_db = db_manager.get_headerdb()  # type: ignore
+            event_bus_light_peer_chain = EventBusLightPeerChain(self.context.event_bus)
+            chain = chain_class(header_db, peer_chain=event_bus_light_peer_chain)
+        else:
+            db = db_manager.get_db()  # type: ignore
+            chain = chain_class(db)
+
+        rpc = RPCServer(chain, self.context.event_bus)
+        ipc_server = IPCServer(rpc, self.context.chain_config.jsonrpc_ipc_path)
+
+        loop = asyncio.get_event_loop()
+        asyncio.ensure_future(exit_on_signal(ipc_server, self.context.event_bus))
+        asyncio.ensure_future(ipc_server.run())
+        loop.run_forever()
+        loop.close()

--- a/trinity/plugins/builtin/light_peer_chain_bridge/__init__.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/__init__.py
@@ -1,0 +1,4 @@
+from .light_peer_chain_bridge import (  # noqa: F401
+    EventBusLightPeerChain,
+    LightPeerChainEventBusHandler,
+)

--- a/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
@@ -1,0 +1,257 @@
+from typing import (
+    List,
+    Type,
+    TypeVar,
+)
+
+from cancel_token import (
+    CancelToken,
+)
+
+from eth_typing import (
+    Address,
+    Hash32,
+)
+
+from eth.rlp.accounts import (
+    Account,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
+from eth.rlp.receipts import (
+    Receipt,
+)
+
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+    Endpoint,
+)
+
+from p2p.service import (
+    BaseService,
+)
+
+from trinity.utils.async_errors import (
+    await_and_wrap_errors,
+)
+from trinity.rlp.block_body import BlockBody
+from trinity.sync.light.service import (
+    BaseLightPeerChain,
+)
+
+
+class BaseLightPeerChainResponse(BaseEvent):
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+
+class BlockHeaderResponse(BaseLightPeerChainResponse):
+
+    def __init__(self, block_header: BlockHeader, error: Exception=None) -> None:
+        super().__init__(error)
+        self.block_header = block_header
+
+
+class BlockBodyResponse(BaseLightPeerChainResponse):
+
+    def __init__(self, block_body: BlockBody, error: Exception=None) -> None:
+        super().__init__(error)
+        self.block_body = block_body
+
+
+class ReceiptsResponse(BaseLightPeerChainResponse):
+
+    def __init__(self, receipts: List[Receipt], error: Exception=None) -> None:
+        super().__init__(error)
+        self.receipts = receipts
+
+
+class AccountResponse(BaseLightPeerChainResponse):
+
+    def __init__(self, account: Account, error: Exception=None) -> None:
+        super().__init__(error)
+        self.account = account
+
+
+class BytesResponse(BaseLightPeerChainResponse):
+
+    def __init__(self, bytez: bytes, error: Exception=None) -> None:
+        super().__init__(error)
+        self.bytez = bytez
+
+
+class GetBlockHeaderByHashRequest(BaseRequestResponseEvent[BlockHeaderResponse]):
+
+    def __init__(self, block_hash: Hash32) -> None:
+        self.block_hash = block_hash
+
+    @staticmethod
+    def expected_response_type() -> Type[BlockHeaderResponse]:
+        return BlockHeaderResponse
+
+
+class GetBlockBodyByHashRequest(BaseRequestResponseEvent[BlockBodyResponse]):
+
+    def __init__(self, block_hash: Hash32) -> None:
+        self.block_hash = block_hash
+
+    @staticmethod
+    def expected_response_type() -> Type[BlockBodyResponse]:
+        return BlockBodyResponse
+
+
+class GetReceiptsRequest(BaseRequestResponseEvent[ReceiptsResponse]):
+
+    def __init__(self, block_hash: Hash32) -> None:
+        self.block_hash = block_hash
+
+    @staticmethod
+    def expected_response_type() -> Type[ReceiptsResponse]:
+        return ReceiptsResponse
+
+
+class GetAccountRequest(BaseRequestResponseEvent[AccountResponse]):
+
+    def __init__(self, block_hash: Hash32, address: Address) -> None:
+        self.block_hash = block_hash
+        self.address = address
+
+    @staticmethod
+    def expected_response_type() -> Type[AccountResponse]:
+        return AccountResponse
+
+
+class GetContractCodeRequest(BaseRequestResponseEvent[BytesResponse]):
+
+    def __init__(self, block_hash: Hash32, address: Address) -> None:
+        self.block_hash = block_hash
+        self.address = address
+
+    @staticmethod
+    def expected_response_type() -> Type[BytesResponse]:
+        return BytesResponse
+
+
+class LightPeerChainEventBusHandler(BaseService):
+    """
+    The ``LightPeerChainEventBusHandler`` listens for certain events on the eventbus and
+    delegates them to the ``LightPeerChain`` to get answers. It then propagates responses
+    back to the caller.
+    """
+
+    def __init__(self,
+                 chain: BaseLightPeerChain,
+                 event_bus: Endpoint,
+                 token: CancelToken = None) -> None:
+        super().__init__(token)
+        self.chain = chain
+        self.event_bus = event_bus
+
+    async def _run(self) -> None:
+        self.logger.info("Running LightPeerChainEventBusHandler")
+
+        self.run_daemon_task(self.handle_get_blockheader_by_hash_requests())
+        self.run_daemon_task(self.handle_get_blockbody_by_hash_requests())
+        self.run_daemon_task(self.handle_get_receipts_by_hash_requests())
+        self.run_daemon_task(self.handle_get_account_requests())
+        self.run_daemon_task(self.handle_get_contract_code_requests())
+
+    async def handle_get_blockheader_by_hash_requests(self) -> None:
+        async for event in self.event_bus.stream(GetBlockHeaderByHashRequest):
+
+            val, error = await await_and_wrap_errors(
+                self.chain.coro_get_block_header_by_hash(event.block_hash)
+            )
+
+            self.event_bus.broadcast(
+                event.expected_response_type()(val, error),
+                event.broadcast_config()
+            )
+
+    async def handle_get_blockbody_by_hash_requests(self) -> None:
+        async for event in self.event_bus.stream(GetBlockBodyByHashRequest):
+
+            val, error = await await_and_wrap_errors(
+                self.chain.coro_get_block_body_by_hash(event.block_hash)
+            )
+
+            self.event_bus.broadcast(
+                event.expected_response_type()(val, error),
+                event.broadcast_config()
+            )
+
+    async def handle_get_receipts_by_hash_requests(self) -> None:
+        async for event in self.event_bus.stream(GetReceiptsRequest):
+
+            val, error = await await_and_wrap_errors(self.chain.coro_get_receipts(event.block_hash))
+
+            self.event_bus.broadcast(
+                event.expected_response_type()(val, error),
+                event.broadcast_config()
+            )
+
+    async def handle_get_account_requests(self) -> None:
+        async for event in self.event_bus.stream(GetAccountRequest):
+
+            val, error = await await_and_wrap_errors(
+                self.chain.coro_get_account(event.block_hash, event.address)
+            )
+
+            self.event_bus.broadcast(
+                event.expected_response_type()(val, error),
+                event.broadcast_config()
+            )
+
+    async def handle_get_contract_code_requests(self) -> None:
+
+        async for event in self.event_bus.stream(GetContractCodeRequest):
+
+            val, error = await await_and_wrap_errors(
+                self.chain.coro_get_contract_code(event.block_hash, event.address)
+            )
+
+            self.event_bus.broadcast(
+                event.expected_response_type()(val, error),
+                event.broadcast_config()
+            )
+
+
+class EventBusLightPeerChain(BaseLightPeerChain):
+    """
+    The ``EventBusLightPeerChain`` is an implementation of the ``BaseLightPeerChain`` that can
+    be used from within any process.
+    """
+
+    def __init__(self, event_bus: Endpoint) -> None:
+        self.event_bus = event_bus
+
+    async def coro_get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
+        event = GetBlockHeaderByHashRequest(block_hash)
+        return self._pass_or_raise(await self.event_bus.request(event)).block_header
+
+    async def coro_get_block_body_by_hash(self, block_hash: Hash32) -> BlockBody:
+        event = GetBlockBodyByHashRequest(block_hash)
+        return self._pass_or_raise(await self.event_bus.request(event)).block_body
+
+    async def coro_get_receipts(self, block_hash: Hash32) -> List[Receipt]:
+        event = GetReceiptsRequest(block_hash)
+        return self._pass_or_raise(await self.event_bus.request(event)).receipts
+
+    async def coro_get_account(self, block_hash: Hash32, address: Address) -> Account:
+        event = GetAccountRequest(block_hash, address)
+        return self._pass_or_raise(await self.event_bus.request(event)).account
+
+    async def coro_get_contract_code(self, block_hash: Hash32, address: Address) -> bytes:
+        event = GetContractCodeRequest(block_hash, address)
+        return self._pass_or_raise(await self.event_bus.request(event)).bytez
+
+    TResponse = TypeVar("TResponse", bound=BaseLightPeerChainResponse)
+
+    def _pass_or_raise(self, response: TResponse) -> TResponse:
+        if response.error is not None:
+            raise response.error
+
+        return response

--- a/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
@@ -1,0 +1,55 @@
+import asyncio
+from typing import (
+    cast
+)
+
+from eth.chains.base import (
+    BaseChain
+)
+
+from trinity.constants import (
+    SYNC_LIGHT
+)
+from trinity.extensibility import (
+    BaseEvent,
+    BasePlugin,
+)
+from trinity.chains.light import (
+    LightDispatchChain,
+)
+from trinity.extensibility.events import (
+    ResourceAvailableEvent
+)
+from trinity.plugins.builtin.light_peer_chain_bridge import (
+    LightPeerChainEventBusHandler
+)
+
+
+class LightPeerChainBridgePlugin(BasePlugin):
+    """
+    The ``LightPeerChainBridgePlugin`` runs in the ``networking`` process and acts as a bridge
+    between other processes and the ``LightPeerChain``.
+    It runs only in ``light`` mode.
+    Other plugins can instantiate the ``EventBusLightPeerChain`` from separate processes to
+    interact with the ``LightPeerChain`` indirectly.
+    """
+
+    chain: BaseChain = None
+
+    @property
+    def name(self) -> str:
+        return "LightPeerChain Bridge"
+
+    def should_start(self) -> bool:
+        return self.chain is not None and self.context.chain_config.sync_mode == SYNC_LIGHT
+
+    def handle_event(self, activation_event: BaseEvent) -> None:
+        if isinstance(activation_event, ResourceAvailableEvent):
+            if activation_event.resource_type is BaseChain:
+                self.chain = activation_event.resource
+
+    def start(self) -> None:
+        self.logger.info('LightPeerChain Bridge started')
+        chain = cast(LightDispatchChain, self.chain)
+        handler = LightPeerChainEventBusHandler(chain._peer_chain, self.context.event_bus)
+        asyncio.ensure_future(handler.run())

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -6,8 +6,14 @@ from trinity.plugins.builtin.attach.plugin import (
 from trinity.plugins.builtin.fix_unclean_shutdown.plugin import (
     FixUncleanShutdownPlugin
 )
+from trinity.plugins.builtin.json_rpc.plugin import (
+    JsonRpcServerPlugin,
+)
 from trinity.plugins.builtin.tx_pool.plugin import (
     TxPlugin,
+)
+from trinity.plugins.builtin.light_peer_chain_bridge.plugin import (
+    LightPeerChainBridgePlugin
 )
 
 
@@ -27,5 +33,7 @@ def is_ipython_available() -> bool:
 ENABLED_PLUGINS = [
     AttachPlugin() if is_ipython_available() else AttachPlugin(use_ipython=False),
     FixUncleanShutdownPlugin(),
+    JsonRpcServerPlugin(),
+    LightPeerChainBridgePlugin(),
     TxPlugin(),
 ]

--- a/trinity/rpc/format.py
+++ b/trinity/rpc/format.py
@@ -21,7 +21,7 @@ from eth_utils import (
 import rlp
 
 from eth.chains.base import (
-    BaseChain
+    AsyncChain
 )
 from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
@@ -102,7 +102,7 @@ def header_to_dict(header: BlockHeader) -> Dict[str, str]:
 
 
 def block_to_dict(block: BaseBlock,
-                  chain: BaseChain,
+                  chain: AsyncChain,
                   include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
 
     header_dict = header_to_dict(block.header)
@@ -126,11 +126,11 @@ def block_to_dict(block: BaseBlock,
 def format_params(*formatters: Any) -> Callable[..., Any]:
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         @functools.wraps(func)
-        def formatted_func(self: Any, *args: Any) -> Callable[..., Any]:
+        async def formatted_func(self: Any, *args: Any) -> Callable[..., Any]:
             if len(formatters) != len(args):
                 raise TypeError("could not apply %d formatters to %r" % (len(formatters), args))
             formatted = (formatter(arg) for formatter, arg in zip(formatters, args))
-            return func(self, *formatted)
+            return await func(self, *formatted)
         return formatted_func
     return decorator
 

--- a/trinity/rpc/ipc.py
+++ b/trinity/rpc/ipc.py
@@ -99,7 +99,7 @@ async def connection_loop(execute_rpc: Callable[[Any], Any],
             continue
 
         try:
-            result = execute_rpc(request)
+            result = await execute_rpc(request)
         except Exception as e:
             logger.exception("Unrecognized exception while executing RPC")
             await cancel_token.cancellable_wait(

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -99,9 +99,9 @@ class RPCServer:
         except AttributeError:
             raise ValueError("Method not implemented: %r" % rpc_method)
 
-    def _get_result(self,
-                    request: Dict[str, Any],
-                    debug: bool=False) -> Tuple[Any, Union[Exception, str]]:
+    async def _get_result(self,
+                          request: Dict[str, Any],
+                          debug: bool=False) -> Tuple[Any, Union[Exception, str]]:
         '''
         :returns: (result, error) - result is None if error is provided. Error must be
             convertable to string with ``str(error)``.
@@ -114,7 +114,7 @@ class RPCServer:
 
             method = self._lookup_method(request['method'])
             params = request.get('params', [])
-            result = method(*params)
+            result = await method(*params)
 
             if request['method'] == 'evm_resetToGenesisFixture':
                 self.chain, result = result, True
@@ -133,11 +133,11 @@ class RPCServer:
         else:
             return result, None
 
-    def execute(self, request: Dict[str, Any]) -> str:
+    async def execute(self, request: Dict[str, Any]) -> str:
         '''
         The key entry point for all incoming requests
         '''
-        result, error = self._get_result(request)
+        result, error = await self._get_result(request)
         return generate_response(request, result, error)
 
     @property

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -12,10 +12,12 @@ from eth_utils import (
 )
 
 from eth.chains.base import (
-    BaseChain
+    AsyncChain,
 )
 
-from p2p.peer import BasePeerPool
+from lahja import (
+    Endpoint
+)
 
 from trinity.rpc.modules import (
     Eth,
@@ -72,11 +74,11 @@ class RPCServer:
         Web3,
     )
 
-    def __init__(self, chain: BaseChain=None, peer_pool: BasePeerPool=None) -> None:
+    def __init__(self, chain: AsyncChain=None, event_bus: Endpoint=None) -> None:
         self.modules: Dict[str, RPCModule] = {}
         self.chain = chain
         for M in self.module_classes:
-            self.modules[M.__name__.lower()] = M(chain, peer_pool)
+            self.modules[M.__name__.lower()] = M(chain, event_bus)
         if len(self.modules) != len(self.module_classes):
             raise ValueError("apparent name conflict in RPC module_classes", self.module_classes)
 
@@ -141,11 +143,11 @@ class RPCServer:
         return generate_response(request, result, error)
 
     @property
-    def chain(self) -> BaseChain:
+    def chain(self) -> AsyncChain:
         return self.__chain
 
     @chain.setter
-    def chain(self, new_chain: BaseChain) -> None:
+    def chain(self, new_chain: AsyncChain) -> None:
         self.__chain = new_chain
         for module in self.modules.values():
             module.set_chain(new_chain)

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -129,75 +129,75 @@ class Eth(RPCModule):
     Any attribute without an underscore is publicly accessible.
     '''
 
-    def accounts(self) -> List[str]:
+    async def accounts(self) -> List[str]:
         # trinity does not manage accounts for the user
         return []
 
-    def blockNumber(self) -> str:
+    async def blockNumber(self) -> str:
         num = self._chain.get_canonical_head().block_number
         return hex(num)
 
     @format_params(identity, to_int_if_hex)
-    def call(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
+    async def call(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
         header = get_header(self._chain, at_block)
         validate_transaction_call_dict(txn_dict, self._chain.get_vm(header))
         transaction = dict_to_spoof_transaction(self._chain, header, txn_dict)
         result = self._chain.get_transaction_result(transaction, header)
         return encode_hex(result)
 
-    def coinbase(self) -> Hash32:
+    async def coinbase(self) -> Hash32:
         raise NotImplementedError()
 
     @format_params(identity, to_int_if_hex)
-    def estimateGas(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
+    async def estimateGas(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
         header = get_header(self._chain, at_block)
         validate_transaction_gas_estimation_dict(txn_dict, self._chain.get_vm(header))
         transaction = dict_to_spoof_transaction(self._chain, header, txn_dict)
         gas = self._chain.estimate_gas(transaction, header)
         return hex(gas)
 
-    def gasPrice(self) -> int:
+    async def gasPrice(self) -> int:
         raise NotImplementedError()
 
     @format_params(decode_hex, to_int_if_hex)
-    def getBalance(self, address: Address, at_block: Union[str, int]) -> str:
+    async def getBalance(self, address: Address, at_block: Union[str, int]) -> str:
         account_db = account_db_at_block(self._chain, at_block)
         balance = account_db.get_balance(address)
 
         return hex(balance)
 
     @format_params(decode_hex, identity)
-    def getBlockByHash(self,
+    async def getBlockByHash(self,
                        block_hash: Hash32,
                        include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
         block = self._chain.get_block_by_hash(block_hash)
         return block_to_dict(block, self._chain, include_transactions)
 
     @format_params(to_int_if_hex, identity)
-    def getBlockByNumber(self,
+    async def getBlockByNumber(self,
                          at_block: Union[str, int],
                          include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
         block = get_block_at_number(self._chain, at_block)
         return block_to_dict(block, self._chain, include_transactions)
 
     @format_params(decode_hex)
-    def getBlockTransactionCountByHash(self, block_hash: Hash32) -> str:
+    async def getBlockTransactionCountByHash(self, block_hash: Hash32) -> str:
         block = self._chain.get_block_by_hash(block_hash)
         return hex(len(block.transactions))
 
     @format_params(to_int_if_hex)
-    def getBlockTransactionCountByNumber(self, at_block: Union[str, int]) -> str:
+    async def getBlockTransactionCountByNumber(self, at_block: Union[str, int]) -> str:
         block = get_block_at_number(self._chain, at_block)
         return hex(len(block.transactions))
 
     @format_params(decode_hex, to_int_if_hex)
-    def getCode(self, address: Address, at_block: Union[str, int]) -> str:
+    async def getCode(self, address: Address, at_block: Union[str, int]) -> str:
         account_db = account_db_at_block(self._chain, at_block)
         code = account_db.get_code(address)
         return encode_hex(code)
 
     @format_params(decode_hex, to_int_if_hex, to_int_if_hex)
-    def getStorageAt(self, address: Address, position: int, at_block: Union[str, int]) -> str:
+    async def getStorageAt(self, address: Address, position: int, at_block: Union[str, int]) -> str:
         if not is_integer(position) or position < 0:
             raise TypeError("Position of storage must be a whole number, but was: %r" % position)
 
@@ -206,13 +206,13 @@ class Eth(RPCModule):
         return encode_hex(int_to_big_endian(stored_val))
 
     @format_params(decode_hex, to_int_if_hex)
-    def getTransactionByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
+    async def getTransactionByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
         block = self._chain.get_block_by_hash(block_hash)
         transaction = block.transactions[index]
         return transaction_to_dict(transaction)
 
     @format_params(to_int_if_hex, to_int_if_hex)
-    def getTransactionByBlockNumberAndIndex(self,
+    async def getTransactionByBlockNumberAndIndex(self,
                                             at_block: Union[str, int],
                                             index: int) -> Dict[str, str]:
         block = get_block_at_number(self._chain, at_block)
@@ -220,43 +220,43 @@ class Eth(RPCModule):
         return transaction_to_dict(transaction)
 
     @format_params(decode_hex, to_int_if_hex)
-    def getTransactionCount(self, address: Address, at_block: Union[str, int]) -> str:
+    async def getTransactionCount(self, address: Address, at_block: Union[str, int]) -> str:
         account_db = account_db_at_block(self._chain, at_block)
         nonce = account_db.get_nonce(address)
         return hex(nonce)
 
     @format_params(decode_hex)
-    def getUncleCountByBlockHash(self, block_hash: Hash32) -> str:
+    async def getUncleCountByBlockHash(self, block_hash: Hash32) -> str:
         block = self._chain.get_block_by_hash(block_hash)
         return hex(len(block.uncles))
 
     @format_params(to_int_if_hex)
-    def getUncleCountByBlockNumber(self, at_block: Union[str, int]) -> str:
+    async def getUncleCountByBlockNumber(self, at_block: Union[str, int]) -> str:
         block = get_block_at_number(self._chain, at_block)
         return hex(len(block.uncles))
 
     @format_params(decode_hex, to_int_if_hex)
-    def getUncleByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
+    async def getUncleByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
         block = self._chain.get_block_by_hash(block_hash)
         uncle = block.uncles[index]
         return header_to_dict(uncle)
 
     @format_params(to_int_if_hex, to_int_if_hex)
-    def getUncleByBlockNumberAndIndex(self,
+    async def getUncleByBlockNumberAndIndex(self,
                                       at_block: Union[str, int],
                                       index: int) -> Dict[str, str]:
         block = get_block_at_number(self._chain, at_block)
         uncle = block.uncles[index]
         return header_to_dict(uncle)
 
-    def hashrate(self) -> str:
+    async def hashrate(self) -> str:
         raise NotImplementedError()
 
-    def mining(self) -> bool:
+    async def mining(self) -> bool:
         return False
 
-    def protocolVersion(self) -> str:
+    async def protocolVersion(self) -> str:
         return "63"
 
-    def syncing(self) -> bool:
+    async def syncing(self) -> bool:
         raise NotImplementedError()

--- a/trinity/rpc/modules/evm.py
+++ b/trinity/rpc/modules/evm.py
@@ -25,7 +25,7 @@ from trinity.rpc.modules import (
 
 class EVM(RPCModule):
     @format_params(normalize_blockchain_fixtures)
-    def resetToGenesisFixture(self, chain_info: Any) -> Chain:
+    async def resetToGenesisFixture(self, chain_info: Any) -> Chain:
         '''
         This method is a special case. It returns a new chain object
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`
@@ -34,7 +34,7 @@ class EVM(RPCModule):
         return new_chain_from_fixture(chain_info)
 
     @format_params(normalize_block)
-    def applyBlockFixture(self, block_info: Any) -> str:
+    async def applyBlockFixture(self, block_info: Any) -> str:
         '''
         This method is a special case. It returns a new chain object
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`

--- a/trinity/rpc/modules/evm.py
+++ b/trinity/rpc/modules/evm.py
@@ -31,7 +31,7 @@ class EVM(RPCModule):
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`
         for all future calls.
         '''
-        return new_chain_from_fixture(chain_info)
+        return new_chain_from_fixture(chain_info, type(self._chain))
 
     @format_params(normalize_block)
     async def applyBlockFixture(self, block_info: Any) -> str:

--- a/trinity/rpc/modules/main.py
+++ b/trinity/rpc/modules/main.py
@@ -1,16 +1,18 @@
 from eth.chains.base import (
-    BaseChain
+    AsyncChain
 )
 
-from p2p.peer import BasePeerPool
+from lahja import (
+    Endpoint
+)
 
 
 class RPCModule:
     _chain = None
 
-    def __init__(self, chain: BaseChain, peer_pool: BasePeerPool) -> None:
+    def __init__(self, chain: AsyncChain, event_bus: Endpoint) -> None:
         self._chain = chain
-        self._peer_pool = peer_pool
+        self._event_bus = event_bus
 
-    def set_chain(self, chain: BaseChain) -> None:
+    def set_chain(self, chain: AsyncChain) -> None:
         self._chain = chain

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -4,19 +4,19 @@ from trinity.rpc.modules import (
 
 
 class Net(RPCModule):
-    def version(self) -> str:
+    async def version(self) -> str:
         """
         Returns the current network ID.
         """
         return str(self._chain.network_id)
 
-    def peerCount(self) -> str:
+    async def peerCount(self) -> str:
         """
         Return the number of peers that are currently connected to the node
         """
         return hex(len(self._peer_pool))  # type: ignore
 
-    def listening(self) -> bool:
+    async def listening(self) -> bool:
         """
         Return `True` if the client is actively listening for network connections
         """

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -1,3 +1,6 @@
+from p2p.events import (
+    PeerCountRequest
+)
 from trinity.rpc.modules import (
     RPCModule,
 )
@@ -14,7 +17,8 @@ class Net(RPCModule):
         """
         Return the number of peers that are currently connected to the node
         """
-        return hex(len(self._peer_pool))  # type: ignore
+        response = await self._event_bus.request(PeerCountRequest())
+        return hex(response.peer_count)
 
     async def listening(self) -> bool:
         """

--- a/trinity/rpc/modules/web3.py
+++ b/trinity/rpc/modules/web3.py
@@ -9,13 +9,13 @@ from trinity.rpc.modules import (
 
 
 class Web3(RPCModule):
-    def clientVersion(self) -> str:
+    async def clientVersion(self) -> str:
         """
         Returns the current client version.
         """
         return construct_trinity_client_identifier()
 
-    def sha3(self, data: str) -> str:
+    async def sha3(self, data: str) -> str:
         """
         Returns Keccak-256 of the given data.
         """

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -15,6 +15,10 @@ from eth_utils import big_endian_to_int
 
 from cancel_token import CancelToken, OperationCancelled
 
+from lahja import (
+    Endpoint
+)
+
 from eth.chains import AsyncChain
 
 from eth_typing import BlockNumber
@@ -87,9 +91,11 @@ class BaseServer(BaseService):
                  bootstrap_nodes: Tuple[Node, ...] = None,
                  preferred_nodes: Sequence[Node] = None,
                  use_discv5: bool = False,
+                 event_bus: Endpoint = None,
                  token: CancelToken = None,
                  ) -> None:
         super().__init__(token)
+        self.event_bus = event_bus
         self.headerdb = headerdb
         self.chaindb = chaindb
         self.chain = chain
@@ -301,6 +307,7 @@ class FullServer(BaseServer):
             max_peers=self.max_peers,
             context=context,
             token=self.cancel_token,
+            event_bus=self.event_bus
         )
 
     def _make_syncer(self) -> FullNodeSyncer:
@@ -325,6 +332,7 @@ class LightServer(BaseServer):
             max_peers=self.max_peers,
             context=context,
             token=self.cancel_token,
+            event_bus=self.event_bus
         )
 
     def _make_syncer(self) -> LightChainSyncer:

--- a/trinity/utils/async_dispatch.py
+++ b/trinity/utils/async_dispatch.py
@@ -1,0 +1,18 @@
+import asyncio
+import functools
+from typing import (
+    Any,
+    Awaitable,
+    Callable
+)
+
+
+def async_method(method_name: str) -> Callable[..., Any]:
+    async def method(self: Any, *args: Any, **kwargs: Any) -> Awaitable[Any]:
+        loop = asyncio.get_event_loop()
+
+        func = getattr(self, method_name)
+        pfunc = functools.partial(func, *args, **kwargs)
+
+        return await loop.run_in_executor(None, pfunc)
+    return method

--- a/trinity/utils/async_errors.py
+++ b/trinity/utils/async_errors.py
@@ -1,0 +1,19 @@
+from typing import (
+    Awaitable,
+    Optional,
+    Tuple,
+    TypeVar,
+)
+
+
+TReturn = TypeVar("TReturn")
+
+
+async def await_and_wrap_errors(
+        awaitable: Awaitable[TReturn]) -> Tuple[Optional[TReturn], Optional[Exception]]:
+    try:
+        val = await awaitable
+    except Exception as e:
+        return None, e
+    else:
+        return val, None

--- a/trinity/utils/db_proxy.py
+++ b/trinity/utils/db_proxy.py
@@ -1,0 +1,34 @@
+from multiprocessing.managers import (
+    BaseManager,
+)
+import pathlib
+
+from trinity.chains import (
+    AsyncHeaderChainProxy,
+    ChainProxy,
+)
+from trinity.db.chain import ChainDBProxy
+from trinity.db.base import DBProxy
+from trinity.db.header import (
+    AsyncHeaderDBProxy
+)
+
+
+def create_db_manager(ipc_path: pathlib.Path) -> BaseManager:
+    """
+    We're still using 'str' here on param ipc_path because an issue with
+    multi-processing not being able to interpret 'Path' objects correctly
+    """
+    class DBManager(BaseManager):
+        pass
+
+    # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
+    # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
+    DBManager.register('get_db', proxytype=DBProxy)  # type: ignore
+    DBManager.register('get_chaindb', proxytype=ChainDBProxy)  # type: ignore
+    DBManager.register('get_chain', proxytype=ChainProxy)  # type: ignore
+    DBManager.register('get_headerdb', proxytype=AsyncHeaderDBProxy)  # type: ignore
+    DBManager.register('get_header_chain', proxytype=AsyncHeaderChainProxy)  # type: ignore
+
+    manager = DBManager(address=str(ipc_path))  # type: ignore
+    return manager

--- a/trinity/utils/shutdown.py
+++ b/trinity/utils/shutdown.py
@@ -1,0 +1,27 @@
+import asyncio
+import signal
+
+from lahja import (
+    Endpoint,
+)
+
+from p2p.service import (
+    BaseService,
+)
+
+
+async def exit_on_signal(service_to_exit: BaseService, endpoint: Endpoint = None) -> None:
+    loop = service_to_exit.get_event_loop()
+    sigint_received = asyncio.Event()
+    for sig in [signal.SIGINT, signal.SIGTERM]:
+        # TODO also support Windows
+        loop.add_signal_handler(sig, sigint_received.set)
+
+    await sigint_received.wait()
+    try:
+        await service_to_exit.cancel()
+        if endpoint is not None:
+            endpoint.stop()
+        service_to_exit._executor.shutdown(wait=True)
+    finally:
+        loop.stop()


### PR DESCRIPTION
### What was wrong?

Currently the `JSON-RPC` server runs in the `networking` process together the syncing and other messaging. Now that isolated plugins are a thing, it's a good idea to move the `JSON-RPC` server because:

- a separate process provides better isolation
  - DDOS attacks
  - crashes in the JSON-RPC can't bring the syncing down
- better code organization


### How was it fixed?

- provide a `LightPeerChainBridge` plugin that brings an `EventBusLightPeerChain` to be consumed from other processes
- enforce all RPC modules to be async
- turn existing JSON-RPC server into an isolated plugin

In addition to the current functionality of the `JSON-RPC` server, the new plugin-based version can be disabled by passing `--disable-rpc` at startup

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/24/60/ff/2460ffbdecceef0db953ee0f4f897754.jpg)
