### PR TITLE
Delete duplicate assign statement

### DIFF
--- a/eth/vm/forks/spurious_dragon/state.py
+++ b/eth/vm/forks/spurious_dragon/state.py
@@ -37,5 +37,4 @@ class SpuriousDragonTransactionExecutor(HomesteadTransactionExecutor):
 
 class SpuriousDragonState(HomesteadState):
     computation_class = SpuriousDragonComputation
-    computation_class = SpuriousDragonComputation
     transaction_executor = SpuriousDragonTransactionExecutor  # Type[BaseTransactionExecutor]


### PR DESCRIPTION
### What was wrong?
`computation_class = SpuriousDragonComputation` has been assigned twice.https://github.com/ethereum/py-evm/blob/0e3663568651dcdcd8b7e4a1341219f9252bba96/eth/vm/forks/spurious_dragon/state.py#L39-L40

### How was it fixed?
delete

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT1kGSOYlBtrCQWcgLq039khLtbraAF8cIlvk4BCP0XFzLNuIO2)
