### PR TITLE
Add BaseService.is_operational

### DIFF
--- a/p2p/DEVELOPMENT.md
+++ b/p2p/DEVELOPMENT.md
@@ -18,7 +18,7 @@ library.
 ## BaseService
 
 - If your service needs to run coroutines in the background, you should use the `BaseService.run_task()` method and
-  ensure they exit when `is_running` is False or when the cancel token is triggered.
+  ensure they exit when `is_operational` is False or when the cancel token is triggered.
 - If your service runs other services in the background, you should pass your CancelToken down to
   those services and run those using `BaseService.run_child_service()`, or
   `BaseService.run_daemon()` if you want the parent to be terminated when the child dies

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -337,7 +337,7 @@ class DiscoveryService(BaseService):
         await self._start_udp_listener()
         connect_loop_sleep = 2
         self.run_task(self.proto.bootstrap())
-        while not self.cancel_token.triggered:
+        while self.is_operational:
             await self.maybe_connect_to_more_peers()
             await self.sleep(connect_loop_sleep)
 

--- a/p2p/nat.py
+++ b/p2p/nat.py
@@ -72,7 +72,7 @@ class UPnPService(BaseService):
         On every iteration we configure the port mapping with a lifetime of 30 minutes and then
         sleep for that long as well.
         """
-        while not self.cancel_token.triggered:
+        while self.is_operational:
             try:
                 # Wait for the port mapping lifetime, and then try registering it again
                 await self.wait(asyncio.sleep(self._nat_portmap_lifetime))

--- a/tests/p2p/test_service.py
+++ b/tests/p2p/test_service.py
@@ -27,8 +27,10 @@ async def test_daemon_exit_causes_parent_cancellation():
     service = ParentService()
     asyncio.ensure_future(service.run())
     await asyncio.sleep(0.01)
+    assert service.daemon.is_operational
     assert service.daemon.is_running
     await service.daemon.cancel()
     await asyncio.sleep(0.01)
+    assert not service.is_operational
     assert not service.is_running
     await service.events.cleaned_up.wait()

--- a/tests/trinity/core/integration_test_helpers.py
+++ b/tests/trinity/core/integration_test_helpers.py
@@ -16,7 +16,7 @@ from trinity.db.header import AsyncHeaderDB
 
 async def connect_to_peers_loop(peer_pool, nodes):
     """Loop forever trying to connect to one of the given nodes if the pool is not yet full."""
-    while not peer_pool.cancel_token.triggered:
+    while peer_pool.is_operational:
         try:
             if not peer_pool.is_full:
                 await peer_pool.connect_to_nodes(nodes)

--- a/trinity/plugins/builtin/tx_pool/pool.py
+++ b/trinity/plugins/builtin/tx_pool/pool.py
@@ -73,7 +73,7 @@ class TxPool(BaseService, PeerSubscriber):
         self.logger.info("Running Tx Pool")
 
         with self.subscribe(self._peer_pool):
-            while not self.cancel_token.triggered:
+            while self.is_operational:
                 peer, cmd, msg = await self.wait(
                     self.msg_queue.get(), token=self.cancel_token)
                 peer = cast(ETHPeer, peer)

--- a/trinity/protocol/common/exchanges.py
+++ b/trinity/protocol/common/exchanges.py
@@ -60,7 +60,7 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
         - the manager service is running
         - the payload validator is primed with the request payload
         """
-        if not self._manager.is_running:
+        if not self._manager.is_operational:
             await self._manager.launch_service()
 
         # bind the outbound request payload to the payload validator

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -147,7 +147,7 @@ class StateDownloader(BaseService, PeerSubscriber):
             raise NoIdlePeers()
 
     async def _handle_msg_loop(self) -> None:
-        while self.is_running:
+        while self.is_operational:
             peer, cmd, msg = await self.wait(self.msg_queue.get())
             # Run self._handle_msg() with self.run_task() instead of awaiting for it so that we
             # can keep consuming msgs while _handle_msg() performs cpu-intensive tasks in separate
@@ -281,7 +281,7 @@ class StateDownloader(BaseService, PeerSubscriber):
             await self._process_nodes(node_data)
 
     async def _periodically_retry_timedout_and_missing(self) -> None:
-        while self.is_running:
+        while self.is_operational:
             timed_out = self.request_tracker.get_timed_out()
             if timed_out:
                 self.logger.debug("Re-requesting %d timed out trie nodes", len(timed_out))
@@ -330,7 +330,7 @@ class StateDownloader(BaseService, PeerSubscriber):
         self.logger.info("Finished state sync with root hash %s", encode_hex(self.root_hash))
 
     async def _periodically_report_progress(self) -> None:
-        while self.is_running:
+        while self.is_operational:
             requested_nodes = sum(
                 len(node_keys) for _, node_keys in self.request_tracker.active_requests.values())
             msg = "processed=%d  " % self._total_processed_nodes

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -95,7 +95,7 @@ class LightPeerChain(PeerSubscriber, BaseService):
 
     async def _run(self) -> None:
         with self.subscribe(self.peer_pool):
-            while not self.cancel_token.triggered:
+            while self.is_operational:
                 peer, cmd, msg = await self.wait(self.msg_queue.get())
                 if isinstance(msg, dict):
                     request_id = msg.get('request_id')

--- a/trinity/sync/sharding/service.py
+++ b/trinity/sync/sharding/service.py
@@ -115,7 +115,7 @@ class ShardSyncer(BaseService, PeerSubscriber):
     #
     async def _run(self) -> None:
         with self.subscribe(self.peer_pool):
-            while not self.cancel_token.triggered:
+            while self.is_operational:
                 peer, cmd, msg = await self.cancel_token.cancellable_wait(
                     self.msg_queue.get())
 


### PR DESCRIPTION
### What was wrong?

There was a sprinkling of `while service.is_running:` and `while not service.cancel_token.triggered:` throughout the code base. Almost all of the `is_running` calls were evil: they continue silently running something even after the cancel token was triggered.

### How was it fixed?

Added `is_operational`, which is true after the server pre-start steps are complete and until cancel has been triggered.

Now all the while loops are non-negative, and independent of the cancel implementation.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://funnypicsonly.com/wp-content/uploads/2016/09/Ridiculously-Cute-and-Happy-Animals-23.jpg)
