### PR TITLE
Ensure shared process plugins shutdown cleanly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ deps = {
         "upnpclient>=0.0.8,<1",
     ],
     'trinity': [
+        "async-generator==1.10",
         "bloom-filter==1.3",
         "cachetools>=2.1.0,<3.0.0",
         "coincurve>=8.0.0,<9.0.0",

--- a/trinity/extensibility/__init__.py
+++ b/trinity/extensibility/__init__.py
@@ -2,15 +2,17 @@ from trinity.extensibility.events import (  # noqa: F401
     BaseEvent
 )
 from trinity.extensibility.plugin import (  # noqa: F401
-    BasePlugin,
+    BaseAsyncStopPlugin,
+    BaseMainProcessPlugin,
     BaseIsolatedPlugin,
+    BasePlugin,
+    BaseSyncStopPlugin,
     DebugPlugin,
     PluginContext,
-    PluginProcessScope,
 )
 from trinity.extensibility.plugin_manager import (  # noqa: F401
+    BaseManagerProcessScope,
     MainAndIsolatedProcessScope,
     PluginManager,
-    ManagerProcessScope,
     SharedProcessScope,
 )

--- a/trinity/extensibility/exceptions.py
+++ b/trinity/extensibility/exceptions.py
@@ -1,0 +1,12 @@
+from trinity.exceptions import (
+    BaseTrinityError,
+)
+
+
+class UnsuitableShutdownError(BaseTrinityError):
+    """
+    Raised when `shutdown` was called on a ``PluginManager`` instance that operates
+    in the ``MainAndIsolatedProcessScope`` or when ``shutdown_blocking`` was called on a
+    ``PluginManager`` instance that operates in the ``SharedProcessScope``.
+    """
+    pass

--- a/trinity/plugins/builtin/attach/plugin.py
+++ b/trinity/plugins/builtin/attach/plugin.py
@@ -9,7 +9,7 @@ from trinity.config import (
     ChainConfig,
 )
 from trinity.extensibility import (
-    BasePlugin,
+    BaseMainProcessPlugin,
 )
 
 from trinity.plugins.builtin.attach.console import (
@@ -17,7 +17,7 @@ from trinity.plugins.builtin.attach.console import (
 )
 
 
-class AttachPlugin(BasePlugin):
+class AttachPlugin(BaseMainProcessPlugin):
 
     def __init__(self, use_ipython: bool = True) -> None:
         super().__init__()

--- a/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
+++ b/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
@@ -9,14 +9,14 @@ from trinity.config import (
     ChainConfig,
 )
 from trinity.extensibility import (
-    BasePlugin,
+    BaseMainProcessPlugin,
 )
 from trinity.utils.ipc import (
     kill_process_id_gracefully,
 )
 
 
-class FixUncleanShutdownPlugin(BasePlugin):
+class FixUncleanShutdownPlugin(BaseMainProcessPlugin):
 
     @property
     def name(self) -> str:

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -23,7 +23,7 @@ from trinity.utils.db_proxy import (
     create_db_manager
 )
 from trinity.utils.shutdown import (
-    exit_on_signal
+    exit_with_service_and_endpoint,
 )
 
 
@@ -64,7 +64,7 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
         ipc_server = IPCServer(rpc, self.context.chain_config.jsonrpc_ipc_path)
 
         loop = asyncio.get_event_loop()
-        asyncio.ensure_future(exit_on_signal(ipc_server, self.context.event_bus))
+        asyncio.ensure_future(exit_with_service_and_endpoint(ipc_server, self.context.event_bus))
         asyncio.ensure_future(ipc_server.run())
         loop.run_forever()
         loop.close()

--- a/trinity/utils/shutdown.py
+++ b/trinity/utils/shutdown.py
@@ -1,5 +1,11 @@
 import asyncio
+from async_generator import (
+    asynccontextmanager,
+)
 import signal
+from typing import (
+    AsyncGenerator,
+)
 
 from lahja import (
     Endpoint,
@@ -10,8 +16,27 @@ from p2p.service import (
 )
 
 
-async def exit_on_signal(service_to_exit: BaseService, endpoint: Endpoint = None) -> None:
+async def exit_with_service_and_endpoint(service_to_exit: BaseService, endpoint: Endpoint) -> None:
+    async with exit_signal_with_service(service_to_exit):
+        endpoint.stop()
+
+
+async def exit_with_service(service_to_exit: BaseService) -> None:
+    async with exit_signal_with_service(service_to_exit):
+        pass
+
+
+@asynccontextmanager
+async def exit_signal_with_service(service_to_exit: BaseService) -> AsyncGenerator[None, None]:
     loop = service_to_exit.get_event_loop()
+    async with exit_signal(loop):
+        await service_to_exit.cancel()
+        yield
+        service_to_exit._executor.shutdown(wait=True)
+
+
+@asynccontextmanager
+async def exit_signal(loop: asyncio.AbstractEventLoop) -> AsyncGenerator[None, None]:
     sigint_received = asyncio.Event()
     for sig in [signal.SIGINT, signal.SIGTERM]:
         # TODO also support Windows
@@ -19,9 +44,6 @@ async def exit_on_signal(service_to_exit: BaseService, endpoint: Endpoint = None
 
     await sigint_received.wait()
     try:
-        await service_to_exit.cancel()
-        if endpoint is not None:
-            endpoint.stop()
-        service_to_exit._executor.shutdown(wait=True)
+        yield
     finally:
         loop.stop()


### PR DESCRIPTION
### What was wrong?

Currently, plugins that run in the shared network process do not shutdown cleanly in all scenarios (see #1284). To be more precise, they only shutdown if they happen to be chained with some `CancelToken` which is triggered. This means that for all current plugins that run in the networking process (`TxPool`, `LightPeerChainBridge`) there isn't a real problem as these will simply shutdown based the fact that e.g the `PeerPool` shuts down or the `LightPeerChain` shuts down. However, this is still leaving us with two problems:

1. Plugins that do not have a logical dependency that they can rely on to initiate cancellation are left out
2. Plugins can't stopped individually (think, future command `trinity stop-plugin <plugin-name>`

### How was it fixed?

#### Understanding the sync vs async scenario

Before we dive into how exactly it was fixed, let's first take a moment to reflect on the three different kind of operational models that we currently have for plugins.

**1. Plugins that overtake the whole main process**

This category of plugin doesn't need any special tear down treatment as it is basically breaking out of the standard trinity boot sequence early and entirely redefines what the trinity process even means.

**2. Plugins that spawn there own process**

The teardown for these plugins is similar to how we shut down other non-plugin processes.

https://github.com/ethereum/py-evm/blob/d225f4a26811aa15f450378aa8d618caa573b158/trinity/extensibility/plugin.py#L180-L182 

Notice that `kill_process_gracefully` is a blocking operation.

**3. Plugins that run in a shared process (currently `networking`)**

Plugins that run in the shared networking process are required to be written in a non-blocking fashion using `asyncio` (This is a **MUST** for builtin plugins and at least a strong recommendation for any user defined plugin).

>**Sidenote:** That doesn't mean that plugins that spawn their own process can't be written in the same async fashion (in fact, most should) but since they run in an isolated space they can do pretty much everything they want including spinning up a virtual system to run a PHP server on Windows 95)

Means, since these plugins run asynchronously, they need to be stopped asynchronously as well.

#### Enter `shutdown` vs `shutdown_nowait`

Initially, I tried to streamline the shutdown of the `PluginManager` to either enforce being:

1. Always synchronous (turning non blocking operations into blocking ones)
2. Always asynchronous (turning blocking operations into non-blocking ones)

This has proven to be problematic for various reasons (I can elaborate if needed). So what I settled with instead is to come up with `shutdown` and `shutdown_nowait` (naming is inline with other places of our code base (and python stdlib) that use that pattern ).

Then inside the `kill_trinity_gracefully()` function, we continue to call the synchronous version (only isolated plugins are managed by this plugin manager instance) and in the unwind routine of the `networking` process we await the async version of shutdown (only async plugins run in this plugin manager instance.

### Refactorings

I refactored a bunch of stuff around plugins to make this possible:

1. Because some plugins need no `stop()` at all, some need `async def stop()` and some need `def stop()`, this method was removed from the `BasePlugin` and new derived plugins `BaseAsyncStopPlugin` as well as `BaseSyncStopPlugin` where defined accordingly. 

2. `PluginProcessScope` is no more. Otherwise it would be possible to e.g. derive from `BaseAsyncStopPlugin` but set `PluginProcessScope.MAIN` which is a contradicting configuration.

3. The `PluginManager` itself was refactored to rely more on composition. It now delegates to `scope.is_responsible_for_plugin(...)` and `scope.create_plugin_context(...)` instead of hardcoding if/else rules in methods of the `PluginManager` directly.

4. A new `AsyncContextManager` (backport from Python 3.7) was created to allow more flexible teardown of event loops compared to what we previously had with `exit_on_signal`. The `exit_on_signal` helper does still exist but it is now built on top of said `AsyncContextManager`-based API.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.designbolts.com/wp-content/uploads/2012/12/Stunning-wildlife-photography.jpg)
