### PR TITLE
Solves DecryptionError Escaping

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -385,13 +385,21 @@ class BasePeer(BaseService):
 
     async def read_msg(self) -> Tuple[protocol.Command, protocol.PayloadType]:
         header_data = await self.read(HEADER_LEN + MAC_LEN)
-        header = self.decrypt_header(header_data)
+        try:
+            header = self.decrypt_header(header_data)
+        except DecryptionError as err:
+            self.logger.debug("Error in Decrypting message from peer")
+            raise MalformedMessage from err
         frame_size = self.get_frame_size(header)
         # The frame_size specified in the header does not include the padding to 16-byte boundary,
         # so need to do this here to ensure we read all the frame's data.
         read_size = roundup_16(frame_size)
         frame_data = await self.read(read_size + MAC_LEN)
-        msg = self.decrypt_body(frame_data, frame_size)
+        try:
+            msg = self.decrypt_body(frame_data, frame_size)
+        except DecryptionError as err:
+            self.logger.debug("Error in Decrypting message from peer")
+            raise MalformedMessage from err
         cmd = self.get_protocol_command_for(msg)
         # NOTE: This used to be a bottleneck but it doesn't seem to be so anymore. If we notice
         # too much time is being spent on this again, we need to consider running this in a


### PR DESCRIPTION
### What was wrong?
The DecryptionError needs to be escaped for Malformed Messages.


### How was it fixed?
Calling both the decrypt_body and decrypt_header in try/except blocks.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://camo.githubusercontent.com/20ce88a6f4e680547f79278a4bbe97e391ffe6ed/68747470733a2f2f696d616765732e706578656c732e636f6d2f70686f746f732f35303537372f6865646765686f672d616e696d616c2d626162792d637574652d35303537372e6a7065673f6175746f3d636f6d70726573732663733d74696e797372676226683d333530)
