### PR TITLE
Use BaseChainPeer instead of HeaderRequestingPeer

### DIFF
--- a/trinity/protocol/common/handlers.py
+++ b/trinity/protocol/common/handlers.py
@@ -1,11 +1,16 @@
 from abc import ABC, abstractmethod
 from typing import (
     Any,
+    Awaitable,
+    Callable,
     Dict,
     Iterator,
+    Tuple,
     Type,
+    TYPE_CHECKING,
 )
 
+from eth.rlp.headers import BlockHeader
 from p2p.peer import BasePeer
 
 from trinity.protocol.common.exchanges import (
@@ -46,3 +51,16 @@ class BaseExchangeHandler(ABC):
             for exchange
             in self
         }
+
+
+if TYPE_CHECKING:
+    from mypy_extensions import DefaultArg
+    BlockHeadersCallable = Callable[
+        [BaseExchangeHandler, int, int, DefaultArg(int, 'skip'), DefaultArg(int, 'reverse')],
+        Awaitable[Tuple[BlockHeader, ...]]
+    ]
+
+
+# This class is only needed to please mypy for type checking
+class BaseChainExchangeHandler(BaseExchangeHandler):
+    get_block_headers: 'BlockHeadersCallable'

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 import operator
 import random
 from typing import (
@@ -28,6 +29,7 @@ from p2p.peer import (
 )
 
 from trinity.db.header import BaseAsyncHeaderDB
+from trinity.protocol.common.handlers import BaseChainExchangeHandler
 
 from .boot import DAOCheckBootManager
 from .context import ChainContext
@@ -46,6 +48,16 @@ class BaseChainPeer(BasePeer):
 
     head_td: int = None
     head_hash: Hash32 = None
+
+    @property
+    @abstractmethod
+    def requests(self) -> BaseChainExchangeHandler:
+        pass
+
+    @property
+    @abstractmethod
+    def max_headers_fetch(self) -> int:
+        pass
 
     @property
     def headerdb(self) -> BaseAsyncHeaderDB:

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -1,5 +1,5 @@
 from trinity.protocol.common.handlers import (
-    BaseExchangeHandler,
+    BaseChainExchangeHandler,
 )
 
 from .exchanges import (
@@ -10,7 +10,7 @@ from .exchanges import (
 )
 
 
-class ETHExchangeHandler(BaseExchangeHandler):
+class ETHExchangeHandler(BaseChainExchangeHandler):
     _exchange_config = {
         'get_block_bodies': GetBlockBodiesExchange,
         'get_block_headers': GetBlockHeadersExchange,
@@ -20,6 +20,5 @@ class ETHExchangeHandler(BaseExchangeHandler):
 
     # These are needed only to please mypy.
     get_block_bodies: GetBlockBodiesExchange
-    get_block_headers: GetBlockHeadersExchange
     get_node_data: GetNodeDataExchange
     get_receipts: GetReceiptsExchange

--- a/trinity/protocol/les/handlers.py
+++ b/trinity/protocol/les/handlers.py
@@ -1,13 +1,11 @@
 from trinity.protocol.common.handlers import (
-    BaseExchangeHandler,
+    BaseChainExchangeHandler,
 )
 
 from .exchanges import GetBlockHeadersExchange
 
 
-class LESExchangeHandler(BaseExchangeHandler):
+class LESExchangeHandler(BaseChainExchangeHandler):
     _exchange_config = {
         'get_block_headers': GetBlockHeadersExchange,
     }
-
-    get_block_headers: GetBlockHeadersExchange

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -15,7 +15,6 @@ from typing import (
     Set,
     Tuple,
     Type,
-    Union,
     cast,
 )
 
@@ -49,6 +48,7 @@ from p2p.protocol import Command
 
 from trinity.db.chain import AsyncChainDB
 from trinity.db.header import AsyncHeaderDB
+from trinity.protocol.common.peer import BaseChainPeer
 from trinity.protocol.eth import commands
 from trinity.protocol.eth.constants import (
     MAX_BODIES_FETCH,
@@ -57,7 +57,6 @@ from trinity.protocol.eth.constants import (
 )
 from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
 from trinity.protocol.eth.requests import HeaderRequest
-from trinity.protocol.les.peer import LESPeer
 from trinity.rlp.block_body import BlockBody
 from trinity.sync.common.chain import BaseHeaderChainSyncer
 from trinity.utils.datastructures import (
@@ -69,7 +68,6 @@ from trinity.utils.datastructures import (
 )
 from trinity.utils.timer import Timer
 
-HeaderRequestingPeer = Union[LESPeer, ETHPeer]
 # (ReceiptBundle, (Receipt, (root_hash, receipt_trie_data))
 ReceiptBundle = Tuple[Tuple[Receipt, ...], Tuple[Hash32, Dict[Hash32, bytes]]]
 # (BlockBody, (txn_root, txn_trie_data), uncles_hash)
@@ -334,7 +332,7 @@ class BaseBodyChainSyncer(BaseHeaderChainSyncer):
 
         return block_body_bundles
 
-    async def _handle_msg(self, peer: HeaderRequestingPeer, cmd: protocol.Command,
+    async def _handle_msg(self, peer: BaseChainPeer, cmd: protocol.Command,
                           msg: protocol._DecodedMsgType) -> None:
         peer = cast(ETHPeer, peer)
 

--- a/trinity/sync/light/chain.py
+++ b/trinity/sync/light/chain.py
@@ -4,7 +4,6 @@ from typing import (
     Dict,
     Set,
     Type,
-    Union,
 )
 
 from p2p.protocol import (
@@ -12,14 +11,12 @@ from p2p.protocol import (
     _DecodedMsgType,
 )
 
-from trinity.protocol.eth.peer import ETHPeer
+from trinity.protocol.common.peer import BaseChainPeer
 from trinity.protocol.les import commands
 from trinity.protocol.les.peer import LESPeer
 from trinity.protocol.les.requests import HeaderRequest
 from trinity.sync.common.chain import BaseHeaderChainSyncer
 from trinity.utils.timer import Timer
-
-HeaderRequestingPeer = Union[ETHPeer, LESPeer]
 
 
 class LightChainSyncer(BaseHeaderChainSyncer):
@@ -35,7 +32,7 @@ class LightChainSyncer(BaseHeaderChainSyncer):
         self.run_task(self._persist_headers())
         await super()._run()
 
-    async def _handle_msg(self, peer: HeaderRequestingPeer, cmd: Command,
+    async def _handle_msg(self, peer: BaseChainPeer, cmd: Command,
                           msg: _DecodedMsgType) -> None:
         if isinstance(cmd, commands.Announce):
             self._sync_requests.put_nowait(peer)

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -346,7 +346,12 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
         """
         self.logger.debug("Fetching header %s from %s", encode_hex(block_hash), peer)
         max_headers = 1
-        headers = await peer.requests.get_block_headers(block_hash, max_headers, 0, False)
+        headers = await peer.requests.get_block_headers(
+            block_hash,
+            max_headers,
+            skip=0,
+            reverse=False,
+        )
         if not headers:
             raise HeaderNotFound("Peer {} has no block with hash {}".format(peer, block_hash))
         header = headers[0]


### PR DESCRIPTION
### What was wrong?

_I hadn't had a good tussle with mypy for a while, and I like punishment._

`HeaderRequestingPeer` was an old "poor coder's" version of `BaseChainPeer`

### How was it fixed?

_Rope-a-dope with mypy, plus a crucial assist from cburgdorf._

Replaced `HeaderRequestingPeer` with `BaseChainPeer`, and resolve the mypy fallout.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://78.media.tumblr.com/3462e0b2295798b7573b1162e30524cc/tumblr_o9c6veRRob1uae2w5o1_1280.jpg)
