### PR TITLE
Update ethereum/tests fixtures

### DIFF
--- a/eth/precompiles/modexp.py
+++ b/eth/precompiles/modexp.py
@@ -35,7 +35,7 @@ def _compute_complexity(length):
             length ** 2 // 4 + 96 * length - 3072
         )
     else:
-        return 2 ** 2 // 16 + 480 * length - 199680
+        return length ** 2 // 16 + 480 * length - 199680
 
 
 def _extract_lengths(data):

--- a/tests/core/vm/test_modexp_precompile.py
+++ b/tests/core/vm/test_modexp_precompile.py
@@ -41,11 +41,11 @@ EIP198_VECTOR_C = decode_hex(
         (EIP198_VECTOR_A, 13056),
         (
             EIP198_VECTOR_C,
-            708647586132375115992254428253169996062012306153720251921480414128428353393856280,
+            10684346944173007063723051170445283632835119638284563472873463025465780712173320789629146724657549280936306536701227228889744512638312451529980055895215896,  # noqa: E501
         ),
     ),
 )
-def test_modexp_gas_fee_calcultation(data, expected):
+def test_modexp_gas_fee_calculation(data, expected):
     actual = _compute_modexp_gas_fee(data)
     assert actual == expected
 

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -32,17 +32,33 @@ ROOT_PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 BASE_FIXTURE_PATH = os.path.join(ROOT_PROJECT_DIR, 'fixtures', 'BlockchainTests')
 
 
+# These are tests that are thought to be incorrect or buggy upstream,
+# at the commit currently checked out in submodule `fixtures`.
+# Ideally, this list should be empty.
+# WHEN ADDING ENTRIES, ALWAYS PROVIDE AN EXPLANATION!
+INCORRECT_UPSTREAM_TESTS = {
+    # The test considers a "synthetic" scenario (the state described there can't
+    # be arrived at using regular consensus rules).
+    # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
+    # The result is in conflict with the yellow-paper:
+    # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418800369
+    ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_Byzantium'),  # noqa: E501
+}
+
+
 def blockchain_fixture_mark_fn(fixture_path, fixture_name):
     if fixture_path.startswith('bcExploitTest'):
         return pytest.mark.skip("Exploit tests are slow")
     elif fixture_path == 'bcWalletTest/walletReorganizeOwners.json':
         return pytest.mark.skip("Wallet owner reorganization tests are slow")
+    elif (fixture_path, fixture_name) in INCORRECT_UPSTREAM_TESTS:
+        return pytest.mark.xfail(reason="Listed in INCORRECT_UPSTREAM_TESTS.")
 
 
 def blockchain_fixture_ignore_fn(fixture_path, fixture_name):
     if fixture_path.startswith('GeneralStateTests'):
         # General state tests are also exported as blockchain tests.  We
-        # skip them here so we don't run them twice"
+        # skip them here so we don't run them twice
         return True
 
 

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -138,6 +138,12 @@ SLOWEST_TESTS = {
 # Ideally, this list should be empty.
 # WHEN ADDING ENTRIES, ALWAYS PROVIDE AN EXPLANATION!
 INCORRECT_UPSTREAM_TESTS = {
+    # The test considers a "synthetic" scenario (the state described there can't
+    # be arrived at using regular consensus rules).
+    # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
+    # The result is in conflict with the yellow-paper:
+    # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418800369
+    ('stRevertTest/RevertInCreateInInit.json', 'RevertInCreateInInit', 'Byzantium', 0),
 }
 
 

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -133,6 +133,19 @@ SLOWEST_TESTS = {
 }
 
 
+# These are tests that are thought to be incorrect or buggy upstream,
+# at the commit currently checked out in submodule `fixtures`.
+# Ideally, this list should be empty.
+# WHEN ADDING ENTRIES, ALWAYS PROVIDE AN EXPLANATION!
+INCORRECT_UPSTREAM_TESTS = {
+    # Upstream seems to specify that the precompile call fails, but `py-evm`
+    # handles it just fine.
+    # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-417351843
+    # * https://github.com/ethereum/tests/pull/405#issuecomment-417855812
+    ('stReturnDataTest/modexp_modsize0_returndatasize.json', 'modexp_modsize0_returndatasize', 'Byzantium', 4),  # noqa: E501
+}
+
+
 def mark_statetest_fixtures(fixture_path, fixture_key, fixture_fork, fixture_index):
     fixture_id = (fixture_path, fixture_key, fixture_fork, fixture_index)
     if fixture_path.startswith('stTransactionTest/zeroSigTransa'):
@@ -144,6 +157,8 @@ def mark_statetest_fixtures(fixture_path, fixture_key, fixture_fork, fixture_ind
             return pytest.mark.skip("Skipping slow test")
     elif fixture_path.startswith('stQuadraticComplexityTest'):
         return pytest.mark.skip("Skipping slow test")
+    elif fixture_id in INCORRECT_UPSTREAM_TESTS:
+        return pytest.mark.xfail(reason="Listed in INCORRECT_UPSTREAM_TESTS.")
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -138,11 +138,6 @@ SLOWEST_TESTS = {
 # Ideally, this list should be empty.
 # WHEN ADDING ENTRIES, ALWAYS PROVIDE AN EXPLANATION!
 INCORRECT_UPSTREAM_TESTS = {
-    # Upstream seems to specify that the precompile call fails, but `py-evm`
-    # handles it just fine.
-    # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-417351843
-    # * https://github.com/ethereum/tests/pull/405#issuecomment-417855812
-    ('stReturnDataTest/modexp_modsize0_returndatasize.json', 'modexp_modsize0_returndatasize', 'Byzantium', 4),  # noqa: E501
 }
 
 

--- a/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -92,6 +92,19 @@ SLOW_TESTS = (
     'DelegateCallSpam_EIP150',
 )
 
+# These are tests that are thought to be incorrect or buggy upstream,
+# at the commit currently checked out in submodule `fixtures`.
+# Ideally, this list should be empty.
+# WHEN ADDING ENTRIES, ALWAYS PROVIDE AN EXPLANATION!
+INCORRECT_UPSTREAM_TESTS = {
+    # The test considers a "synthetic" scenario (the state described there can't
+    # be arrived at using regular consensus rules).
+    # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418775512
+    # The result is in conflict with the yellow-paper:
+    # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418800369
+    ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_Byzantium'),  # noqa: E501
+}
+
 RPC_STATE_NORMALIZERS = {
     'balance': remove_leading_zeros,
     'code': empty_to_0x,
@@ -162,6 +175,8 @@ def blockchain_fixture_mark_fn(fixture_path, fixture_name):
             if not should_run_slow_tests():
                 return pytest.mark.skip("skipping slow test on a quick run")
             break
+    if (fixture_path, fixture_name) in INCORRECT_UPSTREAM_TESTS:
+        return pytest.mark.xfail(reason="Listed in INCORRECT_UPSTREAM_TESTS.")
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
### What was wrong?

See issue #1152, in particular https://github.com/ethereum/py-evm/issues/1152#issuecomment-417284202.

* The `ethereum/tests` git submodule in `fixtures` is rather old:
  * 2017-12-08 - https://github.com/ethereum/tests/commit/47b09f42c0681548a00da5ab1c98808b368af49a - merge of PR https://github.com/ethereum/tests/pull/374.
* `py-evm` PR #1181 enables `ConstantinopleVM` testing with a much newer test set; having these changes "lumped together" makes it harder to attribute CI run failures to one or the other, at least at a cursory look.


### How was it fixed?

Incrementally:

* [Updates the submodule](https://github.com/ethereum/py-evm/pull/1224/commits/3fef4bd3d596eb4a16fc63ae4c6795bfaa03b641) to:
  * 2018-01-22 - https://github.com/ethereum/tests/commit/db8ae9de91c303caad3eb9354015c07a0ec3adc3 - merge of PR https://github.com/ethereum/tests/pull/401
  * all tests pass without `py-evm` modifications.
* [Updates the submodule](https://github.com/ethereum/py-evm/pull/1224/commits/b11a7b8887828d397aeb67dbcbc9e549f4ee1e81) to:
  * 2018-01-30 - https://github.com/ethereum/tests/commit/9b1f07c58a70d1b17c4489c49eb9bebf4a27d290 - merge of PR https://github.com/ethereum/tests/pull/405
  * [applies fix for complexity calculation](https://github.com/ethereum/py-evm/pull/1224/commits/7752f05d1df95e519d2daab3b971678d7244b3c6) - calling the `MODEXP` precompile was too cheap.
* [Updates the submodule](https://github.com/ethereum/py-evm/pull/1224/commits/11d61b005f73eef3f6ee441228b13ff9b97fa794) to:
  * 2018-03-01 - https://github.com/ethereum/tests/commit/61185fe4b8762118fe9ee318539683b47cb04ed6 - merge of PR https://github.com/ethereum/tests/pull/419
  * marks the upstream test `RevertInCreateInInit` as `xfail`, for both `StateTests` and `BlockchainTests`.
* [Updates the submodule](https://github.com/ethereum/py-evm/pull/1224/commits/fd26ec65c725d40aaab11e8d87ca8c14a56ef45d) to:
  * 2018-05-11 - https://github.com/ethereum/tests/commit/f4faae91c5ba192c3fd9b8cf418c24e627786312 - merge of PR https://github.com/ethereum/tests/pull/444
  * all tests still pass.


### WIP: current state

- [x] Evaluated PR https://github.com/ethereum/tests/pull/405: a particularly large modulus length in data to the `MODEXP` precompile. `py-evm` calculated the gas price wrong (this is _not_ the same bug Parity had). Discussion starts at https://github.com/ethereum/py-evm/pull/1224#issuecomment-417351843.
- [x] Evaluated PR https://github.com/ethereum/tests/pull/419: "revert in `CREATE` in init code, followed by returndatasize/copy". Discussion starts at https://github.com/ethereum/py-evm/pull/1224#issuecomment-418408696.
- [x] Took a glance at where the remaining 74 failures originate from - seemingly https://github.com/ethereum/tests/pull/437. Looks like it changed the fixture JSON generator; perhaps the file format, too. Best tackled in a follow-up PR.


### Cute Animal Picture

"Love this fixture..."

![Cat hugs lamp shade](https://i.imgur.com/E6jbC3G.png)

Source: [eleejhon @ imgur](https://imgur.com/gallery/E6jbC3G)