### PR TITLE
Some simple warning fixups

### DIFF
--- a/eth/tools/fixtures/fillers/formatters.py
+++ b/eth/tools/fixtures/fillers/formatters.py
@@ -1,5 +1,5 @@
-from eth_utils import (
-    combine_argument_formatters,
+from eth_utils.curried import (
+    apply_formatters_to_sequence,
     encode_hex,
     to_checksum_address,
     to_hex,
@@ -18,7 +18,7 @@ environment_formatter = eth_utils.curried.apply_formatters_to_dict({
 })
 
 
-storage_item_formatter = combine_argument_formatters(to_hex, to_hex)
+storage_item_formatter = apply_formatters_to_sequence([to_hex, to_hex])
 storage_formatter = cytoolz.curried.itemmap(storage_item_formatter)
 
 
@@ -30,7 +30,7 @@ account_state_formatter = eth_utils.curried.apply_formatters_to_dict({
 })
 
 
-state_item_formatter = combine_argument_formatters(to_checksum_address, account_state_formatter)
+state_item_formatter = apply_formatters_to_sequence([to_checksum_address, account_state_formatter])
 state_formatter = cytoolz.curried.itemmap(state_item_formatter)
 
 

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -768,7 +768,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
 
         def process(received_echo: Hash32, response: List[kademlia.Node]) -> None:
             if received_echo != echo:
-                self.logger.warn(
+                self.logger.warning(
                     "Unexpected topic_nodes from %s, expected echo %s, got %s",
                     encode_hex(echo), encode_hex(received_echo))
                 return

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -236,8 +236,11 @@ class RoutingTable:
     def get_random_nodes(self, count: int) -> Iterator[Node]:
         if count > len(self):
             if time.monotonic() - self._initialized_at > 30:
-                self.logger.warn(
-                    "Cannot get %d nodes as RoutingTable contains only %d nodes", count, len(self))
+                self.logger.warning(
+                    "Cannot get %d nodes as RoutingTable contains only %d nodes",
+                    count,
+                    len(self),
+                )
             count = len(self)
         seen: List[Node] = []
         # This is a rather inneficient way of randomizing nodes from all buckets, but even if we

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -68,7 +68,7 @@ class Disconnect(Command):
         try:
             raw_decoded = cast(Dict[str, int], super().decode(data))
         except rlp.exceptions.ListDeserializationError:
-            self.logger.warn("Malformed Disconnect message: %s", data)
+            self.logger.warning("Malformed Disconnect message: %s", data)
             raise MalformedMessage(f"Malformed Disconnect message: {data}")
         return assoc(raw_decoded, 'reason_name', self.get_reason_name(raw_decoded['reason']))
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -367,7 +367,7 @@ class BasePeer(BaseService):
                     "%s stopped responding (%r), disconnecting", self.remote, err)
                 return
             except DecryptionError as err:
-                self.logger.warn(
+                self.logger.warning(
                     "Unable to decrypt message from %s, disconnecting: %r",
                     self, err,
                     exc_info=True,
@@ -434,13 +434,13 @@ class BasePeer(BaseService):
                 in self._subscribers
             )
             if not any(was_added):
-                self.logger.warn(
+                self.logger.warning(
                     "Peer %s has no subscribers for msg type %s",
                     self,
                     cmd_type.__name__,
                 )
         else:
-            self.logger.warn("Peer %s has no subscribers, discarding %s msg", self, cmd)
+            self.logger.warning("Peer %s has no subscribers, discarding %s msg", self, cmd)
 
     def process_msg(self, cmd: protocol.Command, msg: protocol.PayloadType) -> None:
         if cmd.is_base_protocol:
@@ -680,7 +680,7 @@ class PeerSubscriber(ABC):
             return True
         except asyncio.queues.QueueFull:
             if hasattr(self, 'logger'):
-                self.logger.warn(  # type: ignore
+                self.logger.warning(  # type: ignore
                     "%s msg queue is full; discarding %s msg from %s",
                     self.__class__.__name__, cmd, peer)
             return False
@@ -927,7 +927,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             self.logger.info("%s finished, removing from pool", peer)
             self.connected_nodes.pop(peer.remote)
         else:
-            self.logger.warn(
+            self.logger.warning(
                 "%s finished but was not found in connected_nodes (%s)", peer, self.connected_nodes)
         for subscriber in self._subscribers:
             subscriber.deregister_peer(peer)

--- a/tests/json-fixtures/test_state.py
+++ b/tests/json-fixtures/test_state.py
@@ -329,7 +329,7 @@ def test_state_fixtures(fixture, fixture_vm_class):
     except ValidationError as err:
         block = vm.block
         transaction_error = err
-        logger.warn("Got transaction error", exc_info=True)
+        logger.warning("Got transaction error", exc_info=True)
     else:
         transaction_error = False
 

--- a/trinity/plugins/builtin/attach/console.py
+++ b/trinity/plugins/builtin/attach/console.py
@@ -11,8 +11,6 @@ from trinity.utils.log_messages import (
 
 from cytoolz import merge
 
-import web3
-
 
 DEFAULT_BANNER: str = (
     "Trinity Console\n"
@@ -66,8 +64,9 @@ def console(ipc_path: Path,
     if not ipc_path.exists():
         raise FileNotFoundError(create_missing_ipc_error_message(ipc_path))
 
-    # cast needed until https://github.com/ethereum/web3.py/issues/867 is fixed
-    w3 = web3.Web3(web3.IPCProvider(str(ipc_path)))
+    # wait to import web3, because it's somewhat large, and not usually used
+    import web3
+    w3 = web3.Web3(web3.IPCProvider(ipc_path))
 
     namespace = merge({'w3': w3}, env)
 

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -114,7 +114,7 @@ class BaseServer(BaseService):
         self.peer_pool = self._make_peer_pool()
 
         if not bootstrap_nodes:
-            self.logger.warn("Running with no bootstrap nodes")
+            self.logger.warning("Running with no bootstrap nodes")
 
     @abstractmethod
     def _make_peer_pool(self) -> ANY_PEER_POOL:

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -186,11 +186,11 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
                 self.logger.info("Sync with %s completed", peer)
                 break
             except TimeoutError:
-                self.logger.warn("Timeout waiting for header batch from %s, aborting sync", peer)
+                self.logger.warning("Timeout waiting for header batch from %s, aborting sync", peer)
                 await peer.disconnect(DisconnectReason.timeout)
                 break
             except ValidationError as err:
-                self.logger.warn(
+                self.logger.warning(
                     "Invalid header response sent by peer %s disconnecting: %s",
                     peer, err,
                 )
@@ -226,11 +226,14 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
                         self.db.coro_get_block_header_by_hash(first.parent_hash)
                     )
                 except HeaderNotFound:
-                    self.logger.warn("Unable to find common ancestor betwen our chain and %s", peer)
+                    self.logger.warning(
+                        "Unable to find common ancestor betwen our chain and %s",
+                        peer,
+                    )
                     break
             elif last_received_header.hash != first.parent_hash:
                 # on follow-ups, require the first header in this batch to be next in succession
-                self.logger.warn(
+                self.logger.warning(
                     "Header batch starts with %r, with parent %s, but last header was %r",
                     first,
                     encode_hex(first.parent_hash[:4]),
@@ -250,7 +253,7 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
                     self._seal_check_random_sample_rate,
                 )
             except ValidationError as e:
-                self.logger.warn("Received invalid headers from %s, disconnecting: %s", peer, e)
+                self.logger.warning("Received invalid headers from %s, disconnecting: %s", peer, e)
                 await peer.disconnect(DisconnectReason.subprotocol_error)
                 break
 

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -194,7 +194,7 @@ class StateDownloader(BaseService, PeerSubscriber):
             node_hashes = cast(List[Hash32], msg)[:eth_constants.MAX_STATE_FETCH]
             await self._handler.handle_get_node_data(peer, node_hashes)
         else:
-            self.logger.warn("%s not handled during StateSync, must be implemented", cmd)
+            self.logger.warning("%s not handled during StateSync, must be implemented", cmd)
 
     async def _handle_get_block_headers(self, peer: ETHPeer, request: HeaderRequest) -> None:
         headers = await self._handler.lookup_headers(request)
@@ -243,7 +243,7 @@ class StateDownloader(BaseService, PeerSubscriber):
             )
             node_data = tuple()
         except AlreadyWaiting as err:
-            self.logger.warn(
+            self.logger.warning(
                 "Already waiting for a NodeData response from %s", peer,
             )
             return
@@ -251,7 +251,7 @@ class StateDownloader(BaseService, PeerSubscriber):
         try:
             self.request_tracker.active_requests.pop(peer)
         except KeyError:
-            self.logger.warn("Unexpected error removing peer from active requests: %s", peer)
+            self.logger.warning("Unexpected error removing peer from active requests: %s", peer)
 
         self.logger.debug("Got %d NodeData entries from %s", len(node_data), peer)
 

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -385,7 +385,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
             try:
                 return await make_request_to_peer(peer)
             except BadLESResponse as exc:
-                self.logger.warn("Disconnecting from peer, because: %s", exc)
+                self.logger.warning("Disconnecting from peer, because: %s", exc)
                 await peer.disconnect(DisconnectReason.subprotocol_error)
                 # reattempt after removing this peer from our pool
 


### PR DESCRIPTION
### What was wrong?

A couple simple warnings are being raised in trinity code. These were found with #1312 

### How was it fixed?

- Stop using the deprecated `combine_argument_formatters()`
- Use `logging.warning` instead of `logging.warn`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/vkuny9on0f511.jpg)
