### PR TITLE
Refactor plugin support to exclusively use EventBus events

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ deps = {
         "ipython>=6.2.1,<7.0.0",
         "plyvel==1.0.5",
         "web3==4.4.1",
-        "lahja==0.8.0",
+        "lahja==0.9.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin'",
         "websockets==5.0.1",
     ],

--- a/tests/trinity/conftest.py
+++ b/tests/trinity/conftest.py
@@ -65,11 +65,11 @@ def event_loop():
 
 
 @pytest.fixture(scope='module')
-def event_bus(event_loop):
+async def event_bus(event_loop):
     bus = EventBus()
     endpoint = bus.create_endpoint('test')
     bus.start(event_loop)
-    endpoint.connect(event_loop)
+    await endpoint.connect(event_loop)
     try:
         yield endpoint
     finally:

--- a/trinity/extensibility/events.py
+++ b/trinity/extensibility/events.py
@@ -3,12 +3,9 @@ from typing import (
     Type,
     TYPE_CHECKING,
 )
-from argparse import (
-    Namespace,
-)
 
-from trinity.config import (
-    TrinityConfig,
+from lahja import (
+    BaseEvent,
 )
 
 
@@ -18,23 +15,12 @@ if TYPE_CHECKING:
     )
 
 
-class BaseEvent:
-    """
-    The base class for all plugin events. Plugin events can be broadcasted for all different
-    kind of reasons. Plugins can act based on these events and consume the events even before
-    the plugin is started, giving plugins the chance to start based on an event or a series of
-    events. The startup of Trinity itself can be an event as well as the start of a plugin itself
-    which, for instance, gives other plugins the chance to start based on these previous events.
-    """
-    pass
-
-
 class PluginStartedEvent(BaseEvent):
     """
     Broadcasted when a plugin was started
     """
-    def __init__(self, plugin: 'BasePlugin') -> None:
-        self.plugin = plugin
+    def __init__(self, plugin_type: Type['BasePlugin']) -> None:
+        self.plugin_type = plugin_type
 
 
 class ResourceAvailableEvent(BaseEvent):

--- a/trinity/extensibility/events.py
+++ b/trinity/extensibility/events.py
@@ -29,15 +29,6 @@ class BaseEvent:
     pass
 
 
-class TrinityStartupEvent(BaseEvent):
-    """
-    Broadcasted when Trinity is starting.
-    """
-    def __init__(self, args: Namespace, trinity_config: TrinityConfig) -> None:
-        self.args = args
-        self.trinity_config = trinity_config
-
-
 class PluginStartedEvent(BaseEvent):
     """
     Broadcasted when a plugin was started

--- a/trinity/extensibility/exceptions.py
+++ b/trinity/extensibility/exceptions.py
@@ -10,3 +10,11 @@ class UnsuitableShutdownError(BaseTrinityError):
     ``PluginManager`` instance that operates in the ``SharedProcessScope``.
     """
     pass
+
+
+class EventBusNotReady(BaseTrinityError):
+    """
+    Raised when a plugin tried to access an EventBus before the plugin
+    had received its ``ready`` call.
+    """
+    pass

--- a/trinity/extensibility/plugin_manager.py
+++ b/trinity/extensibility/plugin_manager.py
@@ -195,7 +195,6 @@ class PluginManager:
             try:
                 self._logger.info("Stopping plugin: %s", plugin.name)
                 plugin.stop()
-                plugin.running = False
                 self._logger.info("Successfully stopped plugin: %s", plugin.name)
             except Exception:
                 self._logger.exception("Exception thrown while stopping plugin %s", plugin.name)
@@ -224,7 +223,6 @@ class PluginManager:
                     'Exception thrown while stopping plugin %s: %s', plugin.name, result
                 )
             else:
-                plugin.running = False
                 self._logger.info("Successfully stopped plugin: %s", plugin.name)
 
     def _stop_plugins(self,

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -49,9 +49,6 @@ from trinity.extensibility import (
     PluginManager,
     SharedProcessScope,
 )
-from trinity.extensibility.events import (
-    TrinityStartupEvent
-)
 from trinity.plugins.registry import (
     ENABLED_PLUGINS
 )
@@ -270,10 +267,7 @@ def trinity_boot(args: Namespace,
     )
 
     plugin_manager.prepare(args, trinity_config, extra_kwargs)
-    plugin_manager.broadcast(TrinityStartupEvent(
-        args,
-        trinity_config
-    ))
+
     try:
         loop = asyncio.get_event_loop()
         loop.run_forever()
@@ -361,10 +355,6 @@ def launch_node(args: Namespace, trinity_config: TrinityConfig, endpoint: Endpoi
 
         plugin_manager = setup_plugins(SharedProcessScope(endpoint))
         plugin_manager.prepare(args, trinity_config)
-        plugin_manager.broadcast(TrinityStartupEvent(
-            args,
-            trinity_config
-        ))
 
         node = NodeClass(plugin_manager, trinity_config)
         loop = node.get_event_loop()

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -22,7 +22,6 @@ class FullNode(Node):
         self._node_key = trinity_config.nodekey
         self._node_port = trinity_config.port
         self._max_peers = trinity_config.max_peers
-        self.notify_resource_available()
 
     def get_chain(self) -> BaseChain:
         if self._chain is None:

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -47,7 +47,6 @@ class LightNode(Node):
             cast(LESPeerPool, self.get_peer_pool()),
             token=self.cancel_token,
         )
-        self.notify_resource_available()
 
     async def _run(self) -> None:
         self.run_daemon(self._peer_chain)
@@ -77,7 +76,7 @@ class LightNode(Node):
                 preferred_nodes=self._preferred_nodes,
                 use_discv5=self._use_discv5,
                 token=self.cancel_token,
-                event_bus=self._plugin_manager.event_bus_endpoint,
+                event_bus=self.event_bus,
             )
         return self._p2p_server
 

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -71,25 +71,25 @@ class EthstatsPlugin(BaseIsolatedPlugin):
             default=os.environ.get('ETHSTATS_NODE_CONTACT', ''),
         )
 
-    def should_start(self) -> bool:
+    def ready(self) -> None:
         args = self.context.args
 
         if not args.ethstats:
-            return False
+            return
 
         if not (args.ethstats_server_url or self.get_default_server_url()):
             self.logger.error(
                 'You must provide ethstats server url using the `--ethstats-server-url`'
             )
             self.context.shutdown_host()
-            return False
+            return
 
         if not args.ethstats_server_secret:
             self.logger.error(
                 'You must provide ethstats server secret using `--ethstats-server-secret`'
             )
             self.context.shutdown_host()
-            return False
+            return
 
         if (args.ethstats_server_url):
             self.server_url = args.ethstats_server_url
@@ -101,12 +101,9 @@ class EthstatsPlugin(BaseIsolatedPlugin):
         self.node_id = args.ethstats_node_id
         self.node_contact = args.ethstats_node_contact
 
-        return True
+        self.boot()
 
     def start(self) -> None:
-        self.logger.info('Ethstats service started')
-        self.context.event_bus.connect()
-
         service = EthstatsService(
             self.context,
             self.server_url,

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -101,9 +101,9 @@ class EthstatsPlugin(BaseIsolatedPlugin):
         self.node_id = args.ethstats_node_id
         self.node_contact = args.ethstats_node_contact
 
-        self.boot()
+        self.start()
 
-    def start(self) -> None:
+    def _start(self) -> None:
         service = EthstatsService(
             self.context,
             self.server_url,

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -33,8 +33,9 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
     def name(self) -> str:
         return "JSON-RPC Server"
 
-    def should_start(self) -> bool:
-        return not self.context.args.disable_rpc
+    def ready(self) -> None:
+        if not self.context.args.disable_rpc:
+            self.boot()
 
     def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
@@ -44,9 +45,6 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
         )
 
     def start(self) -> None:
-        self.logger.info('JSON-RPC Server started')
-        self.context.event_bus.connect()
-
         db_manager = create_db_manager(self.context.trinity_config.database_ipc_path)
         db_manager.connect()
 

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -35,7 +35,7 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
 
     def ready(self) -> None:
         if not self.context.args.disable_rpc:
-            self.boot()
+            self.start()
 
     def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
@@ -44,7 +44,7 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
             help="Disables the JSON-RPC Server",
         )
 
-    def start(self) -> None:
+    def _start(self) -> None:
         db_manager = create_db_manager(self.context.trinity_config.database_ipc_path)
         db_manager.connect()
 

--- a/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
@@ -55,14 +55,14 @@ class LightPeerChainBridgePlugin(BaseAsyncStopPlugin):
     def handle_event(self, event: ResourceAvailableEvent) -> None:
         if event.resource_type is BaseChain:
             self.chain = event.resource
-            self.boot()
+            self.start()
 
-    def start(self) -> None:
+    def _start(self) -> None:
         chain = cast(LightDispatchChain, self.chain)
         self.handler = LightPeerChainEventBusHandler(chain._peer_chain, self.context.event_bus)
         asyncio.ensure_future(self.handler.run())
 
-    async def stop(self) -> None:
+    async def _stop(self) -> None:
         # This isn't really needed for the standard shutdown case as the LightPeerChain will
         # automatically shutdown whenever the `CancelToken` it was chained with is triggered.
         # It may still be useful to stop the LightPeerChain Bridge plugin individually though.

--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -75,9 +75,9 @@ class TxPlugin(BaseAsyncStopPlugin):
             self.chain = event.resource
 
         if all((self.peer_pool is not None, self.chain is not None, self.is_enabled)):
-            self.boot()
+            self.start()
 
-    def start(self) -> None:
+    def _start(self) -> None:
         if isinstance(self.chain, BaseMainnetChain):
             validator = DefaultTransactionValidator(self.chain, BYZANTIUM_MAINNET_BLOCK)
         elif isinstance(self.chain, BaseRopstenChain):
@@ -90,7 +90,7 @@ class TxPlugin(BaseAsyncStopPlugin):
         self.tx_pool = TxPool(self.peer_pool, validator, self.cancel_token)
         asyncio.ensure_future(self.tx_pool.run())
 
-    async def stop(self) -> None:
+    async def _stop(self) -> None:
         # This isn't really needed for the standard shutdown case as the TxPool will automatically
         # shutdown whenever the `CancelToken` it was chained with is triggered. It may still be
         # useful to stop the TxPool plugin individually though.


### PR DESCRIPTION
### What was wrong?

Currently plugins have two different ways of consuming events:

1. Comsuming `lahja` events through the `EventBus`

2. Consuming *plugin events*  through `handle_event`

With the upcoming `lahja` release, this can be unified.

### How was it fixed?

1. Plugins consume `EventBus` events only
2. `should_start` is gone. The model has turned. While previously the `PluginManager` called `_start()` on the plugins, plugins do now call `handle_start()` themselves.
3. Because of the former, it is now the responsible of the plugin base classes to flip a `running` property on which the `PluginManager` figures out which plugins need to be stopped
3. The `Node` does not depend on the `PluginManager` any more

### Known issues:

2. I think the `start` and `handle_start`  methods could use better names. The `handle_start` method is what plugins need to *call* to start the plugin whereas the `start` method is what they need to *implement*.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://m.voomed.com/u/2014/09/wildlife.jpg)
