### PR TITLE
Remove no-longer-needed catch of OperationCancelled

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -956,10 +956,7 @@ class PeerPool(BaseService, AsyncIterable[BasePeer]):
                 for line in peer.get_extra_stats():
                     self.logger.debug("    %s", line)
             self.logger.debug("== End peer details == ")
-            try:
-                await self.sleep(self._report_interval)
-            except OperationCancelled:
-                break
+            await self.sleep(self._report_interval)
 
 
 class ConnectedPeersIterator(AsyncIterator[BasePeer]):


### PR DESCRIPTION
extracted from https://github.com/ethereum/py-evm/pull/1258/files#r215635281

### What was wrong?

We no longer need to handle `OperationCancelled` within the stats reporting task since it is run with `BaseService.run_task()`

### How was it fixed?

Removed the `try/except`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
