### PR TITLE
Clearer service exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	tox -elint-py3{6,5}
+	tox -epy3{6,5}-lint
 
 test:
 	py.test --tb native tests

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -732,7 +732,7 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
             peer.remove_subscriber(subscriber)
 
     async def start_peer(self, peer: BasePeer) -> None:
-        self.run_task(peer.run())
+        self.run_child_service(peer)
         await self.wait(peer.events.started.wait(), timeout=1)
         try:
             # Although connect() may seem like a more appropriate place to perform the DAO fork

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -13,9 +13,12 @@ from typing import (
 )
 from weakref import WeakSet
 
-from eth.tools.logging import TraceLogger
-
 from cancel_token import CancelToken, OperationCancelled
+from eth_utils import (
+    ValidationError,
+)
+
+from eth.tools.logging import TraceLogger
 
 from p2p.cancellable import CancellableMixin
 from p2p.utils import get_asyncio_executor
@@ -88,9 +91,9 @@ class BaseService(ABC, CancellableMixin):
         finished_callback (if one was passed).
         """
         if self.is_running:
-            raise RuntimeError("Cannot start the service while it's already running")
+            raise ValidationError("Cannot start the service while it's already running")
         elif self.is_cancelled:
-            raise RuntimeError("Cannot restart a service that has already been cancelled")
+            raise ValidationError("Cannot restart a service that has already been cancelled")
 
         if finished_callback:
             self._finished_callbacks.append(finished_callback)
@@ -144,6 +147,15 @@ class BaseService(ABC, CancellableMixin):
         """
         Run a child service and keep a reference to it to be considered during the cleanup.
         """
+        if child_service.is_running:
+            raise ValidationError(
+                f"Can't start service {child_service!r}, child of {self!r}: it's already running"
+            )
+        elif child_service.is_cancelled:
+            raise ValidationError(
+                f"Can't restart {child_service!r}, child of {self!r}: it's already completed"
+            )
+
         self._child_services.add(child_service)
         self.run_task(child_service.run())
 
@@ -153,6 +165,16 @@ class BaseService(ABC, CancellableMixin):
 
         If the service finishes while we're still running, we'll terminate as well.
         """
+        if service.is_running:
+            raise ValidationError(
+                f"Can't start daemon {child_service!r}, child of {self!r}: it's already running"
+            )
+        elif service.is_cancelled:
+            raise ValidationError(
+                f"Can't restart daemon {service!r}, child of {self!r}: it's already completed"
+            )
+
+
         self._child_services.add(service)
 
         async def _run_daemon_wrapper() -> None:
@@ -193,7 +215,7 @@ class BaseService(ABC, CancellableMixin):
             self.logger.warning("Tried to cancel %s, but it was already cancelled", self)
             return
         elif not self.is_running:
-            raise RuntimeError("Cannot cancel a service that has not been started")
+            raise ValidationError("Cannot cancel a service that has not been started")
 
         self.logger.debug("Cancelling %s", self)
         self.events.cancelled.set()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist=
     py{36}-rpc-state-{frontier,homestead,eip150,eip158,byzantium,quadratic}
     py{35,36}-native-state-{frontier,homestead,eip150,eip158,byzantium,constantinople,metropolis}
     py37-{core,trinity,trinity-integration}
-    lint-py{35,36}
+    py{35,36}-lint
 
 [flake8]
 max-line-length= 100


### PR DESCRIPTION
### What was wrong?

When child services couldn't start (in `run_child_service` or `run_daemon`), the stack had lost who the calling parent was because of asyncio indirection.

### How was it fixed?

- Raise exceptions earlier in the flow, with clearer messaging
- ValidationError slightly more helpful than RuntimeError

Also, prefer `run_child_service` over `run_task` in peer, because it has more info
to give better error messages.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img.etsystatic.com/il/e655fa/1158933639/il_570xN.1158933639_bdxp.jpg?version=0)
