### PR TITLE
Fix Minor Bugs in Tools

### DIFF
--- a/eth/tools/fixtures/normalization.py
+++ b/eth/tools/fixtures/normalization.py
@@ -24,6 +24,7 @@ from eth_utils import (
     is_hex,
     is_integer,
     is_string,
+    is_text,
     to_bytes,
     to_canonical_address,
     to_dict,

--- a/eth/tools/fixtures/normalization.py
+++ b/eth/tools/fixtures/normalization.py
@@ -66,13 +66,10 @@ def normalize_int(value):
 
 
 def normalize_bytes(value):
-    # type(value) maybe also bytes. But for `is_hex(value)` function
-    # value has to be only of the type string
-    value = value.decode('utf-8')
-    if len(value) or is_hex(value) == 0:
-        return decode_hex(value)
-    elif is_bytes(value):
+    if is_bytes(value):
         return value
+    elif is_text(value) and is_hex(value):
+        return decode_hex(value)
     else:
         raise TypeError("Value must be either a string or bytes object")
 

--- a/eth/tools/fixtures/normalization.py
+++ b/eth/tools/fixtures/normalization.py
@@ -66,7 +66,10 @@ def normalize_int(value):
 
 
 def normalize_bytes(value):
-    if is_hex(value) or len(value) == 0:
+    # type(value) maybe also bytes. But for `is_hex(value)` function
+    # value has to be only of the type string
+    value = value.decode('utf-8')
+    if len(value) or is_hex(value) == 0:
         return decode_hex(value)
     elif is_bytes(value):
         return value


### PR DESCRIPTION
### What was wrong?
There are 2 issues with the function `normalize_bytes` in eth/tools/fixtures/normalization.py#L68
1) The `if condition` should be checking whether the `len(value)` is 0 first, and then move on to verifying `is_hex(value)`. The problem arises when `value = b''`
2) As per the `eth_util library`, `is_hex function` takes only strings as argument. So the bytes should be converted to string using value = value.decode('utf-8') in the beginning of the function.


### How was it fixed?
1) The `if condition` was reversed
2) `bytes` is converted to `string` using `decode('utf-8')` function


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.pexels.com/photos/374906/pexels-photo-374906.jpeg?auto=compress&cs=tinysrgb&h=350)
