### PR TITLE
Pin setuptools>=36.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ deps = {
     'dev': [
         "bumpversion>=0.5.3,<1",
         "wheel",
+        "setuptools>=36.2.0",
         "tox==2.7.0",
         "twine",
     ],


### PR DESCRIPTION
### What was wrong?
prevent releases from using outdated setuptools which strips enviroment markers from the released wheel.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8933231/45392262-60b8f700-b5db-11e8-8825-1c66aa2b2628.png)
