### PR TITLE
Peer shutdown race conditions

### DIFF
--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -248,7 +248,14 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
             timeout: float = None) -> TResult:
 
         if not self.is_operational:
-            raise ValidationError("You must call `launch_service` before initiating a peer request")
+            if self.service is None or not self.service.is_cancelled:
+                raise ValidationError(
+                    f"Must call `launch_service` before sending request to {self._peer}"
+                )
+            else:
+                raise PeerConnectionLost(
+                    f"Response stream closed before sending request to {self._peer}"
+                )
 
         stream = self._response_stream
 

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -206,7 +206,7 @@ class BaseBodyChainSyncer(BaseHeaderChainSyncer):
         trivial_headers = tuple(header for header in all_headers if _is_body_empty(header))
 
         if trivial_headers:
-            self.logger.debug(
+            self.logger.trace(
                 "Found %d/%d trivial block bodies, skipping those requests",
                 len(trivial_headers),
                 len(all_headers),


### PR DESCRIPTION
### What was wrong?

Mildly related race conditions during peer shutdown:

1. A peer's response future might be set, but not collected, when it is shut down. This was causing uncaught `asyncio.InvalidStateError` when trying to set an exception on the response future.
2. A peer may get launched and shut down immediately, which was confusing the `ExchangeManager`. It interpreted a closed service as always being unstarted.

### How was it fixed?

1. Catch the error, log it, and continue (nothing further needs to happen).
2. Detect if the service has been started and shut down, and return a `PeerConnectionLost` to indicate to the caller that the peer is now unavailable.

Plus, drop a typically unnecessary log down to trace.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://wienerfestlacrosse.com/wp-content/uploads/2017/05/wdraces.jpg)
