### PR TITLE
[conceptual] configured sub-protocols

### DIFF
--- a/trinity/protocol/common/boot.py
+++ b/trinity/protocol/common/boot.py
@@ -33,7 +33,7 @@ class DAOCheckBootManager(BasePeerBootManager):
         wait for that we may receive other messages from the peer, which are returned so that they
         can be re-added to our subscribers' queues when the peer is finally added to the pool.
         """
-        for start_block, vm_class in self.peer.context.vm_configuration:
+        for start_block, vm_class in self.peer.chain_proto.vm_configuration:
             if not issubclass(vm_class, HomesteadVM):
                 continue
             elif not vm_class.support_dao_fork:

--- a/trinity/protocol/common/proto.py
+++ b/trinity/protocol/common/proto.py
@@ -1,0 +1,53 @@
+
+
+class ChainProtocol(Protocol, ABC):
+
+    @classmethod
+    def configure_protocol(
+            cls,
+            headerdb: BaseAsyncHeaderDB,
+            network_id: int,
+            vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...]) -> Type[ChainProtocol]:
+        return type(
+            f'{cls.__name__}Network{network_id}',
+            (cls, ),
+            dict(
+                headerdb=headerdb,
+                network_id=network_id,
+                vm_configuration=vm_configuration,
+            ),
+        )
+
+    @abstractmethod
+    @property
+    def headerdb(self):
+        pass
+
+    @abstractmethod
+    @property
+    def network_id(self):
+        pass
+
+    @abstractmethod
+    @property
+    def vm_configuration(self):
+        pass
+
+    @property
+    async def genesis(self) -> BlockHeader:
+        genesis_hash = await self.wait(
+            self.headerdb.coro_get_canonical_block_hash(BlockNumber(GENESIS_BLOCK_NUMBER)))
+        return await self.wait(self.headerdb.coro_get_block_header_by_hash(genesis_hash))
+
+    @property
+    async def _local_chain_info(self) -> ChainInfo:
+        genesis = await self.genesis
+        head = await self.wait(self.headerdb.coro_get_canonical_head())
+        total_difficulty = await self.headerdb.coro_get_score(head.hash)
+        return ChainInfo(
+            block_number=head.block_number,
+            block_hash=head.hash,
+            total_difficulty=total_difficulty,
+            genesis_hash=genesis.hash,
+        )
+

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -74,7 +74,7 @@ class ETHPeer(BaseChainPeer):
             raise HandshakeFailure(
                 "{} network ({}) does not match ours ({}), disconnecting".format(
                     self, msg['network_id'], self.network_id))
-        genesis = await self.genesis
+        genesis = await self.chain_proto.genesis
         if msg['genesis_hash'] != genesis.hash:
             await self.disconnect(DisconnectReason.useless_peer)
             raise HandshakeFailure(

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -1,3 +1,4 @@
+from abc import ABC
 import logging
 from typing import (
     List,
@@ -20,6 +21,7 @@ from p2p.protocol import (
 )
 
 from trinity.protocol.common.peer import ChainInfo
+from trinity.protocol.common.protocol import ChainProtocol
 from trinity.rlp.block_body import BlockBody
 
 from .commands import (
@@ -41,7 +43,7 @@ if TYPE_CHECKING:
     from .peer import ETHPeer  # noqa: F401
 
 
-class ETHProtocol(Protocol):
+class ETHProtocol(ChainProtocol):
     name = 'eth'
     version = 63
     _commands = [
@@ -56,7 +58,7 @@ class ETHProtocol(Protocol):
     def send_handshake(self, chain_info: ChainInfo) -> None:
         resp = {
             'protocol_version': self.version,
-            'network_id': self.peer.network_id,
+            'network_id': self.network_id,
             'td': chain_info.total_difficulty,
             'best_hash': chain_info.block_hash,
             'genesis_hash': chain_info.genesis_hash,

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -298,7 +298,7 @@ class BaseServer(BaseService):
 
 class FullServer(BaseServer):
     def _make_peer_pool(self) -> ETHPeerPool:
-        context = ChainContext(
+        eth_network_protocol = ETHProtocol.configure_protocol(
             headerdb=self.headerdb,
             network_id=self.network_id,
             vm_configuration=self.chain.get_vm_configuration(),
@@ -306,7 +306,7 @@ class FullServer(BaseServer):
         return ETHPeerPool(
             privkey=self.privkey,
             max_peers=self.max_peers,
-            context=context,
+            subprotocols=(eth_network_protocol, ),
             token=self.cancel_token,
             event_bus=self.event_bus
         )


### PR DESCRIPTION
### What was wrong?

Conversation from here was hard to continue without code: https://github.com/ethereum/py-evm/pull/1294#discussion_r218194387

### How was it fixed?

Made a few changes demonstrating the idea of pre-configuring subprotocols, as a way to get rid of the chain context. I think it also starts to send us in the nice direction of removing a bunch of sub-protocol specific APIs from peer, and putting them down in the `sub_proto` attribute where it makes a bit more sense.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://c.pxhere.com/photos/51/9c/bear_dog_pet_cute_home_animal_toy_mess-458183.jpg!d)