### PR TITLE
Move ShutdownRequest to trinity.extensibility.events

### DIFF
--- a/trinity/events.py
+++ b/trinity/events.py
@@ -1,7 +1,0 @@
-from lahja import (
-    BaseEvent
-)
-
-
-class ShutdownRequest(BaseEvent):
-    pass

--- a/trinity/extensibility/events.py
+++ b/trinity/extensibility/events.py
@@ -7,6 +7,8 @@ from argparse import (
     Namespace,
 )
 
+import lahja
+
 from trinity.config import (
     ChainConfig,
 )
@@ -53,3 +55,14 @@ class ResourceAvailableEvent(BaseEvent):
     def __init__(self, resource: Any, resource_type: Type[Any]) -> None:
         self.resource = resource
         self.resource_type = resource_type
+
+
+# The following events are based on the event bus. The mix of two different
+# `BaseEvent` classes is temporary. In the future, the events based on
+# the Lahja EventBus will become the only ones used for plugins.
+
+class ShutdownRequest(lahja.BaseEvent):
+    """
+    Request the host system to perform a full shutdown
+    """
+    pass

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -31,11 +31,9 @@ from trinity.config import (
 from trinity.constants import (
     MAIN_EVENTBUS_ENDPOINT
 )
-from trinity.events import (
-    ShutdownRequest
-)
 from trinity.extensibility.events import (
-    BaseEvent
+    BaseEvent,
+    ShutdownRequest
 )
 from trinity.utils.ipc import (
     kill_process_gracefully

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -46,9 +46,6 @@ from trinity.constants import (
     MAIN_EVENTBUS_ENDPOINT,
     NETWORKING_EVENTBUS_ENDPOINT,
 )
-from trinity.events import (
-    ShutdownRequest
-)
 from trinity.extensibility import (
     PluginManager,
     MainAndIsolatedProcessScope,
@@ -56,7 +53,8 @@ from trinity.extensibility import (
     SharedProcessScope,
 )
 from trinity.extensibility.events import (
-    TrinityStartupEvent
+    ShutdownRequest,
+    TrinityStartupEvent,
 )
 from trinity.plugins.registry import (
     ENABLED_PLUGINS


### PR DESCRIPTION
### What was wrong?

This is a small architectural cleanup that I just became aware of. The `ShutdownRequest` was introduced at `trinity.events`. However, I believe it is more appropriate for that to live under `trinity.extensibility.events`.

Reasoning:

Imagine we would rip the whole `trinity.extensibility` system out of Trinity to be used in other projects (No plans for that, just hypothetically!). A plugin would still be able to call `self.context.shutdown_host()` as it pretty much has the same meaning no matter if we are talking about the plugin system within Trinity or within a different app that uses that plugin system.

Hence, it makes more sense to have the `ShutdownRequest` event be part of `trinity.extensibility.events` as opposed to `trinity.events`.

In general, the less `trinity.extensibility` imports from outside of that namespace, the more generic it remains. While I'm not advocating for making our live harder by trying to build a *generic* plugin mechanism aimed to become a standalone project, at the same time I see no reason to artificially increase coupling when it isn't needed.

### How was it fixed?

Moved class.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media1.giphy.com/media/MSqZaYsZJGUGk/giphy.gif)
