### PR TITLE
Extract tracker concept from normalizers

### DIFF
--- a/tests/trinity/core/p2p-proto/test_stats.py
+++ b/tests/trinity/core/p2p-proto/test_stats.py
@@ -71,7 +71,7 @@ async def les_peer_and_remote(request, event_loop):
 async def test_eth_get_headers_empty_stats(eth_peer_and_remote):
     peer, remote = eth_peer_and_remote
     stats = peer.requests.get_stats()
-    assert all(status == 'Uninitialized' for status in stats.values())
+    assert all(status == 'None' for status in stats.values())
     assert 'BlockHeaders' in stats.keys()
 
 
@@ -90,8 +90,9 @@ async def test_eth_get_headers_stats(eth_peer_and_remote):
 
         stats = peer.requests.get_stats()
 
-        assert stats['BlockHeaders'].startswith('count={0}, items={0}, avg_rtt='.format(idx))
-        assert stats['BlockHeaders'].endswith(', timeouts=0')
+        assert stats['BlockHeaders'].startswith('count={0}  items={0}  avg_rtt='.format(idx))
+        assert 'timeouts=0' in stats['BlockHeaders']
+        assert 'missing=0' in stats['BlockHeaders']
 
 
 @pytest.mark.asyncio
@@ -113,5 +114,6 @@ async def test_les_get_headers_stats(les_peer_and_remote):
 
         stats = peer.requests.get_stats()
 
-        assert stats['BlockHeaders'].startswith('count={0}, items={0}, avg_rtt='.format(idx))
-        assert stats['BlockHeaders'].endswith(', timeouts=0')
+        assert stats['BlockHeaders'].startswith('count={0}  items={0}  avg_rtt='.format(idx))
+        assert 'timeouts=0' in stats['BlockHeaders']
+        assert 'missing=0' in stats['BlockHeaders']

--- a/trinity/protocol/common/exchanges.py
+++ b/trinity/protocol/common/exchanges.py
@@ -14,7 +14,12 @@ from p2p.protocol import (
 )
 
 from trinity.utils.decorators import classproperty
-from .managers import ExchangeManager
+from .trackers import (
+    BasePerformanceTracker,
+)
+from .managers import (
+    ExchangeManager,
+)
 from .normalizers import BaseNormalizer
 from .types import (
     TResponsePayload,
@@ -42,9 +47,12 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
     """
 
     request_class: Type[BaseRequest[TRequestPayload]]
+    tracker_class: Type[BasePerformanceTracker[Any, TResult]]
+    tracker: BasePerformanceTracker[BaseRequest[Any], TResult]
 
     def __init__(self, mgr: ExchangeManager[TRequestPayload, TResponsePayload, TResult]) -> None:
         self._manager = mgr
+        self.tracker = self.tracker_class()
 
     async def get_result(
             self,
@@ -71,7 +79,8 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
             normalizer,
             result_validator.validate_result,
             message_validator,
-            timeout=timeout
+            self.tracker,
+            timeout,
         )
 
     @classproperty

--- a/trinity/protocol/common/handlers.py
+++ b/trinity/protocol/common/handlers.py
@@ -1,10 +1,12 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import (
     Any,
     Dict,
-    Set,
+    Iterable,
     Type,
 )
+
+from eth_utils import to_tuple
 
 from p2p.peer import BasePeer
 
@@ -16,19 +18,23 @@ from trinity.protocol.common.managers import (
 )
 
 
-class BaseExchangeHandler:
-    _exchange_managers: Set[ExchangeManager[Any, Any, Any]]
-
+class BaseExchangeHandler(ABC):
     @property
     @abstractmethod
-    def _exchanges(self) -> Dict[str, Type[BaseExchange[Any, Any, Any]]]:
+    def _exchange_config(self) -> Dict[str, Type[BaseExchange[Any, Any, Any]]]:
         pass
+
+    # https://github.com/python/mypy/issues/1362
+    @property  # type: ignore
+    @to_tuple
+    def exchanges(self) -> Iterable[Type[BaseExchange[Any, Any, Any]]]:
+        for key in self._exchange_config:
+            yield getattr(self, key)
 
     def __init__(self, peer: BasePeer) -> None:
         self._peer = peer
-        self._exchange_managers = set()
 
-        for attr, exchange_cls in self._exchanges.items():
+        for attr, exchange_cls in self._exchange_config.items():
             if hasattr(self, attr):
                 raise AttributeError(
                     "Unable to set manager on attribute `{0}` which is already "
@@ -36,9 +42,12 @@ class BaseExchangeHandler:
                 )
             manager: ExchangeManager[Any, Any, Any]
             manager = ExchangeManager(self._peer, exchange_cls.response_cmd_type, peer.cancel_token)
-            self._exchange_managers.add(manager)
             exchange = exchange_cls(manager)
             setattr(self, attr, exchange)
 
     def get_stats(self) -> Dict[str, str]:
-        return dict(exchange_manager.get_stats() for exchange_manager in self._exchange_managers)
+        return {
+            exchange.response_cmd_type.__name__: exchange.tracker.get_stats()
+            for exchange
+            in self.exchanges
+        }

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from typing import (  # noqa: F401 -- AsyncGenerator needed by mypy
+from typing import (
     Any,
     AsyncGenerator,
     Callable,
@@ -29,35 +29,11 @@ from p2p.service import BaseService
 from trinity.exceptions import AlreadyWaiting
 
 from .normalizers import BaseNormalizer
+from .trackers import BasePerformanceTracker
 from .types import (
     TResponsePayload,
     TResult,
 )
-
-
-class ResponseTimeTracker:
-
-    def __init__(self) -> None:
-        self.total_msgs = 0
-        self.total_items = 0
-        self.total_timeouts = 0
-        self.total_response_time = 0.0
-
-    def get_stats(self) -> str:
-        if not self.total_msgs:
-            return 'None'
-        avg_rtt = self.total_response_time / self.total_msgs
-        if not self.total_items:
-            per_item_rtt = 0.0
-        else:
-            per_item_rtt = self.total_response_time / self.total_items
-        return 'count=%d, items=%d, avg_rtt=%.2f, avg_time_per_item=%.5f, timeouts=%d' % (
-            self.total_msgs, self.total_items, avg_rtt, per_item_rtt, self.total_timeouts)
-
-    def add(self, time: float, size: int) -> None:
-        self.total_msgs += 1
-        self.total_items += size
-        self.total_response_time += time
 
 
 class ResponseCandidateStream(
@@ -87,13 +63,14 @@ class ResponseCandidateStream(
             token: CancelToken) -> None:
         super().__init__(token)
         self._peer = peer
-        self.response_times = ResponseTimeTracker()
         self.response_msg_type = response_msg_type
 
     async def payload_candidates(
             self,
             request: BaseRequest[TRequestPayload],
-            timeout: int = None) -> 'AsyncGenerator[TResponsePayload, None]':
+            tracker: BasePerformanceTracker[Any, Any],
+            *,
+            timeout: int = None) -> AsyncGenerator[TResponsePayload, None]:
         """
         Make a request and iterate through candidates for a valid response.
 
@@ -105,15 +82,20 @@ class ResponseCandidateStream(
 
         self._request(request)
         while self._is_pending():
-            yield await self._get_payload(timeout)
+            try:
+                yield await self._get_payload(timeout)
+            except TimeoutError:
+                tracker.record_timeout()
+                raise
 
     @property
     def response_msg_name(self) -> str:
         return self.response_msg_type.__name__
 
-    def complete_request(self, item_count: int) -> None:
+    def complete_request(self) -> None:
+        if self.pending_request is None:
+            self.logger.warning("`complete_request` was called when there was no pending request")
         self.pending_request = None
-        self.response_times.add(self.last_response_time, item_count)
 
     #
     # Service API
@@ -147,9 +129,6 @@ class ResponseCandidateStream(
         send_time, future = self.pending_request
         try:
             payload = await self.wait(future, timeout=timeout)
-        except TimeoutError:
-            self.response_times.total_timeouts += 1
-            raise
         finally:
             self.pending_request = None
 
@@ -192,9 +171,6 @@ class ResponseCandidateStream(
             _, future = self.pending_request
             future.set_exception(PeerConnectionLost("Pending request can't complete: peer is gone"))
 
-    def get_stats(self) -> Tuple[str, str]:
-        return (self.response_msg_name, self.response_times.get_stats())
-
     def __repr__(self) -> str:
         return f'<ResponseCandidateStream({self._peer!s}, {self.response_msg_type!r})>'
 
@@ -230,6 +206,7 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
             normalizer: BaseNormalizer[TResponsePayload, TResult],
             validate_result: Callable[[TResult], None],
             payload_validator: Callable[[TResponsePayload], None],
+            tracker: BasePerformanceTracker[BaseRequest[TRequestPayload], TResult],
             timeout: int = None) -> TResult:
 
         if not self.is_operational:
@@ -237,7 +214,7 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
 
         stream = self._response_stream
 
-        async for payload in stream.payload_candidates(request, timeout):
+        async for payload in stream.payload_candidates(request, tracker, timeout=timeout):
             try:
                 payload_validator(payload)
 
@@ -256,8 +233,12 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
                 )
                 continue
             else:
-                num_items = normalizer.get_num_results(result)
-                stream.complete_request(num_items)
+                tracker.record_response(
+                    time=stream.last_response_time,
+                    request=request,
+                    result=result,
+                )
+                stream.complete_request()
                 return result
 
         raise ValidationError("Manager is not pending a response, but no valid response received")
@@ -268,9 +249,3 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
         This service that needs to be running for calls to execute properly
         """
         return self._response_stream
-
-    def get_stats(self) -> Tuple[str, str]:
-        if self._response_stream is None:
-            return (self._response_command_type.__name__, 'Uninitialized')
-        else:
-            return self._response_stream.get_stats()

--- a/trinity/protocol/common/normalizers.py
+++ b/trinity/protocol/common/normalizers.py
@@ -28,14 +28,6 @@ class BaseNormalizer(ABC, Generic[TResponsePayload, TResult]):
         """
         raise NotImplementedError()
 
-    @staticmethod
-    @abstractmethod
-    def get_num_results(result: TResult) -> int:
-        """
-        Count the number of items returned in the result.
-        """
-        raise NotImplementedError()
-
 
 TPassthrough = TypeVar('TPassthrough', bound=PayloadType)
 
@@ -44,7 +36,3 @@ class NoopNormalizer(BaseNormalizer[TPassthrough, TPassthrough]):
     @staticmethod
     def normalize_result(message: TPassthrough) -> TPassthrough:
         return message
-
-    @staticmethod
-    def get_num_results(result: TPassthrough) -> int:
-        return len(result)

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -1,0 +1,115 @@
+from abc import ABC, abstractmethod
+import logging
+from typing import (
+    Any,
+    cast,
+    Generic,
+    Optional,
+    TypeVar,
+)
+
+from eth.tools.logging import TraceLogger
+
+from p2p.protocol import (
+    BaseRequest,
+)
+from .types import (
+    TResult,
+)
+
+
+TRequest = TypeVar('TRequest', bound=BaseRequest[Any])
+
+
+class BasePerformanceTracker(ABC, Generic[TRequest, TResult]):
+    def __init__(self) -> None:
+        self.total_msgs = 0
+        self.total_items = 0
+        self.total_missing = 0
+        self.total_timeouts = 0
+        self.total_response_time = 0.0
+
+    _logger: TraceLogger = None
+
+    @property
+    def logger(self) -> TraceLogger:
+        if self._logger is None:
+            self._logger = cast(
+                TraceLogger,
+                logging.getLogger(self.__module__ + '.' + self.__class__.__name__)
+            )
+        return self._logger
+
+    @abstractmethod
+    def _get_request_size(self, request: TRequest) -> Optional[int]:
+        """
+        The request size represents the number of *things* that were requested,
+        not taking into account the sizes of individual items.
+        """
+        pass
+
+    @abstractmethod
+    def _get_result_size(self, result: TResult) -> int:
+        """
+        The result size represents the number of *things* that were returned,
+        not taking into account the sizes of individual items.
+        """
+        pass
+
+    @abstractmethod
+    def _get_result_item_count(self, result: TResult) -> int:
+        """
+        The item count is intended to more accurately represent the size of the
+        response, taking into account things like the size of individual
+        response items such as the number of transactions in a block.
+        """
+        pass
+
+    def get_stats(self) -> str:
+        """
+        Return a human readable string representing the stats for this tracker.
+        """
+        if not self.total_msgs:
+            return 'None'
+        avg_rtt = self.total_response_time / self.total_msgs
+        if not self.total_items:
+            per_item_rtt = 0.0
+        else:
+            per_item_rtt = self.total_response_time / self.total_items
+        return 'count=%d  items=%d  avg_rtt=%.2f  avg_tpi=%.5f  timeouts=%d  missing=%d' % (
+            self.total_msgs,
+            self.total_items,
+            avg_rtt,
+            per_item_rtt,
+            self.total_timeouts,
+            self.total_missing
+        )
+
+    def record_timeout(self) -> None:
+        self.total_msgs += 1
+        self.total_timeouts += 1
+
+    def record_response(self,
+                        time: float,
+                        request: TRequest,
+                        result: TResult) -> None:
+        self.total_msgs += 1
+
+        request_size = self._get_request_size(request)
+        response_size = self._get_result_size(result)
+        num_items = self._get_result_item_count(result)
+
+        if request_size is None:
+            pass
+        elif response_size > request_size:
+            self.logger.warning(
+                "%s got oversized response.  requested: %d  received: %d",
+                type(self).__name__,
+                request_size,
+                response_size,
+            )
+        else:
+            self.total_missing += (request_size - response_size)
+
+        self.total_items += num_items
+        self.total_response_time += time

--- a/trinity/protocol/common/types.py
+++ b/trinity/protocol/common/types.py
@@ -21,6 +21,10 @@ TResponsePayload = TypeVar('TResponsePayload', bound=PayloadType)
 # The returned value at the end of an exchange
 TResult = TypeVar('TResult')
 
+# (
+#   (node_hash, node),
+#   ...
+# )
 NodeDataBundles = Tuple[Tuple[Hash32, bytes], ...]
 
 # (receipts_in_block_a, receipts_in_block_b, ...)

--- a/trinity/protocol/eth/exchanges.py
+++ b/trinity/protocol/eth/exchanges.py
@@ -38,6 +38,12 @@ from .requests import (
     GetNodeDataRequest,
     GetReceiptsRequest,
 )
+from .trackers import (
+    GetBlockHeadersTracker,
+    GetBlockBodiesTracker,
+    GetNodeDataTracker,
+    GetReceiptsTracker
+)
 from .validators import (
     GetBlockBodiesValidator,
     GetBlockHeadersValidator,
@@ -55,6 +61,7 @@ BaseGetBlockHeadersExchange = BaseExchange[
 class GetBlockHeadersExchange(BaseGetBlockHeadersExchange):
     _normalizer = NoopNormalizer[Tuple[BlockHeader, ...]]()
     request_class = GetBlockHeadersRequest
+    tracker_class = GetBlockHeadersTracker
 
     async def __call__(  # type: ignore
             self,
@@ -83,6 +90,7 @@ BaseNodeDataExchange = BaseExchange[Tuple[Hash32, ...], Tuple[bytes, ...], NodeD
 class GetNodeDataExchange(BaseNodeDataExchange):
     _normalizer = GetNodeDataNormalizer()
     request_class = GetNodeDataRequest
+    tracker_class = GetNodeDataTracker
 
     async def __call__(self, node_hashes: Tuple[Hash32, ...]) -> NodeDataBundles:  # type: ignore
         validator = GetNodeDataValidator(node_hashes)
@@ -93,6 +101,7 @@ class GetNodeDataExchange(BaseNodeDataExchange):
 class GetReceiptsExchange(BaseExchange[Tuple[Hash32, ...], ReceiptsByBlock, ReceiptsBundles]):
     _normalizer = ReceiptsNormalizer()
     request_class = GetReceiptsRequest
+    tracker_class = GetReceiptsTracker
 
     async def __call__(self, headers: Tuple[BlockHeader, ...]) -> ReceiptsBundles:  # type: ignore
         validator = ReceiptsValidator(headers)
@@ -113,6 +122,7 @@ BaseGetBlockBodiesExchange = BaseExchange[
 class GetBlockBodiesExchange(BaseGetBlockBodiesExchange):
     _normalizer = GetBlockBodiesNormalizer()
     request_class = GetBlockBodiesRequest
+    tracker_class = GetBlockBodiesTracker
 
     async def __call__(self, headers: Tuple[BlockHeader, ...]) -> BlockBodyBundles:  # type: ignore
         validator = GetBlockBodiesValidator(headers)

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -11,7 +11,7 @@ from .exchanges import (
 
 
 class ETHExchangeHandler(BaseExchangeHandler):
-    _exchanges = {
+    _exchange_config = {
         'get_block_bodies': GetBlockBodiesExchange,
         'get_block_headers': GetBlockHeadersExchange,
         'get_node_data': GetNodeDataExchange,

--- a/trinity/protocol/eth/normalizers.py
+++ b/trinity/protocol/eth/normalizers.py
@@ -30,10 +30,6 @@ class GetNodeDataNormalizer(BaseNormalizer[Tuple[bytes, ...], NodeDataBundles]):
         result = tuple(zip(node_keys, msg))
         return result
 
-    @staticmethod
-    def get_num_results(result: NodeDataBundles) -> int:
-        return len(result)
-
 
 class ReceiptsNormalizer(BaseNormalizer[ReceiptsByBlock, ReceiptsBundles]):
     is_normalization_slow = True
@@ -42,10 +38,6 @@ class ReceiptsNormalizer(BaseNormalizer[ReceiptsByBlock, ReceiptsBundles]):
     def normalize_result(message: ReceiptsByBlock) -> ReceiptsBundles:
         trie_roots_and_data = tuple(map(make_trie_root_and_nodes, message))
         return tuple(zip(message, trie_roots_and_data))
-
-    @staticmethod
-    def get_num_results(result: ReceiptsBundles) -> int:
-        return sum(len(item) for item in result)
 
 
 class GetBlockBodiesNormalizer(BaseNormalizer[Tuple[BlockBody, ...], BlockBodyBundles]):
@@ -64,7 +56,3 @@ class GetBlockBodiesNormalizer(BaseNormalizer[Tuple[BlockBody, ...], BlockBodyBu
 
         body_bundles = tuple(zip(msg, transaction_roots_and_trie_data, uncles_hashes))
         return body_bundles
-
-    @staticmethod
-    def get_num_results(result: BlockBodyBundles) -> int:
-        return len(result)

--- a/trinity/protocol/eth/requests.py
+++ b/trinity/protocol/eth/requests.py
@@ -28,6 +28,11 @@ from .commands import (
 
 
 class HeaderRequest(BaseHeaderRequest):
+    """
+    TODO: this should be removed from this module.  It exists to allow
+    `p2p.handlers.PeerRequestHandler` to have a common API between light and
+    full chains so maybe it should go there
+    """
     max_size = MAX_HEADERS_FETCH
 
     def __init__(self,

--- a/trinity/protocol/eth/trackers.py
+++ b/trinity/protocol/eth/trackers.py
@@ -1,0 +1,88 @@
+from typing import (
+    Optional,
+    Tuple,
+)
+
+from eth.rlp.headers import BlockHeader
+
+from trinity.protocol.common.trackers import BasePerformanceTracker
+from trinity.protocol.common.types import (
+    BlockBodyBundles,
+    NodeDataBundles,
+    ReceiptsBundles,
+)
+from trinity.utils.headers import sequence_builder
+
+from .requests import (
+    GetBlockBodiesRequest,
+    GetBlockHeadersRequest,
+    GetNodeDataRequest,
+    GetReceiptsRequest,
+)
+
+
+BaseGetBlockHeadersTracker = BasePerformanceTracker[
+    GetBlockHeadersRequest,
+    Tuple[BlockHeader, ...],
+]
+
+
+class GetBlockHeadersTracker(BaseGetBlockHeadersTracker):
+    def _get_request_size(self, request: GetBlockHeadersRequest) -> int:
+        payload = request.command_payload
+        if isinstance(payload['block_number_or_hash'], int):
+            return len(sequence_builder(
+                start_number=payload['block_number_or_hash'],
+                max_length=payload['max_headers'],
+                skip=payload['skip'],
+                reverse=payload['reverse'],
+            ))
+        else:
+            return None
+
+    def _get_result_size(self, result: Tuple[BlockHeader, ...]) -> Optional[int]:
+        return len(result)
+
+    def _get_result_item_count(self, result: Tuple[BlockHeader, ...]) -> int:
+        return len(result)
+
+
+class GetBlockBodiesTracker(BasePerformanceTracker[GetBlockBodiesRequest, BlockBodyBundles]):
+    def _get_request_size(self, request: GetBlockBodiesRequest) -> Optional[int]:
+        return len(request.command_payload)
+
+    def _get_result_size(self, result: BlockBodyBundles) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: BlockBodyBundles) -> int:
+        return sum(
+            len(body.uncles) + len(body.transactions)
+            for body, trie_data, uncles_hash
+            in result
+        )
+
+
+class GetReceiptsTracker(BasePerformanceTracker[GetReceiptsRequest, ReceiptsBundles]):
+    def _get_request_size(self, request: GetReceiptsRequest) -> Optional[int]:
+        return len(request.command_payload)
+
+    def _get_result_size(self, result: ReceiptsBundles) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: ReceiptsBundles) -> int:
+        return sum(
+            len(receipts)
+            for receipts, trie_data
+            in result
+        )
+
+
+class GetNodeDataTracker(BasePerformanceTracker[GetNodeDataRequest, NodeDataBundles]):
+    def _get_request_size(self, request: GetNodeDataRequest) -> Optional[int]:
+        return len(request.command_payload)
+
+    def _get_result_size(self, result: NodeDataBundles) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: NodeDataBundles) -> int:
+        return len(result)

--- a/trinity/protocol/les/exchanges.py
+++ b/trinity/protocol/les/exchanges.py
@@ -21,6 +21,9 @@ from .normalizers import (
 from .requests import (
     GetBlockHeadersRequest,
 )
+from .trackers import (
+    GetBlockHeadersTracker,
+)
 from .validators import (
     GetBlockHeadersValidator,
     match_payload_request_id,
@@ -35,6 +38,7 @@ LESExchange = BaseExchange[Dict[str, Any], Dict[str, Any], TResult]
 class GetBlockHeadersExchange(LESExchange[Tuple[BlockHeader, ...]]):
     _normalizer = BlockHeadersNormalizer()
     request_class = GetBlockHeadersRequest
+    tracker_class = GetBlockHeadersTracker
 
     async def __call__(  # type: ignore
             self,

--- a/trinity/protocol/les/handlers.py
+++ b/trinity/protocol/les/handlers.py
@@ -6,7 +6,7 @@ from .exchanges import GetBlockHeadersExchange
 
 
 class LESExchangeHandler(BaseExchangeHandler):
-    _exchanges = {
+    _exchange_config = {
         'get_block_headers': GetBlockHeadersExchange,
     }
 

--- a/trinity/protocol/les/normalizers.py
+++ b/trinity/protocol/les/normalizers.py
@@ -18,7 +18,3 @@ class BlockHeadersNormalizer(LESNormalizer[Tuple[BlockHeader, ...]]):
     def normalize_result(message: Dict[str, Any]) -> Tuple[BlockHeader, ...]:
         result = message['headers']
         return result
-
-    @staticmethod
-    def get_num_results(result: Tuple[BlockHeader, ...]) -> int:
-        return len(result)

--- a/trinity/protocol/les/trackers.py
+++ b/trinity/protocol/les/trackers.py
@@ -1,0 +1,39 @@
+from typing import (
+    Optional,
+    Tuple,
+)
+
+from eth.rlp.headers import BlockHeader
+
+from trinity.protocol.common.trackers import BasePerformanceTracker
+from trinity.utils.headers import sequence_builder
+
+from .requests import (
+    GetBlockHeadersRequest,
+)
+
+
+BaseGetBlockHeadersTracker = BasePerformanceTracker[
+    GetBlockHeadersRequest,
+    Tuple[BlockHeader, ...],
+]
+
+
+class GetBlockHeadersTracker(BaseGetBlockHeadersTracker):
+    def _get_request_size(self, request: GetBlockHeadersRequest) -> Optional[int]:
+        payload = request.command_payload['query']
+        if isinstance(payload['block_number_or_hash'], int):
+            return len(sequence_builder(
+                start_number=payload['block_number_or_hash'],
+                max_length=payload['max_headers'],
+                skip=payload['skip'],
+                reverse=payload['reverse'],
+            ))
+        else:
+            return None
+
+    def _get_result_size(self, result: Tuple[BlockHeader, ...]) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: Tuple[BlockHeader, ...]) -> int:
+        return len(result)


### PR DESCRIPTION
### What was wrong?

In the peer Exchange api, currently the normalizer classes are required to implement the logic for computing the item count.  This seems wrong.

### How was it fixed?

New tracker classes that handle this logic.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
