### PR TITLE
Do not use deprecated sphinx option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,10 @@ extensions = [
     'sphinxcontrib.asyncio',
 ]
 
-autodoc_default_flags = ['undoc-members']
+autodoc_default_options = {
+    'undoc-members': None,
+}
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
### What was wrong?

CI build fails for docs job https://circleci.com/gh/ethereum/py-evm/75639?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

### How was it fixed?

Use the newer option format

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.giphy.com/media/2iKqvSZ2e1DLG/giphy.gif)
