### PR TITLE
Swap py-prefix in lint job names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,18 +82,18 @@ geth_steps: &geth_steps
         key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  lint-py35:
+  py35-lint:
     <<: *common
     docker:
       - image: circleci/python:3.5
         environment:
           TOXENV: lint-py35
-  lint-py36:
+  py36-lint:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: lint-py36
+          TOXENV: py36-lint
 
   py36-docs:
     <<: *common
@@ -361,5 +361,5 @@ workflows:
       - py35-transactions
       - py35-database
 
-      - lint-py35
-      - lint-py36
+      - py35-lint
+      - py36-lint

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
 commands=
     flake8 {toxinidir}/eth
 
-[testenv:lint-py35]
+[testenv:py35-lint]
 deps = {[common-lint]deps}
 setenv = {[common-lint]setenv}
 commands=
@@ -103,7 +103,7 @@ commands=
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
     mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs -p eth
 
-[testenv:lint-py36]
+[testenv:py36-lint]
 deps = {[common-lint]deps}
 setenv = {[common-lint]setenv}
 commands=


### PR DESCRIPTION
### What was wrong?

All CI jobs except for the linter jobs use the `py{version}` as a prefix while the linter jobs have it as a suffix. This is confusing me again and again when running tox locally. I think I'm even the one who screwed that up as one of the first things I screwed up in the repo :grin: 

### How was it fixed?

Swap it!

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.wagwalkingweb.com/media/articles/dog/why-is-my-dog-dizzy/why-is-my-dog-dizzy.jpg)
