### PR TITLE
eth/vm/logic/arithmetic: handle exp(X,0) == 1.

### DIFF
--- a/eth/vm/logic/arithmetic.py
+++ b/eth/vm/logic/arithmetic.py
@@ -147,7 +147,9 @@ def exp(computation, gas_per_byte):
     bit_size = exponent.bit_length()
     byte_size = ceil8(bit_size) // 8
 
-    if base == 0:
+    if exponent == 0:
+        result = 1
+    elif base == 0:
         result = 0
     else:
         result = pow(base, exponent, constants.UINT_256_CEILING)

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -124,6 +124,32 @@ def test_mul(vm_class, val1, val2, expected):
 
 
 @pytest.mark.parametrize(
+    'vm_class, base, exponent, expected',
+    (
+        (ByzantiumVM, 0, 1, 0,),
+        (ByzantiumVM, 0, 0, 1,),
+        (SpuriousDragonVM, 0, 1, 0,),
+        (SpuriousDragonVM, 0, 0, 1,),
+        (TangerineWhistleVM, 0, 1, 0,),
+        (TangerineWhistleVM, 0, 0, 1,),
+        (HomesteadVM, 0, 1, 0,),
+        (HomesteadVM, 0, 0, 1,),
+        (FrontierVM, 0, 1, 0,),
+        (FrontierVM, 0, 0, 1,),
+    )
+)
+def test_exp(vm_class, base, exponent, expected):
+    computation = prepare_computation(vm_class)
+    computation.stack_push(exponent)
+    computation.stack_push(base)
+    computation.opcodes[opcode_values.EXP](computation)
+
+    result = computation.stack_pop(type_hint=constants.UINT256)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
     # Testcases from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md#shl-shift-left
     'vm_class, val1, val2, expected',
     (


### PR DESCRIPTION
### What was wrong?

0^0 == 1, but this wasn't tested for.

### How was it fixed?

Caught by [`exp8.json` test](https://github.com/ethereum/tests/blob/10ab37c095bb87d2e781bcf112b6104912fccb44/VMTests/vmArithmeticTest/exp8.json) (not yet tracked in tests fixture on `master`).

Semi-accidentally caught in PR #1181, which updated the JSON test fixtures to a newer version, which does contain the `exp8.json` test. The failure got lost among others.

Can be seen in `py3{5,6}-vm` CI tests: for the EVM bytecode `0x600060000a600055`, which is:

```
000000: PUSH1 0x00
000002: PUSH1 0x00
000004: EXP
000005: PUSH1 0x00
000007: SSTORE
```

... there was a `15000` gas use delta (to that of expected): as if the storage was (re-)set to 0, not 1. Mentioned CI runs:

* [py35-vm](https://circleci.com/gh/ethereum/py-evm/59992?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
* [py36-vm](https://circleci.com/gh/ethereum/py-evm/59987?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://peepeth.s3-us-west-1.amazonaws.com/images/peep_pics/GFPL5qnV/large.jpg?1535414685)

Source: not sure; via [`@ano` at peepeth](https://peepeth.com/ano/peeps/QmfQHVNqCHzj73e9hXiiEC5jdxr2yJHS1er4mFBvnegu1u)