### PR TITLE
During node discovery, skip those with invalid addresses

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -58,6 +58,22 @@ class Address:
         self._ip = ipaddress.ip_address(ip)
 
     @property
+    def is_loopback(self) -> bool:
+        return self._ip.is_loopback
+
+    @property
+    def is_unspecified(self) -> bool:
+        return self._ip.is_unspecified
+
+    @property
+    def is_reserved(self) -> bool:
+        return self._ip.is_reserved
+
+    @property
+    def is_private(self) -> bool:
+        return self._ip.is_private
+
+    @property
     def ip(self) -> str:
         return str(self._ip)
 
@@ -300,6 +316,23 @@ class RoutingTable:
                     if len(nodes) == k * 2:
                         break
         return sort_by_distance(nodes, node_id)[:k]
+
+
+def check_relayed_addr(sender: Address, addr: Address) -> bool:
+    """Check if an address relayed by the given sender is valid.
+
+    Reserved and unspecified addresses are always invalid.
+    Private addresses are valid if the sender is a private host.
+    Loopback addresses are valid if the sender is a loopback host.
+    All other addresses are valid.
+    """
+    if addr.is_unspecified or addr.is_reserved:
+        return False
+    if addr.is_private and not sender.is_private:
+        return False
+    if addr.is_loopback and not sender.is_loopback:
+        return False
+    return True
 
 
 def binary_get_bucket_for_node(buckets: List[KBucket], node: Node) -> KBucket:

--- a/tests/p2p/test_discovery.py
+++ b/tests/p2p/test_discovery.py
@@ -84,7 +84,8 @@ def _test_find_node_neighbours(use_v5):
     for packet in [packet1, packet2]:
         node, payload = packet
         assert node == bob.this_node
-        neighbours.extend(discovery._extract_nodes_from_payload(payload[0]))
+        neighbours.extend(discovery._extract_nodes_from_payload(
+            node.address, payload[0], bob.logger))
     assert len(neighbours) == kademlia.k_bucket_size
 
 

--- a/tests/p2p/test_kademlia.py
+++ b/tests/p2p/test_kademlia.py
@@ -207,6 +207,25 @@ def test_compute_shared_prefix_bits():
     assert kademlia._compute_shared_prefix_bits(nodes) == kademlia.k_id_size - 3
 
 
+def test_check_relayed_addr():
+    public_host = kademlia.Address('8.8.8.8', 80)
+    local_host = kademlia.Address('127.0.0.1', 80)
+    assert kademlia.check_relayed_addr(local_host, local_host)
+    assert not kademlia.check_relayed_addr(public_host, local_host)
+
+    private = kademlia.Address('192.168.1.1', 80)
+    assert kademlia.check_relayed_addr(private, private)
+    assert not kademlia.check_relayed_addr(public_host, private)
+
+    reserved = kademlia.Address('240.0.0.1', 80)
+    assert not kademlia.check_relayed_addr(local_host, reserved)
+    assert not kademlia.check_relayed_addr(public_host, reserved)
+
+    unspecified = kademlia.Address('0.0.0.0', 80)
+    assert not kademlia.check_relayed_addr(local_host, unspecified)
+    assert not kademlia.check_relayed_addr(public_host, unspecified)
+
+
 def random_pubkey():
     pk = int_to_big_endian(random.getrandbits(kademlia.k_pubkey_size))
     return keys.PublicKey(b'\x00' * (kademlia.k_pubkey_size // 8 - len(pk)) + pk)


### PR DESCRIPTION
Sometimes a NEIGHBOURS response from remote peers will include nodes
with a loopback or private network address that is not reachable to us,
so we must skip those. We must also skip those on reserved networks or
with an unspecified address (0.0.0.0).

Closes: #821