### PR TITLE
p2p string formatting with f-strings

### DIFF
--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -193,7 +193,7 @@ class HandshakeInitiator(HandshakeBase):
 
     def decode_auth_ack_message(self, ciphertext: bytes) -> Tuple[datatypes.PublicKey, bytes]:
         if len(ciphertext) < ENCRYPTED_AUTH_ACK_LEN:
-            raise BadAckMessage("Auth ack msg too short: {}".format(len(ciphertext)))
+            raise BadAckMessage(f"Auth ack msg too short: {len(ciphertext)}")
         elif len(ciphertext) == ENCRYPTED_AUTH_ACK_LEN:
             eph_pubkey, nonce, _ = decode_ack_plain(ciphertext, self.privkey)
         else:
@@ -260,7 +260,7 @@ def decode_ack_plain(
     """
     message = ecies.decrypt(ciphertext, privkey)
     if len(message) != AUTH_ACK_LEN:
-        raise BadAckMessage("Unexpected size for ack message: {}".format(len(message)))
+        raise BadAckMessage(f"Unexpected size for ack message: {len(message)}")
     eph_pubkey = keys.PublicKey(message[:PUBKEY_LEN])
     nonce = message[PUBKEY_LEN: PUBKEY_LEN + HASH_LEN]
     return eph_pubkey, nonce, SUPPORTED_RLPX_VERSION
@@ -286,7 +286,7 @@ def decode_auth_plain(ciphertext: bytes, privkey: datatypes.PrivateKey) -> Tuple
     """Decode legacy pre-EIP-8 auth message format"""
     message = ecies.decrypt(ciphertext, privkey)
     if len(message) != AUTH_MSG_LEN:
-        raise BadAckMessage("Unexpected size for auth message: {}".format(len(message)))
+        raise BadAckMessage(f"Unexpected size for auth message: {len(message)}")
     signature = keys.Signature(signature_bytes=message[:SIGNATURE_LEN])
     pubkey_start = SIGNATURE_LEN + HASH_LEN
     pubkey = keys.PublicKey(message[pubkey_start: pubkey_start + PUBKEY_LEN])
@@ -320,7 +320,7 @@ def decode_authentication(ciphertext: bytes,
     Returns the initiator's ephemeral pubkey, nonce, and pubkey.
     """
     if len(ciphertext) < ENCRYPTED_AUTH_MSG_LEN:
-        raise DecryptionError("Auth msg too short: {}".format(len(ciphertext)))
+        raise DecryptionError(f"Auth msg too short: {len(ciphertext)}")
     elif len(ciphertext) == ENCRYPTED_AUTH_MSG_LEN:
         sig, initiator_pubkey, initiator_nonce, _ = decode_auth_plain(
             ciphertext, privkey)

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -349,7 +349,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         elif cmd == CMD_NEIGHBOURS:
             return self.recv_neighbours
         else:
-            raise ValueError("Unknwon command: {}".format(cmd))
+            raise ValueError(f"Unknown command: {cmd}")
 
     def _get_max_neighbours_per_packet(self) -> int:
         if self._max_neighbours_per_packet_cache is not None:
@@ -593,7 +593,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         elif cmd == CMD_TOPIC_NODES:
             return self.recv_topic_nodes
         else:
-            raise ValueError("Unknwon command: {}".format(cmd))
+            raise ValueError(f"Unknown command: {cmd}")
 
     def receive_v5(self, address: kademlia.Address, message: bytes) -> None:
         try:
@@ -933,8 +933,7 @@ class CallbackManager(UserDict):
             if not self.locked(key):
                 del self[key]
             else:
-                raise AlreadyWaitingDiscoveryResponse(
-                    "Already waiting on callback for: {0}".format(key))
+                raise AlreadyWaitingDiscoveryResponse(f"Already waiting on callback for: {key}")
 
         lock = CallbackLock(callback)
         self[key] = lock

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -205,7 +205,7 @@ class KBucket(Sized):
 
     def __lt__(self, other: 'KBucket') -> bool:
         if not isinstance(other, self.__class__):
-            raise TypeError("Cannot compare KBucket with type {}.".format(other.__class__))
+            raise TypeError(f"Cannot compare KBucket with type {other.__class__}")
         return self.end < other.start
 
 
@@ -312,7 +312,7 @@ def binary_get_bucket_for_node(buckets: List[KBucket], node: Node) -> KBucket:
         assert bucket.start <= node.id <= bucket.end
         return bucket
     except (IndexError, AssertionError):
-        raise ValueError("No bucket found for node with id {}".format(node.id))
+        raise ValueError(f"No bucket found for node with id {node.id}")
 
 
 def _compute_shared_prefix_bits(nodes: List[Node]) -> int:

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -69,7 +69,7 @@ class Disconnect(Command):
             raw_decoded = cast(Dict[str, int], super().decode(data))
         except rlp.exceptions.ListDeserializationError:
             self.logger.warn("Malformed Disconnect message: %s", data)
-            raise MalformedMessage("Malformed Disconnect message: {0}".format(data))
+            raise MalformedMessage(f"Malformed Disconnect message: {data}")
         return assoc(raw_decoded, 'reason_name', self.get_reason_name(raw_decoded['reason']))
 
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -256,8 +256,8 @@ class BasePeer(BaseService):
             msg = cast(Dict[str, Any], msg)
             # Peers sometimes send a disconnect msg before they send the sub-proto handshake.
             raise HandshakeFailure(
-                "{} disconnected before completing sub-proto handshake: {}".format(
-                    self, msg['reason_name']))
+                f"{self} disconnected before completing sub-proto handshake: {msg['reason_name']}"
+            )
         await self.process_sub_proto_handshake(cmd, msg)
         self.logger.debug("Finished %s handshake with %s", self.sub_proto, self.remote)
 
@@ -278,8 +278,9 @@ class BasePeer(BaseService):
         if isinstance(cmd, Disconnect):
             msg = cast(Dict[str, Any], msg)
             # Peers sometimes send a disconnect msg before they send the initial P2P handshake.
-            raise HandshakeFailure("{} disconnected before completing handshake: {}".format(
-                self, msg['reason_name']))
+            raise HandshakeFailure(
+                f"{self} disconnected before completing sub-proto handshake: {msg['reason_name']}"
+            )
         await self.process_p2p_handshake(cmd, msg)
 
     @property
@@ -313,7 +314,7 @@ class BasePeer(BaseService):
         elif cmd_id < self.sub_proto.cmd_id_offset + self.sub_proto.cmd_length:
             return self.sub_proto.cmd_by_id[cmd_id]
         else:
-            raise UnknownProtocolCommand("No protocol found for cmd_id {}".format(cmd_id))
+            raise UnknownProtocolCommand(f"No protocol found for cmd_id {cmd_id}")
 
     async def read(self, n: int) -> bytes:
         self.logger.trace("Waiting for %s bytes from %s", n, self.remote)
@@ -405,7 +406,7 @@ class BasePeer(BaseService):
             # update the last time we heard from a peer in our DB (which doesn't exist yet).
             pass
         else:
-            raise UnexpectedMessage("Unexpected msg: {} ({})".format(cmd, msg))
+            raise UnexpectedMessage(f"Unexpected msg: {cmd} ({msg})")
 
     def handle_sub_proto_msg(self, cmd: protocol.Command, msg: protocol.PayloadType) -> None:
         cmd_type = type(cmd)
@@ -436,22 +437,23 @@ class BasePeer(BaseService):
         msg = cast(Dict[str, Any], msg)
         if not isinstance(cmd, Hello):
             await self.disconnect(DisconnectReason.bad_protocol)
-            raise HandshakeFailure("Expected a Hello msg, got {}, disconnecting".format(cmd))
+            raise HandshakeFailure(f"Expected a Hello msg, got {cmd}, disconnecting")
         remote_capabilities = msg['capabilities']
         try:
             self.sub_proto = self.select_sub_protocol(remote_capabilities)
         except NoMatchingPeerCapabilities:
             await self.disconnect(DisconnectReason.useless_peer)
             raise HandshakeFailure(
-                "No matching capabilities between us ({}) and {} ({}), disconnecting".format(
-                    self.capabilities, self.remote, remote_capabilities))
+                f"No matching capabilities between us ({self.capabilities}) and {self.remote} "
+                f"({remote_capabilities}), disconnecting"
+            )
         self.logger.debug(
             "Finished P2P handshake with %s, using sub-protocol %s",
             self.remote, self.sub_proto)
 
     def encrypt(self, header: bytes, frame: bytes) -> bytes:
         if len(header) != HEADER_LEN:
-            raise ValueError("Unexpected header length: {}".format(len(header)))
+            raise ValueError(f"Unexpected header length: {len(header)}")
 
         header_ciphertext = self.aes_enc.update(header)
         mac_secret = self.egress_mac.digest()[:HEADER_LEN]
@@ -470,7 +472,9 @@ class BasePeer(BaseService):
 
     def decrypt_header(self, data: bytes) -> bytes:
         if len(data) != HEADER_LEN + MAC_LEN:
-            raise ValueError("Unexpected header length: {}".format(len(data)))
+            raise ValueError(
+                f"Unexpected header length: {len(data)}, expected {HEADER_LEN} + {MAC_LEN}"
+            )
 
         header_ciphertext = data[:HEADER_LEN]
         header_mac = data[HEADER_LEN:]
@@ -479,15 +483,17 @@ class BasePeer(BaseService):
         self.ingress_mac.update(sxor(aes, header_ciphertext))
         expected_header_mac = self.ingress_mac.digest()[:HEADER_LEN]
         if not bytes_eq(expected_header_mac, header_mac):
-            raise DecryptionError('Invalid header mac: expected {}, got {}'.format(
-                expected_header_mac, header_mac))
+            raise DecryptionError(
+                f'Invalid header mac: expected {expected_header_mac}, got {header_mac}'
+            )
         return self.aes_dec.update(header_ciphertext)
 
     def decrypt_body(self, data: bytes, body_size: int) -> bytes:
         read_size = roundup_16(body_size)
         if len(data) < read_size + MAC_LEN:
-            raise ValueError('Insufficient body length; Got {}, wanted {}'.format(
-                len(data), (read_size + MAC_LEN)))
+            raise ValueError(
+                f'Insufficient body length; Got {len(data)}, wanted {read_size} + {MAC_LEN}'
+            )
 
         frame_ciphertext = data[:read_size]
         frame_mac = data[read_size:read_size + MAC_LEN]
@@ -497,8 +503,9 @@ class BasePeer(BaseService):
         self.ingress_mac.update(sxor(self.mac_enc(fmac_seed), fmac_seed))
         expected_frame_mac = self.ingress_mac.digest()[:MAC_LEN]
         if not bytes_eq(expected_frame_mac, frame_mac):
-            raise DecryptionError('Invalid frame mac: expected {}, got {}'.format(
-                expected_frame_mac, frame_mac))
+            raise DecryptionError(
+                f'Invalid frame mac: expected {expected_frame_mac}, got {frame_mac}'
+            )
         return self.aes_dec.update(frame_ciphertext)[:body_size]
 
     def get_frame_size(self, header: bytes) -> int:
@@ -526,7 +533,8 @@ class BasePeer(BaseService):
         """
         if not isinstance(reason, DisconnectReason):
             raise ValueError(
-                "Reason must be an item of DisconnectReason, got {}".format(reason))
+                f"Reason must be an item of DisconnectReason, got {reason}"
+            )
         self.logger.debug("Disconnecting from remote peer; reason: %s", reason.name)
         self.base_protocol.send_disconnect(reason.value)
         self.close()
@@ -555,10 +563,10 @@ class BasePeer(BaseService):
         raise NoMatchingPeerCapabilities()
 
     def __str__(self) -> str:
-        return "{} {}".format(self.__class__.__name__, self.remote)
+        return f"{self.__class__.__name__} {self.remote}"
 
     def __repr__(self) -> str:
-        return "{} {}".format(self.__class__.__name__, repr(self.remote))
+        return f"{self.__class__.__name__} {self.remote!r}"
 
     def __hash__(self) -> int:
         return hash(self.remote)
@@ -867,16 +875,16 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
 
             except (TimeoutError, PeerConnectionLost) as err:
                 raise DAOForkCheckFailure(
-                    "Timed out waiting for DAO fork header from {}: {}".format(peer, err)
+                    f"Timed out waiting for DAO fork header from {peer}: {err}"
                 ) from err
             except ValidationError as err:
                 raise DAOForkCheckFailure(
-                    "Invalid header response during DAO fork check: {}".format(err)
+                    f"Invalid header response during DAO fork check: {err}"
                 ) from err
 
             if len(headers) != 2:
                 raise DAOForkCheckFailure(
-                    "Peer %s failed to return DAO fork check headers".format(peer)
+                    f"Peer {peer} failed to return DAO fork check headers"
                 )
             else:
                 parent, header = headers
@@ -884,7 +892,7 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
             try:
                 vm_class.validate_header(header, parent, check_seal=True)
             except ValidationError as err:
-                raise DAOForkCheckFailure("Peer failed DAO fork check validation: {}".format(err))
+                raise DAOForkCheckFailure(f"Peer failed DAO fork check validation: {err}")
 
     def _peer_finished(self, peer: BaseService) -> None:
         """Remove the given peer from our list of connected nodes.


### PR DESCRIPTION
### What was wrong?

There were a few places where the formatted strings were not injecting the correct variables. Part of the issue was using `format()` with `%s`.

### How was it fixed?

f-strings are the best. We should use them more. Using a variety of the formatting in the same repo is bound to lead to bugs (like a couple found here). Ergo, let's standardize on f-strings in p2p and trinity. This one only touches p2p.

Replaced every `format()` usage with an f-string.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media-cdn.tripadvisor.com/media/photo-s/09/0d/3f/0a/so-cute.jpg)
