### PR TITLE
Remove chain info property from LESPeer

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -103,6 +103,7 @@ from .constants import (
 
 if TYPE_CHECKING:
     from trinity.db.header import BaseAsyncHeaderDB  # noqa: F401
+    from trinity.protocol.common.proto import ChainInfo  # noqa: F401
     from trinity.protocol.eth.requests import HeaderRequest  # noqa: F401
     from trinity.protocol.base_request import BaseRequest  # noqa: F401
 
@@ -291,6 +292,7 @@ class BasePeer(BaseService):
 
     @property
     async def _local_chain_info(self) -> 'ChainInfo':
+        from trinity.protocol.common.proto import ChainInfo  # noqa: F811
         genesis = await self.genesis
         head = await self.wait(self.headerdb.coro_get_canonical_head())
         total_difficulty = await self.headerdb.coro_get_score(head.hash)
@@ -1018,18 +1020,6 @@ DEFAULT_PREFERRED_NODES: Dict[int, Tuple[Node, ...]] = {
              Address("34.198.237.7", 30303, 30303)),
     ),
 }
-
-
-class ChainInfo:
-    def __init__(self,
-                 block_number: int,
-                 block_hash: Hash32,
-                 total_difficulty: int,
-                 genesis_hash: Hash32) -> None:
-        self.block_number = block_number
-        self.block_hash = block_hash
-        self.total_difficulty = total_difficulty
-        self.genesis_hash = genesis_hash
 
 
 def _test() -> None:

--- a/tests/trinity/integration/test_lightchain_integration.py
+++ b/tests/trinity/integration/test_lightchain_integration.py
@@ -207,9 +207,8 @@ async def test_lightchain_integration(
         '0xf709ed2c57efc18a1675e8c740f3294c9e2cb36ba7bb3b89d3ab4c8fef9d8860')
 
     assert len(peer_pool) == 1
-    head_info = peer_pool.highest_td_peer.head_info
-    head = await peer_chain.get_block_header_by_hash(head_info.block_hash)
-    assert head.block_number == head_info.block_number
+    peer = peer_pool.highest_td_peer
+    head = await peer_chain.get_block_header_by_hash(peer.head_hash)
 
     # In order to answer queries for contract code, geth needs the state trie entry for the block
     # we specify in the query, but because of fast sync we can only assume it has that for recent

--- a/trinity/protocol/common/proto.py
+++ b/trinity/protocol/common/proto.py
@@ -1,0 +1,13 @@
+from typing import NamedTuple
+
+from eth_typing import (
+    BlockNumber,
+    Hash32,
+)
+
+
+class ChainInfo(NamedTuple):
+    block_number: BlockNumber
+    block_hash: Hash32
+    total_difficulty: int
+    genesis_hash: Hash32

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -2,7 +2,6 @@ import logging
 from typing import (
     List,
     Tuple,
-    TYPE_CHECKING,
     Union,
 )
 
@@ -19,6 +18,7 @@ from p2p.protocol import (
     Protocol,
 )
 
+from trinity.protocol.common.proto import ChainInfo
 from trinity.rlp.block_body import BlockBody
 
 from .commands import (
@@ -36,11 +36,6 @@ from .commands import (
     Transactions,
 )
 
-if TYPE_CHECKING:
-    from p2p.peer import (  # noqa: F401
-        ChainInfo
-    )
-
 
 class ETHProtocol(Protocol):
     name = 'eth'
@@ -52,13 +47,13 @@ class ETHProtocol(Protocol):
     cmd_length = 17
     logger = logging.getLogger("p2p.eth.ETHProtocol")
 
-    def send_handshake(self, head_info: 'ChainInfo') -> None:
+    def send_handshake(self, chain_info: ChainInfo) -> None:
         resp = {
             'protocol_version': self.version,
             'network_id': self.peer.network_id,
-            'td': head_info.total_difficulty,
-            'best_hash': head_info.block_hash,
-            'genesis_hash': head_info.genesis_hash,
+            'td': chain_info.total_difficulty,
+            'best_hash': chain_info.block_hash,
+            'genesis_hash': chain_info.genesis_hash,
         }
         cmd = Status(self.cmd_id_offset)
         self.logger.debug("Sending ETH/Status msg: %s", resp)

--- a/trinity/protocol/les/commands.py
+++ b/trinity/protocol/les/commands.py
@@ -111,15 +111,6 @@ class Status(Command):
             # See comment in the definition of item_sedes as to why we do this.
             return b''
 
-    def as_head_info(self, decoded: _DecodedMsgType) -> HeadInfo:
-        decoded = cast(Dict[str, Any], decoded)
-        return HeadInfo(
-            block_number=decoded['headNum'],
-            block_hash=decoded['headHash'],
-            total_difficulty=decoded['headTd'],
-            reorg_depth=0,
-        )
-
 
 class Announce(Command):
     _cmd_id = 1
@@ -128,19 +119,10 @@ class Announce(Command):
         ('head_number', sedes.big_endian_int),
         ('head_td', sedes.big_endian_int),
         ('reorg_depth', sedes.big_endian_int),
+        # TODO: The params CountableList may contain any of the values from the
+        # Status msg.  Need to extend this command to process that too.
         ('params', sedes.CountableList(sedes.List([sedes.text, sedes.raw]))),
     ]
-    # TODO: The params CountableList above may contain any of the values from the Status msg.
-    # Need to extend this command to process that too.
-
-    def as_head_info(self, decoded: _DecodedMsgType) -> HeadInfo:
-        decoded = cast(Dict[str, Any], decoded)
-        return HeadInfo(
-            block_number=decoded['head_number'],
-            block_hash=decoded['head_hash'],
-            total_difficulty=decoded['head_td'],
-            reorg_depth=decoded['reorg_depth'],
-        )
 
 
 class GetBlockHeadersQuery(rlp.Serializable):

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -1,7 +1,6 @@
 from typing import (
     List,
     Tuple,
-    TYPE_CHECKING,
     Union,
 )
 
@@ -15,6 +14,8 @@ from eth.rlp.headers import BlockHeader
 from p2p.protocol import (
     Protocol,
 )
+
+from trinity.protocol.common.proto import ChainInfo
 
 from .commands import (
     Status,
@@ -38,11 +39,6 @@ from .commands import (
 )
 from . import constants
 
-if TYPE_CHECKING:
-    from p2p.peer import (  # noqa: F401
-        ChainInfo
-    )
-
 
 class LESProtocol(Protocol):
     name = 'les'
@@ -51,7 +47,7 @@ class LESProtocol(Protocol):
                  ContractCodes]
     cmd_length = 15
 
-    def send_handshake(self, chain_info: 'ChainInfo') -> None:
+    def send_handshake(self, chain_info: ChainInfo) -> None:
         resp = {
             'protocolVersion': self.version,
             'networkId': self.peer.network_id,
@@ -148,7 +144,7 @@ class LESProtocolV2(LESProtocol):
                  ProofsV2, ContractCodes]
     cmd_length = 21
 
-    def send_handshake(self, chain_info: 'ChainInfo') -> None:
+    def send_handshake(self, chain_info: ChainInfo) -> None:
         resp = {
             'announceType': constants.LES_ANNOUNCE_SIMPLE,
             'protocolVersion': self.version,

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -278,7 +278,7 @@ class LightPeerChain(PeerSubscriber, BaseService):
             # our best peer doesn't have the header we want, there are no eligible peers.
             raise NoEligiblePeers("Our best peer does not have the header %s" % block_hash)
 
-        head_number = peer.head_info.block_number
+        head_number = peer.head_number
         if head_number - header.block_number > MAX_REORG_DEPTH:
             # The peer claims to be far ahead of the header we requested
             if self.headerdb.get_canonical_block_hash(header.block_number) == block_hash:


### PR DESCRIPTION
Another extraction from #1259 

### What is this?

This cleans up the usage of the `ChainInfo` object.  The light peer previously stored a reference to this locally.  I suspect we can revive something like this at some point but for now this reduces some complexity and makes #1259 cleaner to read.

#### Cute Animal Picture


![monkey-on-dog](https://user-images.githubusercontent.com/824194/45227543-00922000-b27e-11e8-91c6-8c6faee05aaa.png)
