### PR TITLE
WIP: Enable auto-discovering plugins

### DIFF
--- a/tests/trinity/integration/test_autodiscovery_plugins.py
+++ b/tests/trinity/integration/test_autodiscovery_plugins.py
@@ -1,0 +1,16 @@
+import pytest
+from subprocess import call
+
+
+@pytest.yield_fixture(scope="function")
+def manage_plugin_install(event_loop):
+    path_plugin = 'tests/trinity/integration/trinity_test_plugin/'
+    call(['pip', 'install', path_plugin])
+    yield
+    call(['pip', 'uninstall', '-y', 'trinity_test_plugin'])
+
+
+def test_autodiscovery_plugins(manage_plugin_install):
+    from trinity_test_plugin import TestPlugin
+    from trinity.plugins.registry import ALL_PLUGINS
+    assert TestPlugin in ALL_PLUGINS

--- a/tests/trinity/integration/trinity_test_plugin/setup.py
+++ b/tests/trinity/integration/trinity_test_plugin/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from setuptools import setup
+
+setup(
+    name='trinity_test_plugin',
+    py_modules=['trinity_test_plugin'],
+    entry_points={'trinity.plugins': 'trinity_test_plugin=trinity_test_plugin:TestPlugin'},
+)

--- a/tests/trinity/integration/trinity_test_plugin/trinity_test_plugin.py
+++ b/tests/trinity/integration/trinity_test_plugin/trinity_test_plugin.py
@@ -1,0 +1,5 @@
+class TestPlugin():
+
+    @property
+    def name(self) -> str:
+        return "TestPlugin"

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -57,8 +57,7 @@ from trinity.extensibility.events import (
     TrinityStartupEvent
 )
 from trinity.plugins.registry import (
-    BUILTIN_PLUGINS,
-    DISCOVERED_PLUGINS,
+    ALL_PLUGINS,
 )
 from trinity.utils.ipc import (
     wait_for_ipc,
@@ -398,6 +397,6 @@ async def handle_networking_exit(service: BaseService,
 def setup_plugins(scope: BaseManagerProcessScope) -> PluginManager:
     plugin_manager = PluginManager(scope)
     # TODO: Implement auto-discovery of plugins based on some convention/configuration scheme
-    plugin_manager.register(BUILTIN_PLUGINS + DISCOVERED_PLUGINS)
+    plugin_manager.register(ALL_PLUGINS)
 
     return plugin_manager

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -57,7 +57,8 @@ from trinity.extensibility.events import (
     TrinityStartupEvent
 )
 from trinity.plugins.registry import (
-    ENABLED_PLUGINS
+    BUILTIN_PLUGINS,
+    DISCOVERED_PLUGINS,
 )
 from trinity.utils.ipc import (
     wait_for_ipc,
@@ -397,6 +398,6 @@ async def handle_networking_exit(service: BaseService,
 def setup_plugins(scope: BaseManagerProcessScope) -> PluginManager:
     plugin_manager = PluginManager(scope)
     # TODO: Implement auto-discovery of plugins based on some convention/configuration scheme
-    plugin_manager.register(ENABLED_PLUGINS)
+    plugin_manager.register(BUILTIN_PLUGINS + DISCOVERED_PLUGINS)
 
     return plugin_manager

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -30,10 +30,15 @@ def is_ipython_available() -> bool:
 # we'll be able to load plugins from some path and control via Trinity
 # config file which plugin is enabled or not
 
-ENABLED_PLUGINS = [
+BUILTIN_PLUGINS = [
     AttachPlugin() if is_ipython_available() else AttachPlugin(use_ipython=False),
     FixUncleanShutdownPlugin(),
     JsonRpcServerPlugin(),
     LightPeerChainBridgePlugin(),
     TxPlugin(),
 ]
+
+# To enable discovery plugins need to define entrypoints at 'trinity.plugins'
+# https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata
+DISCOVERED_PLUGINS = [
+    entry_point.load() for entry_point in pkg_resources.iter_entry_points('trinity.plugins')]

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -42,3 +42,5 @@ BUILTIN_PLUGINS = [
 # https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata
 DISCOVERED_PLUGINS = [
     entry_point.load() for entry_point in pkg_resources.iter_entry_points('trinity.plugins')]
+
+ALL_PLUGINS = BUILTIN_PLUGINS + DISCOVERED_PLUGINS


### PR DESCRIPTION
### What was wrong?
Need to enable auto-discovery of plugins.
Issue: https://github.com/ethereum/py-evm/issues/1230

### How was it fixed?
Populating the plugin registry by plugins who have mentioned in their entrypoint as 'trinity.plugins'
1. https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata 

**Question**
Do you want an approach where we can select/deselect discovered plugins through a config.ini file? Maybe as mentioned in the issue, not needed to be implemented in this PR. 

#### Things to be done
1. Need to write tests.
2. Need to update the docs
 
#### Cute _Fictional_ Animal Picture

![put a cute animal picture link inside the parentheses](https://static.thetoptens.com/img/lists/8244lg.jpg)
