### PR TITLE
Remove Unnecessary Lazy Extension Code

### DIFF
--- a/eth/vm/memory.py
+++ b/eth/vm/memory.py
@@ -48,12 +48,6 @@ class Memory(object):
             validate_length(value, length=size)
             validate_lte(start_position + size, maximum=len(self))
 
-            if len(self._bytes) < start_position + size:
-                self._bytes.extend(itertools.repeat(
-                    0,
-                    len(self._bytes) - (start_position + size),
-                ))
-
             for idx, v in enumerate(value):
                 self._bytes[start_position + idx] = v
 


### PR DESCRIPTION
### What was wrong?
The If Clause code will never be executed and `validate_lte` would replace its functionality always. Hence need to delete this lazy extension.


### How was it fixed?
The If Clause is to be deleted instead of the `validate_lte`, because if that was kept then we would be increasing memory without charging gas for the increased memory.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://camo.githubusercontent.com/94b253e9e252ba059a533373b78bf32e27170127/68747470733a2f2f692e7974696d672e636f6d2f76692f355241514e32357a454f452f687164656661756c742e6a7067)
