### PR TITLE
Improve fast-sync reliability & clean up messages

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -497,7 +497,7 @@ class BasePeer(BaseService):
         self.ingress_mac.update(sxor(self.mac_enc(fmac_seed), fmac_seed))
         expected_frame_mac = self.ingress_mac.digest()[:MAC_LEN]
         if not bytes_eq(expected_frame_mac, frame_mac):
-            raise DecryptionError('Invalid frame mac: expected %s, got %s'.format(
+            raise DecryptionError('Invalid frame mac: expected {}, got {}'.format(
                 expected_frame_mac, frame_mac))
         return self.aes_dec.update(frame_ciphertext)[:body_size]
 

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -93,7 +93,7 @@ class Command:
             data = rlp.decode(rlp_data, sedes=decoder, recursive_cache=True)
         except rlp.DecodingError as err:
             raise MalformedMessage(
-                "Malformed %s message: %r".format(type(self).__name__, err)
+                "Malformed {} message: {!r}".format(type(self).__name__, err)
             ) from err
 
         if isinstance(self.structure, sedes.CountableList):

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -187,8 +187,7 @@ class BaseService(ABC, CancellableMixin):
 
         self.events.cleaned_up.set()
 
-    async def cancel(self) -> None:
-        """Trigger the CancelToken and wait for the cleaned_up event to be set."""
+    def cancel_nowait(self) -> None:
         if self.is_cancelled:
             self.logger.warning("Tried to cancel %s, but it was already cancelled", self)
             return
@@ -198,6 +197,11 @@ class BaseService(ABC, CancellableMixin):
         self.logger.debug("Cancelling %s", self)
         self.events.cancelled.set()
         self.cancel_token.trigger()
+
+    async def cancel(self) -> None:
+        """Trigger the CancelToken and wait for the cleaned_up event to be set."""
+        self.cancel_nowait()
+
         try:
             await asyncio.wait_for(
                 self.events.cleaned_up.wait(), timeout=self._wait_until_finished_timeout)

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -19,13 +19,13 @@ from .commands import (
     NewBlock,
     Status,
 )
-from trinity.protocol.eth import constants
+from .constants import MAX_HEADERS_FETCH
 from .proto import ETHProtocol
 from .handlers import ETHExchangeHandler
 
 
 class ETHPeer(BasePeer):
-    max_headers_fetch = constants.MAX_HEADERS_FETCH
+    max_headers_fetch = MAX_HEADERS_FETCH
 
     _supported_sub_protocols = [ETHProtocol]
     sub_proto: ETHProtocol = None

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -23,7 +23,7 @@ from .commands import (
     Status,
     StatusV2,
 )
-from trinity.protocol.les.constants import (
+from .constants import (
     MAX_HEADERS_FETCH,
 )
 from .proto import (


### PR DESCRIPTION
### What was wrong?

Some sync cases were crashing:
- when no peers available for sync download
- when no receipts are received in the entire batch

Some messages are not formatted correctly, or unclear

Some unnecessary cruft remained from exploratory implementations.

### How was it fixed?

Crash fixes:
- early escape from no receipts
- catch `NoEligiblePeers`, log, and pause

Improve & fix formatting on exception messages and logs

Remove cruft (like the `complete_token`, in favor of just canceling the service)

Add a new `BaseService.cancel_nowait()` that can be called from inside the service without hanging.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://cdn.earthporm.com/wp-content/uploads/2015/05/surprised-shocked-animals-funny-16__700.jpg)
