### PR TITLE
Docs: Use automodule instead of autofunction to workaround RTD issue

### DIFF
--- a/docs/api/eth/tools/api.tools.builders.rst
+++ b/docs/api/eth/tools/api.tools.builders.rst
@@ -16,23 +16,14 @@ Constructing Chain Classes
 
 The following utilities are provided to assist with constructing a chain class.
 
-
-.. autofunction:: eth.tools.builder.chain.fork_at
-
-
-.. autofunction:: eth.tools.builder.chain.dao_fork_at
-
-
-.. autofunction:: eth.tools.builder.chain.disable_dao_fork
-
-
-.. autofunction:: eth.tools.builder.chain.enable_pow_mining
-
-
-.. autofunction:: eth.tools.builder.chain.disable_pow_check
-
-
-.. autofunction:: eth.tools.builder.chain.name
+.. automodule:: eth.tools.builder.chain
+  :noindex:
+  :members: fork_at,
+            dao_fork_at,
+            disable_dao_fork,
+            enable_pow_mining,
+            disable_pow_check,
+            name
 
 
 Initializing Chains
@@ -41,7 +32,9 @@ Initializing Chains
 The following utilities are provided to assist with initializing a chain into
 the genesis state.
 
-.. autofunction:: eth.tools.builder.chain.genesis
+.. automodule:: eth.tools.builder.chain
+  :noindex:
+  :members: genesis
 
 
 Building Chains
@@ -50,23 +43,12 @@ Building Chains
 The following utilities are provided to assist with building out chains of
 blocks.
 
-
-.. autofunction:: eth.tools.builder.chain.copy
-
-
-.. autofunction:: eth.tools.builder.chain.import_block
-
-
-.. autofunction:: eth.tools.builder.chain.import_blocks
-
-
-.. autofunction:: eth.tools.builder.chain.mine_block
-
-
-.. autofunction:: eth.tools.builder.chain.mine_blocks
-
-
-.. autofunction:: eth.tools.builder.chain.chain_split
-
-
-.. autofunction:: eth.tools.builder.chain.at_block_number
+.. automodule:: eth.tools.builder.chain
+  :noindex:
+  :members: copy,
+            import_block,
+            import_blocks,
+            mine_block,
+            mine_blocks,
+            chain_split,
+            at_block_number

--- a/docs/api/eth/tools/api.tools.fixtures.rst
+++ b/docs/api/eth/tools/api.tools.fixtures.rst
@@ -60,129 +60,138 @@ sequence of functions.
     :func:`~eth.tools.fixtures.expect`, expect to be passed a dictionary
     as their single argument and return an updated version of the dictionary.
 
-
-.. autofunction:: eth.tools.fixtures.fillers.common.setup_main_filler
-
-    This function kicks off the filler generation process by creating the general filler scaffold with
-    a test name and general information about the testing environment.
-
-    For tests for the main chain, the `environment` parameter is expected to be a dictionary with some
-    or all of the following keys:
-
-    +------------------------+---------------------------------+
-    | key                    | description                     |
-    +========================+=================================+
-    | ``"currentCoinbase"``  | the coinbase address            |
-    +------------------------+---------------------------------+
-    | ``"currentNumber"``    | the block number                |
-    +------------------------+---------------------------------+
-    | ``"previousHash"``     | the hash of the parent block    |
-    +------------------------+---------------------------------+
-    | ``"currentDifficulty"``| the block's difficulty          |
-    +------------------------+---------------------------------+
-    | ``"currentGasLimit"``  | the block's gas limit           |
-    +------------------------+---------------------------------+
-    | ``"currentTimestamp"`` | the timestamp of the block      |
-    +------------------------+---------------------------------+
+.. automodule:: eth.tools.fixtures.fillers
+  :noindex:
+  :members: setup_main_filler
 
 
-.. autofunction:: eth.tools.fixtures.fillers.pre_state
+This function kicks off the filler generation process by creating the general filler scaffold with
+a test name and general information about the testing environment.
 
-    This function specifies the state prior to the test execution. Multiple invocations don't override
-    the state but extend it instead.
+For tests for the main chain, the `environment` parameter is expected to be a dictionary with some
+or all of the following keys:
 
-    In general, the elements of `state_definitions` are nested dictionaries of the following form:
++------------------------+---------------------------------+
+| key                    | description                     |
++========================+=================================+
+| ``"currentCoinbase"``  | the coinbase address            |
++------------------------+---------------------------------+
+| ``"currentNumber"``    | the block number                |
++------------------------+---------------------------------+
+| ``"previousHash"``     | the hash of the parent block    |
++------------------------+---------------------------------+
+| ``"currentDifficulty"``| the block's difficulty          |
++------------------------+---------------------------------+
+| ``"currentGasLimit"``  | the block's gas limit           |
++------------------------+---------------------------------+
+| ``"currentTimestamp"`` | the timestamp of the block      |
++------------------------+---------------------------------+
 
-    .. code-block:: python
+.. automodule:: eth.tools.fixtures.fillers
+  :noindex:
+  :members: pre_state
 
-        {
-            address: {
-                "nonce": <account nonce>,
-                "balance": <account balance>,
-                "code": <account code>,
-                "storage": {
-                    <storage slot>: <storage value>
-                }
+
+This function specifies the state prior to the test execution. Multiple invocations don't override
+the state but extend it instead.
+
+In general, the elements of `state_definitions` are nested dictionaries of the following form:
+
+.. code-block:: python
+
+    {
+        address: {
+            "nonce": <account nonce>,
+            "balance": <account balance>,
+            "code": <account code>,
+            "storage": {
+                <storage slot>: <storage value>
             }
         }
+    }
 
-    To avoid unnecessary nesting especially if only few fields per account are specified, the following
-    and similar formats are possible as well:
+To avoid unnecessary nesting especially if only few fields per account are specified, the following
+and similar formats are possible as well:
 
-    .. code-block:: python
+.. code-block:: python
 
-        (address, "balance", <account balance>)
-        (address, "storage", <storage slot>, <storage value>)
-        (address, "storage", {<storage slot>: <storage value>})
-        (address, {"balance", <account balance>})
+    (address, "balance", <account balance>)
+    (address, "storage", <storage slot>, <storage value>)
+    (address, "storage", {<storage slot>: <storage value>})
+    (address, {"balance", <account balance>})
 
-
-.. autofunction:: eth.tools.fixtures.fillers.execution
-
-    For VM tests, this function specifies the code that is being run as well as the current state of
-    the EVM. State tests don't support this object. The parameter is a dictionary specifying some or
-    all of the following keys:
-
-    +--------------------+------------------------------------------------------------+
-    |  key               | description                                                |
-    +====================+============================================================+
-    | ``"address"``      | the address of the account executing the code              |
-    +--------------------+------------------------------------------------------------+
-    | ``"caller"``       | the caller address                                         |
-    +--------------------+------------------------------------------------------------+
-    | ``"origin"``       | the origin address (defaulting to the caller address)      |
-    +--------------------+------------------------------------------------------------+
-    | ``"value"``        | the value of the call                                      |
-    +--------------------+------------------------------------------------------------+
-    | ``"data"``         | the data passed with the call                              |
-    +--------------------+------------------------------------------------------------+
-    | ``"gasPrice"``     | the gas price of the call                                  |
-    +--------------------+------------------------------------------------------------+
-    | ``"gas"``          | the amount of gas allocated for the call                   |
-    +--------------------+------------------------------------------------------------+
-    | ``"code"``         | the bytecode to execute                                    |
-    +--------------------+------------------------------------------------------------+
-    | ``"vyperLLLCode"`` | the code in Vyper LLL (compiled to bytecode automatically) |
-    +--------------------+------------------------------------------------------------+
+.. automodule:: eth.tools.fixtures.fillers
+  :noindex:
+  :members: execution
 
 
-.. autofunction:: eth.tools.fixtures.fillers.expect
+For VM tests, this function specifies the code that is being run as well as the current state of
+the EVM. State tests don't support this object. The parameter is a dictionary specifying some or
+all of the following keys:
 
-    This specifies the expected result of the test.
++--------------------+------------------------------------------------------------+
+|  key               | description                                                |
++====================+============================================================+
+| ``"address"``      | the address of the account executing the code              |
++--------------------+------------------------------------------------------------+
+| ``"caller"``       | the caller address                                         |
++--------------------+------------------------------------------------------------+
+| ``"origin"``       | the origin address (defaulting to the caller address)      |
++--------------------+------------------------------------------------------------+
+| ``"value"``        | the value of the call                                      |
++--------------------+------------------------------------------------------------+
+| ``"data"``         | the data passed with the call                              |
++--------------------+------------------------------------------------------------+
+| ``"gasPrice"``     | the gas price of the call                                  |
++--------------------+------------------------------------------------------------+
+| ``"gas"``          | the amount of gas allocated for the call                   |
++--------------------+------------------------------------------------------------+
+| ``"code"``         | the bytecode to execute                                    |
++--------------------+------------------------------------------------------------+
+| ``"vyperLLLCode"`` | the code in Vyper LLL (compiled to bytecode automatically) |
++--------------------+------------------------------------------------------------+
 
-    For state tests, multiple expectations can be given, differing in the transaction data, gas
-    limit, and value, in the applicable networks, and as a result also in the post state. VM tests
-    support only a single expectation with no specified network and no transaction (here, its role is
-    played by :func:`~eth.tools.fixtures.fillers.execution`).
 
-    * ``post_state`` is a list of state definition in the same form as expected
-      by :func:`~eth.tools.fixtures.fillers.pre_state`. State items that are
-      not set explicitly default to their pre state.
+.. automodule:: eth.tools.fixtures.fillers
+  :noindex:
+  :members: expect
 
-    * ``networks`` defines the forks under which the expectation is applicable. It should be a sublist of
-      the following identifiers (also available in `ALL_FORKS`):
 
-      * ``"Frontier"``
-      * ``"Homestead"``
-      * ``"EIP150"``
-      * ``"EIP158"``
-      * ``"Byzantium"``
+This specifies the expected result of the test.
 
-    * ``transaction`` is a dictionary coming in two variants. For the main shard:
+For state tests, multiple expectations can be given, differing in the transaction data, gas
+limit, and value, in the applicable networks, and as a result also in the post state. VM tests
+support only a single expectation with no specified network and no transaction (here, its role is
+played by :func:`~eth.tools.fixtures.fillers.execution`).
 
-      +----------------+-------------------------------+
-      | key            | description                   |
-      +================+===============================+
-      | ``"data"``     | the transaction data,         |
-      +----------------+-------------------------------+
-      | ``"gasLimit"`` | the transaction gas limit,    |
-      +----------------+-------------------------------+
-      | ``"gasPrice"`` | the gas price,                |
-      +----------------+-------------------------------+
-      | ``"nonce"``    | the transaction nonce,        |
-      +----------------+-------------------------------+
-      | ``"value"``    | the transaction value         |
-      +----------------+-------------------------------+
+* ``post_state`` is a list of state definition in the same form as expected
+    by :func:`~eth.tools.fixtures.fillers.pre_state`. State items that are
+    not set explicitly default to their pre state.
 
-    In addition, one should specify either the signature itself (via keys ``"v"``, ``"r"``, and ``"s"``) or
-    a private key used for signing (via ``"secretKey"``).
+* ``networks`` defines the forks under which the expectation is applicable. It should be a sublist of
+    the following identifiers (also available in `ALL_FORKS`):
+
+    * ``"Frontier"``
+    * ``"Homestead"``
+    * ``"EIP150"``
+    * ``"EIP158"``
+    * ``"Byzantium"``
+
+* ``transaction`` is a dictionary coming in two variants. For the main shard:
+
+    +----------------+-------------------------------+
+    | key            | description                   |
+    +================+===============================+
+    | ``"data"``     | the transaction data,         |
+    +----------------+-------------------------------+
+    | ``"gasLimit"`` | the transaction gas limit,    |
+    +----------------+-------------------------------+
+    | ``"gasPrice"`` | the gas price,                |
+    +----------------+-------------------------------+
+    | ``"nonce"``    | the transaction nonce,        |
+    +----------------+-------------------------------+
+    | ``"value"``    | the transaction value         |
+    +----------------+-------------------------------+
+
+In addition, one should specify either the signature itself (via keys ``"v"``, ``"r"``, and ``"s"``) or
+a private key used for signing (via ``"secretKey"``).


### PR DESCRIPTION
### What was wrong?

Live docs are broken (#1222)

### How was it fixed?

This achieves the same visuals but doesn't use `autofunction` which I believe is causing the issue with the live docs.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://38.media.tumblr.com/8261d1419932c19098b0aa753924b9e9/tumblr_mz7vcs2wpe1su9uo7o1_500.gif)
