### PR TITLE
added default server URL for mainnet and ropsten, improved help message

### DIFF
--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -27,6 +27,10 @@ DEFAULT_SERVERS_URLS = {
 
 
 class EthstatsPlugin(BaseIsolatedPlugin):
+    server_url: str
+    server_secret: str
+    node_id: str
+    node_contact: str
 
     @property
     def name(self) -> str:
@@ -66,16 +70,20 @@ class EthstatsPlugin(BaseIsolatedPlugin):
         )
 
     def should_start(self) -> bool:
-        if not self.context.args.ethstats:
+        args = self.context.args
+
+        if not args.ethstats:
             return False
 
-        self.server_url: str = (
-            self.context.args.ethstats_server_url or self.get_default_server_url()
-        )
-        self.server_secret: str = self.context.args.ethstats_server_secret
+        if (args.ethstats_server_url):
+            self.server_url = args.ethstats_server_url
+        else:
+            self.server_url = self.get_default_server_url()
 
-        self.node_id: str = self.context.args.ethstats_node_id
-        self.node_contact: str = self.context.args.ethstats_node_contact
+        self.server_secret = args.ethstats_server_secret
+
+        self.node_id = args.ethstats_node_id
+        self.node_contact = args.ethstats_node_contact
 
         configuration_provided: bool = all((
             self.server_url,

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -75,6 +75,20 @@ class EthstatsPlugin(BaseIsolatedPlugin):
         if not args.ethstats:
             return False
 
+        if not (args.ethstats_server_url or self.get_default_server_url()):
+            self.logger.error(
+                'You must provide ethstats server url using the `--ethstats-server-url`'
+            )
+            self.context.shutdown_host()
+            return False
+
+        if not args.ethstats_server_secret:
+            self.logger.error(
+                'You must provide ethstats server secret using `--ethstats-server-secret`'
+            )
+            self.context.shutdown_host()
+            return False
+
         if (args.ethstats_server_url):
             self.server_url = args.ethstats_server_url
         else:
@@ -84,15 +98,6 @@ class EthstatsPlugin(BaseIsolatedPlugin):
 
         self.node_id = args.ethstats_node_id
         self.node_contact = args.ethstats_node_contact
-
-        configuration_provided: bool = all((
-            self.server_url,
-            self.server_secret,
-        ))
-
-        if not configuration_provided:
-            self.logger.warning('Ethstats configuration not provided, skipping')
-            return False
 
         return True
 


### PR DESCRIPTION
### What was wrong?

Users were using ethstats server URL without path. Fixes #1337.

### How was it fixed?

Added example with path in `--help` output, added default server URLs for mainnet and ropsten.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://static.boredpanda.com/blog/wp-content/uploads/2016/04/cute-baby-beavers-73-570663022bbf8__605.jpg)
