### PR TITLE
Move receipt validation to Chain and VM methods

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -281,7 +281,7 @@ class BaseChain(Configurable, ABC):
     # Validation API
     #
     @abstractmethod
-    def validate_receipt(self, block_number: BlockNumber, receipt: Receipt) -> None:
+    def validate_receipt(self, receipt: Receipt, at_header: BlockHeader) -> None:
         raise NotImplementedError("Chain classes must implement this method")
 
     @abstractmethod
@@ -672,8 +672,8 @@ class Chain(BaseChain):
     #
     # Validation API
     #
-    def validate_receipt(self, block_number: BlockNumber, receipt: Receipt) -> None:
-        VM = self.get_vm_class_for_block_number(block_number)
+    def validate_receipt(self, receipt: Receipt, at_header: BlockHeader) -> None:
+        VM = self.get_vm_class(at_header)
         VM.validate_receipt(receipt)
 
     def validate_block(self, block: BaseBlock) -> None:
@@ -889,6 +889,6 @@ class AsyncChain(Chain):
         raise NotImplementedError()
 
     async def coro_validate_receipt(self,
-                                    block_number: BlockNumber,
-                                    receipt: Receipt) -> None:
+                                    receipt: Receipt,
+                                    at_header: BlockHeader) -> None:
         raise NotImplementedError()

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -78,6 +78,9 @@ from eth.rlp.headers import (
     BlockHeader,
     HeaderParams,
 )
+from eth.rlp.receipts import (
+    Receipt,
+)
 from eth.rlp.transactions import (
     BaseTransaction,
     BaseUnsignedTransaction,
@@ -277,6 +280,10 @@ class BaseChain(Configurable, ABC):
     #
     # Validation API
     #
+    @abstractmethod
+    def validate_receipt(self, block_number: BlockNumber, receipt: Receipt) -> None:
+        raise NotImplementedError("Chain classes must implement this method")
+
     @abstractmethod
     def validate_block(self, block: BaseBlock) -> None:
         raise NotImplementedError("Chain classes must implement this method")
@@ -665,6 +672,10 @@ class Chain(BaseChain):
     #
     # Validation API
     #
+    def validate_receipt(self, block_number: BlockNumber, receipt: Receipt) -> None:
+        VM = self.get_vm_class_for_block_number(block_number)
+        VM.validate_receipt(receipt)
+
     def validate_block(self, block: BaseBlock) -> None:
         """
         Performs validation on a block that is either being mined or imported.
@@ -875,4 +886,9 @@ class AsyncChain(Chain):
             parent: BlockHeader,
             chain: Tuple[BlockHeader, ...],
             seal_check_random_sample_rate: int = 1) -> None:
+        raise NotImplementedError()
+
+    async def coro_validate_receipt(self,
+                                    block_number: BlockNumber,
+                                    receipt: Receipt) -> None:
         raise NotImplementedError()

--- a/eth/rlp/receipts.py
+++ b/eth/rlp/receipts.py
@@ -6,15 +6,11 @@ from rlp.sedes import (
     CountableList,
     binary,
 )
-from eth_utils import (
-    ValidationError,
-)
 
 from eth_bloom import BloomFilter
 
 from .sedes import (
     int256,
-    int32,
 )
 
 from .logs import Log
@@ -47,20 +43,6 @@ class Receipt(rlp.Serializable):
             bloom=bloom,
             logs=logs,
         )
-
-        for log_idx, log in enumerate(self.logs):
-            if log.address not in self.bloom_filter:
-                raise ValidationError(
-                    "The address from the log entry at position {0} is not "
-                    "present in the provided bloom filter.".format(log_idx)
-                )
-            for topic_idx, topic in enumerate(log.topics):
-                if int32.serialize(topic) not in self.bloom_filter:
-                    raise ValidationError(
-                        "The topic at position {0} from the log entry at "
-                        "position {1} is not present in the provided bloom "
-                        "filter.".format(topic_idx, log_idx)
-                    )
 
     @property
     def bloom_filter(self) -> BloomFilter:

--- a/eth/vm/forks/byzantium/__init__.py
+++ b/eth/vm/forks/byzantium/__init__.py
@@ -2,10 +2,16 @@ from typing import (  # noqa: F401
     Type,
 )
 
+from eth_utils import (
+    encode_hex,
+    ValidationError,
+)
+
 from eth.constants import (
     MAX_UNCLE_DEPTH,
 )
 from eth.rlp.blocks import BaseBlock  # noqa: F401
+from eth.rlp.receipts import Receipt
 from eth.validation import (
     validate_lte,
 )
@@ -38,6 +44,12 @@ def make_byzantium_receipt(base_header, transaction, computation, state):
     return frontier_receipt.copy(state_root=status_code)
 
 
+EIP658_STATUS_CODES = {
+    EIP658_TRANSACTION_STATUS_CODE_SUCCESS,
+    EIP658_TRANSACTION_STATUS_CODE_FAILURE,
+}
+
+
 class ByzantiumVM(SpuriousDragonVM):
     # fork name
     fork = 'byzantium'
@@ -51,6 +63,19 @@ class ByzantiumVM(SpuriousDragonVM):
     compute_difficulty = staticmethod(compute_byzantium_difficulty)
     configure_header = configure_byzantium_header
     make_receipt = staticmethod(make_byzantium_receipt)
+
+    @classmethod
+    def validate_receipt(cls, receipt: Receipt) -> None:
+        super().validate_receipt(receipt)
+        if receipt.state_root not in EIP658_STATUS_CODES:
+            raise ValidationError(
+                "The receipt's `state_root` must be one of [{0}, {1}].  Got: "
+                "{2}".format(
+                    encode_hex(EIP658_TRANSACTION_STATUS_CODE_SUCCESS),
+                    encode_hex(EIP658_TRANSACTION_STATUS_CODE_FAILURE),
+                    encode_hex(receipt.state_root),
+                )
+            )
 
     @staticmethod
     def get_block_reward():

--- a/tests/trinity/core/integration_test_helpers.py
+++ b/tests/trinity/core/integration_test_helpers.py
@@ -76,14 +76,17 @@ class FakeAsyncRopstenChain(RopstenChain):
     chaindb_class = FakeAsyncChainDB
     coro_import_block = coro_import_block
     coro_validate_chain = async_passthrough('validate_chain')
+    coro_validate_receipt = async_passthrough('validate_receipt')
 
 
 class FakeAsyncMainnetChain(MainnetChain):
     chaindb_class = FakeAsyncChainDB
     coro_import_block = coro_import_block
     coro_validate_chain = async_passthrough('validate_chain')
+    coro_validate_receipt = async_passthrough('validate_receipt')
 
 
 class FakeAsyncChain(MiningChain):
     coro_import_block = coro_import_block
     coro_validate_chain = async_passthrough('validate_chain')
+    coro_validate_receipt = async_passthrough('validate_receipt')

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -261,6 +261,7 @@ def get_chaindb_manager(chain_config: ChainConfig, base_db: BaseDB) -> BaseManag
 class ChainProxy(BaseProxy):
     coro_import_block = async_method('import_block')
     coro_validate_chain = async_method('validate_chain')
+    coro_validate_receipt = async_method('validate_receipt')
     get_vm_configuration = sync_method('get_vm_configuration')
     get_vm_class = sync_method('get_vm_class')
     get_vm_class_for_block_number = sync_method('get_vm_class_for_block_number')

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -213,7 +213,7 @@ class LightDispatchChain(BaseChain):
     #
     # Validation API
     #
-    def validate_receipt(self, block_number: BlockNumber, receipt: Receipt) -> None:
+    def validate_receipt(self, receipt: Receipt, at_header: BlockHeader) -> None:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
     def validate_block(self, block: BaseBlock) -> None:

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -213,6 +213,9 @@ class LightDispatchChain(BaseChain):
     #
     # Validation API
     #
+    def validate_receipt(self, block_number: BlockNumber, receipt: Receipt) -> None:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
     def validate_block(self, block: BaseBlock) -> None:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -23,6 +23,8 @@ from cytoolz import (
 
 from eth_typing import Hash32
 
+from eth_utils import ValidationError
+
 from eth.constants import (
     BLANK_ROOT_HASH, EMPTY_UNCLE_HASH, GENESIS_PARENT_HASH)
 from eth.rlp.headers import BlockHeader
@@ -30,6 +32,7 @@ from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransaction
 
 from p2p import protocol
+from p2p.p2p_proto import DisconnectReason
 from p2p.exceptions import NoEligiblePeers, PeerConnectionLost
 from p2p.protocol import Command
 
@@ -354,7 +357,38 @@ class FastChainSyncer(BaseHeaderChainSyncer):
         if not receipt_bundles:
             return tuple(), batch
 
-        receipts, trie_roots_and_data_dicts = zip(*receipt_bundles)
+        # First validate the receipts.
+        headers_by_root = {
+            header.receipt_root: header
+            for header in batch
+            if not _is_receipts_empty(header)
+        }
+        receipts_by_root = {
+            receipt_root: receipt
+            for (receipt, (receipt_root, _))
+            in receipt_bundles
+            if receipt_root != BLANK_ROOT_HASH
+        }
+        receipts_by_header = {
+            headers_by_root[receipt_root]: receipts
+            for receipt_root, receipts
+            in receipts_by_root.items()
+            if receipt_root != BLANK_ROOT_HASH
+        }
+        for header, receipts in receipts_by_header.items():
+            for receipt in receipts:
+                try:
+                    await self.chain.coro_validate_receipt(header.block_number, receipt)
+                except ValidationError as err:
+                    self.logger.info(
+                        "Disconnecting from %s: sent invalid receipt: %s",
+                        peer,
+                        err,
+                    )
+                    await peer.disconnect(DisconnectReason.bad_protocol)
+                    return tuple(), batch
+
+        _, trie_roots_and_data_dicts = zip(*receipt_bundles)
         receipt_roots, trie_data_dicts = zip(*trie_roots_and_data_dicts)
         receipt_roots_set = set(receipt_roots)
         missing = tuple(


### PR DESCRIPTION
fixes #1246

### What was wrong?

See #1246 

### How was it fixed?

Both the `Chain` and `VM` classes now expose a `validate_receipt` method.  This validation is called during receipt creation by the VM class as well as during chain sync.


#### Cute Animal Picture

![x26noborder](https://user-images.githubusercontent.com/824194/45235261-88375900-b295-11e8-9578-bf46cfbe0e62.jpeg)

