### PR TITLE
Fix live docs (this time for real!)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,4 +5,6 @@ python:
   version: 3.6
   pip_install: True
   extra_requirements:
+    - p2p
+    - trinity
     - doc

--- a/docs/api/eth/tools/api.tools.builders.rst
+++ b/docs/api/eth/tools/api.tools.builders.rst
@@ -16,14 +16,23 @@ Constructing Chain Classes
 
 The following utilities are provided to assist with constructing a chain class.
 
-.. automodule:: eth.tools.builder.chain
-  :noindex:
-  :members: fork_at,
-            dao_fork_at,
-            disable_dao_fork,
-            enable_pow_mining,
-            disable_pow_check,
-            name
+
+.. autofunction:: eth.tools.builder.chain.fork_at
+
+
+.. autofunction:: eth.tools.builder.chain.dao_fork_at
+
+
+.. autofunction:: eth.tools.builder.chain.disable_dao_fork
+
+
+.. autofunction:: eth.tools.builder.chain.enable_pow_mining
+
+
+.. autofunction:: eth.tools.builder.chain.disable_pow_check
+
+
+.. autofunction:: eth.tools.builder.chain.name
 
 
 Initializing Chains
@@ -32,9 +41,7 @@ Initializing Chains
 The following utilities are provided to assist with initializing a chain into
 the genesis state.
 
-.. automodule:: eth.tools.builder.chain
-  :noindex:
-  :members: genesis
+.. autofunction:: eth.tools.builder.chain.genesis
 
 
 Building Chains
@@ -43,12 +50,23 @@ Building Chains
 The following utilities are provided to assist with building out chains of
 blocks.
 
-.. automodule:: eth.tools.builder.chain
-  :noindex:
-  :members: copy,
-            import_block,
-            import_blocks,
-            mine_block,
-            mine_blocks,
-            chain_split,
-            at_block_number
+
+.. autofunction:: eth.tools.builder.chain.copy
+
+
+.. autofunction:: eth.tools.builder.chain.import_block
+
+
+.. autofunction:: eth.tools.builder.chain.import_blocks
+
+
+.. autofunction:: eth.tools.builder.chain.mine_block
+
+
+.. autofunction:: eth.tools.builder.chain.mine_blocks
+
+
+.. autofunction:: eth.tools.builder.chain.chain_split
+
+
+.. autofunction:: eth.tools.builder.chain.at_block_number

--- a/docs/api/eth/tools/api.tools.fixtures.rst
+++ b/docs/api/eth/tools/api.tools.fixtures.rst
@@ -60,138 +60,129 @@ sequence of functions.
     :func:`~eth.tools.fixtures.expect`, expect to be passed a dictionary
     as their single argument and return an updated version of the dictionary.
 
-.. automodule:: eth.tools.fixtures.fillers
-  :noindex:
-  :members: setup_main_filler
+
+.. autofunction:: eth.tools.fixtures.fillers.common.setup_main_filler
+
+    This function kicks off the filler generation process by creating the general filler scaffold with
+    a test name and general information about the testing environment.
+
+    For tests for the main chain, the `environment` parameter is expected to be a dictionary with some
+    or all of the following keys:
+
+    +------------------------+---------------------------------+
+    | key                    | description                     |
+    +========================+=================================+
+    | ``"currentCoinbase"``  | the coinbase address            |
+    +------------------------+---------------------------------+
+    | ``"currentNumber"``    | the block number                |
+    +------------------------+---------------------------------+
+    | ``"previousHash"``     | the hash of the parent block    |
+    +------------------------+---------------------------------+
+    | ``"currentDifficulty"``| the block's difficulty          |
+    +------------------------+---------------------------------+
+    | ``"currentGasLimit"``  | the block's gas limit           |
+    +------------------------+---------------------------------+
+    | ``"currentTimestamp"`` | the timestamp of the block      |
+    +------------------------+---------------------------------+
 
 
-This function kicks off the filler generation process by creating the general filler scaffold with
-a test name and general information about the testing environment.
+.. autofunction:: eth.tools.fixtures.fillers.pre_state
 
-For tests for the main chain, the `environment` parameter is expected to be a dictionary with some
-or all of the following keys:
+    This function specifies the state prior to the test execution. Multiple invocations don't override
+    the state but extend it instead.
 
-+------------------------+---------------------------------+
-| key                    | description                     |
-+========================+=================================+
-| ``"currentCoinbase"``  | the coinbase address            |
-+------------------------+---------------------------------+
-| ``"currentNumber"``    | the block number                |
-+------------------------+---------------------------------+
-| ``"previousHash"``     | the hash of the parent block    |
-+------------------------+---------------------------------+
-| ``"currentDifficulty"``| the block's difficulty          |
-+------------------------+---------------------------------+
-| ``"currentGasLimit"``  | the block's gas limit           |
-+------------------------+---------------------------------+
-| ``"currentTimestamp"`` | the timestamp of the block      |
-+------------------------+---------------------------------+
+    In general, the elements of `state_definitions` are nested dictionaries of the following form:
 
-.. automodule:: eth.tools.fixtures.fillers
-  :noindex:
-  :members: pre_state
+    .. code-block:: python
 
-
-This function specifies the state prior to the test execution. Multiple invocations don't override
-the state but extend it instead.
-
-In general, the elements of `state_definitions` are nested dictionaries of the following form:
-
-.. code-block:: python
-
-    {
-        address: {
-            "nonce": <account nonce>,
-            "balance": <account balance>,
-            "code": <account code>,
-            "storage": {
-                <storage slot>: <storage value>
+        {
+            address: {
+                "nonce": <account nonce>,
+                "balance": <account balance>,
+                "code": <account code>,
+                "storage": {
+                    <storage slot>: <storage value>
+                }
             }
         }
-    }
 
-To avoid unnecessary nesting especially if only few fields per account are specified, the following
-and similar formats are possible as well:
+    To avoid unnecessary nesting especially if only few fields per account are specified, the following
+    and similar formats are possible as well:
 
-.. code-block:: python
+    .. code-block:: python
 
-    (address, "balance", <account balance>)
-    (address, "storage", <storage slot>, <storage value>)
-    (address, "storage", {<storage slot>: <storage value>})
-    (address, {"balance", <account balance>})
-
-.. automodule:: eth.tools.fixtures.fillers
-  :noindex:
-  :members: execution
+        (address, "balance", <account balance>)
+        (address, "storage", <storage slot>, <storage value>)
+        (address, "storage", {<storage slot>: <storage value>})
+        (address, {"balance", <account balance>})
 
 
-For VM tests, this function specifies the code that is being run as well as the current state of
-the EVM. State tests don't support this object. The parameter is a dictionary specifying some or
-all of the following keys:
+.. autofunction:: eth.tools.fixtures.fillers.execution
 
-+--------------------+------------------------------------------------------------+
-|  key               | description                                                |
-+====================+============================================================+
-| ``"address"``      | the address of the account executing the code              |
-+--------------------+------------------------------------------------------------+
-| ``"caller"``       | the caller address                                         |
-+--------------------+------------------------------------------------------------+
-| ``"origin"``       | the origin address (defaulting to the caller address)      |
-+--------------------+------------------------------------------------------------+
-| ``"value"``        | the value of the call                                      |
-+--------------------+------------------------------------------------------------+
-| ``"data"``         | the data passed with the call                              |
-+--------------------+------------------------------------------------------------+
-| ``"gasPrice"``     | the gas price of the call                                  |
-+--------------------+------------------------------------------------------------+
-| ``"gas"``          | the amount of gas allocated for the call                   |
-+--------------------+------------------------------------------------------------+
-| ``"code"``         | the bytecode to execute                                    |
-+--------------------+------------------------------------------------------------+
-| ``"vyperLLLCode"`` | the code in Vyper LLL (compiled to bytecode automatically) |
-+--------------------+------------------------------------------------------------+
+    For VM tests, this function specifies the code that is being run as well as the current state of
+    the EVM. State tests don't support this object. The parameter is a dictionary specifying some or
+    all of the following keys:
 
-
-.. automodule:: eth.tools.fixtures.fillers
-  :noindex:
-  :members: expect
+    +--------------------+------------------------------------------------------------+
+    |  key               | description                                                |
+    +====================+============================================================+
+    | ``"address"``      | the address of the account executing the code              |
+    +--------------------+------------------------------------------------------------+
+    | ``"caller"``       | the caller address                                         |
+    +--------------------+------------------------------------------------------------+
+    | ``"origin"``       | the origin address (defaulting to the caller address)      |
+    +--------------------+------------------------------------------------------------+
+    | ``"value"``        | the value of the call                                      |
+    +--------------------+------------------------------------------------------------+
+    | ``"data"``         | the data passed with the call                              |
+    +--------------------+------------------------------------------------------------+
+    | ``"gasPrice"``     | the gas price of the call                                  |
+    +--------------------+------------------------------------------------------------+
+    | ``"gas"``          | the amount of gas allocated for the call                   |
+    +--------------------+------------------------------------------------------------+
+    | ``"code"``         | the bytecode to execute                                    |
+    +--------------------+------------------------------------------------------------+
+    | ``"vyperLLLCode"`` | the code in Vyper LLL (compiled to bytecode automatically) |
+    +--------------------+------------------------------------------------------------+
 
 
-This specifies the expected result of the test.
+.. autofunction:: eth.tools.fixtures.fillers.expect
 
-For state tests, multiple expectations can be given, differing in the transaction data, gas
-limit, and value, in the applicable networks, and as a result also in the post state. VM tests
-support only a single expectation with no specified network and no transaction (here, its role is
-played by :func:`~eth.tools.fixtures.fillers.execution`).
+    This specifies the expected result of the test.
 
-* ``post_state`` is a list of state definition in the same form as expected
-    by :func:`~eth.tools.fixtures.fillers.pre_state`. State items that are
-    not set explicitly default to their pre state.
+    For state tests, multiple expectations can be given, differing in the transaction data, gas
+    limit, and value, in the applicable networks, and as a result also in the post state. VM tests
+    support only a single expectation with no specified network and no transaction (here, its role is
+    played by :func:`~eth.tools.fixtures.fillers.execution`).
 
-* ``networks`` defines the forks under which the expectation is applicable. It should be a sublist of
-    the following identifiers (also available in `ALL_FORKS`):
+    * ``post_state`` is a list of state definition in the same form as expected
+      by :func:`~eth.tools.fixtures.fillers.pre_state`. State items that are
+      not set explicitly default to their pre state.
 
-    * ``"Frontier"``
-    * ``"Homestead"``
-    * ``"EIP150"``
-    * ``"EIP158"``
-    * ``"Byzantium"``
+    * ``networks`` defines the forks under which the expectation is applicable. It should be a sublist of
+      the following identifiers (also available in `ALL_FORKS`):
 
-* ``transaction`` is a dictionary coming in two variants. For the main shard:
+      * ``"Frontier"``
+      * ``"Homestead"``
+      * ``"EIP150"``
+      * ``"EIP158"``
+      * ``"Byzantium"``
 
-    +----------------+-------------------------------+
-    | key            | description                   |
-    +================+===============================+
-    | ``"data"``     | the transaction data,         |
-    +----------------+-------------------------------+
-    | ``"gasLimit"`` | the transaction gas limit,    |
-    +----------------+-------------------------------+
-    | ``"gasPrice"`` | the gas price,                |
-    +----------------+-------------------------------+
-    | ``"nonce"``    | the transaction nonce,        |
-    +----------------+-------------------------------+
-    | ``"value"``    | the transaction value         |
-    +----------------+-------------------------------+
+    * ``transaction`` is a dictionary coming in two variants. For the main shard:
 
-In addition, one should specify either the signature itself (via keys ``"v"``, ``"r"``, and ``"s"``) or
-a private key used for signing (via ``"secretKey"``).
+      +----------------+-------------------------------+
+      | key            | description                   |
+      +================+===============================+
+      | ``"data"``     | the transaction data,         |
+      +----------------+-------------------------------+
+      | ``"gasLimit"`` | the transaction gas limit,    |
+      +----------------+-------------------------------+
+      | ``"gasPrice"`` | the gas price,                |
+      +----------------+-------------------------------+
+      | ``"nonce"``    | the transaction nonce,        |
+      +----------------+-------------------------------+
+      | ``"value"``    | the transaction value         |
+      +----------------+-------------------------------+
+
+    In addition, one should specify either the signature itself (via keys ``"v"``, ``"r"``, and ``"s"``) or
+    a private key used for signing (via ``"secretKey"``).


### PR DESCRIPTION
### What was wrong?

The live docs are broken (#1222)

### How was it fixed?

This does:

1. Bump up the dependencies requirements for the RTD job to include `p2p` and `trinity` which matches the `py36-docs` job. That does also mean that in the future, if docs break because of some dependency drama, we should notice that in CI as the job is equivalent with the RTD job

2. Revert the previous attempted fix that replaced `autofunction` with some hacky workaround as that didn't have anything to do with it.

I validated that this works by pushing a `doc_fix` branch into this repo (that I will remove again in a second) and reconfiguring RTD to use that branch.

Here's the working live site based on that branch

![image](https://user-images.githubusercontent.com/521109/44843082-bee2f300-ac47-11e8-94de-c915dc2f622e.png)


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.avso.org/wp-content/uploads/files/8/3/3/cool-caravans-for-pets-designer-dog-house-on-wheels-0-833.jpg)
