### PR TITLE
Remove unneeded safeguard in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ RUN apt-get update && apt-get install -y pandoc
 #Copy the application py-evm to the /usr/src/app folder
 COPY . /usr/src/app
 
-# Remove existing virtualenv directory
-RUN rm -rf venv_docker_build
 # Install python dependencies
 RUN pip install virtualenv
 RUN cd /usr/src/app


### PR DESCRIPTION
### What was wrong?

It turned out, the `Dockerfile` had a `rm -rf venv_docker_build` as a safe guard that wasn't really needed. See discussion: https://github.com/ethereum/py-evm/pull/1180#discussion_r218338369

### How was it fixed?

Removed it.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://s-media-cache-ak0.pinimg.com/originals/81/af/ed/81afed8b73174329a324d05eab40d8aa.jpg)
