### PR TITLE
Implement node discovery by topic, using discv5

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
 else:
     UserDict = collections.UserDict
 
+MAX_ENTRIES_PER_TOPIC = 50
 # UDP packet constants.
 V5_ID_STRING = b"temporary discovery v5"
 MAC_SIZE = 256 // 8  # 32
@@ -126,6 +127,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
     """A Kademlia-like protocol to discover RLPx nodes."""
     logger: TraceLogger = cast(TraceLogger, logging.getLogger("p2p.discovery.DiscoveryProtocol"))
     transport: asyncio.DatagramTransport = None
+    use_v5 = False
     _max_neighbours_per_packet_cache = None
 
     def __init__(self,
@@ -138,9 +140,11 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         self.bootstrap_nodes = bootstrap_nodes
         self.this_node = kademlia.Node(self.pubkey, address)
         self.routing = kademlia.RoutingTable(self.this_node)
+        self.topic_table = TopicTable(self.logger)
         self.pong_callbacks = CallbackManager()
         self.ping_callbacks = CallbackManager()
         self.neighbours_callbacks = CallbackManager()
+        self.topic_nodes_callbacks = CallbackManager()
         self.parity_pong_tokens: Dict[Hash32, Hash32] = {}
         self.cancel_token = cancel_token
 
@@ -165,7 +169,10 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         elif node == self.this_node:
             return False
 
-        token = self.send_ping(node)
+        if self.use_v5:
+            token = self.send_ping_v5(node, [])
+        else:
+            token = self.send_ping_v4(node)
 
         try:
             got_pong = await self.wait_pong(node, token)
@@ -267,6 +274,12 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
     def _mkpingid(self, token: Hash32, node: kademlia.Node) -> Hash32:
         return token + node.pubkey.to_bytes()
 
+    def _send_find_node(self, node: kademlia.Node, target_node_id: int) -> None:
+        if self.use_v5:
+            self.send_find_node_v5(node, target_node_id)
+        else:
+            self.send_find_node_v4(node, target_node_id)
+
     async def lookup(self, node_id: int) -> List[kademlia.Node]:
         """Lookup performs a network search for nodes close to the given target.
 
@@ -280,7 +293,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             # Short-circuit in case our token has been triggered to avoid trying to send requests
             # over a transport that is probably closed already.
             self.cancel_token.raise_if_triggered()
-            self.send_find_node(remote, node_id)
+            self._send_find_node(remote, node_id)
             candidates = await self.wait_neighbours(remote)
             if not candidates:
                 self.logger.debug("got no candidates from %s, returning", remote)
@@ -341,13 +354,13 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
     def _get_handler(self, cmd: DiscoveryCommand
                      ) -> Callable[[kademlia.Node, Tuple[Any, ...], Hash32], None]:
         if cmd == CMD_PING:
-            return self.recv_ping
+            return self.recv_ping_v4
         elif cmd == CMD_PONG:
-            return self.recv_pong
+            return self.recv_pong_v4
         elif cmd == CMD_FIND_NODE:
-            return self.recv_find_node
+            return self.recv_find_node_v4
         elif cmd == CMD_NEIGHBOURS:
-            return self.recv_neighbours
+            return self.recv_neighbours_v4
         else:
             raise ValueError(f"Unknown command: {cmd}")
 
@@ -425,25 +438,25 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         handler = self._get_handler(cmd)
         handler(node, payload, message_hash)
 
-    def recv_pong(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
+    def recv_pong_v4(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
         # The pong payload should have 3 elements: to, token, expiration
         _, token, _ = payload
         self.logger.trace('<<< pong (v4) from %s (token == %s)', node, encode_hex(token))
         self.process_pong(node, token)
 
-    def recv_neighbours(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
+    def recv_neighbours_v4(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
         # The neighbours payload should have 2 elements: nodes, expiration
         nodes, _ = payload
         neighbours = _extract_nodes_from_payload(nodes)
         self.logger.trace('<<< neighbours from %s: %s', node, neighbours)
         self.process_neighbours(node, neighbours)
 
-    def recv_ping(self, node: kademlia.Node, _: Any, message_hash: Hash32) -> None:
+    def recv_ping_v4(self, node: kademlia.Node, _: Any, message_hash: Hash32) -> None:
         self.logger.trace('<<< ping(v4) from %s', node)
         self.process_ping(node, message_hash)
-        self.send_pong(node, message_hash)
+        self.send_pong_v4(node, message_hash)
 
-    def recv_find_node(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
+    def recv_find_node_v4(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
         # The find_node payload should have 2 elements: node_id, expiration
         self.logger.trace('<<< find_node from %s', node)
         node_id, _ = payload
@@ -455,9 +468,9 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             return
         self.update_routing_table(node)
         found = self.routing.neighbours(big_endian_to_int(node_id))
-        self.send_neighbours(node, found)
+        self.send_neighbours_v4(node, found)
 
-    def send_ping(self, node: kademlia.Node) -> Hash32:
+    def send_ping_v4(self, node: kademlia.Node) -> Hash32:
         version = rlp.sedes.big_endian_int.serialize(PROTO_VERSION)
         payload = (version, self.address.to_endpoint(), node.address.to_endpoint())
         message = _pack_v4(CMD_PING.id, payload, self.privkey)
@@ -472,20 +485,20 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         self.parity_pong_tokens[parity_token] = token
         return token
 
-    def send_find_node(self, node: kademlia.Node, target_node_id: int) -> None:
+    def send_find_node_v4(self, node: kademlia.Node, target_node_id: int) -> None:
         node_id = int_to_big_endian(
             target_node_id).rjust(kademlia.k_pubkey_size // 8, b'\0')
         self.logger.trace('>>> find_node to %s', node)
         message = _pack_v4(CMD_FIND_NODE.id, tuple([node_id]), self.privkey)
         self.send(node, message)
 
-    def send_pong(self, node: kademlia.Node, token: Hash32) -> None:
+    def send_pong_v4(self, node: kademlia.Node, token: Hash32) -> None:
         self.logger.trace('>>> pong %s', node)
         payload = (node.address.to_endpoint(), token)
         message = _pack_v4(CMD_PONG.id, payload, self.privkey)
         self.send(node, message)
 
-    def send_neighbours(self, node: kademlia.Node, neighbours: List[kademlia.Node]) -> None:
+    def send_neighbours_v4(self, node: kademlia.Node, neighbours: List[kademlia.Node]) -> None:
         nodes = []
         neighbours = sorted(neighbours)
         for n in neighbours:
@@ -581,9 +594,9 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         elif cmd == CMD_PONG_V5:
             return self.recv_pong_v5
         elif cmd == CMD_FIND_NODE:
-            return self.recv_find_node
+            return self.recv_find_node_v5
         elif cmd == CMD_NEIGHBOURS:
-            return self.recv_neighbours
+            return self.recv_neighbours_v5
         elif cmd == CMD_FIND_NODEHASH:
             return self.recv_find_nodehash
         elif cmd == CMD_TOPIC_REGISTER:
@@ -617,9 +630,9 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         self.logger.trace('<<< ping(v5) from %s, topics: %s', node, topics)
         self.process_ping(node, message_hash)
         topic_hash = keccak(rlp.encode(topics))
-        # TODO: Create a new ticket for the given node and use that in the pong
-        ticket_serial = 0
-        wait_periods: List[int] = []
+        ticket_serial = self.topic_table.issue_ticket(node)
+        # TODO: Generate wait_periods list according to spec.
+        wait_periods: List[int] = [60] * len(topics)
         self.send_pong_v5(node, message_hash, topic_hash, ticket_serial, wait_periods)
 
     def recv_pong_v5(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
@@ -627,7 +640,15 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         _, token, _, _, _, _ = payload
         self.logger.trace('<<< pong (v5) from %s (token == %s)', node, encode_hex(token))
         self.process_pong(node, token)
-        # TODO: Create/store ticket(s)
+        # TODO: Create/store ticket in ticket store.
+
+    def recv_find_node_v5(
+            self, node: kademlia.Node, payload: Tuple[Any, ...], msg_hash: Hash32) -> None:
+        self.recv_find_node_v4(node, payload, msg_hash)
+
+    def recv_neighbours_v5(
+            self, node: kademlia.Node, payload: Tuple[Any, ...], msg_hash: Hash32) -> None:
+        self.recv_neighbours_v4(node, payload, msg_hash)
 
     def recv_find_nodehash(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
         target_hash, _ = payload
@@ -635,22 +656,30 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         # TODO: Reply with a neighbours msg.
 
     def recv_topic_register(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
-        topics, idx, pong = payload
+        topics, idx, raw_pong = payload
         self.logger.trace('<<< topic_register from %s, topics: %s', node, topics)
-        # TODO: Store the ad if it matches the last ticket we issued for this node, and mark the
-        # ticket as used.
+        _, _, pong_payload, _ = _unpack_v5(raw_pong)
+        _, _, _, _, ticket_serial, _ = pong_payload
+        self.topic_table.use_ticket(node, ticket_serial, topics[idx])
 
-    def recv_topic_query(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
+    def recv_topic_query(
+            self, node: kademlia.Node, payload: Tuple[Any, ...], message_hash: Hash32) -> None:
         topic, _ = payload
-        self.logger.trace('<<< topic_query from %s, topic: %s', node, topic)
-        # TODO: Lookup nodes matching the given topic and send a topic_nodes msg
+        self.logger.trace('<<< topic_query (%s) from %s', topic, node)
+        nodes = self.topic_table.get_nodes(topic)
+        self.send_topic_nodes(node, message_hash, nodes)
 
     def recv_topic_nodes(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
         echo, raw_nodes = payload
         nodes = _extract_nodes_from_payload(raw_nodes)
         self.logger.trace('<<< topic_nodes from %s: %s', node, nodes)
-        # TODO: Match 'echo' against hash of topic_query msg sent to the same node, and store a
-        # link from the topic to the nodes.
+        try:
+            callback = self.topic_nodes_callbacks.get_callback(node)
+        except KeyError:
+            self.logger.debug(
+                'Unexpected topic_nodes from %s, probably came too late', node)
+        else:
+            callback(echo, nodes)
 
     def send_ping_v5(self, node: kademlia.Node, topics: List[bytes]) -> Hash32:
         version = rlp.sedes.big_endian_int.serialize(PROTO_VERSION_V5)
@@ -680,13 +709,63 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         message = _pack_v5(CMD_FIND_NODE.id, (node_id, _get_msg_expiration()), self.privkey)
         self.send_v5(node, message)
 
-    def send_topic_query(self, node: kademlia.Node, topic: Hash32) -> None:
-        self.logger.trace('>>> topic_query to %s', node)
+    def send_topic_query(self, node: kademlia.Node, topic: bytes) -> Hash32:
+        self.logger.trace('>>> topic_query (%s) to %s', topic, node)
         payload = (topic, _get_msg_expiration())
         message = _pack_v5(CMD_TOPIC_QUERY.id, payload, self.privkey)
-        # TODO: Get the msg hash and store it in the ticket store to match against received
-        # topic_node msgs.
-        self.send_v5(node, message)
+        return self.send_v5(node, message)
+
+    def send_topic_nodes(
+            self, node: kademlia.Node, echo: Hash32, nodes: Tuple[kademlia.Node, ...]) -> None:
+        encoded_nodes = []
+        for n in nodes:
+            encoded_nodes.append(n.address.to_endpoint() + [n.pubkey.to_bytes()])
+
+        max_neighbours = self._get_max_neighbours_per_packet()
+        for i in range(0, len(encoded_nodes), max_neighbours):
+            message = _pack_v5(
+                CMD_TOPIC_NODES.id,
+                (echo, encoded_nodes[i:i + max_neighbours]),
+                self.privkey)
+            self.logger.trace('>>> topic_nodes to %s: %s', node, nodes[i:i + max_neighbours])
+            self.send_v5(node, message)
+
+    async def wait_topic_nodes(
+            self, remote: kademlia.Node, echo: Hash32) -> Tuple[kademlia.Node, ...]:
+        """Wait for a topic_nodes msg from the given node.
+
+        Returns the list of nodes received.
+        """
+        event = asyncio.Event()
+        nodes: List[kademlia.Node] = []
+
+        def process(received_echo: Hash32, response: List[kademlia.Node]) -> None:
+            if received_echo != echo:
+                self.logger.warn(
+                    "Unexpected topic_nodes from %s, expected echo %s, got %s",
+                    encode_hex(echo), encode_hex(received_echo))
+                return
+
+            nodes.extend(response)
+            # This callback may be called multiple times if the number of nodes returned by the
+            # peer make the msg exceed the 1280 bytes limit, so we only call event.set() once
+            # we've received enough neighbours.
+            if len(nodes) >= MAX_ENTRIES_PER_TOPIC:
+                event.set()
+
+        with self.topic_nodes_callbacks.acquire(remote, process):
+            try:
+                await self.cancel_token.cancellable_wait(
+                    event.wait(), timeout=kademlia.k_request_timeout)
+            except TimeoutError:
+                # A timeout here just means we didn't get at least MAX_ENTRIES_PER_TOPIC nodes,
+                # but we'll still process the ones we get.
+                self.logger.debug(
+                    'timed out waiting for %d neighbours from %s', MAX_ENTRIES_PER_TOPIC, remote)
+            finally:
+                self.logger.debug('got %d topic nodes from %s', len(nodes), remote)
+
+        return tuple(n for n in nodes if n != self.this_node)
 
 
 class PreferredNodeDiscoveryProtocol(DiscoveryProtocol):
@@ -756,6 +835,53 @@ class PreferredNodeDiscoveryProtocol(DiscoveryProtocol):
         yield from super().get_nodes_to_connect(num_nodes_needed)
 
 
+class DiscoveryByTopicProtocol(DiscoveryProtocol):
+    """Experimental discovery implementation that uses topic_query to find compatible nodes"""
+    use_v5 = True
+    _concurrent_topic_nodes_requests = 10
+
+    def __init__(self,
+                 topic: bytes,
+                 privkey: datatypes.PrivateKey,
+                 address: kademlia.Address,
+                 bootstrap_nodes: Tuple[kademlia.Node, ...],
+                 cancel_token: CancelToken) -> None:
+        super().__init__(privkey, address, bootstrap_nodes, cancel_token)
+        self.topic = topic
+
+    def get_nodes_to_connect(self, count: int) -> Iterator[kademlia.Node]:
+        topic_nodes = self.topic_table.get_nodes(self.topic)
+        for node in topic_nodes:
+            yield node
+
+        num_nodes_needed = max(0, count - len(topic_nodes))
+        yield from super().get_nodes_to_connect(num_nodes_needed)
+
+    async def lookup_random(self) -> List[kademlia.Node]:
+        query_nodes = list(self.routing.get_random_nodes(self._concurrent_topic_nodes_requests))
+        expected_echoes = []
+        for n in query_nodes:
+            echo = self.send_topic_query(n, self.topic)
+            expected_echoes.append((n, echo))
+        replies = await asyncio.gather(
+            *[self.wait_topic_nodes(n, echo) for n, echo in expected_echoes])
+        seen_nodes: Set[kademlia.Node] = set()
+        for reply in replies:
+            for node in reply:
+                if node in seen_nodes:
+                    continue
+                seen_nodes.add(node)
+                self.topic_table.add_node(node, self.topic)
+
+        if len(seen_nodes) < kademlia.k_bucket_size:
+            # Not enough nodes were found for our topic, so perform a regular kademlia lookup for
+            # a random node ID.
+            extra_nodes = await super().lookup_random()
+            seen_nodes.update(extra_nodes)
+
+        return list(seen_nodes)
+
+
 class DiscoveryService(BaseService):
     _lookup_running = asyncio.Lock()
     _last_lookup: float = 0
@@ -818,6 +944,63 @@ class DiscoveryService(BaseService):
 
     async def _cleanup(self) -> None:
         await self.proto.stop()
+
+
+class NodeTicketInfo:
+    last_issued: int = 0
+    last_used: int = 0
+
+
+class TopicEntry:
+
+    def __init__(self, node: kademlia.Node, expiry: float) -> None:
+        self.node = node
+        self.expiry = expiry
+
+
+class TopicTable:
+    registration_lifetime = 60 * 60
+
+    def __init__(self, logger: TraceLogger) -> None:
+        self.logger = logger
+        # A per-topic FIFO list of nodes.
+        self.topics: Dict[bytes, List[TopicEntry]] = {}
+        # The IDs of the last issued/used tickets for any given node.
+        self.node_tickets: Dict[kademlia.Node, NodeTicketInfo] = {}
+
+    def add_node(self, node: kademlia.Node, topic: bytes) -> None:
+        entries = self.topics.setdefault(topic, [])
+        if len(entries) >= MAX_ENTRIES_PER_TOPIC:
+            entries.pop(0)
+        entries.append(TopicEntry(node, time.time() + self.registration_lifetime))
+
+    def get_nodes(self, topic: bytes) -> Tuple[kademlia.Node, ...]:
+        if topic not in self.topics:
+            return tuple()
+        else:
+            now = time.time()
+            entries = [entry for entry in self.topics[topic] if entry.expiry > now]
+            self.topics[topic] = entries
+            return tuple(entry.node for entry in entries)
+
+    def use_ticket(self, node: kademlia.Node, ticket_serial: int, topic: bytes) -> None:
+        ticket_info = self.node_tickets.get(node)
+        if ticket_info is None:
+            self.logger.debug("No ticket found for %s", node)
+            return
+
+        if ticket_serial != ticket_info.last_issued:
+            self.logger.debug("Wrong ticket for %s, expected %d, got %d", node,
+                              ticket_info.last_issued, ticket_serial)
+            return
+
+        ticket_info.last_used = ticket_serial
+        self.add_node(node, topic)
+
+    def issue_ticket(self, node: kademlia.Node) -> int:
+        node_info = self.node_tickets.setdefault(node, NodeTicketInfo())
+        node_info.last_issued += 1
+        return node_info.last_issued
 
 
 @to_list
@@ -992,21 +1175,21 @@ def _test() -> None:
     else:
         bootstrap_nodes = tuple(
             kademlia.Node.from_uri(enode) for enode in constants.ROPSTEN_BOOTNODES)
-    discovery = DiscoveryProtocol(privkey, addr, bootstrap_nodes, CancelToken("discovery"))
-    loop.run_until_complete(
-        loop.create_datagram_endpoint(lambda: discovery, local_addr=('0.0.0.0', listen_port)))
+
+    if args.v5:
+        # topic = b'LES2@41941023680923e0'  # LES2/ropsten
+        topic = b'LES2@d4e56740f876aef8'  # LES2/mainnet
+        discovery: DiscoveryProtocol = DiscoveryByTopicProtocol(
+            topic, privkey, addr, bootstrap_nodes, CancelToken("discovery"))
+    else:
+        discovery = DiscoveryProtocol(privkey, addr, bootstrap_nodes, CancelToken("discovery"))
 
     async def run() -> None:
+        await loop.create_datagram_endpoint(lambda: discovery, local_addr=('0.0.0.0', listen_port))
         try:
-            if args.v5:
-                remote = bootstrap_nodes[0]
-                topic = b'LES@41941023680923e0'  # LES/ropsten
-                token = discovery.send_ping_v5(remote, [topic])
-                await discovery.wait_pong(remote, token)
-                discovery.send_find_node_v5(remote, random.randint(0, kademlia.k_max_node_id))
-                await discovery.wait_neighbours(remote)
-            else:
-                await discovery.bootstrap()
+            await discovery.bootstrap()
+            print("******* Found topic nodes *******************")
+            print([e.node for e in discovery.topic_table.topics[topic]])
         except OperationCancelled:
             pass
         finally:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,3 @@
-import logging
-import sys
-
 # from eth.utils.logging import TRACE_LEVEL_NUM
 
 import pytest
@@ -21,29 +18,6 @@ from eth.db.backends.memory import MemoryDB
 # TODO: tests should not be locked into one set of VM rules.  Look at expanding
 # to all mainnet vms.
 from eth.vm.forks.spurious_dragon import SpuriousDragonVM
-
-
-LOGGING_NAMESPACES = ('eth', 'p2p', 'trinity')
-
-
-@pytest.fixture(autouse=True, scope="session")
-def _stdout_logging(namespaces=LOGGING_NAMESPACES):
-    for namespace in namespaces:
-        logger = logging.getLogger(namespace)
-
-        handler = logging.StreamHandler(sys.stdout)
-
-        # level = 5  # TRACE
-        # level = logging.DEBUG
-        # level = logging.INFO
-        level = logging.ERROR
-
-        logger.setLevel(level)
-        handler.setLevel(level)
-
-        logger.addHandler(handler)
-
-        logger.info('Set level for logger: %s', namespace)
 
 
 # Uncomment this to have logs from tests written to a file.  This is useful for

--- a/tests/p2p/test_discovery.py
+++ b/tests/p2p/test_discovery.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+import socket
 import string
 import re
 
@@ -28,13 +29,6 @@ def short_timeout(monkeypatch):
     monkeypatch.setattr(kademlia, 'k_request_timeout', 0.01)
 
 
-# Depend on the event_loop fixture here to make sure CancelToken uses the default loop installed
-# for the tests. More info in https://github.com/pytest-dev/pytest-asyncio/issues/38
-@pytest.fixture
-def cancel_token(event_loop):
-    return CancelToken("cancel_token_fixture")
-
-
 def test_ping_pong():
     alice = get_discovery_protocol(b"alice")
     bob = get_discovery_protocol(b"bob")
@@ -44,9 +38,9 @@ def test_ping_pong():
     link_transports(alice, bob)
     # Collect all pongs received by alice in a list for later inspection.
     received_pongs = []
-    alice.recv_pong = lambda node, payload, hash_: received_pongs.append((node, payload))
+    alice.recv_pong_v4 = lambda node, payload, hash_: received_pongs.append((node, payload))
 
-    token = alice.send_ping(bob.this_node)
+    token = alice.send_ping_v4(bob.this_node)
 
     assert len(received_pongs) == 1
     node, payload = received_pongs[0]
@@ -67,14 +61,14 @@ def _test_find_node_neighbours(use_v5):
     link_transports(alice, bob)
     # Collect all neighbours packets received by alice in a list for later inspection.
     received_neighbours = []
-    alice.recv_neighbours = lambda node, payload, hash_: received_neighbours.append((node, payload))
+    alice.recv_neighbours_v4 = lambda node, payload, hash_: received_neighbours.append((node, payload))  # noqa: E501
     # Pretend that bob and alice have already bonded, otherwise bob will ignore alice's find_node.
     bob.update_routing_table(alice.this_node)
 
     if use_v5:
         alice.send_find_node_v5(bob.this_node, alice.this_node.id)
     else:
-        alice.send_find_node(bob.this_node, alice.this_node.id)
+        alice.send_find_node_v4(bob.this_node, alice.this_node.id)
 
     # Bob should have sent two neighbours packets in order to keep the total packet size under the
     # 1280 bytes limit.
@@ -121,7 +115,7 @@ async def test_wait_ping(echo):
     node = random_node()
 
     # Schedule a call to proto.recv_ping() simulating a ping from the node we expect.
-    recv_ping_coroutine = asyncio.coroutine(lambda: proto.recv_ping(node, echo, b''))
+    recv_ping_coroutine = asyncio.coroutine(lambda: proto.recv_ping_v4(node, echo, b''))
     asyncio.ensure_future(recv_ping_coroutine())
 
     got_ping = await proto.wait_ping(node)
@@ -132,7 +126,7 @@ async def test_wait_ping(echo):
 
     # If we waited for a ping from a different node, wait_ping() would timeout and thus return
     # false.
-    recv_ping_coroutine = asyncio.coroutine(lambda: proto.recv_ping(node, echo, b''))
+    recv_ping_coroutine = asyncio.coroutine(lambda: proto.recv_ping_v4(node, echo, b''))
     asyncio.ensure_future(recv_ping_coroutine())
 
     node2 = random_node()
@@ -151,7 +145,7 @@ async def test_wait_pong():
     token = b'token'
     # Schedule a call to proto.recv_pong() simulating a pong from the node we expect.
     pong_msg_payload = [us.address.to_endpoint(), token, discovery._get_msg_expiration()]
-    recv_pong_coroutine = asyncio.coroutine(lambda: proto.recv_pong(node, pong_msg_payload, b''))
+    recv_pong_coroutine = asyncio.coroutine(lambda: proto.recv_pong_v4(node, pong_msg_payload, b''))
     asyncio.ensure_future(recv_pong_coroutine())
 
     got_pong = await proto.wait_pong(node, token)
@@ -165,7 +159,7 @@ async def test_wait_pong():
     # timeout.
     wrong_token = b"foo"
     pong_msg_payload = [us.address.to_endpoint(), wrong_token, discovery._get_msg_expiration()]
-    recv_pong_coroutine = asyncio.coroutine(lambda: proto.recv_pong(node, pong_msg_payload, b''))
+    recv_pong_coroutine = asyncio.coroutine(lambda: proto.recv_pong_v4(node, pong_msg_payload, b''))
     asyncio.ensure_future(recv_pong_coroutine())
 
     got_pong = await proto.wait_pong(node, token)
@@ -175,18 +169,18 @@ async def test_wait_pong():
 
 
 @pytest.mark.asyncio
-async def test_wait_neighbours(cancel_token):
+async def test_wait_neighbours():
     proto = MockDiscoveryProtocol([])
     node = random_node()
 
-    # Schedule a call to proto.recv_neighbours() simulating a neighbours response from the node we
-    # expect.
+    # Schedule a call to proto.recv_neighbours_v4() simulating a neighbours response from the node
+    # we expect.
     neighbours = (random_node(), random_node(), random_node())
     neighbours_msg_payload = [
         [n.address.to_endpoint() + [n.pubkey.to_bytes()] for n in neighbours],
         discovery._get_msg_expiration()]
     recv_neighbours_coroutine = asyncio.coroutine(
-        lambda: proto.recv_neighbours(node, neighbours_msg_payload, b''))
+        lambda: proto.recv_neighbours_v4(node, neighbours_msg_payload, b''))
     asyncio.ensure_future(recv_neighbours_coroutine())
 
     received_neighbours = await proto.wait_neighbours(node)
@@ -203,13 +197,13 @@ async def test_wait_neighbours(cancel_token):
 
 
 @pytest.mark.asyncio
-async def test_bond(cancel_token):
+async def test_bond():
     proto = MockDiscoveryProtocol([])
     node = random_node()
 
     token = b'token'
     # Do not send pings, instead simply return the pingid we'd expect back together with the pong.
-    proto.send_ping = lambda remote: token
+    proto.send_ping_v4 = lambda remote: token
 
     # Pretend we get a pong from the node we are bonding with.
     proto.wait_pong = asyncio.coroutine(lambda n, t: t == token and n == node)
@@ -303,7 +297,7 @@ def test_v5_handlers(monkeypatch):
         recv_find_nodehash='74656d706f7261727920646973636f7665727920763558dc895847c5d2cc9ab6f722f25b9ff1b9c188af6ff7ed7c716a3cde2e93f3ec1e2b897acb1a33aa1d345c72ea34912287b21480c80ef99241d4bd9fd53711ee0105e6a038f7bb96e94bcd39866baa56038367ad6145de1ee8f4a8b0993ebdf8883a0ad8845b7e5593',  # noqa: E501
         recv_topic_query='74656d706f7261727920646973636f76657279207635308621f1ed59a67613da52da3f84bac3d927d0dc1650b27552b10a0a823fb2133cebf3680f68bf88457bb0c07787031357430985d03afa1af0574e8ef0eab7fc0007d7954c455332406434653536373430663837366165663880',  # noqa: E501
         recv_topic_nodes='74656d706f7261727920646973636f76657279207635e33166b59d20f206f0df2502be59186cb971c76ee91dba94ea9b1bbeb1308a5f4efbdf945ead9ba89d7c2c55d5d841dacdef69a455c98e1a5415e489508afa450008f87ea0cff0456ecbf2e6b0a40bc6541bd209c60ced192509470b405c256a17443674b3f85bf8599000000000000000000000ffff904c1f9c82765f82765fb840e7d624c642b86d3d48cea3e395305345c3a0226fc4c2dfdfbeb94cb6891e5e72b4467c69684ac14b072d2e4fa9c7a731cc1fdf0283abe41186d00b4c879f80ed',  # noqa: E501
-        recv_neighbours='74656d706f7261727920646973636f766572792076358f6671ae9611c82c9cb04538aeed13a8b4e8eb8ad0d0dbba4b161ded52b195846c6086a0d42eef44cfcc0b793a0b9420613727958a8956139c127810b94d4e830004f90174f9016cf8599000000000000000000000ffff59401a22826597826597b840d723e264da67820fb0cedb0d03d5d975cc82bffdadd2879f3e5fa58b5525de5fdd0b90002bba44ac9232247dfbccb2a730e5ea98201bab1f1fe72422aa58143ff8599000000000000000000000ffffae6c601a82765f82765fb840779f19056e0a0486c3f6838896a931bf920cd8f551f664022a50690d4cca4730b50a97058aac11a5aa0cc55db6f9207e12a9cd389269f414a98e5b6a2f6c9f89f8599000000000000000000000ffff287603df827663827663b84085c85d7143ae8bb96924f2b54f1b3e70d8c4d367af305325d30a61385a432f247d2c75c45c6b4a60335060d072d7f5b35dd1d4c45f76941f62a4f83b6e75daaff8599000000000000000000000ffff0d4231b0820419820419b8407b46cc366b6cbaec088a7d15688a2c12bb8ba4cf7ee8e01b22ab534829f9ff13f7cc4130f10a4021f7d77e9b9c80a9777f5ddc035efb130fe3b6786434367973845b7e5569',  # noqa: E501
+        recv_neighbours_v5='74656d706f7261727920646973636f766572792076358f6671ae9611c82c9cb04538aeed13a8b4e8eb8ad0d0dbba4b161ded52b195846c6086a0d42eef44cfcc0b793a0b9420613727958a8956139c127810b94d4e830004f90174f9016cf8599000000000000000000000ffff59401a22826597826597b840d723e264da67820fb0cedb0d03d5d975cc82bffdadd2879f3e5fa58b5525de5fdd0b90002bba44ac9232247dfbccb2a730e5ea98201bab1f1fe72422aa58143ff8599000000000000000000000ffffae6c601a82765f82765fb840779f19056e0a0486c3f6838896a931bf920cd8f551f664022a50690d4cca4730b50a97058aac11a5aa0cc55db6f9207e12a9cd389269f414a98e5b6a2f6c9f89f8599000000000000000000000ffff287603df827663827663b84085c85d7143ae8bb96924f2b54f1b3e70d8c4d367af305325d30a61385a432f247d2c75c45c6b4a60335060d072d7f5b35dd1d4c45f76941f62a4f83b6e75daaff8599000000000000000000000ffff0d4231b0820419820419b8407b46cc366b6cbaec088a7d15688a2c12bb8ba4cf7ee8e01b22ab534829f9ff13f7cc4130f10a4021f7d77e9b9c80a9777f5ddc035efb130fe3b6786434367973845b7e5569',  # noqa: E501
     )
 
     proto = get_discovery_protocol()
@@ -340,6 +334,28 @@ def test_ping_pong_v5():
 
 def test_find_node_neighbours_v5():
     _test_find_node_neighbours(use_v5=True)
+
+
+@pytest.mark.asyncio
+async def test_topic_query(event_loop):
+    bob_addr = kademlia.Address("127.0.0.1", 12345)
+    bob = get_discovery_protocol(b"bob", bob_addr)
+    await event_loop.create_datagram_endpoint(
+        lambda: bob, local_addr=(bob_addr.ip, bob_addr.udp_port), family=socket.AF_INET)
+    les_nodes = [random_node() for _ in range(10)]
+    topic = b'les'
+    for n in les_nodes:
+        bob.topic_table.add_node(n, topic)
+    alice_addr = kademlia.Address("127.0.0.1", 12346)
+    alice = get_discovery_protocol(b"alice", alice_addr)
+    await event_loop.create_datagram_endpoint(
+        lambda: alice, local_addr=(alice_addr.ip, alice_addr.udp_port), family=socket.AF_INET)
+
+    echo = alice.send_topic_query(bob.this_node, topic)
+    received_nodes = await alice.wait_topic_nodes(bob.this_node, echo)
+
+    assert len(received_nodes) == 10
+    assert sorted(received_nodes) == sorted(les_nodes)
 
 
 def remove_whitespace(s):
@@ -408,9 +424,11 @@ eip8_packets = {
 }
 
 
-def get_discovery_protocol(seed=b"seed"):
+def get_discovery_protocol(seed=b"seed", address=None):
     privkey = keys.PrivateKey(keccak(seed))
-    return discovery.DiscoveryProtocol(privkey, random_address(), [], CancelToken("discovery-test"))
+    if address is None:
+        address = random_address()
+    return discovery.DiscoveryProtocol(privkey, address, [], CancelToken("discovery-test"))
 
 
 def link_transports(proto1, proto2):
@@ -454,16 +472,16 @@ class MockDiscoveryProtocol(discovery.DiscoveryProtocol):
         privkey = keys.PrivateKey(keccak(b"seed"))
         super().__init__(privkey, random_address(), bootnodes, CancelToken("discovery-test"))
 
-    def send_ping(self, node):
+    def send_ping_v4(self, node):
         echo = hex(random.randint(0, 2**256))[-32:]
         self.messages.append((node, 'ping', echo))
         return echo
 
-    def send_pong(self, node, echo):
+    def send_pong_v4(self, node, echo):
         self.messages.append((node, 'pong', echo))
 
-    def send_find_node(self, node, nodeid):
+    def send_find_node_v4(self, node, nodeid):
         self.messages.append((node, 'find_node', nodeid))
 
-    def send_neighbours(self, node, neighbours):
+    def send_neighbours_v4(self, node, neighbours):
         self.messages.append((node, 'neighbours', neighbours))


### PR DESCRIPTION
New, highly experimental, DiscoveryByTopicProtocol class that looks
up nodes by topic and falls back to kademlia's random node ID lookups
when not enough topic nodes are found.