### PR TITLE
Fix a never-ending subtask in BasePeerPool

### DIFF
--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -135,10 +135,6 @@ def setup_queue_logging(log_queue: 'Queue[str]', level: int) -> None:
     logger.addHandler(queue_handler)
     logger.setLevel(level)
 
-    # These loggers generates too much DEBUG noise, drowning out the important things, so force
-    # the INFO level for it until https://github.com/ethereum/py-evm/issues/806 is fixed.
-    logging.getLogger('p2p.kademlia').setLevel(logging.INFO)
-    logging.getLogger('p2p.discovery').setLevel(logging.INFO)
     logger.debug('Logging initialized: PID=%s', os.getpid())
 
 

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -39,6 +39,16 @@ LOG_BACKUP_COUNT = 10
 LOG_MAX_MB = 5
 
 
+class TrinityLogFormatter(logging.Formatter):
+
+    def __init__(self, fmt: str, datefmt: str) -> None:
+        super().__init__(fmt, datefmt)
+
+    def format(self, record: logging.LogRecord) -> str:
+        record.shortname = record.name.split('.')[-1]  # type: ignore
+        return super().format(record)
+
+
 class HasTraceLogger:
     _logger: TraceLogger = None
 
@@ -69,8 +79,8 @@ def setup_trinity_stderr_logging(level: int=None,
     handler_stream.setLevel(level)
 
     # TODO: allow configuring `detailed` logging
-    formatter = logging.Formatter(
-        fmt='%(levelname)8s  %(asctime)s  %(module)10s  %(message)s',
+    formatter = TrinityLogFormatter(
+        fmt='%(levelname)8s  %(asctime)s  %(shortname)20s  %(message)s',
         datefmt='%m-%d %H:%M:%S'
     )
 


### PR DESCRIPTION
The handle_peer_count_requests() coroutine runs as a background task but
did not exit when the pool's cancel token was triggered.

Also introduce a custom log formatter for trinity that uses the last
element of the logger's name instead of the module, otherwise it's not
clear where they're coming from (specially for those generated by
BaseService subclasses).