### PR TITLE
Fast sync start forked

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -52,6 +52,7 @@ from eth.db.header import (
 )
 from eth.constants import (
     BLANK_ROOT_HASH,
+    EMPTY_UNCLE_HASH,
     MAX_UNCLE_DEPTH,
 )
 from eth.estimators import (
@@ -720,6 +721,10 @@ class Chain(BaseChain):
         """
         Validate the uncles for the given block.
         """
+        if block.header.uncles_hash == EMPTY_UNCLE_HASH and len(block.uncles) == 0:
+            # optimization to avoid checking ancestors if the block has no uncles
+            return
+
         # Check for duplicates
         uncle_groups = groupby(operator.attrgetter('hash'), block.uncles)
         duplicate_uncles = tuple(sorted(

--- a/eth/utils/rlp.py
+++ b/eth/utils/rlp.py
@@ -56,6 +56,15 @@ def validate_rlp_equal(obj_a, obj_b, obj_a_name=None, obj_b_name=None):
         obj_b_name = obj_b.__class__.__name__ + '_b'
 
     diff = diff_rlp_object(obj_a, obj_b)
+    if len(diff) == 0:
+        raise TypeError(
+            "{} ({!r}) != {} ({!r}) but got an empty diff".format(
+                obj_a_name,
+                obj_a,
+                obj_b_name,
+                obj_b,
+            )
+        )
     longest_field_name = max(len(field_name) for field_name, _, _ in diff)
     error_message = (
         "Mismatch between {obj_a_name} and {obj_b_name} on {0} fields:\n - {1}".format(

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -220,7 +220,7 @@ class BaseService(ABC, CancellableMixin):
 
         @functools.wraps(callback)
         async def _call_later_wrapped() -> None:
-            self.sleep(delay)
+            await self.sleep(delay)
             callback(*args)
 
         self.run_task(_call_later_wrapped())


### PR DESCRIPTION
### What was wrong?

When running fast sync, it might start on a fork from the end of the last sync. This was causing a crash.

Other similar problems are currently possible (but [shouldn't be for long](https://github.com/ethereum/py-evm/pull/1279)), like starting later than the canonical head, because headers were saved into an inconsistent state.

### How was it fixed?

Catch the `ValidationError` when trying to register the block/receipt download tasks. Confirm that the parent header already exists (which the common sync should have already done). Then allow the sync to continue, with a log.

This required a change in `OrderedTaskPreparation`: it can now accept multiple "already finished" tasks.

Some other bonus fixes:

- speed up uncle validation if a block has no uncles
- logging a weird RLP bug from an overnight ropsten run
- await a sleep from an old PR :man_facepalming: 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://3.bp.blogspot.com/-qAHvW49EDF8/UB-wb6O4tBI/AAAAAAAALvE/GVikPUjh60g/s1600/Funny+Panther_.jpg)
