### PR TITLE
Use uvloop on unix and darwin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ deps = {
         "plyvel==1.0.5",
         "web3==4.4.1",
         "lahja==0.6.1",
+        "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin'",
     ],
     'test': [
         "hypothesis==3.69.5",

--- a/tests/trinity/integration/test_trinity_cli.py
+++ b/tests/trinity/integration/test_trinity_cli.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 
 from trinity.tools.async_process_runner import AsyncProcessRunner
@@ -19,7 +18,6 @@ from trinity.utils.async_iter import (
 # This ensures the AsyncProcessRunner will never leave a process behind
 @pytest.fixture(scope="function")
 def async_process_runner(event_loop):
-    asyncio.get_child_watcher().attach_loop(event_loop)
     runner = AsyncProcessRunner(
         # This allows running pytest with -s and observing the output
         debug_fn=lambda line: print(line)

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -1,4 +1,5 @@
 import pkg_resources
+import sys
 
 # TODO: update this to use the `trinity` version once extracted from py-evm
 __version__: str
@@ -11,6 +12,12 @@ except pkg_resources.DistributionNotFound:
 
 # This is to ensure we call setup_trace_logging() before anything else.
 import eth as _eth_module  # noqa: F401
+
+if sys.platform in {'darwin', 'linux'}:
+    # Set `uvloop` as the default event loop
+    import asyncio  # noqa: E402
+    import uvloop  # noqa: E402
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 from .main import (  # noqa: F401
     main,

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -27,9 +27,10 @@ class AsyncProcessRunner():
             *cmds,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.PIPE,
             # We need this because Trinity spawns multiple processes and we need to take down
             # the entire group of processes.
-            preexec_fn=os.setsid
+            preexec_fn=os.setsid,
         )
         self.proc = proc
         asyncio.ensure_future(self.kill_after_timeout(timeout_sec))


### PR DESCRIPTION
### What was wrong?

The default event loop provided by `asyncio` is written in python.  Python is slow...

There exists a library called [`uvloop`](https://github.com/MagicStack/uvloop) which is a c implementation of the python event loop which is supposed to be up to 2x faster.

### How was it fixed?

If the installation platform is Linux or Darwin, install `uvloop` and set it as the default event loop.

#### Cute Animal Picture

![hqdefault](https://user-images.githubusercontent.com/824194/45455580-db017e00-b6a4-11e8-8c30-144daba6c62f.jpg)

