### PR TITLE
Fix minor typing issues

### DIFF
--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -171,8 +171,7 @@ class TracebackRecorder:
             return record_traceback_on_error(attr)
 
 
-# Need to "type: ignore" here because we run mypy with --disallow-any-generics
-def record_traceback_on_error(attr: Callable) -> Callable:  # type: ignore
+def record_traceback_on_error(attr: Callable[..., Any]) -> Callable[..., Any]:
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             return attr(*args, **kwargs)

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -20,7 +20,6 @@ from typing import (
     Tuple,
     TYPE_CHECKING,
     Callable,
-    Union,
 )
 
 from cytoolz import dissoc
@@ -53,7 +52,7 @@ class HasTraceLogger:
         return self._logger
 
 
-def setup_log_levels(log_levels: Dict[Union[None, str], int]) -> None:
+def setup_log_levels(log_levels: Dict[str, int]) -> None:
     for name, level in log_levels.items():
         logger = logging.getLogger(name)
         logger.setLevel(level)


### PR DESCRIPTION
### What was wrong?

Just fixing two minor mypy things I came across.

- one unnecessary `type: ignore`
- one superfluous `Union[...]`  

### How was it fixed?

Removed `Union` and added correct type hints.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.lightnfocus.com/wp-content/uploads/2016/10/funny-owls-Comedy-wildlife-photography-awards-2016-shortlist.jpg)
