### PR TITLE
Rename ChainConfig to TrinityConfig

### DIFF
--- a/scripts/db-shell.py
+++ b/scripts/db-shell.py
@@ -14,7 +14,7 @@ from eth.chains.ropsten import ROPSTEN_NETWORK_ID
 from eth.db.chain import ChainDB
 from eth.db.backends.level import LevelDB
 
-from trinity.config import ChainConfig
+from trinity.config import TrinityConfig
 from trinity.constants import SYNC_FULL, SYNC_LIGHT
 
 
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     if args.light:
         sync_mode = SYNC_LIGHT
 
-    cfg = ChainConfig(network_id, sync_mode=sync_mode)
+    cfg = TrinityConfig(network_id, sync_mode=sync_mode)
     chaindb = ChainDB(LevelDB(cfg.database_dir))
     head = chaindb.get_canonical_head()
     print("Head #%d; hash: %s, state_root: %s" % (

--- a/tests/trinity/core/chain-management/test_initialize_data_dir.py
+++ b/tests/trinity/core/chain-management/test_initialize_data_dir.py
@@ -7,58 +7,58 @@ from trinity.chains import (
     initialize_data_dir,
 )
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 
 
 @pytest.fixture
-def chain_config():
-    return ChainConfig(network_id=1, max_peers=1)
+def trinity_config():
+    return TrinityConfig(network_id=1)
 
 
 @pytest.fixture
-def data_dir(chain_config):
-    os.makedirs(chain_config.data_dir, exist_ok=True)
-    assert os.path.exists(chain_config.data_dir)
-    return chain_config.data_dir
+def data_dir(trinity_config):
+    os.makedirs(trinity_config.data_dir, exist_ok=True)
+    assert os.path.exists(trinity_config.data_dir)
+    return trinity_config.data_dir
 
 
 @pytest.fixture
-def database_dir(chain_config, data_dir):
-    os.makedirs(chain_config.database_dir, exist_ok=True)
-    assert os.path.exists(chain_config.database_dir)
-    return chain_config.database_dir
+def database_dir(trinity_config, data_dir):
+    os.makedirs(trinity_config.database_dir, exist_ok=True)
+    assert os.path.exists(trinity_config.database_dir)
+    return trinity_config.database_dir
 
 
 @pytest.fixture
-def nodekey(chain_config, data_dir):
-    with open(chain_config.nodekey_path, 'wb') as nodekey_file:
+def nodekey(trinity_config, data_dir):
+    with open(trinity_config.nodekey_path, 'wb') as nodekey_file:
         nodekey_file.write(b'\x01' * 32)
-    return chain_config.nodekey_path
+    return trinity_config.nodekey_path
 
 
-def test_initializing_data_dir_from_nothing(chain_config):
-    assert not os.path.exists(chain_config.data_dir)
-    assert not is_data_dir_initialized(chain_config)
+def test_initializing_data_dir_from_nothing(trinity_config):
+    assert not os.path.exists(trinity_config.data_dir)
+    assert not is_data_dir_initialized(trinity_config)
 
-    initialize_data_dir(chain_config)
+    initialize_data_dir(trinity_config)
 
-    assert is_data_dir_initialized(chain_config)
-
-
-def test_initializing_data_dir_from_empty_data_dir(chain_config, data_dir):
-    assert not os.path.exists(chain_config.database_dir)
-    assert not is_data_dir_initialized(chain_config)
-
-    initialize_data_dir(chain_config)
-
-    assert is_data_dir_initialized(chain_config)
+    assert is_data_dir_initialized(trinity_config)
 
 
-def test_initializing_data_dir_with_missing_nodekey(chain_config, data_dir, database_dir):
-    assert not os.path.exists(chain_config.nodekey_path)
-    assert not is_data_dir_initialized(chain_config)
+def test_initializing_data_dir_from_empty_data_dir(trinity_config, data_dir):
+    assert not os.path.exists(trinity_config.database_dir)
+    assert not is_data_dir_initialized(trinity_config)
 
-    initialize_data_dir(chain_config)
+    initialize_data_dir(trinity_config)
 
-    assert is_data_dir_initialized(chain_config)
+    assert is_data_dir_initialized(trinity_config)
+
+
+def test_initializing_data_dir_with_missing_nodekey(trinity_config, data_dir, database_dir):
+    assert not os.path.exists(trinity_config.nodekey_path)
+    assert not is_data_dir_initialized(trinity_config)
+
+    initialize_data_dir(trinity_config)
+
+    assert is_data_dir_initialized(trinity_config)

--- a/tests/trinity/core/chain-management/test_initialize_database.py
+++ b/tests/trinity/core/chain-management/test_initialize_database.py
@@ -10,23 +10,23 @@ from trinity.chains import (
     is_database_initialized,
 )
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 
 
 @pytest.fixture
-def chain_config():
-    _chain_config = ChainConfig(network_id=1, max_peers=1)
-    initialize_data_dir(_chain_config)
-    return _chain_config
+def trinity_config():
+    _trinity_config = TrinityConfig(network_id=1)
+    initialize_data_dir(_trinity_config)
+    return _trinity_config
 
 
 @pytest.fixture
-def chaindb(chain_config):
-    return ChainDB(LevelDB(db_path=chain_config.database_dir))
+def chaindb(trinity_config):
+    return ChainDB(LevelDB(db_path=trinity_config.database_dir))
 
 
-def test_initialize_database(chain_config, chaindb):
+def test_initialize_database(trinity_config, chaindb):
     assert not is_database_initialized(chaindb)
-    initialize_database(chain_config, chaindb)
+    initialize_database(trinity_config, chaindb)
     assert is_database_initialized(chaindb)

--- a/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_data_dir_initialized.py
@@ -7,100 +7,100 @@ from trinity.chains import (
     is_data_dir_initialized,
 )
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 
 
 @pytest.fixture
-def chain_config():
-    return ChainConfig(network_id=1, max_peers=1)
+def trinity_config():
+    return TrinityConfig(network_id=1)
 
 
 @pytest.fixture
-def data_dir(chain_config):
-    os.makedirs(chain_config.data_dir, exist_ok=True)
-    assert os.path.exists(chain_config.data_dir)
-    return chain_config.data_dir
+def data_dir(trinity_config):
+    os.makedirs(trinity_config.data_dir, exist_ok=True)
+    assert os.path.exists(trinity_config.data_dir)
+    return trinity_config.data_dir
 
 
 @pytest.fixture
-def logfile_dir(chain_config):
-    chain_config.logfile_path.parent.mkdir(parents=True)
-    return chain_config.logfile_path.parent
+def logfile_dir(trinity_config):
+    trinity_config.logfile_path.parent.mkdir(parents=True)
+    return trinity_config.logfile_path.parent
 
 
 @pytest.fixture
-def logfile_path(chain_config, logfile_dir):
-    chain_config.logfile_path.touch()
-    return chain_config.logfile_path
+def logfile_path(trinity_config, logfile_dir):
+    trinity_config.logfile_path.touch()
+    return trinity_config.logfile_path
 
 
 @pytest.fixture
-def database_dir(chain_config, data_dir):
-    os.makedirs(chain_config.database_dir, exist_ok=True)
-    assert os.path.exists(chain_config.database_dir)
-    return chain_config.database_dir
+def database_dir(trinity_config, data_dir):
+    os.makedirs(trinity_config.database_dir, exist_ok=True)
+    assert os.path.exists(trinity_config.database_dir)
+    return trinity_config.database_dir
 
 
 @pytest.fixture
-def nodekey(chain_config, data_dir):
-    with open(chain_config.nodekey_path, 'wb') as nodekey_file:
+def nodekey(trinity_config, data_dir):
+    with open(trinity_config.nodekey_path, 'wb') as nodekey_file:
         nodekey_file.write(b'\x01' * 32)
-    return chain_config.nodekey_path
+    return trinity_config.nodekey_path
 
 
-def test_not_initialized_without_data_dir(chain_config):
-    assert not os.path.exists(chain_config.data_dir)
-    assert not is_data_dir_initialized(chain_config)
+def test_not_initialized_without_data_dir(trinity_config):
+    assert not os.path.exists(trinity_config.data_dir)
+    assert not is_data_dir_initialized(trinity_config)
 
 
-def test_not_initialized_without_database_dir(chain_config, data_dir):
-    assert not os.path.exists(chain_config.database_dir)
-    assert not is_data_dir_initialized(chain_config)
+def test_not_initialized_without_database_dir(trinity_config, data_dir):
+    assert not os.path.exists(trinity_config.database_dir)
+    assert not is_data_dir_initialized(trinity_config)
 
 
-def test_not_initialized_without_nodekey_file(chain_config, data_dir, database_dir):
-    assert not os.path.exists(chain_config.nodekey_path)
-    assert not is_data_dir_initialized(chain_config)
+def test_not_initialized_without_nodekey_file(trinity_config, data_dir, database_dir):
+    assert not os.path.exists(trinity_config.nodekey_path)
+    assert not is_data_dir_initialized(trinity_config)
 
 
-def test_not_initialized_without_logfile_dir(chain_config, data_dir, database_dir, nodekey):
-    assert not os.path.exists(chain_config.logfile_path.parent)
-    assert not is_data_dir_initialized(chain_config)
+def test_not_initialized_without_logfile_dir(trinity_config, data_dir, database_dir, nodekey):
+    assert not os.path.exists(trinity_config.logfile_path.parent)
+    assert not is_data_dir_initialized(trinity_config)
 
 
 def test_not_initialized_without_logfile_path(
-        chain_config,
+        trinity_config,
         data_dir,
         database_dir,
         nodekey,
         logfile_dir):
-    assert not os.path.exists(chain_config.logfile_path)
-    assert not is_data_dir_initialized(chain_config)
+    assert not os.path.exists(trinity_config.logfile_path)
+    assert not is_data_dir_initialized(trinity_config)
 
 
 def test_full_initialized_data_dir(
-        chain_config,
+        trinity_config,
         data_dir,
         database_dir,
         nodekey,
         logfile_dir,
         logfile_path):
-    assert is_data_dir_initialized(chain_config)
+    assert is_data_dir_initialized(trinity_config)
 
 
 NODEKEY = decode_hex('0xd18445cc77139cd8e09110e99c9384f0601bd2dfa5b230cda917df7e56b69949')
 
 
 def test_full_initialized_data_dir_with_custom_nodekey():
-    chain_config = ChainConfig(network_id=1, max_peers=1, nodekey=NODEKEY)
+    trinity_config = TrinityConfig(network_id=1, nodekey=NODEKEY)
 
-    os.makedirs(chain_config.data_dir, exist_ok=True)
-    os.makedirs(chain_config.database_dir, exist_ok=True)
-    os.makedirs(chain_config.logfile_path, exist_ok=True)
-    chain_config.logfile_path.touch()
+    os.makedirs(trinity_config.data_dir, exist_ok=True)
+    os.makedirs(trinity_config.database_dir, exist_ok=True)
+    os.makedirs(trinity_config.logfile_path, exist_ok=True)
+    trinity_config.logfile_path.touch()
 
-    assert chain_config.nodekey_path is None
-    assert chain_config.nodekey is not None
+    assert trinity_config.nodekey_path is None
+    assert trinity_config.nodekey is not None
 
-    assert is_data_dir_initialized(chain_config)
+    assert is_data_dir_initialized(trinity_config)

--- a/tests/trinity/core/chain-management/test_is_database_initialized.py
+++ b/tests/trinity/core/chain-management/test_is_database_initialized.py
@@ -10,20 +10,20 @@ from trinity.chains import (
     is_database_initialized,
 )
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 
 
 @pytest.fixture
-def chain_config():
-    _chain_config = ChainConfig(network_id=1, max_peers=1)
-    initialize_data_dir(_chain_config)
-    return _chain_config
+def trinity_config():
+    _trinity_config = TrinityConfig(network_id=1)
+    initialize_data_dir(_trinity_config)
+    return _trinity_config
 
 
 @pytest.fixture
-def chaindb(chain_config):
-    return ChainDB(LevelDB(db_path=chain_config.database_dir))
+def chaindb(trinity_config):
+    return ChainDB(LevelDB(db_path=trinity_config.database_dir))
 
 
 def test_database_dir_not_initialized_without_canonical_head_block(chaindb):

--- a/tests/trinity/core/config/test_trinity_config_object.py
+++ b/tests/trinity/core/config/test_trinity_config_object.py
@@ -14,7 +14,7 @@ from trinity.utils.chains import (
     get_nodekey_path,
 )
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
     DATABASE_DIR_NAME,
 )
 from trinity.utils.filesystem import (
@@ -24,7 +24,7 @@ from trinity.utils.filesystem import (
 
 def test_chain_config_computed_properties(xdg_trinity_root):
     data_dir = get_local_data_dir('muffin', xdg_trinity_root)
-    chain_config = ChainConfig(network_id=1234, data_dir=data_dir)
+    chain_config = TrinityConfig(network_id=1234, data_dir=data_dir)
 
     assert chain_config.network_id == 1234
     assert chain_config.data_dir == data_dir
@@ -37,7 +37,7 @@ def test_chain_config_computed_properties_custom_xdg(tmpdir, xdg_trinity_root):
     assert not is_under_path(alt_xdg_root, xdg_trinity_root)
 
     data_dir = get_data_dir_for_network_id(1, alt_xdg_root)
-    chain_config = ChainConfig(trinity_root_dir=alt_xdg_root, network_id=1)
+    chain_config = TrinityConfig(trinity_root_dir=alt_xdg_root, network_id=1)
 
     assert chain_config.network_id == 1
     assert chain_config.data_dir == data_dir
@@ -46,7 +46,7 @@ def test_chain_config_computed_properties_custom_xdg(tmpdir, xdg_trinity_root):
 
 
 def test_chain_config_explicit_properties():
-    chain_config = ChainConfig(
+    chain_config = TrinityConfig(
         network_id=1,
         data_dir='./data-dir',
         nodekey_path='./nodekey'
@@ -74,7 +74,7 @@ def nodekey_path(tmpdir, nodekey_bytes):
 
 
 def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
-    chain_config = ChainConfig(
+    chain_config = TrinityConfig(
         network_id=1,
         nodekey_path=nodekey_path,
     )
@@ -84,7 +84,7 @@ def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
 
 @pytest.mark.parametrize('as_bytes', (True, False))
 def test_chain_config_explictely_provided_nodekey(nodekey_bytes, as_bytes):
-    chain_config = ChainConfig(
+    chain_config = TrinityConfig(
         network_id=1,
         nodekey=nodekey_bytes if as_bytes else keys.PrivateKey(nodekey_bytes),
     )

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -19,7 +19,7 @@ from trinity.chains import (
     get_chaindb_manager,
 )
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 from trinity.db.chain import ChainDBProxy
 from trinity.db.base import DBProxy
@@ -44,19 +44,22 @@ def database_server_ipc_path():
     chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        chain_config = ChainConfig(network_id=ROPSTEN_NETWORK_ID, max_peers=1, data_dir=temp_dir)
+        trinity_config = TrinityConfig(
+            network_id=ROPSTEN_NETWORK_ID,
+            data_dir=temp_dir,
+        )
 
-        manager = get_chaindb_manager(chain_config, core_db)
+        manager = get_chaindb_manager(trinity_config, core_db)
         chaindb_server_process = multiprocessing.Process(
             target=serve_chaindb,
             args=(manager,),
         )
         chaindb_server_process.start()
 
-        wait_for_ipc(chain_config.database_ipc_path)
+        wait_for_ipc(trinity_config.database_ipc_path)
 
         try:
-            yield chain_config.database_ipc_path
+            yield trinity_config.database_ipc_path
         finally:
             kill_process_gracefully(chaindb_server_process, logging.getLogger())
 

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -35,7 +35,7 @@ from p2p import ecies
 from trinity.exceptions import (
     MissingPath,
 )
-from trinity.config import ChainConfig
+from trinity.config import TrinityConfig
 from trinity.db.base import DBProxy
 from trinity.db.chain import AsyncChainDB, ChainDBProxy
 from trinity.db.header import (
@@ -57,31 +57,31 @@ from .header import (
 )
 
 
-def is_data_dir_initialized(chain_config: ChainConfig) -> bool:
+def is_data_dir_initialized(trinity_config: TrinityConfig) -> bool:
     """
     - base dir exists
     - chain data-dir exists
     - nodekey exists and is non-empty
     - canonical chain head in db
     """
-    if not os.path.exists(chain_config.data_dir):
+    if not os.path.exists(trinity_config.data_dir):
         return False
 
-    if not os.path.exists(chain_config.database_dir):
+    if not os.path.exists(trinity_config.database_dir):
         return False
 
-    if not chain_config.logfile_path.parent.exists():
+    if not trinity_config.logfile_path.parent.exists():
         return False
-    elif not chain_config.logfile_path.exists():
+    elif not trinity_config.logfile_path.exists():
         return False
 
-    if chain_config.nodekey_path is None:
+    if trinity_config.nodekey_path is None:
         # has an explicitely defined nodekey
         pass
-    elif not os.path.exists(chain_config.nodekey_path):
+    elif not os.path.exists(trinity_config.nodekey_path):
         return False
 
-    if chain_config.nodekey is None:
+    if trinity_config.nodekey is None:
         return False
 
     return True
@@ -97,60 +97,60 @@ def is_database_initialized(chaindb: AsyncChainDB) -> bool:
         return True
 
 
-def initialize_data_dir(chain_config: ChainConfig) -> None:
+def initialize_data_dir(trinity_config: TrinityConfig) -> None:
     should_create_data_dir = (
-        not chain_config.data_dir.exists() and
-        is_under_path(chain_config.trinity_root_dir, chain_config.data_dir)
+        not trinity_config.data_dir.exists() and
+        is_under_path(trinity_config.trinity_root_dir, trinity_config.data_dir)
     )
     if should_create_data_dir:
-        chain_config.data_dir.mkdir(parents=True, exist_ok=True)
-    elif not chain_config.data_dir.exists():
+        trinity_config.data_dir.mkdir(parents=True, exist_ok=True)
+    elif not trinity_config.data_dir.exists():
         # we don't lazily create the base dir for non-default base directories.
         raise MissingPath(
             "The base chain directory provided does not exist: `{0}`".format(
-                chain_config.data_dir,
+                trinity_config.data_dir,
             ),
-            chain_config.data_dir
+            trinity_config.data_dir
         )
 
     # Logfile
     should_create_logdir = (
-        not chain_config.logdir_path.exists() and
-        is_under_path(chain_config.trinity_root_dir, chain_config.logdir_path)
+        not trinity_config.logdir_path.exists() and
+        is_under_path(trinity_config.trinity_root_dir, trinity_config.logdir_path)
     )
     if should_create_logdir:
-        chain_config.logdir_path.mkdir(parents=True, exist_ok=True)
-        chain_config.logfile_path.touch()
-    elif not chain_config.logdir_path.exists():
+        trinity_config.logdir_path.mkdir(parents=True, exist_ok=True)
+        trinity_config.logfile_path.touch()
+    elif not trinity_config.logdir_path.exists():
         # we don't lazily create the base dir for non-default base directories.
         raise MissingPath(
             "The base logging directory provided does not exist: `{0}`".format(
-                chain_config.logdir_path,
+                trinity_config.logdir_path,
             ),
-            chain_config.logdir_path
+            trinity_config.logdir_path
         )
 
     # Chain data-dir
-    os.makedirs(chain_config.database_dir, exist_ok=True)
+    os.makedirs(trinity_config.database_dir, exist_ok=True)
 
     # Nodekey
-    if chain_config.nodekey is None:
+    if trinity_config.nodekey is None:
         nodekey = ecies.generate_privkey()
-        with open(chain_config.nodekey_path, 'wb') as nodekey_file:
+        with open(trinity_config.nodekey_path, 'wb') as nodekey_file:
             nodekey_file.write(nodekey.to_bytes())
 
 
-def initialize_database(chain_config: ChainConfig, chaindb: AsyncChainDB) -> None:
+def initialize_database(trinity_config: TrinityConfig, chaindb: AsyncChainDB) -> None:
     try:
         chaindb.get_canonical_head()
     except CanonicalHeadNotFound:
-        if chain_config.network_id == ROPSTEN_NETWORK_ID:
+        if trinity_config.network_id == ROPSTEN_NETWORK_ID:
             # We're starting with a fresh DB.
             chaindb.persist_header(ROPSTEN_GENESIS_HEADER)
-        elif chain_config.network_id == MAINNET_NETWORK_ID:
+        elif trinity_config.network_id == MAINNET_NETWORK_ID:
             chaindb.persist_header(MAINNET_GENESIS_HEADER)
         else:
-            # TODO: add genesis data to ChainConfig and if it's present, use it
+            # TODO: add genesis data to TrinityConfig and if it's present, use it
             # here to initialize the chain.
             raise NotImplementedError(
                 "Only the mainnet and ropsten chains are currently supported"
@@ -215,14 +215,14 @@ def rebuild_exc(exc, tb):  # type: ignore
     return exc
 
 
-def get_chaindb_manager(chain_config: ChainConfig, base_db: BaseAtomicDB) -> BaseManager:
+def get_chaindb_manager(trinity_config: TrinityConfig, base_db: BaseAtomicDB) -> BaseManager:
     chaindb = AsyncChainDB(base_db)
     chain_class: Type[BaseChain]
     if not is_database_initialized(chaindb):
-        initialize_database(chain_config, chaindb)
-    if chain_config.network_id == MAINNET_NETWORK_ID:
+        initialize_database(trinity_config, chaindb)
+    if trinity_config.network_id == MAINNET_NETWORK_ID:
         chain_class = MainnetChain
-    elif chain_config.network_id == ROPSTEN_NETWORK_ID:
+    elif trinity_config.network_id == ROPSTEN_NETWORK_ID:
         chain_class = RopstenChain
     else:
         raise NotImplementedError(
@@ -260,7 +260,7 @@ def get_chaindb_manager(chain_config: ChainConfig, base_db: BaseAtomicDB) -> Bas
         proxytype=AsyncHeaderChainProxy,
     )
 
-    manager = DBManager(address=str(chain_config.database_ipc_path))  # type: ignore
+    manager = DBManager(address=str(trinity_config.database_ipc_path))  # type: ignore
     return manager
 
 

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -28,7 +28,7 @@ from trinity.constants import (
 )
 from trinity.protocol.common.constants import DEFAULT_PREFERRED_NODES
 from trinity.utils.chains import (
-    construct_chain_config_params,
+    construct_trinity_config_params,
     get_data_dir_for_network_id,
     get_database_socket_path,
     get_jsonrpc_socket_path,
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 DATABASE_DIR_NAME = 'chain'
 
 
-class ChainConfig:
+class TrinityConfig:
     _trinity_root_dir: Path = None
     _data_dir: Path = None
     _nodekey_path: Path = None
@@ -246,12 +246,12 @@ class ChainConfig:
             )
 
     @classmethod
-    def from_parser_args(cls, parser_args: argparse.Namespace) -> 'ChainConfig':
+    def from_parser_args(cls, parser_args: argparse.Namespace) -> 'TrinityConfig':
         """
         Helper function for initializing from the namespace object produced by
         an ``argparse.ArgumentParser``
         """
-        constructor_kwargs = construct_chain_config_params(parser_args)
+        constructor_kwargs = construct_trinity_config_params(parser_args)
         return cls(**constructor_kwargs)
 
     @property

--- a/trinity/extensibility/events.py
+++ b/trinity/extensibility/events.py
@@ -8,7 +8,7 @@ from argparse import (
 )
 
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 
 
@@ -33,9 +33,9 @@ class TrinityStartupEvent(BaseEvent):
     """
     Broadcasted when Trinity is starting.
     """
-    def __init__(self, args: Namespace, chain_config: ChainConfig) -> None:
+    def __init__(self, args: Namespace, trinity_config: TrinityConfig) -> None:
         self.args = args
-        self.chain_config = chain_config
+        self.trinity_config = trinity_config
 
 
 class PluginStartedEvent(BaseEvent):

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -23,7 +23,7 @@ from lahja import (
 )
 
 from trinity.config import (
-    ChainConfig
+    TrinityConfig
 )
 from trinity.constants import (
     MAIN_EVENTBUS_ENDPOINT
@@ -58,7 +58,7 @@ class PluginContext:
         self.event_bus = endpoint
         self.boot_kwargs: Dict[str, Any] = None
         self.args: Namespace = None
-        self.chain_config: ChainConfig = None
+        self.trinity_config: TrinityConfig = None
 
     def shutdown_host(self) -> None:
         self.event_bus.broadcast(

--- a/trinity/extensibility/plugin_manager.py
+++ b/trinity/extensibility/plugin_manager.py
@@ -25,7 +25,7 @@ from lahja import (
 )
 
 from trinity.config import (
-    ChainConfig
+    TrinityConfig
 )
 from trinity.extensibility.events import (
     BaseEvent,
@@ -63,7 +63,7 @@ class BaseManagerProcessScope(ABC):
     def create_plugin_context(self,
                               plugin: BasePlugin,
                               args: Namespace,
-                              chain_config: ChainConfig,
+                              trinity_config: TrinityConfig,
                               boot_kwargs: Dict[str, Any]) -> PluginContext:
         """
         Create the ``PluginContext`` for a given plugin.
@@ -83,7 +83,7 @@ class MainAndIsolatedProcessScope(BaseManagerProcessScope):
     def create_plugin_context(self,
                               plugin: BasePlugin,
                               args: Namespace,
-                              chain_config: ChainConfig,
+                              trinity_config: TrinityConfig,
                               boot_kwargs: Dict[str, Any]) -> PluginContext:
 
         if isinstance(plugin, BaseIsolatedPlugin):
@@ -92,7 +92,7 @@ class MainAndIsolatedProcessScope(BaseManagerProcessScope):
                 self.event_bus.create_endpoint(plugin.name)
             )
             context.args = args
-            context.chain_config = chain_config
+            context.trinity_config = trinity_config
             context.boot_kwargs = boot_kwargs
             return context
 
@@ -112,13 +112,13 @@ class SharedProcessScope(BaseManagerProcessScope):
     def create_plugin_context(self,
                               plugin: BasePlugin,
                               args: Namespace,
-                              chain_config: ChainConfig,
+                              trinity_config: TrinityConfig,
                               boot_kwargs: Dict[str, Any]) -> PluginContext:
 
         # Plugins that run in a shared process all share the endpoint of the plugin manager
         context = PluginContext(self.endpoint)
         context.args = args
-        context.chain_config = chain_config
+        context.trinity_config = trinity_config
         context.boot_kwargs = boot_kwargs
         return context
 
@@ -195,7 +195,7 @@ class PluginManager:
 
     def prepare(self,
                 args: Namespace,
-                chain_config: ChainConfig,
+                trinity_config: TrinityConfig,
                 boot_kwargs: Dict[str, Any] = None) -> None:
         """
         Create a ``PluginContext`` for every plugin that this plugin manager instance
@@ -206,7 +206,7 @@ class PluginManager:
             if not self._scope.is_responsible_for_plugin(plugin):
                 continue
 
-            context = self._scope.create_plugin_context(plugin, args, chain_config, boot_kwargs)
+            context = self._scope.create_plugin_context(plugin, args, trinity_config, boot_kwargs)
             plugin.set_context(context)
 
     def shutdown_blocking(self) -> None:

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -18,7 +18,7 @@ from trinity.db.header import (
     AsyncHeaderDB,
 )
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 from trinity.extensibility import (
     PluginManager,
@@ -38,14 +38,14 @@ class Node(BaseService):
     """
     chain_class: Type[BaseChain] = None
 
-    def __init__(self, plugin_manager: PluginManager, chain_config: ChainConfig) -> None:
+    def __init__(self, plugin_manager: PluginManager, trinity_config: TrinityConfig) -> None:
         super().__init__()
         self._plugin_manager = plugin_manager
-        self._db_manager = create_db_manager(chain_config.database_ipc_path)
+        self._db_manager = create_db_manager(trinity_config.database_ipc_path)
         self._db_manager.connect()  # type: ignore
         self._headerdb = self._db_manager.get_headerdb()  # type: ignore
 
-        self._jsonrpc_ipc_path: Path = chain_config.jsonrpc_ipc_path
+        self._jsonrpc_ipc_path: Path = trinity_config.jsonrpc_ipc_path
 
     @abstractmethod
     def get_chain(self) -> BaseChain:

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -4,7 +4,7 @@ from eth.chains.base import (
 
 from p2p.peer import BasePeerPool
 
-from trinity.config import ChainConfig
+from trinity.config import TrinityConfig
 from trinity.extensibility import PluginManager
 from trinity.server import FullServer
 
@@ -15,14 +15,14 @@ class FullNode(Node):
     _chain: BaseChain = None
     _p2p_server: FullServer = None
 
-    def __init__(self, plugin_manager: PluginManager, chain_config: ChainConfig) -> None:
-        super().__init__(plugin_manager, chain_config)
-        self._bootstrap_nodes = chain_config.bootstrap_nodes
-        self._preferred_nodes = chain_config.preferred_nodes
-        self._network_id = chain_config.network_id
-        self._node_key = chain_config.nodekey
-        self._node_port = chain_config.port
-        self._max_peers = chain_config.max_peers
+    def __init__(self, plugin_manager: PluginManager, trinity_config: TrinityConfig) -> None:
+        super().__init__(plugin_manager, trinity_config)
+        self._bootstrap_nodes = trinity_config.bootstrap_nodes
+        self._preferred_nodes = trinity_config.preferred_nodes
+        self._network_id = trinity_config.network_id
+        self._node_key = trinity_config.nodekey
+        self._node_port = trinity_config.port
+        self._max_peers = trinity_config.max_peers
         self.notify_resource_available()
 
     def get_chain(self) -> BaseChain:

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -11,7 +11,7 @@ from trinity.chains.light import (
     LightDispatchChain,
 )
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 from trinity.extensibility import (
     PluginManager
@@ -32,16 +32,16 @@ class LightNode(Node):
     network_id: int = None
     nodekey: PrivateKey = None
 
-    def __init__(self, plugin_manager: PluginManager, chain_config: ChainConfig) -> None:
-        super().__init__(plugin_manager, chain_config)
+    def __init__(self, plugin_manager: PluginManager, trinity_config: TrinityConfig) -> None:
+        super().__init__(plugin_manager, trinity_config)
 
-        self._network_id = chain_config.network_id
-        self._nodekey = chain_config.nodekey
-        self._port = chain_config.port
-        self._max_peers = chain_config.max_peers
-        self._bootstrap_nodes = chain_config.bootstrap_nodes
-        self._preferred_nodes = chain_config.preferred_nodes
-        self._use_discv5 = chain_config.use_discv5
+        self._network_id = trinity_config.network_id
+        self._nodekey = trinity_config.nodekey
+        self._port = trinity_config.port
+        self._max_peers = trinity_config.max_peers
+        self._bootstrap_nodes = trinity_config.bootstrap_nodes
+        self._preferred_nodes = trinity_config.preferred_nodes
+        self._use_discv5 = trinity_config.use_discv5
 
         self._peer_chain = LightPeerChain(
             self.headerdb,

--- a/trinity/plugins/builtin/attach/plugin.py
+++ b/trinity/plugins/builtin/attach/plugin.py
@@ -6,7 +6,7 @@ from argparse import (
 import sys
 
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 from trinity.extensibility import (
     BaseMainProcessPlugin,
@@ -36,9 +36,9 @@ class AttachPlugin(BaseMainProcessPlugin):
 
         attach_parser.set_defaults(func=self.run_console)
 
-    def run_console(self, args: Namespace, chain_config: ChainConfig) -> None:
+    def run_console(self, args: Namespace, trinity_config: TrinityConfig) -> None:
         try:
-            console(chain_config.jsonrpc_ipc_path, use_ipython=self.use_ipython)
+            console(trinity_config.jsonrpc_ipc_path, use_ipython=self.use_ipython)
         except FileNotFoundError as err:
             self.logger.error(str(err))
             sys.exit(1)

--- a/trinity/plugins/builtin/ethstats/ethstats_service.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_service.py
@@ -113,8 +113,8 @@ class EthstatsService(BaseService):
             'name': self.node_id,
             'contact': self.node_contact,
             'node': construct_trinity_client_identifier(),
-            'net': self.context.chain_config.network_id,
-            'port': self.context.chain_config.port,
+            'net': self.context.trinity_config.network_id,
+            'port': self.context.trinity_config.port,
             'os': platform.system(),
             'os_v': platform.release(),
             'client': __version__,
@@ -144,12 +144,12 @@ class EthstatsService(BaseService):
         }
 
     def get_chain(self) -> BaseChain:
-        db_manager = create_db_manager(self.context.chain_config.database_ipc_path)
+        db_manager = create_db_manager(self.context.trinity_config.database_ipc_path)
         db_manager.connect()
 
-        chain_class = self.context.chain_config.node_class.chain_class
+        chain_class = self.context.trinity_config.node_class.chain_class
 
-        if self.context.chain_config.sync_mode == SYNC_LIGHT:
+        if self.context.trinity_config.sync_mode == SYNC_LIGHT:
             header_db = db_manager.get_headerdb()  # type: ignore
             chain = chain_class(
                 header_db,

--- a/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
+++ b/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
@@ -6,7 +6,7 @@ from argparse import (
 import time
 
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 from trinity.extensibility import (
     BaseMainProcessPlugin,
@@ -31,11 +31,11 @@ class FixUncleanShutdownPlugin(BaseMainProcessPlugin):
 
         attach_parser.set_defaults(func=self.fix_unclean_shutdown)
 
-    def fix_unclean_shutdown(self, args: Namespace, chain_config: ChainConfig) -> None:
+    def fix_unclean_shutdown(self, args: Namespace, trinity_config: TrinityConfig) -> None:
         self.logger.info("Cleaning up unclean shutdown...")
 
-        self.logger.info("Searching for process id files in %s..." % chain_config.data_dir)
-        pidfiles = tuple(chain_config.data_dir.glob('*.pid'))
+        self.logger.info("Searching for process id files in %s..." % trinity_config.data_dir)
+        pidfiles = tuple(trinity_config.data_dir.glob('*.pid'))
         if len(pidfiles) > 1:
             self.logger.info('Found %d processes from a previous run. Closing...' % len(pidfiles))
         elif len(pidfiles) == 1:
@@ -56,7 +56,7 @@ class FixUncleanShutdownPlugin(BaseMainProcessPlugin):
                     'pidfile %s was gone after killing process id %d' % (pidfile, process_id)
                 )
 
-        db_ipc = chain_config.database_ipc_path
+        db_ipc = trinity_config.database_ipc_path
         try:
             db_ipc.unlink()
             self.logger.info(
@@ -67,7 +67,7 @@ class FixUncleanShutdownPlugin(BaseMainProcessPlugin):
                 'The IPC socket file for database connections at %s was already gone', db_ipc
             )
 
-        jsonrpc_ipc = chain_config.jsonrpc_ipc_path
+        jsonrpc_ipc = trinity_config.jsonrpc_ipc_path
         try:
             jsonrpc_ipc.unlink()
             self.logger.info(

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -47,12 +47,12 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
         self.logger.info('JSON-RPC Server started')
         self.context.event_bus.connect()
 
-        db_manager = create_db_manager(self.context.chain_config.database_ipc_path)
+        db_manager = create_db_manager(self.context.trinity_config.database_ipc_path)
         db_manager.connect()
 
-        chain_class = self.context.chain_config.node_class.chain_class
+        chain_class = self.context.trinity_config.node_class.chain_class
 
-        if self.context.chain_config.sync_mode == SYNC_LIGHT:
+        if self.context.trinity_config.sync_mode == SYNC_LIGHT:
             header_db = db_manager.get_headerdb()  # type: ignore
             event_bus_light_peer_chain = EventBusLightPeerChain(self.context.event_bus)
             chain = chain_class(header_db, peer_chain=event_bus_light_peer_chain)
@@ -61,7 +61,7 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
             chain = chain_class(db)
 
         rpc = RPCServer(chain, self.context.event_bus)
-        ipc_server = IPCServer(rpc, self.context.chain_config.jsonrpc_ipc_path)
+        ipc_server = IPCServer(rpc, self.context.trinity_config.jsonrpc_ipc_path)
 
         loop = asyncio.get_event_loop()
         asyncio.ensure_future(exit_with_service_and_endpoint(ipc_server, self.context.event_bus))

--- a/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
@@ -42,7 +42,7 @@ class LightPeerChainBridgePlugin(BaseAsyncStopPlugin):
         return "LightPeerChain Bridge"
 
     def should_start(self) -> bool:
-        return self.chain is not None and self.context.chain_config.sync_mode == SYNC_LIGHT
+        return self.chain is not None and self.context.trinity_config.sync_mode == SYNC_LIGHT
 
     def handle_event(self, activation_event: BaseEvent) -> None:
         if isinstance(activation_event, ResourceAvailableEvent):

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -124,10 +124,10 @@ def load_nodekey(nodekey_path: Path) -> PrivateKey:
 
 
 @to_dict
-def construct_chain_config_params(
+def construct_trinity_config_params(
         args: argparse.Namespace) -> Iterable[Tuple[str, Union[int, str, Tuple[str, ...]]]]:
     """
-    Helper function for constructing the kwargs to initialize a ChainConfig object.
+    Helper function for constructing the kwargs to initialize a TrinityConfig object.
     """
     yield 'network_id', args.network_id
     yield 'use_discv5', args.discv5

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -29,7 +29,7 @@ from eth.tools.logging import (
 )
 
 from trinity.config import (
-    ChainConfig,
+    TrinityConfig,
 )
 
 if TYPE_CHECKING:
@@ -97,7 +97,7 @@ def setup_trinity_file_and_queue_logging(
         logger: Logger,
         formatter: Formatter,
         handler_stream: StreamHandler,
-        chain_config: ChainConfig,
+        trinity_config: TrinityConfig,
         level: int=None) -> Tuple[Logger, 'Queue[str]', QueueListener]:
     from .mp import ctx
 
@@ -107,7 +107,7 @@ def setup_trinity_file_and_queue_logging(
     log_queue = ctx.Queue()
 
     handler_file = RotatingFileHandler(
-        str(chain_config.logfile_path),
+        str(trinity_config.logfile_path),
         maxBytes=(10000000 * LOG_MAX_MB),
         backupCount=LOG_BACKUP_COUNT
     )


### PR DESCRIPTION
### What was wrong?

As part of https://github.com/ethereum/py-evm/pull/1299 I found that the logic within the `ChainConfig` was getting too complex.  

### How was it fixed?

To combat this, I decided to split the config into two parts.

- The `ChainConfig` which **only** handles configuration of the `Chain` object.
- The `TrinityConfig` which handles everything else.

This pull request does step 1 in this, renaming the existing `ChainConfig` to `TrinityConfig`.  A subsequent PR will introduce the new `ChainConfig`.

#### Cute Animal Picture

![squirrel-and-pumpkin-002](https://user-images.githubusercontent.com/824194/46365560-27056a00-c636-11e8-8aac-bad7a5a526fc.jpg)

