### PR TITLE
AtomicDB

### DIFF
--- a/eth/db/atomic.py
+++ b/eth/db/atomic.py
@@ -1,0 +1,99 @@
+from contextlib import contextmanager
+import logging
+import threading
+from typing import Generator
+
+from eth_utils import (
+    ValidationError,
+)
+
+from eth.db.diff import (
+    DBDiff,
+    DBDiffTracker,
+    DiffMissingError,
+)
+from eth.db.backends.base import BaseDB, BaseAtomicDB
+from eth.db.backends.memory import MemoryDB
+
+
+class AtomicDB(BaseAtomicDB):
+    """
+    This is nearly the same as BatchDB, but it immediately writes out changes if they are
+    not in a batch_write() context.
+    """
+    logger = logging.getLogger("eth.db.AtomicDB")
+
+    wrapped_db = None  # type: BaseDB
+    _track_diff = None  # type: DBDiffTracker
+
+    def __init__(self, wrapped_db: BaseDB = None) -> None:
+        if wrapped_db is None:
+            self.wrapped_db = MemoryDB()
+        else:
+            self.wrapped_db = wrapped_db
+        self._track_diff = DBDiffTracker()
+        self._batch_lock = threading.Lock()
+
+    @contextmanager
+    def atomic_batch(self) -> Generator[None, None, None]:
+        if self._batch_lock.locked():
+            raise ValidationError("AtomicDB does not support recursive batching of writes")
+
+        try:
+            with self._batch_lock:
+                yield
+        except Exception:
+            self.logger.exception(
+                "Unexpected error in atomic db write, dropped partial writes: %r",
+                self._diff(),
+            )
+            self._clear()
+            raise
+        else:
+            self._commit()
+
+    def __getitem__(self, key: bytes) -> bytes:
+        if not self._batch_lock.locked():
+            return self.wrapped_db[key]
+
+        try:
+            value = self._track_diff[key]
+        except DiffMissingError as missing:
+            if missing.is_deleted:
+                raise KeyError(key)
+            else:
+                return self.wrapped_db[key]
+        else:
+            return value
+
+    def __setitem__(self, key: bytes, value: bytes) -> None:
+        if self._batch_lock.locked():
+            self._track_diff[key] = value
+        else:
+            self.wrapped_db[key] = value
+
+    def __delitem__(self, key: bytes) -> None:
+        if key not in self:
+            raise KeyError(key)
+        if self._batch_lock.locked():
+            del self._track_diff[key]
+        else:
+            del self.wrapped_db[key]
+
+    def _diff(self) -> DBDiff:
+        return self._track_diff.diff()
+
+    def _clear(self):
+        self._track_diff = DBDiffTracker()
+
+    def _commit(self) -> None:
+        self._diff().apply_to(self.wrapped_db, apply_deletes=True)
+        self._clear()
+
+    def _exists(self, key: bytes) -> bool:
+        try:
+            self[key]
+        except KeyError:
+            return False
+        else:
+            return True

--- a/eth/db/backends/base.py
+++ b/eth/db/backends/base.py
@@ -52,3 +52,33 @@ class BaseDB(MutableMapping, ABC):
 
     def __len__(self):
         raise NotImplementedError("By default, DB classes cannot return the total number of keys.")
+
+
+class BaseAtomicDB(BaseDB):
+    """
+    This is an abstract key/value lookup that permits batching of updates, such that the batch of
+    changes are atomically saved. They are either all saved, or none are.
+
+    Writes to the database are immediately saved, unless they are explicitly batched
+    in a context, like this:
+
+    ::
+
+        db = AtomicDB()
+        with db.atomic_batch():
+            # changes are not immediately saved to the db, inside this context
+            db[key] = val
+
+            # changes are still locally visible even though they are not yet committed to the db
+            assert db[key] == val
+
+            if some_bad_condition:
+                raise Exception("something went wrong, erase all the pending changes")
+
+            db[key2] = val2
+            # when exiting the context, the values are saved either key and key2 will both be saved,
+            # or neither will
+    """
+    @abstractmethod
+    def atomic_batch(self):
+        raise NotImplementedError

--- a/eth/db/batch.py
+++ b/eth/db/batch.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Type, Dict  # noqa: F401
 
 from eth.db.diff import (
     DBDiff,
@@ -15,7 +14,7 @@ class BatchDB(BaseDB):
     which represents as a dictionary of database keys and values.
     This class should be usable as a context manager, the changes either all fail or all succeed.
     Upon exiting the context, it writes all of the key value pairs from the cache into
-    the underlying database. If anyerror occurred before committing phase,
+    the underlying database. If any error occurred before committing phase,
     we would not apply commits at all.
     """
     logger = logging.getLogger("eth.db.BatchDB")

--- a/tests/database/test_atomic_db.py
+++ b/tests/database/test_atomic_db.py
@@ -1,0 +1,121 @@
+import pytest
+
+from eth_utils import ValidationError
+
+from eth.db.atomic import AtomicDB
+
+
+@pytest.fixture
+def atomic_db(base_db):
+    return AtomicDB(base_db)
+
+
+def test_atomic_db_with_set_and_get(base_db, atomic_db):
+    with atomic_db.atomic_batch():
+        atomic_db.set(b'key-1', b'value-1')
+        atomic_db.set(b'key-2', b'value-2')
+        assert atomic_db.get(b'key-1') == b'value-1'
+        assert atomic_db.get(b'key-2') == b'value-2'
+
+        # keys should not yet be set in base db.
+        assert b'key-1' not in base_db
+        assert b'key-2' not in base_db
+
+    assert base_db.get(b'key-1') == b'value-1'
+    assert base_db.get(b'key-2') == b'value-2'
+
+
+def test_atomic_db_with_set_and_get_unbatched(base_db, atomic_db):
+    atomic_db.set(b'key-1', b'value-1')
+    assert atomic_db.get(b'key-1') == b'value-1'
+    atomic_db.set(b'key-2', b'value-2')
+    assert atomic_db.get(b'key-2') == b'value-2'
+
+    # keys should be immediately set in base db.
+    assert base_db.get(b'key-1') == b'value-1'
+    assert base_db.get(b'key-2') == b'value-2'
+
+
+def test_atomic_db_cannot_recursively_batch(base_db, atomic_db):
+    with atomic_db.atomic_batch():
+        with pytest.raises(ValidationError):
+            with atomic_db.atomic_batch():
+                assert False, "AtomicDB should not permit recursive batching of changes"
+
+
+def test_atomic_db_with_set_and_delete(base_db, atomic_db):
+    base_db[b'key-1'] = b'origin'
+
+    with atomic_db.atomic_batch():
+        atomic_db.delete(b'key-1')
+
+        assert b'key-1' not in atomic_db
+        with pytest.raises(KeyError):
+            assert atomic_db[b'key-1']
+
+        # key should still be in base atomic_db
+        assert b'key-1' in base_db
+        assert b'key-1' not in atomic_db
+
+    with pytest.raises(KeyError):
+        base_db[b'key-1']
+    with pytest.raises(KeyError):
+        atomic_db[b'key-1']
+
+
+def test_atomic_db_with_set_and_delete_unbatched(base_db, atomic_db):
+    base_db[b'key-1'] = b'origin'
+
+    atomic_db.delete(b'key-1')
+
+    assert b'key-1' not in atomic_db
+    with pytest.raises(KeyError):
+        assert atomic_db[b'key-1']
+
+    # key should be immediately removed from base atomic_db
+    with pytest.raises(KeyError):
+        base_db[b'key-1']
+
+
+def test_atomic_db_with_exception(base_db, atomic_db):
+    base_db.set(b'key-1', b'value-1')
+
+    try:
+        with atomic_db.atomic_batch():
+            atomic_db.set(b'key-1', b'new-value-1')
+            atomic_db.set(b'key-2', b'value-2')
+            raise Exception
+    except Exception:
+        pass
+
+    assert base_db.get(b'key-1') == b'value-1'
+
+    with pytest.raises(KeyError):
+        base_db[b'key-2']
+    with pytest.raises(KeyError):
+        atomic_db[b'key-2']
+
+
+def test_atomic_db_with_exception_across_contexts(base_db, atomic_db):
+    base_db[b'key-1'] = b'origin-1'
+    base_db[b'key-2'] = b'origin-2'
+
+    try:
+        with atomic_db.atomic_batch():
+            atomic_db[b'key-1'] = b'value-1'
+            raise Exception('throw')
+    except Exception:
+        pass
+
+    assert base_db[b'key-1'] == b'origin-1'
+    assert atomic_db[b'key-1'] == b'origin-1'
+    assert base_db[b'key-2'] == b'origin-2'
+    assert atomic_db[b'key-2'] == b'origin-2'
+
+    with atomic_db.atomic_batch():
+        atomic_db[b'key-2'] = b'value-2'
+
+    assert base_db[b'key-1'] == b'origin-1'
+    assert atomic_db[b'key-1'] == b'origin-1'
+    assert base_db[b'key-2'] == b'value-2'
+    assert atomic_db[b'key-2'] == b'value-2'


### PR DESCRIPTION
### What was wrong?

There was no way to use LevelDB's built-in write batching.

### How was it fixed?

- Added a new `BaseBatchableDB` which extends the BaseDB API, for write batching
- Added a new `BatchableDB` as a parallel to `MemoryDB` that supports batching. (Note that it's different from `BatchDB`, which *always* batches requests until commit. `BatchableDB` will immediately commit any changes outside of a `batch_write` context.)
- Added support for `batch_write` to the `LevelDB` backend

This is not yet wired up to anything, it's a few starting commits PR stripped off of #1279 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://cute-n-tiny.com/wp-content/uploads/2009/07/cute_funny_animals_14-400x284.jpg)
