### PR TITLE
Fix flakey discovery tests

### DIFF
--- a/tests/p2p/helpers.py
+++ b/tests/p2p/helpers.py
@@ -1,0 +1,32 @@
+import random
+import string
+
+from cancel_token import CancelToken
+
+from eth_utils import (
+    to_bytes,
+    keccak,
+)
+
+from eth_keys import keys
+
+from p2p import discovery
+from p2p import kademlia
+
+
+def random_address():
+    return kademlia.Address(
+        '10.0.0.{}'.format(random.randint(0, 255)), random.randint(0, 9999))
+
+
+def random_node():
+    seed = to_bytes(text="".join(random.sample(string.ascii_lowercase, 10)))
+    priv_key = keys.PrivateKey(keccak(seed))
+    return kademlia.Node(priv_key.public_key, random_address())
+
+
+def get_discovery_protocol(seed=b"seed", address=None):
+    privkey = keys.PrivateKey(keccak(seed))
+    if address is None:
+        address = random_address()
+    return discovery.DiscoveryProtocol(privkey, address, [], CancelToken("discovery-test"))

--- a/tests/p2p/test_discovery_v5.py
+++ b/tests/p2p/test_discovery_v5.py
@@ -1,0 +1,66 @@
+import asyncio
+import os
+import random
+import socket
+
+import pytest
+
+from p2p import kademlia
+
+from tests.p2p.helpers import (
+    get_discovery_protocol,
+    random_node,
+)
+
+
+"""
+NOTE: These tests end up making actual network connections
+"""
+
+
+async def get_listening_discovery_protocol(event_loop):
+    addr = kademlia.Address('127.0.0.1', random.randint(1024, 9999))
+    proto = get_discovery_protocol(os.urandom(4), addr)
+    await event_loop.create_datagram_endpoint(
+        lambda: proto, local_addr=(addr.ip, addr.udp_port), family=socket.AF_INET)
+    return proto
+
+
+@pytest.mark.asyncio
+async def test_topic_query(event_loop):
+    bob = await get_listening_discovery_protocol(event_loop)
+    les_nodes = [random_node() for _ in range(10)]
+    topic = b'les'
+    for n in les_nodes:
+        bob.topic_table.add_node(n, topic)
+    alice = await get_listening_discovery_protocol(event_loop)
+
+    echo = alice.send_topic_query(bob.this_node, topic)
+    received_nodes = await alice.wait_topic_nodes(bob.this_node, echo)
+
+    assert len(received_nodes) == 10
+    assert sorted(received_nodes) == sorted(les_nodes)
+
+
+@pytest.mark.asyncio
+async def test_topic_register(event_loop):
+    bob = await get_listening_discovery_protocol(event_loop)
+    alice = await get_listening_discovery_protocol(event_loop)
+    topics = [b'les', b'les2']
+
+    # In order to register ourselves under a given topic we need to first get a ticket.
+    ticket = await bob.get_ticket(alice.this_node, topics)
+
+    assert ticket is not None
+    assert ticket.topics == topics
+    assert ticket.node == alice.this_node
+    assert len(ticket.registration_times) == 2
+
+    # Now we register ourselves under one of the topics for which we have a ticket.
+    topic_idx = 0
+    bob.send_topic_register(alice.this_node, ticket.topics, topic_idx, ticket.pong)
+    await asyncio.sleep(0.2)
+
+    topic_nodes = alice.topic_table.get_nodes(topics[topic_idx])
+    assert len(topic_nodes) == 1
+    assert topic_nodes[0] == bob.this_node


### PR DESCRIPTION
### What was wrong?

The original `tests/p2p/test_discovery.py` test module monkeypatches the timeout to be `0.01` for kademlia requests because all of the tests used mocked out networking and thus, should not exceed that timeout.

With the addition of discovery v5, some of the tests were now making network requests, which resulted in timeouts on slower hardware (like our CI environment)

### How was it fixed?

Partitioned the tests so that the ones which make actual network requests are separate from the ones that don't.

#### Cute Animal Picture

![article-1351623324350-15c1bf70000005dc-434961_466x460](https://user-images.githubusercontent.com/824194/46370285-6d60c600-c642-11e8-99de-157ab6c7b587.jpg)
