### PR TITLE
expose strange bug

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -945,7 +945,6 @@ class DiscoveryByTopicProtocol(DiscoveryProtocol):
 
 
 class DiscoveryService(BaseService):
-    _lookup_running = asyncio.Lock()
     _last_lookup: float = 0
     _lookup_interval: int = 30
 
@@ -955,6 +954,7 @@ class DiscoveryService(BaseService):
         self.proto = proto
         self.peer_pool = peer_pool
         self.port = port
+        self._lookup_running = asyncio.Lock()
 
     async def _run(self) -> None:
         await self._start_udp_listener()

--- a/tests/trinity/integration/test_trinity_cli.py
+++ b/tests/trinity/integration/test_trinity_cli.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from trinity.tools.async_process_runner import AsyncProcessRunner
@@ -17,13 +18,17 @@ from trinity.utils.async_iter import (
 # This fixture provides a tear down to run after each test that uses it.
 # This ensures the AsyncProcessRunner will never leave a process behind
 @pytest.fixture(scope="function")
-def async_process_runner():
+def async_process_runner(event_loop):
+    asyncio.get_child_watcher().attach_loop(event_loop)
     runner = AsyncProcessRunner(
         # This allows running pytest with -s and observing the output
         debug_fn=lambda line: print(line)
     )
     yield runner
-    runner.kill()
+    try:
+        runner.kill()
+    except ProcessLookupError:
+        pass
 
 # Great for debugging the AsyncProcessRunner
 # @pytest.mark.asyncio


### PR DESCRIPTION
### What was wrong?

The `DiscoveryService` had an `asyncio.Lock` object set as a class variable.  Aside from this being problematic since it would mean that all instances of the `DiscoveryService` share this object, instantiating the `Lock()` object has the side effect of populating the default event loop for the thread.

The `p2p.discovery` module is imported in the `./tests/trinity/conftest.py` file which is loaded when running the integration tests.  This results in the event loop being set prior to the execution of those tests.

While working on https://github.com/ethereum/py-evm/pull/1286/files this import was removed resulting in this CI failure

https://circleci.com/gh/ethereum/py-evm/75904?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

```
trinity/tools/async_process_runner.py:32: in run
    preexec_fn=os.setsid
/usr/local/lib/python3.7/asyncio/subprocess.py:217: in create_subprocess_exec
    stderr=stderr, **kwds)
/usr/local/lib/python3.7/asyncio/base_events.py:1516: in subprocess_exec
    bufsize, **kwargs)
/usr/local/lib/python3.7/asyncio/unix_events.py:193: in _make_subprocess_transport
    self._child_watcher_callback, transp)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <asyncio.unix_events.SafeChildWatcher object at 0x7f2305e4ad68>
pid = 588
callback = <bound method _UnixSelectorEventLoop._child_watcher_callback of <_UnixSelectorEventLoop running=False closed=False debug=False>>
args = (<_UnixSubprocessTransport pid=588 running>,)

    def add_child_handler(self, pid, callback, *args):
        if self._loop is None:
            raise RuntimeError(
>               "Cannot add child handler, "
                "the child watcher does not have a loop attached")
E           RuntimeError: Cannot add child handler, the child watcher does not have a loop attached
```

### How was it fixed?

In the `async_process_runner` fixture, manually attach the event loop to the watcher.

#### Cute Animal Picture

![monkeydogepa_450x300](https://user-images.githubusercontent.com/824194/45453818-257ffc00-b69f-11e8-979e-493e5c0b2477.jpg)

