### PR TITLE
Trinity ethstats plugin: fix CI breakage due to constant having moved

### DIFF
--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -7,8 +7,10 @@ from argparse import (
     _SubParsersAction,
 )
 
-from eth.chains.mainnet import MAINNET_NETWORK_ID
-from eth.chains.ropsten import ROPSTEN_NETWORK_ID
+from trinity.constants import (
+    MAINNET_NETWORK_ID,
+    ROPSTEN_NETWORK_ID,
+)
 from trinity.extensibility import (
     BaseIsolatedPlugin,
 )


### PR DESCRIPTION
### What was wrong?

PR #1343 was merged before (20 hours prior to) PR #1348, but the latter didn't pick up the changes for some reason, and hasn't been run against actual `master` at the moment of merge.

In other words, PR #1348 had all CircleCI integration check-boxes green prior to @cburgdorf squash-merging it, but that was against an old commit.

### How was it fixed?

So far, identified one minor change that caused breaks - network ID constants being moved to a different module.

### Cute Animal Picture

It's a crash!..

![put a cute animal picture link inside the parentheses](https://farm7.staticflickr.com/6200/6092175826_3d6f29c130_z_d.jpg)

Source: [Soggydan Benenovitch on flickr](https://www.flickr.com/photos/soggydan/6092175826/in/pool-62721506@N00)