### PR TITLE
Fix logging configuration

### DIFF
--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -119,10 +119,6 @@ class ValidateAndStoreLogLevel(argparse.Action):
         log_levels[path] = log_level
 
 
-DEFAULT_STDERR_LOG_LEVEL = logging.INFO
-DEFAULT_DEBUG_LOG_LEVEL = logging.DEBUG
-
-
 parser = argparse.ArgumentParser(description='Trinity')
 
 #
@@ -185,7 +181,6 @@ logging_parser.add_argument(
 logging_parser.add_argument(
     '--stderr-log-level',
     dest="stderr_log_level",
-    default=DEFAULT_STDERR_LOG_LEVEL,
     help=(
         "Configure the logging level for the stderr logging."
     ),
@@ -193,7 +188,6 @@ logging_parser.add_argument(
 logging_parser.add_argument(
     '--file-log-level',
     dest="file_log_level",
-    default=DEFAULT_DEBUG_LOG_LEVEL,
     help=(
         "Configure the logging level for file-based logging."
     ),

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -59,8 +59,10 @@ def setup_log_levels(log_levels: Dict[Union[None, str], int]) -> None:
         logger.setLevel(level)
 
 
-def setup_trinity_stderr_logging(level: int=logging.INFO,
+def setup_trinity_stderr_logging(level: int=None,
                                  ) -> Tuple[Logger, Formatter, StreamHandler]:
+    if level is None:
+        level = logging.INFO
     logger = logging.getLogger('trinity')
     logger.setLevel(logging.DEBUG)
 
@@ -87,8 +89,11 @@ def setup_trinity_file_and_queue_logging(
         formatter: Formatter,
         handler_stream: StreamHandler,
         chain_config: ChainConfig,
-        level: int=logging.DEBUG) -> Tuple[Logger, 'Queue[str]', QueueListener]:
+        level: int=None) -> Tuple[Logger, 'Queue[str]', QueueListener]:
     from .mp import ctx
+
+    if level is None:
+        level = logging.DEBUG
 
     log_queue = ctx.Queue()
 


### PR DESCRIPTION
### What was wrong?

Using just `--log-level DEBUG` didn't correctly effect the stderr log level.

### How was it fixed?

Removed the defaults for `--stderr-log-level` so that we can detect when the value has not been provided and to default it to the global log level if provided by `--log-level`.

#### Cute Animal Picture


![qwdasx4](https://user-images.githubusercontent.com/824194/45231061-1f95af80-b288-11e8-877e-49b172d07b73.jpg)
