### PR TITLE
POC: Introduce a bridge to the LightPeerChain to be consumed from other processes

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -892,3 +892,15 @@ class AsyncChain(Chain):
                                     receipt: Receipt,
                                     at_header: BlockHeader) -> None:
         raise NotImplementedError()
+
+    async def coro_get_block_by_hash(self,
+                                     block_hash: Hash32) -> BaseBlock:
+        raise NotImplementedError()
+
+    async def coro_get_block_by_header(self,
+                                       header: BlockHeader) -> BaseBlock:
+        raise NotImplementedError()
+
+    async def coro_get_canonical_block_by_number(self,
+                                                 block_number: BlockNumber) -> BaseBlock:
+        raise NotImplementedError()

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -146,12 +146,12 @@ def genesis_params_from_fixture(fixture):
     }
 
 
-def new_chain_from_fixture(fixture):
+def new_chain_from_fixture(fixture, chain_cls=MainnetChain):
     base_db = MemoryDB()
 
     vm_config = chain_vm_configuration(fixture)
 
-    ChainFromFixture = MainnetChain.configure(
+    ChainFromFixture = chain_cls.configure(
         'ChainFromFixture',
         vm_configuration=vm_config,
     )

--- a/p2p/events.py
+++ b/p2p/events.py
@@ -1,0 +1,13 @@
+from lahja import (
+    BaseEvent
+)
+
+
+class PeerCountRequest(BaseEvent):
+    pass
+
+
+class PeerCountResponse(BaseEvent):
+
+    def __init__(self, peer_count: int) -> None:
+        self.peer_count = peer_count

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -52,6 +52,10 @@ from eth_keys import (
 
 from cancel_token import CancelToken, OperationCancelled
 
+from lahja import (
+    Endpoint,
+)
+
 from eth.chains.mainnet import MAINNET_NETWORK_ID
 from eth.chains.ropsten import ROPSTEN_NETWORK_ID
 from eth.constants import GENESIS_BLOCK_NUMBER
@@ -99,6 +103,11 @@ from .constants import (
     DEFAULT_MAX_PEERS,
     HEADER_LEN,
     MAC_LEN,
+)
+
+from .events import (
+    PeerCountRequest,
+    PeerCountResponse,
 )
 
 if TYPE_CHECKING:
@@ -780,6 +789,7 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
                  vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...],
                  max_peers: int = DEFAULT_MAX_PEERS,
                  token: CancelToken = None,
+                 event_bus: Endpoint = None
                  ) -> None:
         super().__init__(token)
         self.peer_class = peer_class
@@ -790,6 +800,16 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
         self.max_peers = max_peers
         self.connected_nodes: Dict[Node, BasePeer] = {}
         self._subscribers: List[PeerSubscriber] = []
+        self.event_bus = event_bus
+        self.run_task(self.answer_peer_count_requests())
+
+    async def answer_peer_count_requests(self) -> None:
+        async for req in self.event_bus.stream(PeerCountRequest):
+            # We are listening for all `PeerCountRequest` events but we ensure to
+            # only send a `PeerCountResponse` to the callsite that made the request.
+            # We do that by retrieving a `BroadcastConfig` from the request via the
+            # `event.broadcast_config()` API.
+            self.event_bus.broadcast(PeerCountResponse(len(self)), req.broadcast_config())
 
     def __len__(self) -> int:
         return len(self.connected_nodes)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ deps = {
         "ipython>=6.2.1,<7.0.0",
         "plyvel==1.0.5",
         "web3==4.4.1",
-        "lahja==0.6.1",
+        "lahja==0.7.1",
     ],
     'test': [
         "hypothesis==3.69.5",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,8 +78,7 @@ def funded_address_initial_balance():
     return to_wei(1000, 'ether')
 
 
-@pytest.fixture
-def chain_with_block_validation(base_db, genesis_state):
+def _chain_with_block_validation(base_db, genesis_state, chain_cls=Chain):
     """
     Return a Chain object containing just the genesis block.
 
@@ -107,7 +106,8 @@ def chain_with_block_validation(base_db, genesis_state):
         "transaction_root": decode_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),  # noqa: E501
         "uncles_hash": decode_hex("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")  # noqa: E501
     }
-    klass = Chain.configure(
+
+    klass = chain_cls.configure(
         __name__='TestChain',
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVM),
@@ -116,6 +116,11 @@ def chain_with_block_validation(base_db, genesis_state):
     )
     chain = klass.from_genesis(base_db, genesis_params, genesis_state)
     return chain
+
+
+@pytest.fixture
+def chain_with_block_validation(base_db, genesis_state):
+    return _chain_with_block_validation(base_db, genesis_state)
 
 
 def import_block_without_validation(chain, block):

--- a/tests/trinity/conftest.py
+++ b/tests/trinity/conftest.py
@@ -9,8 +9,15 @@ from lahja import (
     EventBus,
 )
 
+from eth.chains import (
+    Chain,
+)
+
 from p2p.peer import PeerPool
 
+from trinity.chains.coro import (
+    AsyncChainMixin,
+)
 from trinity.rpc.main import (
     RPCServer,
 )
@@ -26,6 +33,13 @@ from trinity.utils.xdg import (
 from trinity.utils.filesystem import (
     is_under_path,
 )
+from tests.conftest import (
+    _chain_with_block_validation,
+)
+
+
+class TestAsyncChain(Chain, AsyncChainMixin):
+    pass
 
 
 def pytest_addoption(parser):
@@ -79,6 +93,11 @@ def p2p_server(monkeypatch, jsonrpc_ipc_pipe_path):
     monkeypatch.setattr(
         Server, '_make_peer_pool', lambda s: PeerPool(None, None, None, None, None, None))
     return Server(None, None, None, None, None, None, None)
+
+
+@pytest.fixture
+def chain_with_block_validation(base_db, genesis_state):
+    return _chain_with_block_validation(base_db, genesis_state, TestAsyncChain)
 
 
 @pytest.mark.asyncio

--- a/tests/trinity/conftest.py
+++ b/tests/trinity/conftest.py
@@ -55,7 +55,7 @@ def event_loop():
         loop.close()
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def event_bus(event_loop):
     bus = EventBus()
     endpoint = bus.create_endpoint('test')

--- a/tests/trinity/core/chain-management/test_light_peer_chain.py
+++ b/tests/trinity/core/chain-management/test_light_peer_chain.py
@@ -1,0 +1,19 @@
+from trinity.sync.light.service import (
+    LightPeerChain
+)
+from trinity.plugins.builtin.light_peer_chain_bridge import (
+    EventBusLightPeerChain,
+)
+
+
+# These tests may seem obvious but they safe us from runtime errors where
+# changes are made to the `BaseLightPeerChain` that are then forgotton to
+# implement on both derived chains.
+
+def test_can_instantiate_eventbus_light_peer_chain():
+    chain = EventBusLightPeerChain(None)
+    assert chain is not None
+
+def test_can_instantiate_light_peer_chain():
+    chain = LightPeerChain(None, None)
+    assert chain is not None

--- a/tests/trinity/core/chain-management/test_light_peer_chain.py
+++ b/tests/trinity/core/chain-management/test_light_peer_chain.py
@@ -14,6 +14,7 @@ def test_can_instantiate_eventbus_light_peer_chain():
     chain = EventBusLightPeerChain(None)
     assert chain is not None
 
+
 def test_can_instantiate_light_peer_chain():
     chain = LightPeerChain(None, None)
     assert chain is not None

--- a/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -25,6 +25,9 @@ from eth.tools.fixtures import (
     should_run_slow_tests,
 )
 
+from trinity.chains.mainnet import (
+    MainnetFullChain
+)
 from trinity.rpc import RPCServer
 from trinity.rpc.format import (
     empty_to_0x,
@@ -383,7 +386,7 @@ def chain(chain_without_block_validation):
 
 @pytest.mark.asyncio
 async def test_rpc_against_fixtures(chain, ipc_server, chain_fixture, fixture_data):
-    rpc = RPCServer(None)
+    rpc = RPCServer(MainnetFullChain(None))
 
     setup_result, setup_error = await call_rpc(rpc, 'evm_resetToGenesisFixture', [chain_fixture])
     assert setup_error is None and setup_result is True, "cannot load chain for %r" % fixture_data

--- a/trinity/chains/coro.py
+++ b/trinity/chains/coro.py
@@ -1,0 +1,11 @@
+
+from trinity.utils.async_dispatch import (
+    async_method,
+)
+
+
+class AsyncChainMixin:
+
+    coro_get_canonical_block_by_number = async_method('get_canonical_block_by_number')
+    coro_get_block_by_hash = async_method('get_block_by_hash')
+    coro_get_block_by_header = async_method('get_block_by_header')

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -54,7 +54,7 @@ from eth.vm.computation import (
 )
 
 from trinity.sync.light.service import (
-    LightPeerChain,
+    BaseLightPeerChain,
 )
 
 if TYPE_CHECKING:
@@ -64,14 +64,14 @@ if TYPE_CHECKING:
 class LightDispatchChain(BaseChain):
     """
     Provide the :class:`BaseChain` API, even though only a
-    :class:`LightPeerChain` is syncing. Store results locally so that not
+    :class:`BaseLightPeerChain` is syncing. Store results locally so that not
     all requests hit the light peer network.
     """
 
     ASYNC_TIMEOUT_SECONDS = 10
     _loop = None
 
-    def __init__(self, headerdb: BaseHeaderDB, peer_chain: LightPeerChain) -> None:
+    def __init__(self, headerdb: BaseHeaderDB, peer_chain: BaseLightPeerChain) -> None:
         self._headerdb = headerdb
         self._peer_chain = peer_chain
         self._peer_chain_loop = asyncio.get_event_loop()
@@ -135,14 +135,19 @@ class LightDispatchChain(BaseChain):
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
     def get_block_by_hash(self, block_hash: Hash32) -> BaseBlock:
+        raise NotImplementedError("Use coro_get_block_by_hash")
+
+    async def coro_get_block_by_hash(self, block_hash: Hash32) -> BaseBlock:
         header = self._headerdb.get_block_header_by_hash(block_hash)
-        return self.get_block_by_header(header)
+        return await self.get_block_by_header(header)
 
     def get_block_by_header(self, header: BlockHeader) -> BaseBlock:
+        raise NotImplementedError("Use coro_get_block_by_header")
+
+    async def coro_get_block_by_header(self, header: BlockHeader) -> BaseBlock:
         # TODO check local cache, before hitting peer
-        block_body = self._run_async(
-            self._peer_chain.get_block_body_by_hash(header.hash)
-        )
+
+        block_body = await self._peer_chain.get_block_body_by_hash(header.hash)
 
         block_class = self.get_vm_class_for_block_number(header.block_number).get_block_class()
         transactions = [
@@ -156,12 +161,15 @@ class LightDispatchChain(BaseChain):
         )
 
     def get_canonical_block_by_number(self, block_number: BlockNumber) -> BaseBlock:
+        raise NotImplementedError("Use coro_get_canonical_block_by_number")
+
+    async def coro_get_canonical_block_by_number(self, block_number: BlockNumber) -> BaseBlock:
         """
         Return the block with the given number from the canonical chain.
         Raises HeaderNotFound if it is not found.
         """
         header = self._headerdb.get_canonical_block_header_by_number(block_number)
-        return self.get_block_by_header(header)
+        return await self.get_block_by_header(header)
 
     def get_canonical_block_hash(self, block_number: int) -> Hash32:
         return self._headerdb.get_canonical_block_hash(block_number)
@@ -234,12 +242,3 @@ class LightDispatchChain(BaseChain):
             chain: Tuple[BlockHeader, ...],
             seal_check_random_sample_rate: int = 1) -> None:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
-
-    #
-    # Async utils
-    #
-    T = TypeVar('T')
-
-    def _run_async(self, async_method: Coroutine[T, Any, Any]) -> T:
-        future = asyncio.run_coroutine_threadsafe(async_method, loop=self._peer_chain_loop)
-        return future.result(self.ASYNC_TIMEOUT_SECONDS)

--- a/trinity/chains/mainnet.py
+++ b/trinity/chains/mainnet.py
@@ -1,8 +1,14 @@
 from eth.chains.mainnet import (
     BaseMainnetChain,
+    MainnetChain
 )
 
+from trinity.chains.coro import AsyncChainMixin
 from trinity.chains.light import LightDispatchChain
+
+
+class MainnetFullChain(MainnetChain, AsyncChainMixin):
+    pass
 
 
 class MainnetLightDispatchChain(BaseMainnetChain, LightDispatchChain):

--- a/trinity/chains/ropsten.py
+++ b/trinity/chains/ropsten.py
@@ -1,8 +1,14 @@
 from eth.chains.ropsten import (
     BaseRopstenChain,
+    RopstenChain
 )
 
+from trinity.chains.coro import AsyncChainMixin
 from trinity.chains.light import LightDispatchChain
+
+
+class RopstenFullChain(RopstenChain, AsyncChainMixin):
+    pass
 
 
 class RopstenLightDispatchChain(BaseRopstenChain, LightDispatchChain):

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -1,10 +1,8 @@
 from abc import abstractmethod
-import asyncio
 from pathlib import Path
 from multiprocessing.managers import (
     BaseManager,
 )
-from threading import Thread
 from typing import (
     Type,
 )
@@ -17,23 +15,8 @@ from p2p.peer import (
 from p2p.service import (
     BaseService,
 )
-from trinity.chains import (
-    ChainProxy,
-)
-from trinity.chains.header import (
-    AsyncHeaderChainProxy,
-)
-from trinity.db.chain import ChainDBProxy
-from trinity.db.base import DBProxy
 from trinity.db.header import (
     AsyncHeaderDB,
-    AsyncHeaderDBProxy
-)
-from trinity.rpc.main import (
-    RPCServer,
-)
-from trinity.rpc.ipc import (
-    IPCServer,
 )
 from trinity.config import (
     ChainConfig,
@@ -43,6 +26,9 @@ from trinity.extensibility import (
 )
 from trinity.extensibility.events import (
     ResourceAvailableEvent
+)
+from trinity.utils.db_proxy import (
+    create_db_manager
 )
 
 
@@ -106,69 +92,5 @@ class Node(BaseService):
             resource_type=BaseChain
         ))
 
-    @property
-    def has_ipc_server(self) -> bool:
-        return bool(self._jsonrpc_ipc_path)
-
-    def make_ipc_server(self, loop: asyncio.AbstractEventLoop) -> BaseService:
-        if self.has_ipc_server:
-            rpc = RPCServer(self.get_chain(), self.get_peer_pool())
-            return IPCServer(rpc, self._jsonrpc_ipc_path, loop=loop)
-        else:
-            return None
-
     async def _run(self) -> None:
-        if self.has_ipc_server:
-            # The RPC server needs its own thread, because it provides a synchcronous
-            # API which might call into p2p async methods. These sync->async calls
-            # deadlock if they are run in the same Thread and loop.
-            ipc_loop = self._make_new_loop_thread()
-
-            self._ipc_server = self.make_ipc_server(ipc_loop)
-
-            # keep a copy on self, for later shutdown
-            self._ipc_loop = ipc_loop
-
-            asyncio.run_coroutine_threadsafe(self._ipc_server.run(), loop=ipc_loop)
-
         await self.get_p2p_server().run()
-
-    async def _cleanup(self) -> None:
-        # IPC Server requires special handling because it's running in its own loop & thread
-        if self.has_ipc_server:
-            await self._ipc_server.threadsafe_cancel()
-            # Stop the this IPCServer-specific event loop, so that the IPCServer thread will exit
-            self._ipc_loop.stop()
-
-    def _make_new_loop_thread(self) -> asyncio.AbstractEventLoop:
-        new_loop = asyncio.new_event_loop()
-
-        def start_loop(loop: asyncio.AbstractEventLoop) -> None:
-            asyncio.set_event_loop(loop)
-            loop.run_forever()
-            loop.close()
-
-        thread = Thread(target=start_loop, args=(new_loop, ))
-        thread.start()
-
-        return new_loop
-
-
-def create_db_manager(ipc_path: Path) -> BaseManager:
-    """
-    We're still using 'str' here on param ipc_path because an issue with
-    multi-processing not being able to interpret 'Path' objects correctly
-    """
-    class DBManager(BaseManager):
-        pass
-
-    # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
-    # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
-    DBManager.register('get_db', proxytype=DBProxy)  # type: ignore
-    DBManager.register('get_chaindb', proxytype=ChainDBProxy)  # type: ignore
-    DBManager.register('get_chain', proxytype=ChainProxy)  # type: ignore
-    DBManager.register('get_headerdb', proxytype=AsyncHeaderDBProxy)  # type: ignore
-    DBManager.register('get_header_chain', proxytype=AsyncHeaderChainProxy)  # type: ignore
-
-    manager = DBManager(address=str(ipc_path))  # type: ignore
-    return manager

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -47,6 +47,7 @@ class FullNode(Node):
                 bootstrap_nodes=self._bootstrap_nodes,
                 preferred_nodes=self._preferred_nodes,
                 token=self.cancel_token,
+                event_bus=self._plugin_manager.event_bus_endpoint
             )
         return self._p2p_server
 

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -72,6 +72,7 @@ class LightNode(Node):
                 bootstrap_nodes=self._bootstrap_nodes,
                 preferred_nodes=self._preferred_nodes,
                 token=self.cancel_token,
+                event_bus=self._plugin_manager.event_bus_endpoint,
             )
         return self._p2p_server
 

--- a/trinity/nodes/mainnet.py
+++ b/trinity/nodes/mainnet.py
@@ -1,8 +1,5 @@
-from eth.chains.mainnet import (
-    MainnetChain,
-)
-
 from trinity.chains.mainnet import (
+    MainnetFullChain,
     MainnetLightDispatchChain,
 )
 from trinity.nodes.light import LightNode
@@ -10,7 +7,7 @@ from trinity.nodes.full import FullNode
 
 
 class MainnetFullNode(FullNode):
-    chain_class = MainnetChain
+    chain_class = MainnetFullChain
 
 
 class MainnetLightNode(LightNode):

--- a/trinity/nodes/ropsten.py
+++ b/trinity/nodes/ropsten.py
@@ -1,8 +1,5 @@
-from eth.chains.ropsten import (
-    RopstenChain,
-)
-
 from trinity.chains.ropsten import (
+    RopstenFullChain,
     RopstenLightDispatchChain,
 )
 from trinity.nodes.light import LightNode
@@ -10,7 +7,7 @@ from trinity.nodes.full import FullNode
 
 
 class RopstenFullNode(FullNode):
-    chain_class = RopstenChain
+    chain_class = RopstenFullChain
 
 
 class RopstenLightNode(LightNode):

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -4,28 +4,14 @@ from argparse import (
 )
 import asyncio
 
-from cancel_token import (
-    CancelToken
-)
-
-from eth.chains.base import (
-    BaseChain
-)
-
-from p2p.peer import (
-    PeerPool
-)
-
 from trinity.constants import (
     SYNC_LIGHT
 )
 from trinity.extensibility import (
-    BaseEvent,
     BaseIsolatedPlugin,
-    BasePlugin,
 )
-from trinity.extensibility.events import (
-    ResourceAvailableEvent
+from trinity.plugins.builtin.light_peer_chain_bridge.light_peer_chain_bridge import (
+    EventBusLightPeerChain,
 )
 from trinity.rpc.main import (
     RPCServer,
@@ -48,7 +34,7 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
         return "JSON-RPC Server"
 
     def should_start(self) -> bool:
-        return not self.context.args.disable_rpc and not self.context.args.sync_mode == SYNC_LIGHT
+        return not self.context.args.disable_rpc
 
     def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
@@ -65,8 +51,14 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
         db_manager.connect()
 
         chain_class = self.context.chain_config.node_class.chain_class
-        db = db_manager.get_db()  # type: ignore
-        chain = chain_class(db)
+
+        if self.context.chain_config.sync_mode == SYNC_LIGHT:
+            header_db = db_manager.get_headerdb()  # type: ignore
+            event_bus_light_peer_chain = EventBusLightPeerChain(self.context.event_bus)
+            chain = chain_class(header_db, peer_chain=event_bus_light_peer_chain)
+        else:
+            db = db_manager.get_db()  # type: ignore
+            chain = chain_class(db)
 
         rpc = RPCServer(chain, self.context.event_bus)
         ipc_server = IPCServer(rpc, self.context.chain_config.jsonrpc_ipc_path)
@@ -76,51 +68,3 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
         asyncio.ensure_future(ipc_server.run())
         loop.run_forever()
         loop.close()
-
-
-class JsonRpcServerLightPlugin(BasePlugin):
-    """
-    The ``JsonRpcServerLightPlugin`` is an intermediate step to keep the
-    JSON-RPC server inside the networking process when in ``light`` mode.
-    This is because in ``light`` mode, the chain is more coupled to the
-    ``PeerPool``. This should move when the ``PeerPool`` becomes more
-    multiprocess friendly, exposing events and APIs via event bus.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.peer_pool: PeerPool = None
-        self.cancel_token: CancelToken = None
-        self.chain: BaseChain = None
-
-    @property
-    def name(self) -> str:
-        return "JSON-RPC Server Light"
-
-    def should_start(self) -> bool:
-        return all((self.peer_pool is not None,
-                    self.chain is not None,
-                    not self.context.args.disable_rpc,
-                    self.context.args.sync_mode == SYNC_LIGHT))
-
-    def handle_event(self, activation_event: BaseEvent) -> None:
-        if isinstance(activation_event, ResourceAvailableEvent):
-            if activation_event.resource_type is PeerPool:
-                self.peer_pool, self.cancel_token = activation_event.resource
-            elif activation_event.resource_type is BaseChain:
-                self.chain = activation_event.resource
-
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
-        # The JsonRpcServerPlugin plugin above already configures the --disable-rpc flag
-        pass
-
-    def start(self) -> None:
-        self.logger.info('JSON-RPC Server started')
-
-        rpc = RPCServer(self.chain, self.context.event_bus)
-        # The IPCServer used to have its own event loop because a comment indicated
-        # it may otherwise run into deadlocks. Not sure yet what to do about that
-        # because having two distinct event loops seems to be problematic now that
-        # the RPCServer uses the eventbus to retrieve the peer count
-        ipc = IPCServer(rpc, self.context.chain_config.jsonrpc_ipc_path)
-        asyncio.ensure_future(ipc.run())

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -1,0 +1,58 @@
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction,
+)
+import asyncio
+
+from trinity.extensibility import (
+    BaseIsolatedPlugin,
+)
+from trinity.rpc.main import (
+    RPCServer,
+)
+from trinity.rpc.ipc import (
+    IPCServer,
+)
+from trinity.utils.db_proxy import (
+    create_db_manager
+)
+from trinity.utils.shutdown import (
+    exit_on_signal
+)
+
+
+class JsonRpcServerPlugin(BaseIsolatedPlugin):
+
+    @property
+    def name(self) -> str:
+        return "JSON-RPC Server"
+
+    def should_start(self) -> bool:
+        return not self.context.args.disable_rpc
+
+    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+        arg_parser.add_argument(
+            "--disable-rpc",
+            action="store_true",
+            help="Disables the JSON-RPC Server",
+        )
+
+    def start(self) -> None:
+        self.logger.info('JSON-RPC Server started')
+        self.context.event_bus.connect()
+
+        db_manager = create_db_manager(self.context.chain_config.database_ipc_path)
+        db_manager.connect()
+
+        chain_class = self.context.chain_config.node_class.chain_class
+        db = db_manager.get_db()  # type: ignore
+        chain = chain_class(db)
+
+        rpc = RPCServer(chain, self.context.event_bus)
+        ipc_server = IPCServer(rpc, self.context.chain_config.jsonrpc_ipc_path)
+
+        loop = asyncio.get_event_loop()
+        asyncio.ensure_future(exit_on_signal(ipc_server, self.context.event_bus))
+        asyncio.ensure_future(ipc_server.run())
+        loop.run_forever()
+        loop.close()

--- a/trinity/plugins/builtin/light_peer_chain_bridge/__init__.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/__init__.py
@@ -1,0 +1,6 @@
+from .light_peer_chain_bridge import (  # noqa: F401
+    EventBusLightPeerChain,
+    LightPeerChainEventBusResponder,
+    LightPeerChainRequest,
+    LightPeerChainResponse,
+)

--- a/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
@@ -1,0 +1,154 @@
+import asyncio
+import inspect
+from types import (
+    FrameType
+)
+from typing import (
+    Any,
+    Iterable,
+    List,
+)
+
+from eth_typing import (
+    Address,
+    Hash32,
+)
+
+from eth_utils import (
+    to_tuple,
+)
+
+from eth.rlp.accounts import (
+    Account,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
+from eth.rlp.receipts import (
+    Receipt,
+)
+
+from lahja import (
+    BaseEvent,
+    Endpoint,
+)
+
+from trinity.rlp.block_body import BlockBody
+from trinity.sync.light.service import (
+    BaseLightPeerChain,
+)
+
+
+class LightPeerChainRequest(BaseEvent):
+
+    def __init__(self, method_name: str, payload: Any = None) -> None:
+        self.method_name = method_name
+        self.payload = payload
+
+
+class LightPeerChainResponse(BaseEvent):
+
+    def __init__(self, payload: Any = None) -> None:
+        self.payload = payload
+
+
+class LightPeerChainEventBusResponder:
+    """
+    The ``LightPeerChainEventBusResponder`` listens for certain events on the eventbus and
+    delegates them to the ``LightPeerChain`` to get answers. It then propagates responses
+    back to the caller.
+    """
+
+    def __init__(self, chain: BaseLightPeerChain, event_bus: Endpoint) -> None:
+        self.chain = chain
+        self.event_bus = event_bus
+        asyncio.ensure_future(self.answer_requests())
+
+    async def answer_requests(self) -> None:
+        async for event in self.event_bus.stream(LightPeerChainRequest):
+
+            method = getattr(self.chain, event.method_name)
+
+            if not callable(method):
+                self.event_bus.broadcast(
+                    LightPeerChainResponse(Exception(f"Not a method: {event.method_name}")),
+                    event.broadcast_config()
+                )
+                continue
+
+            try:
+                if event.payload is not None:
+                    response = await method(*event.payload)
+                else:
+                    response = await method()
+            except Exception as e:
+                # we send the exception over to re-raise it on the consumer side (other process)
+                self.event_bus.broadcast(
+                    LightPeerChainResponse(e),
+                    event.broadcast_config()
+                )
+            else:
+                self.event_bus.broadcast(
+                    LightPeerChainResponse(response),
+                    event.broadcast_config()
+                )
+
+
+class EventBusLightPeerChain(BaseLightPeerChain):
+    """
+    The ``EventBusLightPeerChain`` is an implementation of the ``BaseLightPeerChain`` that can
+    be used from within any process.
+    """
+
+    def __init__(self, event_bus: Endpoint) -> None:
+        self.event_bus = event_bus
+
+    async def get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
+        event = self._prepare_event(inspect.currentframe())
+        return self._return_or_raise(await self.event_bus.request(event))
+
+    async def get_block_body_by_hash(self, block_hash: Hash32) -> BlockBody:
+        event = self._prepare_event(inspect.currentframe())
+        return self._return_or_raise(await self.event_bus.request(event))
+
+    async def get_receipts(self, block_hash: Hash32) -> List[Receipt]:
+        event = self._prepare_event(inspect.currentframe())
+        return self._return_or_raise(await self.event_bus.request(event))
+
+    async def get_account(self, block_hash: Hash32, address: Address) -> Account:
+        event = self._prepare_event(inspect.currentframe())
+        return self._return_or_raise(await self.event_bus.request(event))
+
+    async def get_contract_code(self, block_hash: Hash32, address: Address) -> bytes:
+        event = self._prepare_event(inspect.currentframe())
+        return self._return_or_raise(await self.event_bus.request(event))
+
+    async def get_foo(self) -> BlockHeader:
+        event = self._prepare_event(inspect.currentframe())
+        return self._return_or_raise(await self.event_bus.request(event))
+
+    async def get_foobar(self, foo: int, bar: int) -> BlockHeader:
+        event = self._prepare_event(inspect.currentframe())
+        return self._return_or_raise(await self.event_bus.request(event))
+
+    def _return_or_raise(self, response: LightPeerChainResponse) -> Any:
+        if issubclass(type(response.payload), Exception):
+            raise Exception(
+                "Exception raised in LightPeerChain", response.payload
+            ) from response.payload
+
+        return response.payload
+
+    def _prepare_event(self, frame: FrameType) -> LightPeerChainRequest:
+        args = self._extract_args(frame.f_locals.values())
+        fn_name = frame.f_code.co_name
+
+        payload = None if len(args) == 0 else args
+
+        return LightPeerChainRequest(fn_name, payload)
+
+    @to_tuple
+    def _extract_args(self, args: Iterable[Any]) -> Iterable[Any]:
+        for arg in args:
+            if arg is not self:
+                yield arg

--- a/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
@@ -1,0 +1,53 @@
+from typing import (
+    cast
+)
+
+from eth.chains.base import (
+    BaseChain
+)
+
+from trinity.constants import (
+    SYNC_LIGHT
+)
+from trinity.extensibility import (
+    BaseEvent,
+    BasePlugin,
+)
+from trinity.chains.light import (
+    LightDispatchChain,
+)
+from trinity.extensibility.events import (
+    ResourceAvailableEvent
+)
+from trinity.plugins.builtin.light_peer_chain_bridge import (
+    LightPeerChainEventBusResponder
+)
+
+
+class LightPeerChainBridgePlugin(BasePlugin):
+    """
+    The ``LightPeerChainBridgePlugin`` runs in the ``networking`` process and acts as a bridge
+    between other processes and the ``LightPeerChain``.
+    It runs only in ``light`` mode.
+    Other plugins can instantiate the ``EventBusLightPeerChain`` from separate processes to
+    interact with the ``LightPeerChain`` indirectly.
+    """
+
+    chain: BaseChain = None
+
+    @property
+    def name(self) -> str:
+        return "LightPeerChain Bridge"
+
+    def should_start(self) -> bool:
+        return self.chain is not None and self.context.chain_config.sync_mode == SYNC_LIGHT
+
+    def handle_event(self, activation_event: BaseEvent) -> None:
+        if isinstance(activation_event, ResourceAvailableEvent):
+            if activation_event.resource_type is BaseChain:
+                self.chain = activation_event.resource
+
+    def start(self) -> None:
+        self.logger.info('LightPeerChain Bridge started')
+        chain = cast(LightDispatchChain, self.chain)
+        LightPeerChainEventBusResponder(chain._peer_chain, self.context.event_bus)

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -7,11 +7,13 @@ from trinity.plugins.builtin.fix_unclean_shutdown.plugin import (
     FixUncleanShutdownPlugin
 )
 from trinity.plugins.builtin.json_rpc.plugin import (
-    JsonRpcServerLightPlugin,
     JsonRpcServerPlugin,
 )
 from trinity.plugins.builtin.tx_pool.plugin import (
     TxPlugin,
+)
+from trinity.plugins.builtin.light_peer_chain_bridge.plugin import (
+    LightPeerChainBridgePlugin
 )
 
 
@@ -31,7 +33,7 @@ def is_ipython_available() -> bool:
 ENABLED_PLUGINS = [
     AttachPlugin() if is_ipython_available() else AttachPlugin(use_ipython=False),
     FixUncleanShutdownPlugin(),
+    JsonRpcServerPlugin(),
+    LightPeerChainBridgePlugin(),
     TxPlugin(),
-    JsonRpcServerLightPlugin(),
-    JsonRpcServerPlugin()
 ]

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -7,7 +7,8 @@ from trinity.plugins.builtin.fix_unclean_shutdown.plugin import (
     FixUncleanShutdownPlugin
 )
 from trinity.plugins.builtin.json_rpc.plugin import (
-    JsonRpcServerPlugin
+    JsonRpcServerLightPlugin,
+    JsonRpcServerPlugin,
 )
 from trinity.plugins.builtin.tx_pool.plugin import (
     TxPlugin,
@@ -31,5 +32,6 @@ ENABLED_PLUGINS = [
     AttachPlugin() if is_ipython_available() else AttachPlugin(use_ipython=False),
     FixUncleanShutdownPlugin(),
     TxPlugin(),
+    JsonRpcServerLightPlugin(),
     JsonRpcServerPlugin()
 ]

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -6,6 +6,9 @@ from trinity.plugins.builtin.attach.plugin import (
 from trinity.plugins.builtin.fix_unclean_shutdown.plugin import (
     FixUncleanShutdownPlugin
 )
+from trinity.plugins.builtin.json_rpc.plugin import (
+    JsonRpcServerPlugin
+)
 from trinity.plugins.builtin.tx_pool.plugin import (
     TxPlugin,
 )
@@ -28,4 +31,5 @@ ENABLED_PLUGINS = [
     AttachPlugin() if is_ipython_available() else AttachPlugin(use_ipython=False),
     FixUncleanShutdownPlugin(),
     TxPlugin(),
+    JsonRpcServerPlugin()
 ]

--- a/trinity/rpc/ipc.py
+++ b/trinity/rpc/ipc.py
@@ -99,7 +99,7 @@ async def connection_loop(execute_rpc: Callable[[Any], Any],
             continue
 
         try:
-            result = execute_rpc(request)
+            result = await execute_rpc(request)
         except Exception as e:
             logger.exception("Unrecognized exception while executing RPC")
             await cancel_token.cancellable_wait(

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -15,8 +15,8 @@ from eth.chains.base import (
     BaseChain
 )
 
-from p2p.peer import (
-    PeerPool
+from lahja import (
+    Endpoint
 )
 
 from trinity.rpc.modules import (
@@ -74,11 +74,11 @@ class RPCServer:
         Web3,
     )
 
-    def __init__(self, chain: BaseChain=None, peer_pool: PeerPool=None) -> None:
+    def __init__(self, chain: BaseChain=None, event_bus: Endpoint=None) -> None:
         self.modules: Dict[str, RPCModule] = {}
         self.chain = chain
         for M in self.module_classes:
-            self.modules[M.__name__.lower()] = M(chain, peer_pool)
+            self.modules[M.__name__.lower()] = M(chain, event_bus)
         if len(self.modules) != len(self.module_classes):
             raise ValueError("apparent name conflict in RPC module_classes", self.module_classes)
 

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -101,9 +101,9 @@ class RPCServer:
         except AttributeError:
             raise ValueError("Method not implemented: %r" % rpc_method)
 
-    def _get_result(self,
-                    request: Dict[str, Any],
-                    debug: bool=False) -> Tuple[Any, Union[Exception, str]]:
+    async def _get_result(self,
+                          request: Dict[str, Any],
+                          debug: bool=False) -> Tuple[Any, Union[Exception, str]]:
         '''
         :returns: (result, error) - result is None if error is provided. Error must be
             convertable to string with ``str(error)``.
@@ -116,7 +116,7 @@ class RPCServer:
 
             method = self._lookup_method(request['method'])
             params = request.get('params', [])
-            result = method(*params)
+            result = await method(*params)
 
             if request['method'] == 'evm_resetToGenesisFixture':
                 self.chain, result = result, True
@@ -135,11 +135,11 @@ class RPCServer:
         else:
             return result, None
 
-    def execute(self, request: Dict[str, Any]) -> str:
+    async def execute(self, request: Dict[str, Any]) -> str:
         '''
         The key entry point for all incoming requests
         '''
-        result, error = self._get_result(request)
+        result, error = await self._get_result(request)
         return generate_response(request, result, error)
 
     @property

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -12,7 +12,7 @@ from eth_utils import (
 )
 
 from eth.chains.base import (
-    BaseChain
+    AsyncChain,
 )
 
 from lahja import (
@@ -74,7 +74,7 @@ class RPCServer:
         Web3,
     )
 
-    def __init__(self, chain: BaseChain=None, event_bus: Endpoint=None) -> None:
+    def __init__(self, chain: AsyncChain=None, event_bus: Endpoint=None) -> None:
         self.modules: Dict[str, RPCModule] = {}
         self.chain = chain
         for M in self.module_classes:
@@ -143,11 +143,11 @@ class RPCServer:
         return generate_response(request, result, error)
 
     @property
-    def chain(self) -> BaseChain:
+    def chain(self) -> AsyncChain:
         return self.__chain
 
     @chain.setter
-    def chain(self, new_chain: BaseChain) -> None:
+    def chain(self, new_chain: AsyncChain) -> None:
         self.__chain = new_chain
         for module in self.modules.values():
             module.set_chain(new_chain)

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -129,75 +129,75 @@ class Eth(RPCModule):
     Any attribute without an underscore is publicly accessible.
     '''
 
-    def accounts(self) -> List[str]:
+    async def accounts(self) -> List[str]:
         # trinity does not manage accounts for the user
         return []
 
-    def blockNumber(self) -> str:
+    async def blockNumber(self) -> str:
         num = self._chain.get_canonical_head().block_number
         return hex(num)
 
     @format_params(identity, to_int_if_hex)
-    def call(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
+    async def call(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
         header = get_header(self._chain, at_block)
         validate_transaction_call_dict(txn_dict, self._chain.get_vm(header))
         transaction = dict_to_spoof_transaction(self._chain, header, txn_dict)
         result = self._chain.get_transaction_result(transaction, header)
         return encode_hex(result)
 
-    def coinbase(self) -> Hash32:
+    async def coinbase(self) -> Hash32:
         raise NotImplementedError()
 
     @format_params(identity, to_int_if_hex)
-    def estimateGas(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
+    async def estimateGas(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
         header = get_header(self._chain, at_block)
         validate_transaction_gas_estimation_dict(txn_dict, self._chain.get_vm(header))
         transaction = dict_to_spoof_transaction(self._chain, header, txn_dict)
         gas = self._chain.estimate_gas(transaction, header)
         return hex(gas)
 
-    def gasPrice(self) -> int:
+    async def gasPrice(self) -> int:
         raise NotImplementedError()
 
     @format_params(decode_hex, to_int_if_hex)
-    def getBalance(self, address: Address, at_block: Union[str, int]) -> str:
+    async def getBalance(self, address: Address, at_block: Union[str, int]) -> str:
         account_db = account_db_at_block(self._chain, at_block)
         balance = account_db.get_balance(address)
 
         return hex(balance)
 
     @format_params(decode_hex, identity)
-    def getBlockByHash(self,
+    async def getBlockByHash(self,
                        block_hash: Hash32,
                        include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
         block = self._chain.get_block_by_hash(block_hash)
         return block_to_dict(block, self._chain, include_transactions)
 
     @format_params(to_int_if_hex, identity)
-    def getBlockByNumber(self,
+    async def getBlockByNumber(self,
                          at_block: Union[str, int],
                          include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
         block = get_block_at_number(self._chain, at_block)
         return block_to_dict(block, self._chain, include_transactions)
 
     @format_params(decode_hex)
-    def getBlockTransactionCountByHash(self, block_hash: Hash32) -> str:
+    async def getBlockTransactionCountByHash(self, block_hash: Hash32) -> str:
         block = self._chain.get_block_by_hash(block_hash)
         return hex(len(block.transactions))
 
     @format_params(to_int_if_hex)
-    def getBlockTransactionCountByNumber(self, at_block: Union[str, int]) -> str:
+    async def getBlockTransactionCountByNumber(self, at_block: Union[str, int]) -> str:
         block = get_block_at_number(self._chain, at_block)
         return hex(len(block.transactions))
 
     @format_params(decode_hex, to_int_if_hex)
-    def getCode(self, address: Address, at_block: Union[str, int]) -> str:
+    async def getCode(self, address: Address, at_block: Union[str, int]) -> str:
         account_db = account_db_at_block(self._chain, at_block)
         code = account_db.get_code(address)
         return encode_hex(code)
 
     @format_params(decode_hex, to_int_if_hex, to_int_if_hex)
-    def getStorageAt(self, address: Address, position: int, at_block: Union[str, int]) -> str:
+    async def getStorageAt(self, address: Address, position: int, at_block: Union[str, int]) -> str:
         if not is_integer(position) or position < 0:
             raise TypeError("Position of storage must be a whole number, but was: %r" % position)
 
@@ -206,13 +206,13 @@ class Eth(RPCModule):
         return encode_hex(int_to_big_endian(stored_val))
 
     @format_params(decode_hex, to_int_if_hex)
-    def getTransactionByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
+    async def getTransactionByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
         block = self._chain.get_block_by_hash(block_hash)
         transaction = block.transactions[index]
         return transaction_to_dict(transaction)
 
     @format_params(to_int_if_hex, to_int_if_hex)
-    def getTransactionByBlockNumberAndIndex(self,
+    async def getTransactionByBlockNumberAndIndex(self,
                                             at_block: Union[str, int],
                                             index: int) -> Dict[str, str]:
         block = get_block_at_number(self._chain, at_block)
@@ -220,43 +220,43 @@ class Eth(RPCModule):
         return transaction_to_dict(transaction)
 
     @format_params(decode_hex, to_int_if_hex)
-    def getTransactionCount(self, address: Address, at_block: Union[str, int]) -> str:
+    async def getTransactionCount(self, address: Address, at_block: Union[str, int]) -> str:
         account_db = account_db_at_block(self._chain, at_block)
         nonce = account_db.get_nonce(address)
         return hex(nonce)
 
     @format_params(decode_hex)
-    def getUncleCountByBlockHash(self, block_hash: Hash32) -> str:
+    async def getUncleCountByBlockHash(self, block_hash: Hash32) -> str:
         block = self._chain.get_block_by_hash(block_hash)
         return hex(len(block.uncles))
 
     @format_params(to_int_if_hex)
-    def getUncleCountByBlockNumber(self, at_block: Union[str, int]) -> str:
+    async def getUncleCountByBlockNumber(self, at_block: Union[str, int]) -> str:
         block = get_block_at_number(self._chain, at_block)
         return hex(len(block.uncles))
 
     @format_params(decode_hex, to_int_if_hex)
-    def getUncleByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
+    async def getUncleByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
         block = self._chain.get_block_by_hash(block_hash)
         uncle = block.uncles[index]
         return header_to_dict(uncle)
 
     @format_params(to_int_if_hex, to_int_if_hex)
-    def getUncleByBlockNumberAndIndex(self,
+    async def getUncleByBlockNumberAndIndex(self,
                                       at_block: Union[str, int],
                                       index: int) -> Dict[str, str]:
         block = get_block_at_number(self._chain, at_block)
         uncle = block.uncles[index]
         return header_to_dict(uncle)
 
-    def hashrate(self) -> str:
+    async def hashrate(self) -> str:
         raise NotImplementedError()
 
-    def mining(self) -> bool:
+    async def mining(self) -> bool:
         return False
 
-    def protocolVersion(self) -> str:
+    async def protocolVersion(self) -> str:
         return "63"
 
-    def syncing(self) -> bool:
+    async def syncing(self) -> bool:
         raise NotImplementedError()

--- a/trinity/rpc/modules/evm.py
+++ b/trinity/rpc/modules/evm.py
@@ -25,7 +25,7 @@ from trinity.rpc.modules import (
 
 class EVM(RPCModule):
     @format_params(normalize_blockchain_fixtures)
-    def resetToGenesisFixture(self, chain_info: Any) -> Chain:
+    async def resetToGenesisFixture(self, chain_info: Any) -> Chain:
         '''
         This method is a special case. It returns a new chain object
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`
@@ -34,7 +34,7 @@ class EVM(RPCModule):
         return new_chain_from_fixture(chain_info)
 
     @format_params(normalize_block)
-    def applyBlockFixture(self, block_info: Any) -> str:
+    async def applyBlockFixture(self, block_info: Any) -> str:
         '''
         This method is a special case. It returns a new chain object
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`

--- a/trinity/rpc/modules/evm.py
+++ b/trinity/rpc/modules/evm.py
@@ -31,7 +31,7 @@ class EVM(RPCModule):
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`
         for all future calls.
         '''
-        return new_chain_from_fixture(chain_info)
+        return new_chain_from_fixture(chain_info, type(self._chain))
 
     @format_params(normalize_block)
     async def applyBlockFixture(self, block_info: Any) -> str:

--- a/trinity/rpc/modules/main.py
+++ b/trinity/rpc/modules/main.py
@@ -2,17 +2,17 @@ from eth.chains.base import (
     BaseChain
 )
 
-from p2p.peer import (
-    PeerPool,
+from lahja import (
+    Endpoint
 )
 
 
 class RPCModule:
     _chain = None
 
-    def __init__(self, chain: BaseChain, peer_pool: PeerPool) -> None:
+    def __init__(self, chain: BaseChain, event_bus: Endpoint) -> None:
         self._chain = chain
-        self._peer_pool = peer_pool
+        self._event_bus = event_bus
 
     def set_chain(self, chain: BaseChain) -> None:
         self._chain = chain

--- a/trinity/rpc/modules/main.py
+++ b/trinity/rpc/modules/main.py
@@ -1,5 +1,5 @@
 from eth.chains.base import (
-    BaseChain
+    AsyncChain
 )
 
 from lahja import (
@@ -10,9 +10,9 @@ from lahja import (
 class RPCModule:
     _chain = None
 
-    def __init__(self, chain: BaseChain, event_bus: Endpoint) -> None:
+    def __init__(self, chain: AsyncChain, event_bus: Endpoint) -> None:
         self._chain = chain
         self._event_bus = event_bus
 
-    def set_chain(self, chain: BaseChain) -> None:
+    def set_chain(self, chain: AsyncChain) -> None:
         self._chain = chain

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -4,19 +4,19 @@ from trinity.rpc.modules import (
 
 
 class Net(RPCModule):
-    def version(self) -> str:
+    async def version(self) -> str:
         """
         Returns the current network ID.
         """
         return str(self._chain.network_id)
 
-    def peerCount(self) -> str:
+    async def peerCount(self) -> str:
         """
         Return the number of peers that are currently connected to the node
         """
         return hex(len(self._peer_pool))  # type: ignore
 
-    def listening(self) -> bool:
+    async def listening(self) -> bool:
         """
         Return `True` if the client is actively listening for network connections
         """

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -1,3 +1,6 @@
+from p2p.events import (
+    PeerCountRequest
+)
 from trinity.rpc.modules import (
     RPCModule,
 )
@@ -14,7 +17,8 @@ class Net(RPCModule):
         """
         Return the number of peers that are currently connected to the node
         """
-        return hex(len(self._peer_pool))  # type: ignore
+        response = await self._event_bus.request(PeerCountRequest())
+        return hex(response.peer_count)
 
     async def listening(self) -> bool:
         """

--- a/trinity/rpc/modules/web3.py
+++ b/trinity/rpc/modules/web3.py
@@ -9,13 +9,13 @@ from trinity.rpc.modules import (
 
 
 class Web3(RPCModule):
-    def clientVersion(self) -> str:
+    async def clientVersion(self) -> str:
         """
         Returns the current client version.
         """
         return construct_trinity_client_identifier()
 
-    def sha3(self, data: str) -> str:
+    async def sha3(self, data: str) -> str:
         """
         Returns Keccak-256 of the given data.
         """

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -13,6 +13,10 @@ from eth_utils import big_endian_to_int
 
 from cancel_token import CancelToken, OperationCancelled
 
+from lahja import (
+    Endpoint
+)
+
 from eth.chains import AsyncChain
 
 from p2p.auth import (
@@ -78,9 +82,11 @@ class Server(BaseService):
                  peer_class: Type[BasePeer] = ETHPeer,
                  bootstrap_nodes: Tuple[Node, ...] = None,
                  preferred_nodes: Sequence[Node] = None,
+                 event_bus: Endpoint = None,
                  token: CancelToken = None,
                  ) -> None:
         super().__init__(token)
+        self.event_bus = event_bus
         self.headerdb = headerdb
         self.chaindb = chaindb
         self.chain = chain
@@ -128,6 +134,7 @@ class Server(BaseService):
             self.chain.get_vm_configuration(),
             max_peers=self.max_peers,
             token=self.cancel_token,
+            event_bus=self.event_bus,
         )
 
     async def _run(self) -> None:

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -1,3 +1,7 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
 import asyncio
 from functools import (
     partial,
@@ -71,7 +75,38 @@ from trinity.rlp.block_body import BlockBody
 from trinity.utils.les import gen_request_id
 
 
-class LightPeerChain(PeerSubscriber, BaseService):
+class BaseLightPeerChain(ABC):
+
+    @abstractmethod
+    async def get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
+        pass
+
+    @abstractmethod
+    async def get_block_body_by_hash(self, block_hash: Hash32) -> BlockBody:
+        pass
+
+    @abstractmethod
+    async def get_receipts(self, block_hash: Hash32) -> List[Receipt]:
+        pass
+
+    @abstractmethod
+    async def get_account(self, block_hash: Hash32, address: Address) -> Account:
+        pass
+
+    @abstractmethod
+    async def get_contract_code(self, block_hash: Hash32, address: Address) -> bytes:
+        pass
+
+    @abstractmethod
+    async def get_foo(self) -> int:
+        pass
+
+    @abstractmethod
+    async def get_foobar(self, foo: int, bar: int) -> int:
+        pass
+
+
+class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
     reply_timeout = REPLY_TIMEOUT
     headerdb: BaseAsyncHeaderDB = None
 
@@ -137,6 +172,12 @@ class LightPeerChain(PeerSubscriber, BaseService):
         return await self._retry_on_bad_response(
             partial(self._get_block_header_by_hash, block_hash)
         )
+
+    async def get_foobar(self, foo: int, bar: int) -> int:
+        return foo + bar
+
+    async def get_foo(self) -> int:
+        return 5
 
     @alru_cache(maxsize=1024, cache_exceptions=False)
     @service_timeout(COMPLETION_TIMEOUT)

--- a/trinity/utils/async_dispatch.py
+++ b/trinity/utils/async_dispatch.py
@@ -1,0 +1,18 @@
+import asyncio
+import functools
+from typing import (
+    Any,
+    Awaitable,
+    Callable
+)
+
+
+def async_method(method_name: str) -> Callable[..., Any]:
+    async def method(self: Any, *args: Any, **kwargs: Any) -> Awaitable[Any]:
+        loop = asyncio.get_event_loop()
+
+        func = getattr(self, method_name)
+        pfunc = functools.partial(func, *args, **kwargs)
+
+        return await loop.run_in_executor(None, pfunc)
+    return method

--- a/trinity/utils/db_proxy.py
+++ b/trinity/utils/db_proxy.py
@@ -1,0 +1,34 @@
+from multiprocessing.managers import (
+    BaseManager,
+)
+import pathlib
+
+from trinity.chains import (
+    AsyncHeaderChainProxy,
+    ChainProxy,
+)
+from trinity.db.chain import ChainDBProxy
+from trinity.db.base import DBProxy
+from trinity.db.header import (
+    AsyncHeaderDBProxy
+)
+
+
+def create_db_manager(ipc_path: pathlib.Path) -> BaseManager:
+    """
+    We're still using 'str' here on param ipc_path because an issue with
+    multi-processing not being able to interpret 'Path' objects correctly
+    """
+    class DBManager(BaseManager):
+        pass
+
+    # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
+    # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
+    DBManager.register('get_db', proxytype=DBProxy)  # type: ignore
+    DBManager.register('get_chaindb', proxytype=ChainDBProxy)  # type: ignore
+    DBManager.register('get_chain', proxytype=ChainProxy)  # type: ignore
+    DBManager.register('get_headerdb', proxytype=AsyncHeaderDBProxy)  # type: ignore
+    DBManager.register('get_header_chain', proxytype=AsyncHeaderChainProxy)  # type: ignore
+
+    manager = DBManager(address=str(ipc_path))  # type: ignore
+    return manager

--- a/trinity/utils/shutdown.py
+++ b/trinity/utils/shutdown.py
@@ -1,0 +1,27 @@
+import asyncio
+import signal
+
+from lahja import (
+    Endpoint,
+)
+
+from p2p.service import (
+    BaseService,
+)
+
+
+async def exit_on_signal(service_to_exit: BaseService, endpoint: Endpoint = None) -> None:
+    loop = service_to_exit.get_event_loop()
+    sigint_received = asyncio.Event()
+    for sig in [signal.SIGINT, signal.SIGTERM]:
+        # TODO also support Windows
+        loop.add_signal_handler(sig, sigint_received.set)
+
+    await sigint_received.wait()
+    try:
+        await service_to_exit.cancel()
+        if endpoint is not None:
+            endpoint.stop()
+        service_to_exit._executor.shutdown(wait=True)
+    finally:
+        loop.stop()


### PR DESCRIPTION
**DISCLAIMER: This is PoC WIP code so no need to comment on naming, imports or whatever is just *messy***

### What is this?

This is a PoC sitting on top of #1212 

### Motivation

#1212 Moves the `JSON-RPC` service into an isolated plugin to run in its own process. However, that approach didn't work for `--light` mode so far because in that mode the chain is heavily depending on the `PeerPool`. So what #1212 does so far is that it provides a second plugin only for `--light` mode which isn't isolated but continues to run in the networking process instead.

That however isn't ideal because:

a.) we want the `JSON-RPC` plugin to run in a separate process to provide isolation from the rest of the networking stuff (e.g. reduce DDOS vector etc)

b.) Before #1212 (current master) the IPC Server created a separate thread to provide some isolation but I had problems reusing that approach together with the event bus. Leaving the `JSON-RPC` server inside the `networking` process but altering the process model to remove that extra thread scares me :sweat_smile: 

This PoC tries to pave the way for an isolated `JSON-RPC` server plugin that works for both `full` and `light` mode.

### How does it work

First, we create another plugin `LightPeerChainBridgePlugin` which does the following:

- Provide a `EventBusLightPeerChain` which is basically a version the `LightPeerChain` that can be used in any other process
- The `EventBusLightPeerChain` basically issues events via the event bus that will be answered by the plugin that is running inside the `networking` process and hence has access to the `LightPeerChain`. @pipermerriam That is basically no different from what #1212 does with the `peer_count` already and what I think we both agreed on would be the way forward for the general interaction between separate processes.
- I believe the `EventBusLightPeerChain` can become zero maintenance in the sense that it will magically provide all APIs that the `LightPeerChain` has which means whenever APIs change or are added, the `EventBusLightPeerChain` will automatically have them. (In contrast to our existing `Proxy` types that need to be altered whenever the remote type changes. Though, to be fair, I guess we could auto generated the methods for them as well). That isn't currently implemented in this PoC though.
- Notice that the `LightPeerChainBridgePlugin` isn't coupled to this particular use case and can be reused by other plugins that want to run in their own isolated process but need access to the `LightPeerChain`. Also notice that while this *could* equally be implemented in the core code, I believe there is no reason to do so and providing the functionality as a plugin makes it easy to drop it later e.g. when the current networking code becomes more event bus friendly in general (aka exposes thins on the event bus for other processes to consume)

Also in current master, since the IPC Server uses another thread, we are running this async call in another thread and block to make it synchronous.

https://github.com/ethereum/py-evm/blob/55613b7e3ef0a7ca42a981d014911eef2c07874c/trinity/chains/light.py#L143-L145

With the new approach the `JSON-RPC` server that now runs in its own process doesn't have this second thread anymore and hence we schedule that async method on the event loop as we normally would. I *believe* that this would be a win in general.

Would love to receive feedback on the approach in general and also on the idea to make the `EventBusLightPeerChain` zero maintenance through some meta programming magic if we choose to go down the path of this PR.