### PR TITLE
Make the noisy logger to be overridable, but default it to INFO

### DIFF
--- a/trinity/main.py
+++ b/trinity/main.py
@@ -143,7 +143,10 @@ def main() -> None:
     )
 
     if args.log_levels:
-        setup_log_levels(args.log_levels)
+        log_levels = args.log_levels.copy()  # use a copy so we don't mutate the input values.
+        log_levels.setdefault('p2p.kademlia', logging.INFO)
+        log_levels.setdefault('p2p.discovery', logging.INFO)
+        setup_log_levels(log_levels)
 
     try:
         chain_config = ChainConfig.from_parser_args(args)

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -125,10 +125,6 @@ def setup_queue_logging(log_queue: 'Queue[str]', level: int) -> None:
     logger.addHandler(queue_handler)
     logger.setLevel(level)
 
-    # These loggers generates too much DEBUG noise, drowning out the important things, so force
-    # the INFO level for it until https://github.com/ethereum/py-evm/issues/806 is fixed.
-    logging.getLogger('p2p.kademlia').setLevel(logging.INFO)
-    logging.getLogger('p2p.discovery').setLevel(logging.INFO)
     logger.debug('Logging initialized: PID=%s', os.getpid())
 
 


### PR DESCRIPTION
### What was wrong?
We have some defaults that are used to quiet down some noisy loggers:

https://github.com/ethereum/py-evm/blob/v0.2.0-alpha.31/trinity/utils/logging.py#L111-L114

Were the use to supply overrides to these via the command line they would not be respected

Issue Reference: https://github.com/ethereum/py-evm/issues/1243

### How was it fixed?
Default the noisy logger to `INFO`, but make it overridable when the `log_level` argument is supplied

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/profile_images/962170088941019136/lgpCD8X4_400x400.jpg)
