### PR TITLE
WIP: sync chain and state data concurrently

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -770,6 +770,11 @@ class Chain(BaseChain):
             parent: BlockHeader,
             chain: Tuple[BlockHeader, ...],
             seal_check_random_sample_rate: int = 1) -> None:
+        """
+        Validate the `chain` of headers against the given parent.  The
+        `seal_check_random_sample_rate` determines how many of the headers
+        should have their seal's validated.
+        """
 
         all_indices = list(range(len(chain)))
         if seal_check_random_sample_rate == 1:

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -132,6 +132,7 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
         """
         async with self.new_sync_target:
             await self.new_sync_target.wait()
+            # TODO: handle timeouts.
             (target,) = await self.peer_pool.highest_td_peer.requests.get_block_headers(
                 self._sync_target_hash,
                 max_headers=1,
@@ -247,7 +248,7 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
             # Setting the latest header hash for the peer, before queuing header processing tasks
             if peer.head_hash != self._sync_target_hash:
                 self._sync_target_hash = peer.head_hash
-                await self.notify_new_sync_target(headers[-1])
+                await self.notify_new_sync_target(self._sync_target_hash)
 
             unrequested_headers = tuple(h for h in headers if h not in self.header_queue)
             await self.header_queue.add(unrequested_headers)

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -140,16 +140,6 @@ class FastChainSyncer(BaseHeaderChainSyncer):
             "Imported %d blocks (%d txs) in %0.2f seconds, new head: #%d",
             len(headers), txs, timer.elapsed, head.block_number)
 
-        # during fast sync, exit the service when reaching the target hash
-        target_hash = self.get_target_header_hash()
-
-        # Quite often the header batch we receive includes headers past the peer's reported
-        # head (via the NewBlock msg), so we can't compare our head's hash to the peer's in
-        # order to see if the sync is completed. Instead we just check that we have the peer's
-        # head_hash in our chain.
-        if await self.wait(self.db.coro_header_exists(target_hash)):
-            self.complete_token.trigger()
-
     async def _download_block_bodies(self,
                                      target_td: int,
                                      all_headers: Tuple[BlockHeader, ...]

--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -1,3 +1,10 @@
 # How old (in seconds) must our local head be to cause us to start with a
 # fast-sync before we switch to regular-sync.
-FAST_SYNC_CUTOFF = 60 * 60 * 24
+#FAST_SYNC_CUTOFF = 60 * 60 * 24
+FAST_SYNC_CUTOFF = 60
+
+
+# How many blocks should we wait before updating the state root which the state
+# syncer is syncing against.  This is anchored to the `--trie-cache-gens` default
+# in geth.
+STALE_STATE_ROOT_AGE = 120

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -66,12 +66,12 @@ class FullNodeSyncer(BaseService):
         while self.is_operational:
             # TODO: exit when downloader has finished.
             new_target = await chain_syncer.wait_new_sync_target()
-            self.logger('new target: #%d !!!!!!!!!!!!!!!!!!!', new_target.block_number)
+            self.logger.info('new target: #%d !!!!!!!!!!!!!!!!!!!', new_target.block_number)
             # we only update the state root for the chain syncer when the new
             # head is at least STALE_STATE_ROOT_AGE in the future of the
             # previous state sync head
             if new_target.block_number - target.block_number < STALE_STATE_ROOT_AGE:
-                self.logger('not updating to new target!!!!!!!!!!!!!!!!!')
+                self.logger.info('not updating to new target!!!!!!!!!!!!!!!!!')
                 continue
             target = new_target
             await downloader.update_state_root(target.state_root)


### PR DESCRIPTION
### What was wrong?

Work to fix multiple issues.

- speed up sync by syncing chain and state data concurrently
- periodically update `root_hash` that state sync is syncing against
- allow for independent and concurrent calls to the `peer.requests` apis.

### How was it fixed?



#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
