### PR TITLE
BaseService extensions

### DIFF
--- a/p2p/service.py
+++ b/p2p/service.py
@@ -129,7 +129,7 @@ class BaseService(ABC, CancellableMixin):
 
         If it raises OperationCancelled, that is caught and ignored.
         """
-        @functools.wraps(awaitable)
+        @functools.wraps(awaitable)  # type: ignore
         async def _run_task_wrapper() -> None:
             self.logger.trace("Running task %s", awaitable)
             try:
@@ -149,7 +149,7 @@ class BaseService(ABC, CancellableMixin):
         Like :meth:`run_task` but if the task ends without cancelling, then this
         this service will terminate as well.
         """
-        @functools.wraps(awaitable)
+        @functools.wraps(awaitable)  # type: ignore
         async def _run_daemon_task_wrapper() -> None:
             try:
                 await awaitable
@@ -215,6 +215,15 @@ class BaseService(ABC, CancellableMixin):
                     self.cancel_token.trigger()
 
         self.run_task(_run_daemon_wrapper())
+
+    def call_later(self, delay: float, callback: 'Callable[..., None]', *args: Any) -> None:
+
+        @functools.wraps(callback)
+        async def _call_later_wrapped() -> None:
+            self.sleep(delay)
+            callback(*args)
+
+        self.run_task(_call_later_wrapped())
 
     async def _run_in_executor(self, callback: Callable[..., Any], *args: Any) -> Any:
         loop = self.get_event_loop()

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -129,6 +129,7 @@ class BaseService(ABC, CancellableMixin):
 
         If it raises OperationCancelled, that is caught and ignored.
         """
+        @functools.wraps(awaitable)
         async def _run_task_wrapper() -> None:
             self.logger.trace("Running task %s", awaitable)
             try:
@@ -148,6 +149,7 @@ class BaseService(ABC, CancellableMixin):
         Like :meth:`run_task` but if the task ends without cancelling, then this
         this service will terminate as well.
         """
+        @functools.wraps(awaitable)
         async def _run_daemon_task_wrapper() -> None:
             try:
                 await awaitable
@@ -194,6 +196,7 @@ class BaseService(ABC, CancellableMixin):
 
         self._child_services.add(service)
 
+        @functools.wraps(service.run)
         async def _run_daemon_wrapper() -> None:
             try:
                 await service.run()

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -586,8 +586,7 @@ class FastChainSyncer(BaseBodyChainSyncer):
                 # peer returned no results, wait a while before trying again
                 delay = self.EMPTY_PEER_RESPONSE_PENALTY
                 self.logger.debug("Pausing %s for %.1fs, for sending 0 receipts", peer, delay)
-                loop = self.get_event_loop()
-                loop.call_later(delay, partial(self._receipt_peers.put_nowait, peer))
+                self.call_later(delay, self._receipt_peers.put_nowait, peer)
         finally:
             self._receipt_tasks.complete(batch_id, completed_headers)
 


### PR DESCRIPTION
### What was wrong?

Using `loop.call_later` directly won't get cancelled with the service.

`BaseService` wraps a lot of coroutines, which makes for bad messages and stack traces.

### How was it fixed?

- Added a new `BaseService.call_later()` that cancels with `BaseService`.
- Decorate the wrappers with `@functools.wraps(awaitable)`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://3.bp.blogspot.com/-uNalrLS-d5Y/T5rTIU1dBfI/AAAAAAAAIng/HPpDG-6RAew/s640/cute-animal-hugging-pictures-005.jpg)
