### PR TITLE
Prefer time.perf_counter or monotonic over time()

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -132,7 +132,7 @@ class KBucket(Sized):
         self.end = end
         self.nodes: List[Node] = []
         self.replacement_cache: List[Node] = []
-        self.last_updated = time.time()
+        self.last_updated = time.monotonic()
 
     @property
     def midpoint(self) -> int:
@@ -181,7 +181,7 @@ class KBucket(Sized):
         node at the head of the list (i.e. the least recently seen), which should be evicted if it
         fails to respond to a ping.
         """
-        self.last_updated = time.time()
+        self.last_updated = time.monotonic()
         if node in self.nodes:
             self.nodes.remove(node)
             self.nodes.append(node)
@@ -213,13 +213,13 @@ class RoutingTable:
     logger = logging.getLogger("p2p.kademlia.RoutingTable")
 
     def __init__(self, node: Node) -> None:
-        self._initialized_at = time.time()
+        self._initialized_at = time.monotonic()
         self.this_node = node
         self.buckets = [KBucket(0, k_max_node_id)]
 
     def get_random_nodes(self, count: int) -> Iterator[Node]:
         if count > len(self):
-            if time.time() - self._initialized_at > 30:
+            if time.monotonic() - self._initialized_at > 30:
                 self.logger.warn(
                     "Cannot get %d nodes as RoutingTable contains only %d nodes", count, len(self))
             count = len(self)
@@ -245,7 +245,7 @@ class RoutingTable:
 
     @property
     def idle_buckets(self) -> List[KBucket]:
-        idle_cutoff_time = time.time() - k_idle_bucket_refresh_interval
+        idle_cutoff_time = time.monotonic() - k_idle_bucket_refresh_interval
         return [b for b in self.buckets if b.last_updated < idle_cutoff_time]
 
     @property

--- a/scripts/benchmark/utils/meters.py
+++ b/scripts/benchmark/utils/meters.py
@@ -14,7 +14,7 @@ class TimedResult(NamedTuple):
 
 
 def time_call(fn: Callable[..., Any]=None) -> TimedResult:
-    start = time.time()
+    start = time.perf_counter()
     return_value = fn()
-    duration = time.time() - start
+    duration = time.perf_counter() - start
     return TimedResult(duration=duration, wrapped_value=return_value)

--- a/tests/trinity/integration/test_lightchain_integration.py
+++ b/tests/trinity/integration/test_lightchain_integration.py
@@ -117,8 +117,8 @@ def geth_process(geth_command_arguments):
 
 
 def wait_for_socket(ipc_path, timeout=10):
-    start = time.time()
-    while time.time() < start + timeout:
+    start = time.monotonic()
+    while time.monotonic() < start + timeout:
         try:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.connect(str(ipc_path))

--- a/trinity/sync/sharding/service.py
+++ b/trinity/sync/sharding/service.py
@@ -77,7 +77,7 @@ class ShardSyncer(BaseService, PeerSubscriber):
 
         self.collation_hashes_at_peer: Dict[ShardingPeer, Set[Hash32]] = defaultdict(set)
 
-        self.start_time = time.time()
+        self.start_time = time.monotonic()
 
     subscription_msg_types: Set[Type[Command]] = {Collations, GetCollations, NewCollationHashes}
 
@@ -204,4 +204,4 @@ class ShardSyncer(BaseService, PeerSubscriber):
 
     def get_current_period(self) -> int:
         # TODO: get this from main chain
-        return int((time.time() - self.start_time) // COLLATION_PERIOD)
+        return int((time.monotonic() - self.start_time) // COLLATION_PERIOD)

--- a/trinity/utils/ipc.py
+++ b/trinity/utils/ipc.py
@@ -13,8 +13,8 @@ def wait_for_ipc(ipc_path: pathlib.Path, timeout: int=10) -> None:
     Waits up to ``timeout`` seconds for the IPC socket file to appear at path
     ``ipc_path``, or raises a :exc:`TimeoutError` otherwise.
     """
-    start_at = time.time()
-    while time.time() - start_at < timeout:
+    start_at = time.monotonic()
+    while time.monotonic() - start_at < timeout:
         if ipc_path.exists():
             return
         else:

--- a/trinity/utils/timer.py
+++ b/trinity/utils/timer.py
@@ -9,8 +9,8 @@ class Timer:
             self.start()
 
     def start(self) -> None:
-        self._start = time.time()
+        self._start = time.perf_counter()
 
     @property
     def elapsed(self) -> float:
-        return time.time() - self._start
+        return time.perf_counter() - self._start


### PR DESCRIPTION
### What was wrong?

`time.time()` is not the most precise mechanism to measure performance. Also time might go backwards, if the system clock is reset. A number of places presumed a monotonically increasing clock when using `time.time()`. Behavior would be erratic/buggy if time moved backwards.

### How was it fixed?

Depending on the precision needs, `perf_counter()` (high precision) or `monotonic()` normal precision was swapped in.

Still some questionable usages in:
- p2p/discovery.py
- trinity/sync/full/state.py
- tests

But they (potentially) "expose" the time value across API boundaries, which is highly undesirable. (only the diffs should be exposed with `perf_counter` or `monotonic`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.funnyanimalsite.com/pictures/Hooray.jpg)
