### PR TITLE
Download all data in queues (instead of batches) while fast & regular syncing

### DIFF
--- a/trinity/protocol/common/handlers.py
+++ b/trinity/protocol/common/handlers.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import (
     Any,
     Dict,
+    Iterator,
     Type,
 )
 
@@ -35,10 +36,13 @@ class BaseExchangeHandler(ABC):
             exchange = exchange_cls(manager)
             setattr(self, attr, exchange)
 
+    def __iter__(self) -> Iterator[BaseExchange[Any, Any, Any]]:
+        for key in self._exchange_config.keys():
+            yield getattr(self, key)
+
     def get_stats(self) -> Dict[str, str]:
-        exchanges = tuple(getattr(self, key) for key in self._exchange_config.keys())
         return {
             exchange.response_cmd_type.__name__: exchange.tracker.get_stats()
             for exchange
-            in exchanges
+            in self
         }

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -121,7 +121,7 @@ class ResponseCandidateStream(
     # Service API
     #
     async def _run(self) -> None:
-        self.logger.debug("Launching %s for peer %s", self.__class__.__name__, self._peer)
+        self.logger.debug("Launching %r", self)
 
         with self.subscribe_peer(self._peer):
             while self.is_operational:

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -111,10 +111,10 @@ class BasePerformanceTracker(ABC, HasTraceLogger, Generic[TRequest, TResult]):
         if not self.total_msgs:
             return 'None'
         avg_rtt = self.total_response_time / self.total_msgs
-        if not self.total_items:
+        if not self.total_response_time:
             items_per_second = 0.0
         else:
-            items_per_second = self.total_response_time / self.total_items
+            items_per_second = self.total_items / self.total_response_time
 
         # msgs: total number of messages
         # items: total number of items

--- a/trinity/utils/timer.py
+++ b/trinity/utils/timer.py
@@ -11,6 +11,13 @@ class Timer:
     def start(self) -> None:
         self._start = time.perf_counter()
 
+    def pop_elapsed(self) -> float:
+        """Return time elapsed since last start, and start the timer over"""
+        now = time.perf_counter()
+        elapsed = now - self._start
+        self._start = now
+        return elapsed
+
     @property
     def elapsed(self) -> float:
         return time.perf_counter() - self._start


### PR DESCRIPTION
### What was wrong?

Requests for block data and receipts were batched together. A slow peer can dramatically slow down this process.

### How was it fixed?

Roughly, put everything into queues so they can run independently, and one peer isn't waiting on another to finish.

Numbers vary widely, but I've seen as high as 1500 blocks imported in 5 s.

TODO:
- [x] hunt down an occassional `RuntimeError: Cannot restart a service that has already been cancelled`
- [x] manually test
- [ ] overnight manual test
- [x] make code more readable
- [x] linting
- [x] clean commit history

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/75/45/0d/75450d86d1eb693cbdb867e5c461d57d--adorable-baby-animals-funny-animals.jpg)
