### PR TITLE
Implement discv5 topic registration

### DIFF
--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -167,3 +167,10 @@ class AlreadyWaitingDiscoveryResponse(BaseP2PError):
     Raised when we are already waiting for a discovery response from a given remote.
     """
     pass
+
+
+class UnableToGetDiscV5Ticket(BaseP2PError):
+    """
+    Raised when we're unable to get a discv5 ticket from a remote peer.
+    """
+    pass


### PR DESCRIPTION
This basically adds two new APIs that allow us to ask a remote node for
a discv5 ticket (DiscoveryProtocol.get_ticket()) and then use that to
register ourselves under a given topic (DiscoveryProtocol.send_topic_register())