### PR TITLE
Fix mixup with chain_id and network_id

### DIFF
--- a/docs/api/eth/tools/api.tools.builders.rst
+++ b/docs/api/eth/tools/api.tools.builders.rst
@@ -35,6 +35,9 @@ The following utilities are provided to assist with constructing a chain class.
 .. autofunction:: eth.tools.builder.chain.name
 
 
+.. autofunction:: eth.tools.builder.chain.chain_id
+
+
 Initializing Chains
 ~~~~~~~~~~~~~~~~~~~
 

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -23,14 +23,6 @@ from typing import (  # noqa: F401
 
 import logging
 
-from cytoolz import (
-    assoc,
-    compose,
-    groupby,
-    iterate,
-    take,
-)
-
 from eth_typing import (
     Address,
     BlockNumber,
@@ -40,6 +32,13 @@ from eth_typing import (
 from eth_utils import (
     to_set,
     ValidationError,
+)
+from eth_utils.toolz import (
+    assoc,
+    compose,
+    groupby,
+    iterate,
+    take,
 )
 
 from eth.db.backends.base import BaseAtomicDB
@@ -120,7 +119,7 @@ class BaseChain(Configurable, ABC):
     chaindb = None  # type: BaseChainDB
     chaindb_class = None  # type: Type[BaseChainDB]
     vm_configuration = None  # type: Tuple[Tuple[int, Type[BaseVM]], ...]
-    network_id = None  # type: int
+    chain_id = None  # type: int
 
     @abstractmethod
     def __init__(self) -> None:

--- a/eth/chains/header.py
+++ b/eth/chains/header.py
@@ -25,7 +25,7 @@ class BaseHeaderChain(Configurable, ABC):
     _headerdb = None  # type: BaseHeaderDB
 
     header = None  # type: BlockHeader
-    network_id = None  # type: int
+    chain_id = None  # type: int
     vm_configuration = None  # type: Tuple[Tuple[int, Type[BaseVM]], ...]
 
     @abstractmethod

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -79,12 +79,13 @@ MAINNET_VMS = (
 
 MAINNET_VM_CONFIGURATION = tuple(zip(MAINNET_FORK_BLOCKS, MAINNET_VMS))
 
-MAINNET_NETWORK_ID = 1
+
+MAINNET_CHAIN_ID = 1
 
 
 class BaseMainnetChain:
+    chain_id = MAINNET_CHAIN_ID
     vm_configuration = MAINNET_VM_CONFIGURATION  # type: Tuple[Tuple[int, Type[BaseVM]], ...]
-    network_id = MAINNET_NETWORK_ID  # type: int
 
 
 class MainnetChain(BaseMainnetChain, Chain):

--- a/eth/chains/ropsten/__init__.py
+++ b/eth/chains/ropsten/__init__.py
@@ -26,12 +26,12 @@ ROPSTEN_VM_CONFIGURATION = (
 )
 
 
-ROPSTEN_NETWORK_ID = 3
+ROPSTEN_CHAIN_ID = 3
 
 
 class BaseRopstenChain:
     vm_configuration = ROPSTEN_VM_CONFIGURATION  # type: Tuple[Tuple[int, Type[BaseVM]], ...]  # noqa: E501
-    network_id = ROPSTEN_NETWORK_ID  # type: int
+    chain_id = ROPSTEN_CHAIN_ID  # type: int
 
 
 class RopstenChain(BaseRopstenChain, Chain):

--- a/eth/rlp/transactions.py
+++ b/eth/rlp/transactions.py
@@ -84,7 +84,6 @@ class BaseTransactionFields(rlp.Serializable):
 
 
 class BaseTransaction(BaseTransactionFields, BaseTransactionMethods):
-
     @classmethod
     def from_base_transaction(cls, transaction: 'BaseTransaction') -> 'BaseTransaction':
         return rlp.decode(rlp.encode(transaction), sedes=cls)

--- a/eth/tools/builder/chain/__init__.py
+++ b/eth/tools/builder/chain/__init__.py
@@ -1,6 +1,7 @@
 from .builders import (  # noqa: F401
     at_block_number,
     build,
+    chain_id,
     chain_split,
     copy,
     dao_fork_at,
@@ -46,6 +47,12 @@ class API:
     # Configure chain vm_configuration
     fork_at = staticmethod(fork_at)
 
+    # Configure chain name
+    name = staticmethod(name)
+
+    # Configure chain chain_id
+    chain_id = staticmethod(chain_id)
+
     # Mainnet Forks
     frontier_at = staticmethod(frontier_at)
     homestead_at = staticmethod(homestead_at)
@@ -68,7 +75,6 @@ class API:
     #
     # Chain Instance Initialization
     #
-    name = staticmethod(name)
     genesis = staticmethod(genesis)
 
     #

--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -70,6 +70,14 @@ def name(class_name, chain_class):
 
 
 @curry
+def chain_id(chain_id, chain_class):
+    """
+    Set the ``chain_id`` for the chain class.
+    """
+    return chain_class.configure(chain_id=chain_id)
+
+
+@curry
 def fork_at(vm_class, at_block, chain_class):
     """
     Adds the ``vm_class`` to the chain's ``vm_configuration``.

--- a/eth/vm/forks/__init__.py
+++ b/eth/vm/forks/__init__.py
@@ -14,5 +14,5 @@ from .byzantium import (  # noqa: F401
     ByzantiumVM,
 )
 from .constantinople import (  # noqa: F401
-    ConstantinopleVM
+    ConstantinopleVM,
 )

--- a/scripts/chainsync.py
+++ b/scripts/chainsync.py
@@ -32,7 +32,7 @@ def _test() -> None:
     from tests.trinity.core.integration_test_helpers import (
         FakeAsyncChainDB, FakeAsyncMainnetChain, FakeAsyncRopstenChain, FakeAsyncHeaderDB,
         connect_to_peers_loop)
-    from trinity.protocol.common.constants import DEFAULT_PREFERRED_NODES
+    from trinity.constants import DEFAULT_PREFERRED_NODES
     from trinity.protocol.common.context import ChainContext
     from trinity.utils.chains import load_nodekey
 

--- a/scripts/db-shell.py
+++ b/scripts/db-shell.py
@@ -9,13 +9,16 @@ import argparse
 
 from eth_utils import encode_hex
 
-from eth.chains.mainnet import MAINNET_NETWORK_ID
-from eth.chains.ropsten import ROPSTEN_NETWORK_ID
 from eth.db.chain import ChainDB
 from eth.db.backends.level import LevelDB
 
 from trinity.config import TrinityConfig
-from trinity.constants import SYNC_FULL, SYNC_LIGHT
+from trinity.constants import (
+    MAINNET_NETWORK_ID,
+    ROPSTEN_NETWORK_ID,
+    SYNC_FULL,
+    SYNC_LIGHT,
+)
 
 
 if __name__ == '__main__':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,7 @@ def _chain_with_block_validation(base_db, genesis_state, chain_cls=Chain):
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVM),
         ),
-        network_id=1337,
+        chain_id=1337,
     )
     chain = klass.from_genesis(base_db, genesis_params, genesis_state)
     return chain
@@ -170,7 +170,7 @@ def chain_without_block_validation(
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVMForTesting),
         ),
-        network_id=1337,
+        chain_id=1337,
         **overrides,
     )
     genesis_params = {

--- a/tests/core/builder-tools/test_chain_construction.py
+++ b/tests/core/builder-tools/test_chain_construction.py
@@ -6,17 +6,18 @@ from eth.chains.base import MiningChain
 from eth.consensus.pow import check_pow
 from eth.tools.builder.chain import (
     build,
-    enable_pow_mining,
-    disable_pow_check,
-    name,
-    fork_at,
     byzantium_at,
+    chain_id,
+    constantinople_at,
+    disable_pow_check,
+    enable_pow_mining,
+    fork_at,
     frontier_at,
+    genesis,
     homestead_at,
+    name,
     spurious_dragon_at,
     tangerine_whistle_at,
-    constantinople_at,
-    genesis,
 )
 from eth.vm.forks import (
     FrontierVM,
@@ -141,3 +142,11 @@ def test_chain_builder_disable_pow_check():
             block.header.nonce,
             block.header.difficulty,
         )
+
+
+def test_chain_builder_chain_id():
+    chain = build(
+        MiningChain,
+        chain_id(1234),
+    )
+    assert chain.chain_id == 1234

--- a/tests/trinity/core/database/test_database_over_ipc_manager.py
+++ b/tests/trinity/core/database/test_database_over_ipc_manager.py
@@ -7,7 +7,7 @@ import tempfile
 
 import pytest
 
-from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER, ROPSTEN_NETWORK_ID
+from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER
 from eth.db.atomic import (
     AtomicDB,
 )
@@ -21,6 +21,7 @@ from trinity.chains import (
 from trinity.config import (
     TrinityConfig,
 )
+from trinity.constants import ROPSTEN_NETWORK_ID
 from trinity.db.chain import ChainDBProxy
 from trinity.db.base import DBProxy
 from trinity.utils.ipc import (

--- a/tests/trinity/integration/test_lightchain_integration.py
+++ b/tests/trinity/integration/test_lightchain_integration.py
@@ -16,7 +16,6 @@ from eth_utils import (
 from eth_hash.auto import keccak
 
 from eth.chains.ropsten import (
-    ROPSTEN_NETWORK_ID,
     ROPSTEN_GENESIS_HEADER,
     ROPSTEN_VM_CONFIGURATION,
 )
@@ -25,6 +24,7 @@ from eth.db.atomic import AtomicDB
 from p2p import ecies
 from p2p.kademlia import Node
 
+from trinity.constants import ROPSTEN_NETWORK_ID
 from trinity.protocol.common.context import ChainContext
 from trinity.protocol.les.peer import LESPeerPool
 from trinity.sync.light.chain import LightChainSyncer

--- a/trinity/chains/__init__.py
+++ b/trinity/chains/__init__.py
@@ -19,14 +19,8 @@ from eth import MainnetChain, RopstenChain
 from eth.chains.base import (
     BaseChain
 )
-from eth.chains.mainnet import (
-    MAINNET_GENESIS_HEADER,
-    MAINNET_NETWORK_ID,
-)
-from eth.chains.ropsten import (
-    ROPSTEN_GENESIS_HEADER,
-    ROPSTEN_NETWORK_ID,
-)
+from eth.chains.mainnet import MAINNET_GENESIS_HEADER
+from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER
 from eth.db.backends.base import BaseAtomicDB
 from eth.exceptions import CanonicalHeadNotFound
 
@@ -36,6 +30,10 @@ from trinity.exceptions import (
     MissingPath,
 )
 from trinity.config import TrinityConfig
+from trinity.constants import (
+    MAINNET_NETWORK_ID,
+    ROPSTEN_NETWORK_ID,
+)
 from trinity.db.base import DBProxy
 from trinity.db.chain import AsyncChainDB, ChainDBProxy
 from trinity.db.header import (

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -4,18 +4,14 @@ from typing import (
     Any,
 )
 
-from eth.chains.mainnet import (
-    MAINNET_NETWORK_ID,
-)
-from eth.chains.ropsten import (
-    ROPSTEN_NETWORK_ID,
-)
 from eth.tools.logging import TRACE_LEVEL_NUM
 
 from p2p.kademlia import Node
 
 from trinity import __version__
 from trinity.constants import (
+    MAINNET_NETWORK_ID,
+    ROPSTEN_NETWORK_ID,
     SYNC_FULL,
     SYNC_LIGHT,
 )

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -10,12 +10,6 @@ from typing import (
 
 from eth_keys import keys
 from eth_keys.datatypes import PrivateKey
-from eth.chains.mainnet import (
-    MAINNET_NETWORK_ID,
-)
-from eth.chains.ropsten import (
-    ROPSTEN_NETWORK_ID,
-)
 from p2p.kademlia import Node as KademliaNode
 from p2p.constants import (
     MAINNET_BOOTNODES,
@@ -23,10 +17,12 @@ from p2p.constants import (
 )
 
 from trinity.constants import (
+    DEFAULT_PREFERRED_NODES,
+    MAINNET_NETWORK_ID,
+    ROPSTEN_NETWORK_ID,
     SYNC_FULL,
     SYNC_LIGHT,
 )
-from trinity.protocol.common.constants import DEFAULT_PREFERRED_NODES
 from trinity.utils.chains import (
     construct_trinity_config_params,
     get_data_dir_for_network_id,

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -1,3 +1,16 @@
+from typing import Dict, Tuple
+
+from eth_utils import (
+    decode_hex,
+)
+
+from eth_keys import (
+    keys,
+)
+
+from p2p.kademlia import Address, Node
+
+
 SYNC_FULL = 'full'
 SYNC_LIGHT = 'light'
 
@@ -5,3 +18,46 @@ MAIN_EVENTBUS_ENDPOINT = 'main'
 NETWORKING_EVENTBUS_ENDPOINT = 'networking'
 
 MAXIMUM_OBJECT_MEMORY_BYTES = 10000000
+
+MAINNET_NETWORK_ID = 1
+ROPSTEN_NETWORK_ID = 3
+
+# The defalt preferred nodes
+DEFAULT_PREFERRED_NODES: Dict[int, Tuple[Node, ...]] = {
+    MAINNET_NETWORK_ID: (
+        Node(keys.PublicKey(decode_hex("1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082")),  # noqa: E501
+             Address("52.74.57.123", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("78de8a0916848093c73790ead81d1928bec737d565119932b98c6b100d944b7a95e94f847f689fc723399d2e31129d182f7ef3863f2b4c820abbf3ab2722344d")),  # noqa: E501
+             Address("191.235.84.50", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("ddd81193df80128880232fc1deb45f72746019839589eeb642d3d44efbb8b2dda2c1a46a348349964a6066f8afb016eb2a8c0f3c66f32fadf4370a236a4b5286")),  # noqa: E501
+             Address("52.231.202.145", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("3f1d12044546b76342d59d4a05532c14b85aa669704bfe1f864fe079415aa2c02d743e03218e57a33fb94523adb54032871a6c51b2cc5514cb7c7e35b3ed0a99")),  # noqa: E501
+             Address("13.93.211.84", 30303, 30303)),
+    ),
+    ROPSTEN_NETWORK_ID: (
+        Node(keys.PublicKey(decode_hex("053d2f57829e5785d10697fa6c5333e4d98cc564dbadd87805fd4fedeb09cbcb642306e3a73bd4191b27f821fb442fcf964317d6a520b29651e7dd09d1beb0ec")),  # noqa: E501
+             Address("79.98.29.154", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09")),  # noqa: E501
+             Address("192.81.208.223", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("a147a3adde1daddc0d86f44f1a76404914e44cee018c26d49248142d4dc8a9fb0e7dd14b5153df7e60f23b037922ae1f33b8f318844ef8d2b0453b9ab614d70d")),  # noqa: E501
+             Address("72.36.89.11", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("d8714127db3c10560a2463c557bbe509c99969078159c69f9ce4f71c2cd1837bcd33db3b9c3c3e88c971b4604bbffa390a0a7f53fc37f122e2e6e0022c059dfd")),  # noqa: E501
+             Address("51.15.217.106", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("efc75f109d91cdebc62f33be992ca86fce2637044d49a954a8bdceb439b1239afda32e642456e9dfd759af5b440ef4d8761b9bda887e2200001c5f3ab2614043")),  # noqa: E501
+             Address("34.228.166.142", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("c8b9ec645cd7fe570bc73740579064c528771338c31610f44d160d2ae63fd00699caa163f84359ab268d4a0aed8ead66d7295be5e9c08b0ec85b0198273bae1f")),  # noqa: E501
+             Address("178.62.246.6", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("7a34c02d5ef9de43475580cbb88fb492afb2858cfc45f58cf5c7088ceeded5f58e65be769b79c31c5ae1f012c99b3e9f2ea9ef11764d553544171237a691493b")),  # noqa: E501
+             Address("35.227.38.243", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("bbb3ad8be9684fa1d67ac057d18f7357dd236dc01a806fef6977ac9a259b352c00169d092c50475b80aed9e28eff12d2038e97971e0be3b934b366e86b59a723")),  # noqa: E501
+             Address("81.169.153.213", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("30b7ab30a01c124a6cceca36863ece12c4f5fa68e3ba9b0b51407ccc002eeed3b3102d20a88f1c1d3c3154e2449317b8ef95090e77b312d5cc39354f86d5d606")),  # noqa: E501
+             Address("52.176.7.10", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("02508da84b37a1b7f19f77268e5b69acc9e9ab6989f8e5f2f8440e025e633e4277019b91884e46821414724e790994a502892144fc1333487ceb5a6ce7866a46")),  # noqa: E501
+             Address("54.175.255.230", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("0eec3472a46f0b637045e41f923ce1d4a585cd83c1c7418b183c46443a0df7405d020f0a61891b2deef9de35284a0ad7d609db6d30d487dbfef72f7728d09ca9")),  # noqa: E501
+             Address("181.168.193.197", 30303, 30303)),
+        Node(keys.PublicKey(decode_hex("643c31104d497e3d4cd2460ff0dbb1fb9a6140c8bb0fca66159bbf177d41aefd477091c866494efd3f1f59a0652c93ab2f7bb09034ed5ab9f2c5c6841aef8d94")),  # noqa: E501
+             Address("34.198.237.7", 30303, 30303)),
+    ),
+}

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -13,12 +13,6 @@ from lahja import (
     Endpoint,
 )
 
-from eth.chains.mainnet import (
-    MAINNET_NETWORK_ID,
-)
-from eth.chains.ropsten import (
-    ROPSTEN_NETWORK_ID,
-)
 from eth.db.backends.base import BaseDB
 from eth.db.backends.level import LevelDB
 
@@ -42,7 +36,9 @@ from trinity.config import (
 )
 from trinity.constants import (
     MAIN_EVENTBUS_ENDPOINT,
+    MAINNET_NETWORK_ID,
     NETWORKING_EVENTBUS_ENDPOINT,
+    ROPSTEN_NETWORK_ID,
 )
 from trinity.events import (
     ShutdownRequest

--- a/trinity/nodes/events.py
+++ b/trinity/nodes/events.py
@@ -1,0 +1,21 @@
+from typing import (
+    Type,
+)
+
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+)
+
+
+class NetworkIdResponse(BaseEvent):
+
+    def __init__(self, network_id: int) -> None:
+        self.network_id = network_id
+
+
+class NetworkIdRequest(BaseRequestResponseEvent[NetworkIdResponse]):
+
+    @staticmethod
+    def expected_response_type() -> Type[NetworkIdResponse]:
+        return NetworkIdResponse

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -19,7 +19,6 @@ class FullNode(Node):
         super().__init__(plugin_manager, trinity_config)
         self._bootstrap_nodes = trinity_config.bootstrap_nodes
         self._preferred_nodes = trinity_config.preferred_nodes
-        self._network_id = trinity_config.network_id
         self._node_key = trinity_config.nodekey
         self._node_port = trinity_config.port
         self._max_peers = trinity_config.max_peers
@@ -46,7 +45,7 @@ class FullNode(Node):
                 bootstrap_nodes=self._bootstrap_nodes,
                 preferred_nodes=self._preferred_nodes,
                 token=self.cancel_token,
-                event_bus=self._plugin_manager.event_bus_endpoint
+                event_bus=self.event_bus,
             )
         return self._p2p_server
 

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -35,7 +35,6 @@ class LightNode(Node):
     def __init__(self, plugin_manager: PluginManager, trinity_config: TrinityConfig) -> None:
         super().__init__(plugin_manager, trinity_config)
 
-        self._network_id = trinity_config.network_id
         self._nodekey = trinity_config.nodekey
         self._port = trinity_config.port
         self._max_peers = trinity_config.max_peers

--- a/trinity/protocol/common/constants.py
+++ b/trinity/protocol/common/constants.py
@@ -1,17 +1,3 @@
-from typing import Dict, Tuple
-
-from eth_utils import (
-    decode_hex,
-)
-
-from eth_keys import (
-    keys,
-)
-
-from eth.chains.mainnet import MAINNET_NETWORK_ID
-from eth.chains.ropsten import ROPSTEN_NETWORK_ID
-
-from p2p.kademlia import Address, Node
 
 # The default timeout for a round trip API request and response from a peer.
 ROUND_TRIP_TIMEOUT = 20.0
@@ -19,43 +5,3 @@ ROUND_TRIP_TIMEOUT = 20.0
 # Timeout used when performing the check to ensure peers are on the same side of chain splits as
 # us.
 CHAIN_SPLIT_CHECK_TIMEOUT = 15
-
-# The defalt preferred nodes
-DEFAULT_PREFERRED_NODES: Dict[int, Tuple[Node, ...]] = {
-    MAINNET_NETWORK_ID: (
-        Node(keys.PublicKey(decode_hex("1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082")),  # noqa: E501
-             Address("52.74.57.123", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("78de8a0916848093c73790ead81d1928bec737d565119932b98c6b100d944b7a95e94f847f689fc723399d2e31129d182f7ef3863f2b4c820abbf3ab2722344d")),  # noqa: E501
-             Address("191.235.84.50", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("ddd81193df80128880232fc1deb45f72746019839589eeb642d3d44efbb8b2dda2c1a46a348349964a6066f8afb016eb2a8c0f3c66f32fadf4370a236a4b5286")),  # noqa: E501
-             Address("52.231.202.145", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("3f1d12044546b76342d59d4a05532c14b85aa669704bfe1f864fe079415aa2c02d743e03218e57a33fb94523adb54032871a6c51b2cc5514cb7c7e35b3ed0a99")),  # noqa: E501
-             Address("13.93.211.84", 30303, 30303)),
-    ),
-    ROPSTEN_NETWORK_ID: (
-        Node(keys.PublicKey(decode_hex("053d2f57829e5785d10697fa6c5333e4d98cc564dbadd87805fd4fedeb09cbcb642306e3a73bd4191b27f821fb442fcf964317d6a520b29651e7dd09d1beb0ec")),  # noqa: E501
-             Address("79.98.29.154", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09")),  # noqa: E501
-             Address("192.81.208.223", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("a147a3adde1daddc0d86f44f1a76404914e44cee018c26d49248142d4dc8a9fb0e7dd14b5153df7e60f23b037922ae1f33b8f318844ef8d2b0453b9ab614d70d")),  # noqa: E501
-             Address("72.36.89.11", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("d8714127db3c10560a2463c557bbe509c99969078159c69f9ce4f71c2cd1837bcd33db3b9c3c3e88c971b4604bbffa390a0a7f53fc37f122e2e6e0022c059dfd")),  # noqa: E501
-             Address("51.15.217.106", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("efc75f109d91cdebc62f33be992ca86fce2637044d49a954a8bdceb439b1239afda32e642456e9dfd759af5b440ef4d8761b9bda887e2200001c5f3ab2614043")),  # noqa: E501
-             Address("34.228.166.142", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("c8b9ec645cd7fe570bc73740579064c528771338c31610f44d160d2ae63fd00699caa163f84359ab268d4a0aed8ead66d7295be5e9c08b0ec85b0198273bae1f")),  # noqa: E501
-             Address("178.62.246.6", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("7a34c02d5ef9de43475580cbb88fb492afb2858cfc45f58cf5c7088ceeded5f58e65be769b79c31c5ae1f012c99b3e9f2ea9ef11764d553544171237a691493b")),  # noqa: E501
-             Address("35.227.38.243", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("bbb3ad8be9684fa1d67ac057d18f7357dd236dc01a806fef6977ac9a259b352c00169d092c50475b80aed9e28eff12d2038e97971e0be3b934b366e86b59a723")),  # noqa: E501
-             Address("81.169.153.213", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("30b7ab30a01c124a6cceca36863ece12c4f5fa68e3ba9b0b51407ccc002eeed3b3102d20a88f1c1d3c3154e2449317b8ef95090e77b312d5cc39354f86d5d606")),  # noqa: E501
-             Address("52.176.7.10", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("02508da84b37a1b7f19f77268e5b69acc9e9ab6989f8e5f2f8440e025e633e4277019b91884e46821414724e790994a502892144fc1333487ceb5a6ce7866a46")),  # noqa: E501
-             Address("54.175.255.230", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("0eec3472a46f0b637045e41f923ce1d4a585cd83c1c7418b183c46443a0df7405d020f0a61891b2deef9de35284a0ad7d609db6d30d487dbfef72f7728d09ca9")),  # noqa: E501
-             Address("181.168.193.197", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("643c31104d497e3d4cd2460ff0dbb1fb9a6140c8bb0fca66159bbf177d41aefd477091c866494efd3f1f59a0652c93ab2f7bb09034ed5ab9f2c5c6841aef8d94")),  # noqa: E501
-             Address("34.198.237.7", 30303, 30303)),
-    ),
-}

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -1,6 +1,5 @@
-from p2p.events import (
-    PeerCountRequest
-)
+from p2p.events import PeerCountRequest
+from trinity.nodes.events import NetworkIdRequest
 from trinity.rpc.modules import (
     RPCModule,
 )
@@ -11,7 +10,8 @@ class Net(RPCModule):
         """
         Returns the current network ID.
         """
-        return str(self._chain.network_id)
+        response = await self._event_bus.request(NetworkIdRequest())
+        return str(response.network_id)
 
     async def peerCount(self) -> str:
         """

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -58,10 +58,10 @@ from p2p.p2p_proto import (
 from p2p.peer import BasePeer, PeerConnection
 from p2p.service import BaseService
 
+from trinity.constants import DEFAULT_PREFERRED_NODES
 from trinity.db.base import AsyncBaseDB
 from trinity.db.chain import AsyncChainDB
 from trinity.db.header import AsyncHeaderDB
-from trinity.protocol.common.constants import DEFAULT_PREFERRED_NODES
 from trinity.protocol.common.context import ChainContext
 from trinity.protocol.eth.peer import ETHPeerPool
 from trinity.protocol.les.peer import LESPeerPool
@@ -350,11 +350,12 @@ def _test() -> None:
     from pathlib import Path
     import signal
 
-    from eth.chains.ropsten import RopstenChain, ROPSTEN_GENESIS_HEADER
+    from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER
 
     from p2p import ecies
     from p2p.constants import ROPSTEN_BOOTNODES
 
+    from trinity.constants import ROPSTEN_NETWORK_ID
     from trinity.utils.chains import load_nodekey
 
     from tests.trinity.core.integration_test_helpers import (
@@ -403,7 +404,7 @@ def _test() -> None:
         chaindb,
         headerdb,
         db,
-        RopstenChain.network_id,
+        ROPSTEN_NETWORK_ID,
         bootstrap_nodes=bootstrap_nodes,
     )
     server.logger.setLevel(log_level)

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -81,11 +81,11 @@ def _test() -> None:
     import argparse
     import asyncio
     import signal
-    from eth.chains.ropsten import RopstenChain, ROPSTEN_VM_CONFIGURATION
+    from eth.chains.ropsten import ROPSTEN_VM_CONFIGURATION
     from eth.db.backends.level import LevelDB
     from p2p import ecies
     from p2p.kademlia import Node
-    from trinity.protocol.common.constants import DEFAULT_PREFERRED_NODES
+    from trinity.constants import DEFAULT_PREFERRED_NODES, ROPSTEN_NETWORK_ID
     from trinity.protocol.common.context import ChainContext
     from tests.trinity.core.integration_test_helpers import (
         FakeAsyncChainDB, FakeAsyncRopstenChain, connect_to_peers_loop)
@@ -98,7 +98,7 @@ def _test() -> None:
 
     chaindb = FakeAsyncChainDB(LevelDB(args.db))
     chain = FakeAsyncRopstenChain(chaindb)
-    network_id = RopstenChain.network_id
+    network_id = ROPSTEN_NETWORK_ID
     privkey = ecies.generate_privkey()
 
     context = ChainContext(

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -389,10 +389,10 @@ class StateSync(HexaryTrieSync):
 def _test() -> None:
     import argparse
     import signal
-    from eth.chains.ropsten import RopstenChain, ROPSTEN_VM_CONFIGURATION
+    from eth.chains.ropsten import ROPSTEN_VM_CONFIGURATION
     from p2p import ecies
     from p2p.kademlia import Node
-    from trinity.protocol.common.constants import DEFAULT_PREFERRED_NODES
+    from trinity.constants import DEFAULT_PREFERRED_NODES, ROPSTEN_NETWORK_ID
     from trinity.protocol.common.context import ChainContext
     from tests.trinity.core.integration_test_helpers import (
         FakeAsyncChainDB, FakeAsyncLevelDB, connect_to_peers_loop)
@@ -410,7 +410,7 @@ def _test() -> None:
 
     db = FakeAsyncLevelDB(args.db)
     chaindb = FakeAsyncChainDB(db)
-    network_id = RopstenChain.network_id
+    network_id = ROPSTEN_NETWORK_ID
     if args.enode:
         nodes = tuple([Node.from_uri(args.enode)])
     else:

--- a/trinity/utils/chains.py
+++ b/trinity/utils/chains.py
@@ -15,16 +15,13 @@ from eth_utils import (
 from eth_keys import keys
 from eth_keys.datatypes import PrivateKey
 
-from eth.chains.mainnet import (
-    MAINNET_NETWORK_ID,
-)
-from eth.chains.ropsten import (
-    ROPSTEN_NETWORK_ID,
-)
-
 from p2p.constants import DEFAULT_MAX_PEERS
 
-from trinity.constants import SYNC_LIGHT
+from trinity.constants import (
+    SYNC_LIGHT,
+    MAINNET_NETWORK_ID,
+    ROPSTEN_NETWORK_ID,
+)
 
 
 DEFAULT_DATA_DIRS = {


### PR DESCRIPTION
### What was wrong?

The `eth.chains.base.Chain` class had a `network_id` property.  This is *wrong* since `network_id` is *above* the EVM level.  This should have been `chain_id`

### How was it fixed?

- migrated `MAINNET_NEWORK_ID` and `ROPSTEN_...` to live under `trinity.constants`
- migrated `DEFAULT_PREFERRED_NODES` to also live under `trinity` to prevent some weird imports.
- added `MAINNET_CHAIN_ID` and `ROPSTEN_CHAIN_ID` to `eth` module.
- updated the `net` JSON-RPC module to return the `chain_id` (currently served over the event bus by the `Node` class)
  - In a subsequent PR I'd like to move this out of the `Node` class into something stand-alone which serves up the various config values like this.  still mentally fleshing this out.


#### Cute Animal Picture

 
![squirrel-in-a-pumpkin](https://user-images.githubusercontent.com/824194/46368693-16f18880-c63e-11e8-87eb-aeb369383bc2.jpg)

