### PR TITLE
Expand peer stats tracking

### DIFF
--- a/tests/trinity/core/p2p-proto/test_stats.py
+++ b/tests/trinity/core/p2p-proto/test_stats.py
@@ -92,7 +92,8 @@ async def test_eth_get_headers_stats(eth_peer_and_remote):
 
         assert stats['BlockHeaders'].startswith('msgs={0}  items={0}  rtt='.format(idx))
         assert 'timeouts=0' in stats['BlockHeaders']
-        assert 'missing=0' in stats['BlockHeaders']
+        assert 'quality=' in stats['BlockHeaders']
+        assert 'ips=' in stats['BlockHeaders']
 
 
 @pytest.mark.asyncio
@@ -116,4 +117,5 @@ async def test_les_get_headers_stats(les_peer_and_remote):
 
         assert stats['BlockHeaders'].startswith('msgs={0}  items={0}  rtt='.format(idx))
         assert 'timeouts=0' in stats['BlockHeaders']
-        assert 'missing=0' in stats['BlockHeaders']
+        assert 'quality=' in stats['BlockHeaders']
+        assert 'ips=' in stats['BlockHeaders']

--- a/tests/trinity/core/p2p-proto/test_stats.py
+++ b/tests/trinity/core/p2p-proto/test_stats.py
@@ -90,7 +90,7 @@ async def test_eth_get_headers_stats(eth_peer_and_remote):
 
         stats = peer.requests.get_stats()
 
-        assert stats['BlockHeaders'].startswith('count={0}  items={0}  avg_rtt='.format(idx))
+        assert stats['BlockHeaders'].startswith('msgs={0}  items={0}  rtt='.format(idx))
         assert 'timeouts=0' in stats['BlockHeaders']
         assert 'missing=0' in stats['BlockHeaders']
 
@@ -114,6 +114,6 @@ async def test_les_get_headers_stats(les_peer_and_remote):
 
         stats = peer.requests.get_stats()
 
-        assert stats['BlockHeaders'].startswith('count={0}  items={0}  avg_rtt='.format(idx))
+        assert stats['BlockHeaders'].startswith('msgs={0}  items={0}  rtt='.format(idx))
         assert 'timeouts=0' in stats['BlockHeaders']
         assert 'missing=0' in stats['BlockHeaders']

--- a/tests/trinity/core/p2p-proto/test_stats.py
+++ b/tests/trinity/core/p2p-proto/test_stats.py
@@ -71,7 +71,7 @@ async def les_peer_and_remote(request, event_loop):
 async def test_eth_get_headers_empty_stats(eth_peer_and_remote):
     peer, remote = eth_peer_and_remote
     stats = peer.requests.get_stats()
-    assert all(status == 'Uninitialized' for status in stats.values())
+    assert all(status == 'None' for status in stats.values())
     assert 'BlockHeaders' in stats.keys()
 
 
@@ -90,8 +90,9 @@ async def test_eth_get_headers_stats(eth_peer_and_remote):
 
         stats = peer.requests.get_stats()
 
-        assert stats['BlockHeaders'].startswith('count={0}, items={0}, avg_rtt='.format(idx))
-        assert stats['BlockHeaders'].endswith(', timeouts=0')
+        assert stats['BlockHeaders'].startswith('count={0}  items={0}  avg_rtt='.format(idx))
+        assert 'timeouts=0' in stats['BlockHeaders']
+        assert 'missing=0' in stats['BlockHeaders']
 
 
 @pytest.mark.asyncio
@@ -113,5 +114,6 @@ async def test_les_get_headers_stats(les_peer_and_remote):
 
         stats = peer.requests.get_stats()
 
-        assert stats['BlockHeaders'].startswith('count={0}, items={0}, avg_rtt='.format(idx))
-        assert stats['BlockHeaders'].endswith(', timeouts=0')
+        assert stats['BlockHeaders'].startswith('count={0}  items={0}  avg_rtt='.format(idx))
+        assert 'timeouts=0' in stats['BlockHeaders']
+        assert 'missing=0' in stats['BlockHeaders']

--- a/trinity/protocol/common/constants.py
+++ b/trinity/protocol/common/constants.py
@@ -1,0 +1,2 @@
+# The default timeout for a round trip API request and response from a peer.
+ROUND_TRIP_TIMEOUT = 20.0

--- a/trinity/protocol/common/exchanges.py
+++ b/trinity/protocol/common/exchanges.py
@@ -48,7 +48,7 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
 
     request_class: Type[BaseRequest[TRequestPayload]]
     tracker_class: Type[BasePerformanceTracker[Any, TResult]]
-    tracker: BasePerformanceTracker[BaseRequest[Any], TResult]
+    tracker: BasePerformanceTracker[BaseRequest[TRequestPayload], TResult]
 
     def __init__(self, mgr: ExchangeManager[TRequestPayload, TResponsePayload, TResult]) -> None:
         self._manager = mgr
@@ -60,7 +60,7 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
             normalizer: BaseNormalizer[TResponsePayload, TResult],
             result_validator: BaseValidator[TResult],
             payload_validator: Callable[[TRequestPayload, TResponsePayload], None],
-            timeout: int = None) -> TResult:
+            timeout: float = None) -> TResult:
         """
         This is a light convenience wrapper around the ExchangeManager's get_result() method.
 

--- a/trinity/protocol/common/exchanges.py
+++ b/trinity/protocol/common/exchanges.py
@@ -14,7 +14,12 @@ from p2p.protocol import (
 )
 
 from trinity.utils.decorators import classproperty
-from .managers import ExchangeManager
+from .trackers import (
+    BasePerformanceTracker,
+)
+from .managers import (
+    ExchangeManager,
+)
 from .normalizers import BaseNormalizer
 from .types import (
     TResponsePayload,
@@ -42,9 +47,12 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
     """
 
     request_class: Type[BaseRequest[TRequestPayload]]
+    tracker_class: Type[BasePerformanceTracker[Any, TResult]]
+    tracker: BasePerformanceTracker[BaseRequest[Any], TResult]
 
     def __init__(self, mgr: ExchangeManager[TRequestPayload, TResponsePayload, TResult]) -> None:
         self._manager = mgr
+        self.tracker = self.tracker_class()
 
     async def get_result(
             self,
@@ -71,7 +79,8 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
             normalizer,
             result_validator.validate_result,
             message_validator,
-            timeout=timeout
+            self.tracker,
+            timeout,
         )
 
     @classproperty

--- a/trinity/protocol/common/handlers.py
+++ b/trinity/protocol/common/handlers.py
@@ -1,10 +1,12 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import (
     Any,
     Dict,
-    Set,
+    Iterable,
     Type,
 )
+
+from eth_utils import to_tuple
 
 from p2p.peer import BasePeer
 
@@ -16,19 +18,23 @@ from trinity.protocol.common.managers import (
 )
 
 
-class BaseExchangeHandler:
-    _exchange_managers: Set[ExchangeManager[Any, Any, Any]]
-
+class BaseExchangeHandler(ABC):
     @property
     @abstractmethod
-    def _exchanges(self) -> Dict[str, Type[BaseExchange[Any, Any, Any]]]:
+    def _exchange_config(self) -> Dict[str, Type[BaseExchange[Any, Any, Any]]]:
         pass
+
+    # https://github.com/python/mypy/issues/1362
+    @property  # type: ignore
+    @to_tuple
+    def exchanges(self) -> Iterable[Type[BaseExchange[Any, Any, Any]]]:
+        for key in self._exchange_config:
+            yield getattr(self, key)
 
     def __init__(self, peer: BasePeer) -> None:
         self._peer = peer
-        self._exchange_managers = set()
 
-        for attr, exchange_cls in self._exchanges.items():
+        for attr, exchange_cls in self._exchange_config.items():
             if hasattr(self, attr):
                 raise AttributeError(
                     "Unable to set manager on attribute `{0}` which is already "
@@ -36,9 +42,12 @@ class BaseExchangeHandler:
                 )
             manager: ExchangeManager[Any, Any, Any]
             manager = ExchangeManager(self._peer, exchange_cls.response_cmd_type, peer.cancel_token)
-            self._exchange_managers.add(manager)
             exchange = exchange_cls(manager)
             setattr(self, attr, exchange)
 
     def get_stats(self) -> Dict[str, str]:
-        return dict(exchange_manager.get_stats() for exchange_manager in self._exchange_managers)
+        return {
+            exchange.response_cmd_type.__name__: exchange.tracker.get_stats()
+            for exchange
+            in self.exchanges
+        }

--- a/trinity/protocol/common/handlers.py
+++ b/trinity/protocol/common/handlers.py
@@ -2,11 +2,8 @@ from abc import ABC, abstractmethod
 from typing import (
     Any,
     Dict,
-    Iterable,
     Type,
 )
-
-from eth_utils import to_tuple
 
 from p2p.peer import BasePeer
 
@@ -24,13 +21,6 @@ class BaseExchangeHandler(ABC):
     def _exchange_config(self) -> Dict[str, Type[BaseExchange[Any, Any, Any]]]:
         pass
 
-    # https://github.com/python/mypy/issues/1362
-    @property  # type: ignore
-    @to_tuple
-    def exchanges(self) -> Iterable[Type[BaseExchange[Any, Any, Any]]]:
-        for key in self._exchange_config:
-            yield getattr(self, key)
-
     def __init__(self, peer: BasePeer) -> None:
         self._peer = peer
 
@@ -46,8 +36,9 @@ class BaseExchangeHandler(ABC):
             setattr(self, attr, exchange)
 
     def get_stats(self) -> Dict[str, str]:
+        exchanges = tuple(getattr(self, key) for key in self._exchange_config.keys())
         return {
             exchange.response_cmd_type.__name__: exchange.tracker.get_stats()
             for exchange
-            in self.exchanges
+            in exchanges
         }

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from typing import (  # noqa: F401 -- AsyncGenerator needed by mypy
+from typing import (
     Any,
     AsyncGenerator,
     Callable,
@@ -29,35 +29,11 @@ from p2p.service import BaseService
 from trinity.exceptions import AlreadyWaiting
 
 from .normalizers import BaseNormalizer
+from .trackers import BasePerformanceTracker
 from .types import (
     TResponsePayload,
     TResult,
 )
-
-
-class ResponseTimeTracker:
-
-    def __init__(self) -> None:
-        self.total_msgs = 0
-        self.total_items = 0
-        self.total_timeouts = 0
-        self.total_response_time = 0.0
-
-    def get_stats(self) -> str:
-        if not self.total_msgs:
-            return 'None'
-        avg_rtt = self.total_response_time / self.total_msgs
-        if not self.total_items:
-            per_item_rtt = 0.0
-        else:
-            per_item_rtt = self.total_response_time / self.total_items
-        return 'count=%d, items=%d, avg_rtt=%.2f, avg_time_per_item=%.5f, timeouts=%d' % (
-            self.total_msgs, self.total_items, avg_rtt, per_item_rtt, self.total_timeouts)
-
-    def add(self, time: float, size: int) -> None:
-        self.total_msgs += 1
-        self.total_items += size
-        self.total_response_time += time
 
 
 class ResponseCandidateStream(
@@ -87,13 +63,14 @@ class ResponseCandidateStream(
             token: CancelToken) -> None:
         super().__init__(token)
         self._peer = peer
-        self.response_times = ResponseTimeTracker()
         self.response_msg_type = response_msg_type
 
     async def payload_candidates(
             self,
             request: BaseRequest[TRequestPayload],
-            timeout: int = None) -> 'AsyncGenerator[TResponsePayload, None]':
+            tracker: BasePerformanceTracker[Any, Any],
+            *,
+            timeout: int = None) -> AsyncGenerator[TResponsePayload, None]:
         """
         Make a request and iterate through candidates for a valid response.
 
@@ -105,15 +82,20 @@ class ResponseCandidateStream(
 
         self._request(request)
         while self._is_pending():
-            yield await self._get_payload(timeout)
+            try:
+                yield await self._get_payload(timeout)
+            except TimeoutError:
+                tracker.record_timeout()
+                raise
 
     @property
     def response_msg_name(self) -> str:
         return self.response_msg_type.__name__
 
-    def complete_request(self, item_count: int) -> None:
+    def complete_request(self) -> None:
+        if self.pending_request is None:
+            self.logger.warning("`complete_request` was called when there was no pending request")
         self.pending_request = None
-        self.response_times.add(self.last_response_time, item_count)
 
     #
     # Service API
@@ -147,9 +129,6 @@ class ResponseCandidateStream(
         send_time, future = self.pending_request
         try:
             payload = await self.wait(future, timeout=timeout)
-        except TimeoutError:
-            self.response_times.total_timeouts += 1
-            raise
         finally:
             self.pending_request = None
 
@@ -192,9 +171,6 @@ class ResponseCandidateStream(
             _, future = self.pending_request
             future.set_exception(PeerConnectionLost("Pending request can't complete: peer is gone"))
 
-    def get_stats(self) -> Tuple[str, str]:
-        return (self.response_msg_name, self.response_times.get_stats())
-
     def __repr__(self) -> str:
         return f'<ResponseCandidateStream({self._peer!s}, {self.response_msg_type!r})>'
 
@@ -230,6 +206,7 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
             normalizer: BaseNormalizer[TResponsePayload, TResult],
             validate_result: Callable[[TResult], None],
             payload_validator: Callable[[TResponsePayload], None],
+            tracker: BasePerformanceTracker[BaseRequest[TRequestPayload], TResult],
             timeout: int = None) -> TResult:
 
         if not self.is_operational:
@@ -237,7 +214,7 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
 
         stream = self._response_stream
 
-        async for payload in stream.payload_candidates(request, timeout):
+        async for payload in stream.payload_candidates(request, tracker, timeout=timeout):
             try:
                 payload_validator(payload)
 
@@ -256,8 +233,12 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
                 )
                 continue
             else:
-                num_items = normalizer.get_num_results(result)
-                stream.complete_request(num_items)
+                tracker.record_response(
+                    time=stream.last_response_time,
+                    request=request,
+                    result=result,
+                )
+                stream.complete_request()
                 return result
 
         raise ValidationError("Manager is not pending a response, but no valid response received")
@@ -268,9 +249,3 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
         This service that needs to be running for calls to execute properly
         """
         return self._response_stream
-
-    def get_stats(self) -> Tuple[str, str]:
-        if self._response_stream is None:
-            return (self._response_command_type.__name__, 'Uninitialized')
-        else:
-            return self._response_stream.get_stats()

--- a/trinity/protocol/common/normalizers.py
+++ b/trinity/protocol/common/normalizers.py
@@ -28,14 +28,6 @@ class BaseNormalizer(ABC, Generic[TResponsePayload, TResult]):
         """
         raise NotImplementedError()
 
-    @staticmethod
-    @abstractmethod
-    def get_num_results(result: TResult) -> int:
-        """
-        Count the number of items returned in the result.
-        """
-        raise NotImplementedError()
-
 
 TPassthrough = TypeVar('TPassthrough', bound=PayloadType)
 
@@ -44,7 +36,3 @@ class NoopNormalizer(BaseNormalizer[TPassthrough, TPassthrough]):
     @staticmethod
     def normalize_result(message: TPassthrough) -> TPassthrough:
         return message
-
-    @staticmethod
-    def get_num_results(result: TPassthrough) -> int:
-        return len(result)

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -1,0 +1,115 @@
+from abc import ABC, abstractmethod
+import logging
+from typing import (
+    Any,
+    cast,
+    Generic,
+    Optional,
+    TypeVar,
+)
+
+from eth.tools.logging import TraceLogger
+
+from p2p.protocol import (
+    BaseRequest,
+)
+from .types import (
+    TResult,
+)
+
+
+TRequest = TypeVar('TRequest', bound=BaseRequest[Any])
+
+
+class BasePerformanceTracker(ABC, Generic[TRequest, TResult]):
+    def __init__(self) -> None:
+        self.total_msgs = 0
+        self.total_items = 0
+        self.total_missing = 0
+        self.total_timeouts = 0
+        self.total_response_time = 0.0
+
+    _logger: TraceLogger = None
+
+    @property
+    def logger(self) -> TraceLogger:
+        if self._logger is None:
+            self._logger = cast(
+                TraceLogger,
+                logging.getLogger(self.__module__ + '.' + self.__class__.__name__)
+            )
+        return self._logger
+
+    @abstractmethod
+    def _get_request_size(self, request: TRequest) -> Optional[int]:
+        """
+        The request size represents the number of *things* that were requested,
+        not taking into account the sizes of individual items.
+        """
+        pass
+
+    @abstractmethod
+    def _get_result_size(self, result: TResult) -> int:
+        """
+        The result size represents the number of *things* that were returned,
+        not taking into account the sizes of individual items.
+        """
+        pass
+
+    @abstractmethod
+    def _get_result_item_count(self, result: TResult) -> int:
+        """
+        The item count is intended to more accurately represent the size of the
+        response, taking into account things like the size of individual
+        response items such as the number of transactions in a block.
+        """
+        pass
+
+    def get_stats(self) -> str:
+        """
+        Return a human readable string representing the stats for this tracker.
+        """
+        if not self.total_msgs:
+            return 'None'
+        avg_rtt = self.total_response_time / self.total_msgs
+        if not self.total_items:
+            per_item_rtt = 0.0
+        else:
+            per_item_rtt = self.total_response_time / self.total_items
+        return 'count=%d  items=%d  avg_rtt=%.2f  avg_tpi=%.5f  timeouts=%d  missing=%d' % (
+            self.total_msgs,
+            self.total_items,
+            avg_rtt,
+            per_item_rtt,
+            self.total_timeouts,
+            self.total_missing
+        )
+
+    def record_timeout(self) -> None:
+        self.total_msgs += 1
+        self.total_timeouts += 1
+
+    def record_response(self,
+                        time: float,
+                        request: TRequest,
+                        result: TResult) -> None:
+        self.total_msgs += 1
+
+        request_size = self._get_request_size(request)
+        response_size = self._get_result_size(result)
+        num_items = self._get_result_item_count(result)
+
+        if request_size is None:
+            pass
+        elif response_size > request_size:
+            self.logger.warning(
+                "%s got oversized response.  requested: %d  received: %d",
+                type(self).__name__,
+                request_size,
+                response_size,
+            )
+        else:
+            self.total_missing += (request_size - response_size)
+
+        self.total_items += num_items
+        self.total_response_time += time

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -6,7 +6,10 @@ from typing import (
     Generic,
     Optional,
     TypeVar,
+    Union,
 )
+
+from eth_utils import ValidationError
 
 from eth.tools.logging import TraceLogger
 
@@ -21,6 +24,39 @@ from .types import (
 TRequest = TypeVar('TRequest', bound=BaseRequest[Any])
 
 
+class EMA:
+    """
+    Represents an exponential moving average.
+    https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+
+    Smoothing factor, or "alpha" of the exponential moving average.
+
+    - Closer to 0 gives you smoother, slower-to-update, data
+    - Closer to 1 gives you choppier, quicker-to-update, data
+
+    .. note::
+
+        A smoothing factor of 1 would completely ignore history whereas 0 would
+        completely ignore new data
+
+
+    The initial value is the starting value for the EMA
+    """
+    def __init__(self, initial_value: float, smoothing_factor: float) -> None:
+        self._value = initial_value
+        if 0 < smoothing_factor < 1:
+            self._alpha = smoothing_factor
+        else:
+            raise ValidationError("Smoothing factor of EMA must be between 0 and 1")
+
+    def update(self, scalar: Union[int, float]) -> None:
+        self._value = (self._value * (1 - self._alpha)) + (scalar * self._alpha)
+
+    @property
+    def value(self) -> float:
+        return self._value
+
+
 class BasePerformanceTracker(ABC, Generic[TRequest, TResult]):
     def __init__(self) -> None:
         self.total_msgs = 0
@@ -28,6 +64,18 @@ class BasePerformanceTracker(ABC, Generic[TRequest, TResult]):
         self.total_missing = 0
         self.total_timeouts = 0
         self.total_response_time = 0.0
+
+        # a percentage between 0-100 for how much of the requested
+        # data the peer typically returns with 100 meaning they consistently
+        # return all of the data we request and 0 meaning they do not return
+        # only empty responses.
+        self.response_quality_ema = EMA(initial_value=50, smoothing_factor=0.05)
+
+        # an EMA of the round trip request/response time
+        self.round_trip_time_ema = EMA(initial_value=1, smoothing_factor=0.05)
+
+        # an EMA of the items per second
+        self.items_per_second_ema = EMA(initial_value=1, smoothing_factor=0.05)
 
     _logger: TraceLogger = None
 
@@ -73,21 +121,36 @@ class BasePerformanceTracker(ABC, Generic[TRequest, TResult]):
             return 'None'
         avg_rtt = self.total_response_time / self.total_msgs
         if not self.total_items:
-            per_item_rtt = 0.0
+            items_per_second = 0.0
         else:
-            per_item_rtt = self.total_response_time / self.total_items
-        return 'count=%d  items=%d  avg_rtt=%.2f  avg_tpi=%.5f  timeouts=%d  missing=%d' % (
+            items_per_second = self.total_response_time / self.total_items
+
+        # msgs: total number of messages
+        # items: total number of items
+        # rtt: round-trip-time (avg/ema)
+        # ips: items-per-second (avg/ema)
+        # timeouts: total number of timeouts
+        # missing: total number of missing response items
+        # quality: 0-100 for how complete responses are
+        return (
+            'msgs=%d  items=%d  rtt=%.2f/%.2f  ips=%.5f/%.5f  '
+            'timeouts=%d  missing=%d  quality=%d'
+        ) % (
             self.total_msgs,
             self.total_items,
             avg_rtt,
-            per_item_rtt,
+            self.round_trip_time_ema.value,
+            items_per_second,
+            self.items_per_second_ema.value,
             self.total_timeouts,
-            self.total_missing
+            self.total_missing,
+            int(self.response_quality_ema.value),
         )
 
     def record_timeout(self) -> None:
         self.total_msgs += 1
         self.total_timeouts += 1
+        self.response_quality_ema.update(0)
 
     def record_response(self,
                         time: float,
@@ -110,6 +173,27 @@ class BasePerformanceTracker(ABC, Generic[TRequest, TResult]):
             )
         else:
             self.total_missing += (request_size - response_size)
+            if request_size == 0:
+                self.logger.warning(
+                    "%s encountered request for zero items. This should never happen",
+                    type(self).__name__,
+                )
+                self.response_quality_ema.update(100)
+            elif response_size == 0:
+                self.response_quality_ema.update(0)
+            else:
+                percent_returned = 100 * response_size / request_size
+                self.response_quality_ema.update(percent_returned)
 
         self.total_items += num_items
         self.total_response_time += time
+        self.round_trip_time_ema.update(time)
+
+        if time > 0:
+            throughput = num_items / time
+            self.items_per_second_ema.update(throughput)
+        else:
+            self.logger.warning(
+                "%s encountered response time of zero.  This should never happen",
+                type(self).__name__,
+            )

--- a/trinity/protocol/common/types.py
+++ b/trinity/protocol/common/types.py
@@ -21,6 +21,10 @@ TResponsePayload = TypeVar('TResponsePayload', bound=PayloadType)
 # The returned value at the end of an exchange
 TResult = TypeVar('TResult')
 
+# (
+#   (node_hash, node),
+#   ...
+# )
 NodeDataBundles = Tuple[Tuple[Hash32, bytes], ...]
 
 # (receipts_in_block_a, receipts_in_block_b, ...)

--- a/trinity/protocol/eth/exchanges.py
+++ b/trinity/protocol/eth/exchanges.py
@@ -38,6 +38,12 @@ from .requests import (
     GetNodeDataRequest,
     GetReceiptsRequest,
 )
+from .trackers import (
+    GetBlockHeadersTracker,
+    GetBlockBodiesTracker,
+    GetNodeDataTracker,
+    GetReceiptsTracker
+)
 from .validators import (
     GetBlockBodiesValidator,
     GetBlockHeadersValidator,
@@ -55,6 +61,7 @@ BaseGetBlockHeadersExchange = BaseExchange[
 class GetBlockHeadersExchange(BaseGetBlockHeadersExchange):
     _normalizer = NoopNormalizer[Tuple[BlockHeader, ...]]()
     request_class = GetBlockHeadersRequest
+    tracker_class = GetBlockHeadersTracker
 
     async def __call__(  # type: ignore
             self,
@@ -83,6 +90,7 @@ BaseNodeDataExchange = BaseExchange[Tuple[Hash32, ...], Tuple[bytes, ...], NodeD
 class GetNodeDataExchange(BaseNodeDataExchange):
     _normalizer = GetNodeDataNormalizer()
     request_class = GetNodeDataRequest
+    tracker_class = GetNodeDataTracker
 
     async def __call__(self, node_hashes: Tuple[Hash32, ...]) -> NodeDataBundles:  # type: ignore
         validator = GetNodeDataValidator(node_hashes)
@@ -93,6 +101,7 @@ class GetNodeDataExchange(BaseNodeDataExchange):
 class GetReceiptsExchange(BaseExchange[Tuple[Hash32, ...], ReceiptsByBlock, ReceiptsBundles]):
     _normalizer = ReceiptsNormalizer()
     request_class = GetReceiptsRequest
+    tracker_class = GetReceiptsTracker
 
     async def __call__(self, headers: Tuple[BlockHeader, ...]) -> ReceiptsBundles:  # type: ignore
         validator = ReceiptsValidator(headers)
@@ -113,6 +122,7 @@ BaseGetBlockBodiesExchange = BaseExchange[
 class GetBlockBodiesExchange(BaseGetBlockBodiesExchange):
     _normalizer = GetBlockBodiesNormalizer()
     request_class = GetBlockBodiesRequest
+    tracker_class = GetBlockBodiesTracker
 
     async def __call__(self, headers: Tuple[BlockHeader, ...]) -> BlockBodyBundles:  # type: ignore
         validator = GetBlockBodiesValidator(headers)

--- a/trinity/protocol/eth/exchanges.py
+++ b/trinity/protocol/eth/exchanges.py
@@ -69,7 +69,7 @@ class GetBlockHeadersExchange(BaseGetBlockHeadersExchange):
             max_headers: int = None,
             skip: int = 0,
             reverse: bool = True,
-            timeout: int = None) -> Tuple[BlockHeader, ...]:
+            timeout: float = None) -> Tuple[BlockHeader, ...]:
 
         original_request_args = (block_number_or_hash, max_headers, skip, reverse)
         validator = GetBlockHeadersValidator(*original_request_args)
@@ -92,10 +92,18 @@ class GetNodeDataExchange(BaseNodeDataExchange):
     request_class = GetNodeDataRequest
     tracker_class = GetNodeDataTracker
 
-    async def __call__(self, node_hashes: Tuple[Hash32, ...]) -> NodeDataBundles:  # type: ignore
+    async def __call__(self,  # type: ignore
+                       node_hashes: Tuple[Hash32, ...],
+                       timeout: float = None) -> NodeDataBundles:
         validator = GetNodeDataValidator(node_hashes)
         request = self.request_class(node_hashes)
-        return await self.get_result(request, self._normalizer, validator, noop_payload_validator)
+        return await self.get_result(
+            request,
+            self._normalizer,
+            validator,
+            noop_payload_validator,
+            timeout,
+        )
 
 
 class GetReceiptsExchange(BaseExchange[Tuple[Hash32, ...], ReceiptsByBlock, ReceiptsBundles]):
@@ -103,13 +111,21 @@ class GetReceiptsExchange(BaseExchange[Tuple[Hash32, ...], ReceiptsByBlock, Rece
     request_class = GetReceiptsRequest
     tracker_class = GetReceiptsTracker
 
-    async def __call__(self, headers: Tuple[BlockHeader, ...]) -> ReceiptsBundles:  # type: ignore
+    async def __call__(self,  # type: ignore
+                       headers: Tuple[BlockHeader, ...],
+                       timeout: float = None) -> ReceiptsBundles:  # type: ignore
         validator = ReceiptsValidator(headers)
 
         block_hashes = tuple(header.hash for header in headers)
         request = self.request_class(block_hashes)
 
-        return await self.get_result(request, self._normalizer, validator, noop_payload_validator)
+        return await self.get_result(
+            request,
+            self._normalizer,
+            validator,
+            noop_payload_validator,
+            timeout,
+        )
 
 
 BaseGetBlockBodiesExchange = BaseExchange[
@@ -124,10 +140,18 @@ class GetBlockBodiesExchange(BaseGetBlockBodiesExchange):
     request_class = GetBlockBodiesRequest
     tracker_class = GetBlockBodiesTracker
 
-    async def __call__(self, headers: Tuple[BlockHeader, ...]) -> BlockBodyBundles:  # type: ignore
+    async def __call__(self,  # type: ignore
+                       headers: Tuple[BlockHeader, ...],
+                       timeout: float = None) -> BlockBodyBundles:
         validator = GetBlockBodiesValidator(headers)
 
         block_hashes = tuple(header.hash for header in headers)
         request = self.request_class(block_hashes)
 
-        return await self.get_result(request, self._normalizer, validator, noop_payload_validator)
+        return await self.get_result(
+            request,
+            self._normalizer,
+            validator,
+            noop_payload_validator,
+            timeout,
+        )

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -11,7 +11,7 @@ from .exchanges import (
 
 
 class ETHExchangeHandler(BaseExchangeHandler):
-    _exchanges = {
+    _exchange_config = {
         'get_block_bodies': GetBlockBodiesExchange,
         'get_block_headers': GetBlockHeadersExchange,
         'get_node_data': GetNodeDataExchange,

--- a/trinity/protocol/eth/normalizers.py
+++ b/trinity/protocol/eth/normalizers.py
@@ -30,10 +30,6 @@ class GetNodeDataNormalizer(BaseNormalizer[Tuple[bytes, ...], NodeDataBundles]):
         result = tuple(zip(node_keys, msg))
         return result
 
-    @staticmethod
-    def get_num_results(result: NodeDataBundles) -> int:
-        return len(result)
-
 
 class ReceiptsNormalizer(BaseNormalizer[ReceiptsByBlock, ReceiptsBundles]):
     is_normalization_slow = True
@@ -42,10 +38,6 @@ class ReceiptsNormalizer(BaseNormalizer[ReceiptsByBlock, ReceiptsBundles]):
     def normalize_result(message: ReceiptsByBlock) -> ReceiptsBundles:
         trie_roots_and_data = tuple(map(make_trie_root_and_nodes, message))
         return tuple(zip(message, trie_roots_and_data))
-
-    @staticmethod
-    def get_num_results(result: ReceiptsBundles) -> int:
-        return sum(len(item) for item in result)
 
 
 class GetBlockBodiesNormalizer(BaseNormalizer[Tuple[BlockBody, ...], BlockBodyBundles]):
@@ -64,7 +56,3 @@ class GetBlockBodiesNormalizer(BaseNormalizer[Tuple[BlockBody, ...], BlockBodyBu
 
         body_bundles = tuple(zip(msg, transaction_roots_and_trie_data, uncles_hashes))
         return body_bundles
-
-    @staticmethod
-    def get_num_results(result: BlockBodyBundles) -> int:
-        return len(result)

--- a/trinity/protocol/eth/requests.py
+++ b/trinity/protocol/eth/requests.py
@@ -28,6 +28,11 @@ from .commands import (
 
 
 class HeaderRequest(BaseHeaderRequest):
+    """
+    TODO: this should be removed from this module.  It exists to allow
+    `p2p.handlers.PeerRequestHandler` to have a common API between light and
+    full chains so maybe it should go there
+    """
     max_size = MAX_HEADERS_FETCH
 
     def __init__(self,

--- a/trinity/protocol/eth/trackers.py
+++ b/trinity/protocol/eth/trackers.py
@@ -1,0 +1,88 @@
+from typing import (
+    Optional,
+    Tuple,
+)
+
+from eth.rlp.headers import BlockHeader
+
+from trinity.protocol.common.trackers import BasePerformanceTracker
+from trinity.protocol.common.types import (
+    BlockBodyBundles,
+    NodeDataBundles,
+    ReceiptsBundles,
+)
+from trinity.utils.headers import sequence_builder
+
+from .requests import (
+    GetBlockBodiesRequest,
+    GetBlockHeadersRequest,
+    GetNodeDataRequest,
+    GetReceiptsRequest,
+)
+
+
+BaseGetBlockHeadersTracker = BasePerformanceTracker[
+    GetBlockHeadersRequest,
+    Tuple[BlockHeader, ...],
+]
+
+
+class GetBlockHeadersTracker(BaseGetBlockHeadersTracker):
+    def _get_request_size(self, request: GetBlockHeadersRequest) -> int:
+        payload = request.command_payload
+        if isinstance(payload['block_number_or_hash'], int):
+            return len(sequence_builder(
+                start_number=payload['block_number_or_hash'],
+                max_length=payload['max_headers'],
+                skip=payload['skip'],
+                reverse=payload['reverse'],
+            ))
+        else:
+            return None
+
+    def _get_result_size(self, result: Tuple[BlockHeader, ...]) -> Optional[int]:
+        return len(result)
+
+    def _get_result_item_count(self, result: Tuple[BlockHeader, ...]) -> int:
+        return len(result)
+
+
+class GetBlockBodiesTracker(BasePerformanceTracker[GetBlockBodiesRequest, BlockBodyBundles]):
+    def _get_request_size(self, request: GetBlockBodiesRequest) -> Optional[int]:
+        return len(request.command_payload)
+
+    def _get_result_size(self, result: BlockBodyBundles) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: BlockBodyBundles) -> int:
+        return sum(
+            len(body.uncles) + len(body.transactions)
+            for body, trie_data, uncles_hash
+            in result
+        )
+
+
+class GetReceiptsTracker(BasePerformanceTracker[GetReceiptsRequest, ReceiptsBundles]):
+    def _get_request_size(self, request: GetReceiptsRequest) -> Optional[int]:
+        return len(request.command_payload)
+
+    def _get_result_size(self, result: ReceiptsBundles) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: ReceiptsBundles) -> int:
+        return sum(
+            len(receipts)
+            for receipts, trie_data
+            in result
+        )
+
+
+class GetNodeDataTracker(BasePerformanceTracker[GetNodeDataRequest, NodeDataBundles]):
+    def _get_request_size(self, request: GetNodeDataRequest) -> Optional[int]:
+        return len(request.command_payload)
+
+    def _get_result_size(self, result: NodeDataBundles) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: NodeDataBundles) -> int:
+        return len(result)

--- a/trinity/protocol/les/exchanges.py
+++ b/trinity/protocol/les/exchanges.py
@@ -46,7 +46,7 @@ class GetBlockHeadersExchange(LESExchange[Tuple[BlockHeader, ...]]):
             max_headers: int = None,
             skip: int = 0,
             reverse: bool = True,
-            timeout: int = None) -> Tuple[BlockHeader, ...]:
+            timeout: float = None) -> Tuple[BlockHeader, ...]:
 
         original_request_args = (block_number_or_hash, max_headers, skip, reverse)
         validator = GetBlockHeadersValidator(*original_request_args)

--- a/trinity/protocol/les/exchanges.py
+++ b/trinity/protocol/les/exchanges.py
@@ -21,6 +21,9 @@ from .normalizers import (
 from .requests import (
     GetBlockHeadersRequest,
 )
+from .trackers import (
+    GetBlockHeadersTracker,
+)
 from .validators import (
     GetBlockHeadersValidator,
     match_payload_request_id,
@@ -35,6 +38,7 @@ LESExchange = BaseExchange[Dict[str, Any], Dict[str, Any], TResult]
 class GetBlockHeadersExchange(LESExchange[Tuple[BlockHeader, ...]]):
     _normalizer = BlockHeadersNormalizer()
     request_class = GetBlockHeadersRequest
+    tracker_class = GetBlockHeadersTracker
 
     async def __call__(  # type: ignore
             self,

--- a/trinity/protocol/les/handlers.py
+++ b/trinity/protocol/les/handlers.py
@@ -6,7 +6,7 @@ from .exchanges import GetBlockHeadersExchange
 
 
 class LESExchangeHandler(BaseExchangeHandler):
-    _exchanges = {
+    _exchange_config = {
         'get_block_headers': GetBlockHeadersExchange,
     }
 

--- a/trinity/protocol/les/normalizers.py
+++ b/trinity/protocol/les/normalizers.py
@@ -18,7 +18,3 @@ class BlockHeadersNormalizer(LESNormalizer[Tuple[BlockHeader, ...]]):
     def normalize_result(message: Dict[str, Any]) -> Tuple[BlockHeader, ...]:
         result = message['headers']
         return result
-
-    @staticmethod
-    def get_num_results(result: Tuple[BlockHeader, ...]) -> int:
-        return len(result)

--- a/trinity/protocol/les/trackers.py
+++ b/trinity/protocol/les/trackers.py
@@ -1,0 +1,39 @@
+from typing import (
+    Optional,
+    Tuple,
+)
+
+from eth.rlp.headers import BlockHeader
+
+from trinity.protocol.common.trackers import BasePerformanceTracker
+from trinity.utils.headers import sequence_builder
+
+from .requests import (
+    GetBlockHeadersRequest,
+)
+
+
+BaseGetBlockHeadersTracker = BasePerformanceTracker[
+    GetBlockHeadersRequest,
+    Tuple[BlockHeader, ...],
+]
+
+
+class GetBlockHeadersTracker(BaseGetBlockHeadersTracker):
+    def _get_request_size(self, request: GetBlockHeadersRequest) -> Optional[int]:
+        payload = request.command_payload['query']
+        if isinstance(payload['block_number_or_hash'], int):
+            return len(sequence_builder(
+                start_number=payload['block_number_or_hash'],
+                max_length=payload['max_headers'],
+                skip=payload['skip'],
+                reverse=payload['reverse'],
+            ))
+        else:
+            return None
+
+    def _get_result_size(self, result: Tuple[BlockHeader, ...]) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: Tuple[BlockHeader, ...]) -> int:
+        return len(result)

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -40,6 +40,19 @@ LOG_BACKUP_COUNT = 10
 LOG_MAX_MB = 5
 
 
+class HasTraceLogger:
+    _logger: TraceLogger = None
+
+    @property
+    def logger(self) -> TraceLogger:
+        if self._logger is None:
+            self._logger = cast(
+                TraceLogger,
+                logging.getLogger(self.__module__ + '.' + self.__class__.__name__)
+            )
+        return self._logger
+
+
 def setup_log_levels(log_levels: Dict[Union[None, str], int]) -> None:
     for name, level in log_levels.items():
         logger = logging.getLogger(name)


### PR DESCRIPTION
Builds on https://github.com/ethereum/py-evm/pull/1220

### What was wrong?

We need some more useful metrics on peers.

### How was it fixed?

Expanded to collect:

- EMA of the round trip request time
- EMA of the percentage of requested data that was returned (as a number between 0-100)
- EMA of the items-per-second returned by the peer

#### Cute Animal Picture


![monkeyrodeo_wide-307fc1e70816bf01cb93296037a053f1e2977234-s6-c30](https://user-images.githubusercontent.com/824194/44818555-a66ecc00-aba6-11e8-922f-e04d9e5e5d41.jpg)
