### PR TITLE
add handling for MalformedMessage during peer connection

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -812,6 +812,10 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
             # This is kept separate from the `expected_exceptions` to be sure that we aren't
             # silencing an error in our authentication code.
             self.logger.info('Got bad auth ack from %r', remote)
+        except MalformedMessage:
+            # This is kept separate from the `expected_exceptions` to be sure that we aren't
+            # silencing an error in our authentication code.
+            self.logger.info('Got malformed response from %r', remote)
         except expected_exceptions as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))
         except Exception:

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -811,11 +811,15 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
         except BadAckMessage:
             # This is kept separate from the `expected_exceptions` to be sure that we aren't
             # silencing an error in our authentication code.
-            self.logger.info('Got bad auth ack from %r', remote)
+            self.logger.error('Got bad auth ack from %r', remote)
+            # dump the full stacktrace in the debug logs
+            self.logger.debug('Got bad auth ack from %r', remote, exc_info=True)
         except MalformedMessage:
             # This is kept separate from the `expected_exceptions` to be sure that we aren't
-            # silencing an error in our authentication code.
-            self.logger.info('Got malformed response from %r', remote)
+            # silencing an error in how we decode messages during handshake.
+            self.logger.error('Got malformed response from %r during handshake', remote)
+            # dump the full stacktrace in the debug logs
+            self.logger.debug('Got malformed response from %r', remote, exc_info=True)
         except expected_exceptions as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))
         except Exception:


### PR DESCRIPTION
fixes #1241 

### What was wrong?

Unhandled exception when connecting to peers.

### How was it fixed?

Added an `except` clause to handle it.

#### Cute Animal Picture

![monkey-riding-dog2-750x741](https://user-images.githubusercontent.com/824194/44995435-41c5bf80-af60-11e8-8782-fc4534052409.jpg)

