### PR TITLE
Make docker images smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,26 +3,12 @@ FROM python:3.6
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get install -y libssl-dev
-RUN apt-get update && apt-get install -y python3-pip
-RUN apt-get update && apt-get install -y pandoc
-
-#Copy the application py-evm to the /usr/src/app folder
 COPY . /usr/src/app
 
-# Remove existing virtualenv directory
-RUN rm -rf venv_docker_build
-# Install python dependencies
-RUN pip install virtualenv
-RUN cd /usr/src/app
-RUN virtualenv -p python3 venv_docker_build
-RUN  . venv_docker_build/bin/activate
-RUN pip3 install -e .[dev]
-RUN pip3 install -U trinity
+RUN pip install -e .[dev]  --no-cache-dir
+RUN pip install -U trinity --no-cache-dir
 
 RUN echo "Type \`trinity\` to boot or \`trinity --help\` for an overview of commands"
 
 EXPOSE 30303 30303/udp
 ENTRYPOINT ["trinity"]
-
-


### PR DESCRIPTION
- the images is base python:3.6
   so i think don't create new virtual environment

- use --no-cache-dir

The following is a comparison of space

```bash
➜  pyevm git:(master) ✗ docker images ethereum/trinity
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
ethereum/trinity    nocache             adfa8f214bfa        4 minutes ago       1.09GB
ethereum/trinity    latest              8798f7795bc6        9 minutes ago       1.32GB
```
