### PR TITLE
Turn on warnings by default, if in prerelease

### DIFF
--- a/trinity/main.py
+++ b/trinity/main.py
@@ -65,6 +65,7 @@ from trinity.utils.ipc import (
     kill_process_gracefully,
 )
 from trinity.utils.logging import (
+    enable_warnings_by_default,
     setup_log_levels,
     setup_trinity_stderr_logging,
     setup_trinity_file_and_queue_logging,
@@ -81,6 +82,7 @@ from trinity.utils.shutdown import (
 )
 from trinity.utils.version import (
     construct_trinity_client_identifier,
+    is_prerelease,
 )
 
 
@@ -140,6 +142,10 @@ def main() -> None:
             "configured with both `--stderr-log-level` and `--log-level`. "
             "Please remove one of these flags",
         )
+
+    if is_prerelease():
+        # this modifies the asyncio logger, but will be overridden by any custom settings below
+        enable_warnings_by_default()
 
     stderr_logger, formatter, handler_stream = setup_trinity_stderr_logging(
         args.stderr_log_level or (args.log_levels and args.log_levels.get(None))

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -149,3 +149,21 @@ def with_queued_logging(fn: Callable[..., Any]) -> Callable[..., Any]:
 
             return fn(*args, **inner_kwargs)
     return inner
+
+
+def _set_environ_if_missing(name: str, val: str) -> None:
+    """
+    Set the environment variable so that other processes get the changed value.
+    """
+    if os.environ.get(name, '') == '':
+        os.environ[name] = val
+
+
+def enable_warnings_by_default() -> None:
+    """
+    This turns on some python and asyncio warnings, unless
+    the related environment variables are already set.
+    """
+    _set_environ_if_missing('PYTHONWARNINGS', 'default')
+    # PYTHONASYNCIODEBUG is not turned on by default because it slows down sync a *lot*
+    logging.getLogger('asyncio').setLevel(logging.DEBUG)

--- a/trinity/utils/version.py
+++ b/trinity/utils/version.py
@@ -1,5 +1,7 @@
 import sys
 
+import pkg_resources
+
 from trinity import __version__
 
 
@@ -16,3 +18,12 @@ def construct_trinity_client_identifier() -> str:
         # mypy Doesn't recognize the `sys` module as having an `implementation` attribute.
         imp=sys.implementation,  # type: ignore
     )
+
+
+def is_prerelease() -> bool:
+    try:
+        distro = pkg_resources.get_distribution("trinity")
+        # mypy thinks that parsed_version is a tuple. Ignored...
+        return distro.parsed_version.is_prerelease  # type: ignore
+    except pkg_resources.DistributionNotFound:
+        return True


### PR DESCRIPTION
### What was wrong?

`trinity` is spouting a bunch of warnings, and no one noticed. Presumably because none of us explicitly turned warnings on.

### How was it fixed?

Check if we are in a pre-release version (alpha or beta). If so, turn on warnings. This will help us catch warning things sooner.

I'm not totally convinced it's a good idea, but it did help me do some cleanups. Also, it seems to highlight a bunch of unclean connection handling.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://2.bp.blogspot.com/-y-I-zgnm8jA/VO92IsbK7HI/AAAAAAAACoM/dHKCPzLzSkw/s1600/cute-samoyed-dog-gently-wakes-up-owner-video-fb.jpg)
