### PR TITLE
Require BaseAtomicDB in ChainDB and HeaderDB

### DIFF
--- a/docs/cookbooks/index.rst
+++ b/docs/cookbooks/index.rst
@@ -44,13 +44,13 @@ Then to initialize, you can start it up with an in-memory database:
 
 .. doctest::
 
-  >>> from eth.db.backends.memory import MemoryDB
+  >>> from eth.db.atomic import AtomicDB
   >>> from eth.chains.mainnet import MAINNET_GENESIS_HEADER
 
   >>> # start a fresh in-memory db
 
   >>> # initialize a fresh chain
-  >>> chain = chain_class.from_genesis_header(MemoryDB(), MAINNET_GENESIS_HEADER)
+  >>> chain = chain_class.from_genesis_header(AtomicDB(), MAINNET_GENESIS_HEADER)
 
 .. _evm_cookbook_recipe_creating_a_chain_with_custom_state:
 
@@ -66,7 +66,7 @@ state.
   >>> from eth_keys import keys
   >>> from eth import constants
   >>> from eth.chains.mainnet import MainnetChain
-  >>> from eth.db.backends.memory import MemoryDB
+  >>> from eth.db.atomic import AtomicDB
   >>> from eth_utils import to_wei, encode_hex
 
 
@@ -95,7 +95,7 @@ state.
   ...     'nonce': constants.GENESIS_NONCE
   ... }
 
->>> chain = MainnetChain.from_genesis(MemoryDB(), GENESIS_PARAMS, GENESIS_STATE)
+  >>> chain = MainnetChain.from_genesis(AtomicDB(), GENESIS_PARAMS, GENESIS_STATE)
 
 .. _evm_cookbook_recipe_getting_the_balance_from_an_account:
 

--- a/docs/guides/eth/building_an_app_that_uses_pyevm.rst
+++ b/docs/guides/eth/building_an_app_that_uses_pyevm.rst
@@ -70,9 +70,9 @@ Next, we'll create a new directory ``app`` and create a file ``main.py`` inside.
 
 .. code-block:: python
 
-  from evm import constants
-  from evm.chains.mainnet import MainnetChain
-  from evm.db.backends.memory import MemoryDB
+  from eth import constants
+  from eth.chains.mainnet import MainnetChain
+  from eth.db.backends.memory import MemoryDB
 
   from eth_utils import to_wei, encode_hex
 

--- a/docs/guides/eth/understanding_the_mining_process.rst
+++ b/docs/guides/eth/understanding_the_mining_process.rst
@@ -44,11 +44,11 @@ cookbook.
 
 ::
 
-  from eth.db.backends.memory import MemoryDB
+  from eth.db.atomic import AtomicDB
   from eth.chains.mainnet import MAINNET_GENESIS_HEADER
 
   # initialize a fresh chain
-  chain = chain_class.from_genesis_header(MemoryDB(), MAINNET_GENESIS_HEADER)
+  chain = chain_class.from_genesis_header(AtomicDB(), MAINNET_GENESIS_HEADER)
 
 Since we decided to not add any transactions to our block let's just call
 :func:`~~eth.chains.base.MiningChain.mine_block` and see what happens.
@@ -56,7 +56,7 @@ Since we decided to not add any transactions to our block let's just call
 ::
 
   # initialize a fresh chain
-  chain = chain_class.from_genesis_header(MemoryDB(), MAINNET_GENESIS_HEADER)
+  chain = chain_class.from_genesis_header(AtomicDB(), MAINNET_GENESIS_HEADER)
 
   chain.mine_block()
 
@@ -163,7 +163,7 @@ Next, we'll create the chain itself using the defined ``GENESIS_PARAMS`` and the
 
   from eth import MiningChain
   from eth.vm.forks.byzantium import ByzantiumVM
-  from eth.db.backends.memory import MemoryDB
+  from eth.db.backends.memory import AtomicDB
 
 
   klass = MiningChain.configure(
@@ -171,7 +171,7 @@ Next, we'll create the chain itself using the defined ``GENESIS_PARAMS`` and the
       vm_configuration=(
           (constants.GENESIS_BLOCK_NUMBER, ByzantiumVM),
       ))
-  chain = klass.from_genesis(MemoryDB(), GENESIS_PARAMS)
+  chain = klass.from_genesis(AtomicDB(), GENESIS_PARAMS)
 
 
 Now that we have the building blocks available, let's put it all together and mine a proper block!
@@ -319,7 +319,7 @@ zero value transfer transaction.
   >>> from eth.chains.base import MiningChain
   >>> from eth.consensus.pow import mine_pow_nonce
   >>> from eth.vm.forks.byzantium import ByzantiumVM
-  >>> from eth.db.backends.memory import MemoryDB
+  >>> from eth.db.atomic import AtomicDB
 
 
   >>> GENESIS_PARAMS = {
@@ -350,7 +350,7 @@ zero value transfer transaction.
   ...         (constants.GENESIS_BLOCK_NUMBER, ByzantiumVM),
   ...     ))
 
-  >>> chain = klass.from_genesis(MemoryDB(), GENESIS_PARAMS)
+  >>> chain = klass.from_genesis(AtomicDB(), GENESIS_PARAMS)
   >>> vm = chain.get_vm()
 
   >>> nonce = vm.state.account_db.get_nonce(SENDER)

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -42,7 +42,7 @@ from eth_utils import (
     ValidationError,
 )
 
-from eth.db.backends.base import BaseDB
+from eth.db.backends.base import BaseAtomicDB
 from eth.db.chain import (
     BaseChainDB,
     ChainDB,
@@ -144,7 +144,7 @@ class BaseChain(Configurable, ABC):
     @classmethod
     @abstractmethod
     def from_genesis(cls,
-                     base_db: BaseDB,
+                     base_db: BaseAtomicDB,
                      genesis_params: Dict[str, HeaderParams],
                      genesis_state: AccountState=None) -> 'BaseChain':
         raise NotImplementedError("Chain classes must implement this method")
@@ -152,7 +152,7 @@ class BaseChain(Configurable, ABC):
     @classmethod
     @abstractmethod
     def from_genesis_header(cls,
-                            base_db: BaseDB,
+                            base_db: BaseAtomicDB,
                             genesis_header: BlockHeader) -> 'BaseChain':
         raise NotImplementedError("Chain classes must implement this method")
 
@@ -322,7 +322,7 @@ class Chain(BaseChain):
 
     chaindb_class = ChainDB  # type: Type[BaseChainDB]
 
-    def __init__(self, base_db: BaseDB) -> None:
+    def __init__(self, base_db: BaseAtomicDB) -> None:
         if not self.vm_configuration:
             raise ValueError(
                 "The Chain class cannot be instantiated with an empty `vm_configuration`"
@@ -349,7 +349,7 @@ class Chain(BaseChain):
     #
     @classmethod
     def from_genesis(cls,
-                     base_db: BaseDB,
+                     base_db: BaseAtomicDB,
                      genesis_params: Dict[str, HeaderParams],
                      genesis_state: AccountState=None) -> 'BaseChain':
         """
@@ -389,7 +389,7 @@ class Chain(BaseChain):
 
     @classmethod
     def from_genesis_header(cls,
-                            base_db: BaseDB,
+                            base_db: BaseAtomicDB,
                             genesis_header: BlockHeader) -> 'BaseChain':
         """
         Initializes the chain from the genesis header.
@@ -824,7 +824,7 @@ def _extract_uncle_hashes(blocks):
 class MiningChain(Chain):
     header = None  # type: BlockHeader
 
-    def __init__(self, base_db: BaseDB, header: BlockHeader=None) -> None:
+    def __init__(self, base_db: BaseAtomicDB, header: BlockHeader=None) -> None:
         super().__init__(base_db)
         self.header = self.ensure_header(header)
 

--- a/eth/db/__init__.py
+++ b/eth/db/__init__.py
@@ -8,13 +8,13 @@ from eth.utils.module_loading import (
     import_string,
 )
 from eth.db.backends.base import (
-    BaseDB
+    BaseAtomicDB,
 )
 
-DEFAULT_DB_BACKEND = 'eth.db.backends.memory.MemoryDB'
+DEFAULT_DB_BACKEND = 'eth.db.atomic.AtomicDB'
 
 
-def get_db_backend_class(import_path: str = None) -> Type[BaseDB]:
+def get_db_backend_class(import_path: str = None) -> Type[BaseAtomicDB]:
     if import_path is None:
         import_path = os.environ.get(
             'CHAIN_DB_BACKEND_CLASS',
@@ -23,6 +23,6 @@ def get_db_backend_class(import_path: str = None) -> Type[BaseDB]:
     return import_string(import_path)
 
 
-def get_db_backend(import_path: str = None, **init_kwargs: Any) -> BaseDB:
+def get_db_backend(import_path: str = None, **init_kwargs: Any) -> BaseAtomicDB:
     backend_class = get_db_backend_class(import_path)
     return backend_class(**init_kwargs)

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -41,7 +41,7 @@ from eth.exceptions import (
 )
 from eth.db.header import BaseHeaderDB, HeaderDB
 from eth.db.backends.base import (
-    BaseDB
+    BaseAtomicDB
 )
 from eth.db.schema import SchemaV1
 from eth.rlp.headers import (
@@ -74,10 +74,10 @@ class TransactionKey(rlp.Serializable):
 
 
 class BaseChainDB(BaseHeaderDB):
-    db = None  # type: BaseDB
+    db = None  # type: BaseAtomicDB
 
     @abstractmethod
-    def __init__(self, db: BaseDB) -> None:
+    def __init__(self, db: BaseAtomicDB) -> None:
         raise NotImplementedError("ChainDB classes must implement this method")
 
     #
@@ -161,7 +161,7 @@ class BaseChainDB(BaseHeaderDB):
 
 
 class ChainDB(HeaderDB, BaseChainDB):
-    def __init__(self, db: BaseDB) -> None:
+    def __init__(self, db: BaseAtomicDB) -> None:
         self.db = db
 
     #

--- a/eth/db/header.py
+++ b/eth/db/header.py
@@ -28,7 +28,7 @@ from eth.exceptions import (
     HeaderNotFound,
     ParentNotFound,
 )
-from eth.db import BaseDB
+from eth.db.backends.base import BaseDB
 from eth.db.schema import SchemaV1
 from eth.rlp.headers import BlockHeader
 from eth.validation import (

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -9,7 +9,7 @@ from eth_utils import (
 )
 
 from eth import MainnetChain
-from eth.db.backends.memory import MemoryDB
+from eth.db.atomic import AtomicDB
 from eth.utils.state import (
     diff_account_db,
 )
@@ -147,7 +147,7 @@ def genesis_params_from_fixture(fixture):
 
 
 def new_chain_from_fixture(fixture):
-    base_db = MemoryDB()
+    base_db = AtomicDB()
 
     vm_config = chain_vm_configuration(fixture)
 

--- a/scripts/benchmark/utils/chain_plumbing.py
+++ b/scripts/benchmark/utils/chain_plumbing.py
@@ -31,8 +31,8 @@ from eth.vm.base import (
 from eth.chains.mainnet import (
     BaseMainnetChain,
 )
-from eth.db.backends.memory import (
-    MemoryDB
+from eth.db.atomic import (
+    AtomicDB,
 )
 
 AddressSetup = NamedTuple('AddressSetup', [
@@ -83,7 +83,7 @@ def genesis_state(setup: Iterable[AddressSetup]) -> Any:
 
 
 def chain_without_pow(
-        base_db: MemoryDB,
+        base_db: AtomicDB,
         vm: Type[BaseVM],
         genesis_params: Any,
         genesis_state: Any) -> MiningChain:
@@ -101,7 +101,7 @@ def chain_without_pow(
 
 def get_chain(vm: Type[BaseVM]) -> MiningChain:
     return chain_without_pow(
-        MemoryDB(),
+        AtomicDB(),
         vm,
         GENESIS_PARAMS,
         genesis_state([

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from eth.chains.base import (
     Chain,
     MiningChain,
 )
-from eth.db.backends.memory import MemoryDB
+from eth.db.atomic import AtomicDB
 # TODO: tests should not be locked into one set of VM rules.  Look at expanding
 # to all mainnet vms.
 from eth.vm.forks.spurious_dragon import SpuriousDragonVM
@@ -58,7 +58,7 @@ def _file_logging(request):
 
 @pytest.fixture
 def base_db():
-    return MemoryDB()
+    return AtomicDB()
 
 
 @pytest.fixture

--- a/tests/core/chain-object/test_chain_get_ancestors.py
+++ b/tests/core/chain-object/test_chain_get_ancestors.py
@@ -2,6 +2,7 @@ import pytest
 
 from eth.chains.base import MiningChain
 from eth.db.backends.memory import MemoryDB
+from eth.db.atomic import AtomicDB
 
 
 @pytest.fixture
@@ -14,7 +15,7 @@ def chain(chain_without_block_validation):
 @pytest.fixture
 def fork_chain(chain):
     # make a duplicate chain with no shared state
-    fork_db = MemoryDB(chain.chaindb.db.kv_store.copy())
+    fork_db = AtomicDB(MemoryDB(chain.chaindb.db.wrapped_db.kv_store.copy()))
     fork_chain = type(chain)(fork_db, chain.header)
 
     return fork_chain

--- a/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
+++ b/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
@@ -10,7 +10,6 @@ from eth.constants import (
     GENESIS_DIFFICULTY,
     GENESIS_GAS_LIMIT,
 )
-from eth.db.backends.memory import MemoryDB
 from eth.db.chain import ChainDB
 from eth.exceptions import (
     VMNotFound,
@@ -49,11 +48,6 @@ class ChainForTesting(Chain):
         (0, VM_A),
         (10, VM_B),
     )
-
-
-@pytest.fixture()
-def base_db():
-    return MemoryDB()
 
 
 @pytest.fixture()

--- a/tests/core/chain-object/test_header_chain.py
+++ b/tests/core/chain-object/test_header_chain.py
@@ -15,7 +15,6 @@ from eth.constants import (
     GENESIS_DIFFICULTY,
     GENESIS_GAS_LIMIT,
 )
-from eth.db.backends.memory import MemoryDB
 from eth.rlp.headers import (
     BlockHeader,
 )
@@ -37,11 +36,6 @@ def mk_header_chain(base_header, length):
         )
         yield next_header
         previous_header = next_header
-
-
-@pytest.fixture
-def base_db():
-    return MemoryDB()
 
 
 @pytest.fixture

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -9,8 +9,8 @@ from eth_utils import (
 from eth import (
     constants
 )
-from eth.db.backends.memory import (
-    MemoryDB
+from eth.db.atomic import (
+    AtomicDB
 )
 from eth.db.chain import (
     ChainDB
@@ -67,7 +67,7 @@ def prepare_computation(vm_class):
         origin=CANONICAL_ADDRESS_B,
     )
 
-    vm = vm_class(GENESIS_HEADER, ChainDB(MemoryDB()))
+    vm = vm_class(GENESIS_HEADER, ChainDB(AtomicDB()))
 
     computation = vm_class._state_class.computation_class(
         state=vm.state,

--- a/tests/database/test_chaindb.py
+++ b/tests/database/test_chaindb.py
@@ -12,7 +12,6 @@ from eth_hash.auto import keccak
 from eth.constants import (
     BLANK_ROOT_HASH,
 )
-from eth.db.backends.memory import MemoryDB
 from eth.db.chain import (
     ChainDB,
 )
@@ -45,11 +44,6 @@ def set_empty_root(chaindb, header):
         receipt_root=BLANK_ROOT_HASH,
         state_root=BLANK_ROOT_HASH,
     )
-
-
-@pytest.fixture
-def base_db():
-    return MemoryDB()
 
 
 @pytest.fixture

--- a/tests/database/test_header_db.py
+++ b/tests/database/test_header_db.py
@@ -20,7 +20,6 @@ from eth.exceptions import (
     CanonicalHeadNotFound,
     ParentNotFound,
 )
-from eth.db.backends.memory import MemoryDB
 from eth.db.header import HeaderDB
 from eth.rlp.headers import (
     BlockHeader,
@@ -28,11 +27,6 @@ from eth.rlp.headers import (
 from eth.tools.rlp import (
     assert_headers_eq,
 )
-
-
-@pytest.fixture
-def base_db():
-    return MemoryDB()
 
 
 @pytest.fixture

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -8,6 +8,9 @@ import tempfile
 import pytest
 
 from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER, ROPSTEN_NETWORK_ID
+from eth.db.atomic import (
+    AtomicDB,
+)
 from eth.db.chain import (
     ChainDB,
 )
@@ -20,9 +23,6 @@ from trinity.config import (
 )
 from trinity.db.chain import ChainDBProxy
 from trinity.db.base import DBProxy
-from trinity.utils.db import (
-    MemoryDB,
-)
 from trinity.utils.ipc import (
     wait_for_ipc,
     kill_process_gracefully,
@@ -36,7 +36,7 @@ def serve_chaindb(manager):
 
 @pytest.fixture
 def database_server_ipc_path():
-    core_db = MemoryDB()
+    core_db = AtomicDB()
     core_db[b'key-a'] = b'value-a'
 
     chaindb = ChainDB(core_db)

--- a/tests/trinity/core/integration_test_helpers.py
+++ b/tests/trinity/core/integration_test_helpers.py
@@ -8,6 +8,7 @@ from eth.chains.base import (
 )
 from eth.db.backends.level import LevelDB
 from eth.db.backends.memory import MemoryDB
+from eth.db.atomic import AtomicDB
 
 from trinity.db.base import AsyncBaseDB
 from trinity.db.chain import AsyncChainDB
@@ -32,6 +33,11 @@ def async_passthrough(base_name):
         return getattr(self, base_name)(*args, **kwargs)
     passthrough_method.__name__ = coro_name
     return passthrough_method
+
+
+class FakeAsyncAtomicDB(AtomicDB, AsyncBaseDB):
+    coro_set = async_passthrough('set')
+    coro_exists = async_passthrough('exists')
 
 
 class FakeAsyncMemoryDB(MemoryDB, AsyncBaseDB):

--- a/tests/trinity/core/p2p-proto/test_server.py
+++ b/tests/trinity/core/p2p-proto/test_server.py
@@ -7,8 +7,8 @@ from eth_keys import keys
 from cancel_token import CancelToken
 
 from eth.chains.ropsten import RopstenChain, ROPSTEN_GENESIS_HEADER
+from eth.db.atomic import AtomicDB
 from eth.db.chain import ChainDB
-from eth.db.backends.memory import MemoryDB
 
 from p2p.auth import HandshakeInitiator, _handshake
 from p2p.kademlia import (
@@ -63,7 +63,7 @@ class ParagonServer(BaseServer):
 
 
 def get_server(privkey, address):
-    base_db = MemoryDB()
+    base_db = AtomicDB()
     headerdb = FakeAsyncHeaderDB(base_db)
     chaindb = ChainDB(base_db)
     chaindb.persist_header(ROPSTEN_GENESIS_HEADER)

--- a/tests/trinity/core/p2p-proto/test_sync.py
+++ b/tests/trinity/core/p2p-proto/test_sync.py
@@ -19,7 +19,7 @@ from tests.trinity.core.integration_test_helpers import (
     FakeAsyncChain,
     FakeAsyncChainDB,
     FakeAsyncHeaderDB,
-    FakeAsyncMemoryDB,
+    FakeAsyncAtomicDB,
 )
 from tests.trinity.core.peer_helpers import (
     get_directly_linked_peers,
@@ -138,7 +138,7 @@ async def test_light_syncer(request, event_loop, chaindb_fresh, chaindb_20):
 
 @pytest.fixture
 def chaindb_20():
-    chain = PoWMiningChain.from_genesis(FakeAsyncMemoryDB(), GENESIS_PARAMS, GENESIS_STATE)
+    chain = PoWMiningChain.from_genesis(FakeAsyncAtomicDB(), GENESIS_PARAMS, GENESIS_STATE)
     for i in range(20):
         tx = chain.create_unsigned_transaction(
             nonce=i,
@@ -155,7 +155,7 @@ def chaindb_20():
 
 @pytest.fixture
 def chaindb_fresh():
-    chain = PoWMiningChain.from_genesis(FakeAsyncMemoryDB(), GENESIS_PARAMS, GENESIS_STATE)
+    chain = PoWMiningChain.from_genesis(FakeAsyncAtomicDB(), GENESIS_PARAMS, GENESIS_STATE)
     assert chain.chaindb.get_canonical_head().block_number == 0
     return chain.chaindb
 

--- a/tests/trinity/core/peer_helpers.py
+++ b/tests/trinity/core/peer_helpers.py
@@ -3,7 +3,7 @@ from cancel_token import CancelToken
 from eth.chains.mainnet import (
     MAINNET_GENESIS_HEADER,
 )
-from eth.db.backends.memory import MemoryDB
+from eth.db.atomic import AtomicDB
 
 from p2p import ecies
 from p2p.peer import BasePeerContext
@@ -27,7 +27,7 @@ from tests.trinity.core.integration_test_helpers import FakeAsyncHeaderDB
 
 
 def get_fresh_mainnet_headerdb():
-    headerdb = FakeAsyncHeaderDB(MemoryDB())
+    headerdb = FakeAsyncHeaderDB(AtomicDB())
     headerdb.persist_header(MAINNET_GENESIS_HEADER)
     return headerdb
 

--- a/tests/trinity/integration/test_lightchain_integration.py
+++ b/tests/trinity/integration/test_lightchain_integration.py
@@ -20,7 +20,7 @@ from eth.chains.ropsten import (
     ROPSTEN_GENESIS_HEADER,
     ROPSTEN_VM_CONFIGURATION,
 )
-from eth.db.backends.memory import MemoryDB
+from eth.db.atomic import AtomicDB
 
 from p2p import ecies
 from p2p.kademlia import Node
@@ -159,7 +159,7 @@ async def test_lightchain_integration(
     wait_for_socket(geth_ipc_path)
 
     remote = Node.from_uri(enode)
-    base_db = MemoryDB()
+    base_db = AtomicDB()
     chaindb = FakeAsyncChainDB(base_db)
     chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
     headerdb = FakeAsyncHeaderDB(base_db)

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -27,7 +27,7 @@ from eth.chains.ropsten import (
     ROPSTEN_GENESIS_HEADER,
     ROPSTEN_NETWORK_ID,
 )
-from eth.db.backends.base import BaseDB
+from eth.db.backends.base import BaseAtomicDB
 from eth.exceptions import CanonicalHeadNotFound
 
 from p2p import ecies
@@ -215,7 +215,7 @@ def rebuild_exc(exc, tb):  # type: ignore
     return exc
 
 
-def get_chaindb_manager(chain_config: ChainConfig, base_db: BaseDB) -> BaseManager:
+def get_chaindb_manager(chain_config: ChainConfig, base_db: BaseAtomicDB) -> BaseManager:
     chaindb = AsyncChainDB(base_db)
     chain_class: Type[BaseChain]
     if not is_database_initialized(chaindb):


### PR DESCRIPTION
### What was wrong?

We want to use atomic writes in chaindb and headerdb, but they only have access to the `BaseDB` API.

### How was it fixed?

Make `ChainDB` and `HeaderDB` (and all the knock-on effect classes, like `Chain`) require a `BaseAtomicDB` argument for setup.

This PR doesn't actually use the new atomic writes anywhere, it's all setup.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://betterearthing.com.au/wp-content/uploads/2016/06/Cute-atom-with-electrons.jpg)
