### PR TITLE
Use chain builder tools to cleanup benchmarks

### DIFF
--- a/scripts/benchmark/utils/chain_plumbing.py
+++ b/scripts/benchmark/utils/chain_plumbing.py
@@ -1,6 +1,9 @@
 from typing import (
+    Any,
+    Dict,
     Iterable,
-    Type
+    Tuple,
+    Type,
 )
 
 from eth_keys import (
@@ -64,33 +67,33 @@ GENESIS_PARAMS = {
     'nonce': constants.GENESIS_NONCE
 }
 
+DEFAULT_GENESIS_STATE = [
+    (FUNDED_ADDRESS, {
+        "balance": DEFAULT_INITIAL_BALANCE,
+        "code": b'',
+    }),
+    (SECOND_ADDRESS, {
+        "balance": DEFAULT_INITIAL_BALANCE,
+        "code": b'',
+    }),
+]
 
-def get_chain(vm: Type[BaseVM]) -> MiningChain:
-    # Genesis Block state
-    gen_state = [
-        (FUNDED_ADDRESS, {
-            "balance": DEFAULT_INITIAL_BALANCE,
-            "code": b'',
-        }),
-        (SECOND_ADDRESS, {
-            "balance": DEFAULT_INITIAL_BALANCE,
-            "code": b'',
-        }),
-    ]
+GenesisState = Iterable[Tuple[Address, Dict[str, Any]]]
 
-    vm_without_pow = vm.configure(validate_seal=lambda block: None)
+
+def get_chain(vm: Type[BaseVM], genesis_state: GenesisState) -> MiningChain:
 
     chain = build(
         MiningChain,
-        fork_at(vm_without_pow, constants.GENESIS_BLOCK_NUMBER),
+        fork_at(vm, constants.GENESIS_BLOCK_NUMBER),
         disable_pow_check(),
-        genesis(params=GENESIS_PARAMS, state=gen_state)
+        genesis(params=GENESIS_PARAMS, state=genesis_state)
     )
 
     return chain
 
 
-def get_all_chains() -> Iterable[MiningChain]:
+def get_all_chains(genesis_state: GenesisState=DEFAULT_GENESIS_STATE) -> Iterable[MiningChain]:
     for vm in ALL_VM:
-        chain = get_chain(vm)
+        chain = get_chain(vm, DEFAULT_GENESIS_STATE)
         yield chain

--- a/scripts/benchmark/utils/chain_plumbing.py
+++ b/scripts/benchmark/utils/chain_plumbing.py
@@ -29,7 +29,10 @@ from eth.chains.mainnet import (
     BaseMainnetChain,
 )
 from eth.tools.builder.chain import (
-    api,
+    build,
+    disable_pow_check,
+    fork_at,
+    genesis,
 )
 
 ALL_VM = [vm for _, vm in BaseMainnetChain.vm_configuration]
@@ -77,11 +80,11 @@ def get_chain(vm: Type[BaseVM]) -> MiningChain:
 
     vm_without_pow = vm.configure(validate_seal=lambda block: None)
 
-    chain = api.build(
+    chain = build(
         MiningChain,
-        api.fork_at(vm_without_pow, constants.GENESIS_BLOCK_NUMBER),
-        api.disable_pow_check(),
-        api.genesis(params=GENESIS_PARAMS, state=gen_state)
+        fork_at(vm_without_pow, constants.GENESIS_BLOCK_NUMBER),
+        disable_pow_check(),
+        genesis(params=GENESIS_PARAMS, state=gen_state)
     )
 
     return chain

--- a/scripts/benchmark/utils/chain_plumbing.py
+++ b/scripts/benchmark/utils/chain_plumbing.py
@@ -1,7 +1,5 @@
 from typing import (
-    Any,
     Iterable,
-    NamedTuple,
     Type
 )
 
@@ -11,7 +9,6 @@ from eth_keys import (
 
 from eth_utils import (
     decode_hex,
-    to_dict,
     to_wei,
 )
 
@@ -31,15 +28,9 @@ from eth.vm.base import (
 from eth.chains.mainnet import (
     BaseMainnetChain,
 )
-from eth.db.atomic import (
-    AtomicDB,
+from eth.tools.builder.chain import (
+    api,
 )
-
-AddressSetup = NamedTuple('AddressSetup', [
-    ('address', Address),
-    ('balance', int),
-    ('code', bytes)
-])
 
 ALL_VM = [vm for _, vm in BaseMainnetChain.vm_configuration]
 
@@ -71,52 +62,29 @@ GENESIS_PARAMS = {
 }
 
 
-@to_dict
-def genesis_state(setup: Iterable[AddressSetup]) -> Any:
-    for value in setup:
-        yield value.address, {
-            "balance": value.balance,
-            "nonce": 0,
-            "code": value.code,
-            "storage": {}
-        }
-
-
-def chain_without_pow(
-        base_db: AtomicDB,
-        vm: Type[BaseVM],
-        genesis_params: Any,
-        genesis_state: Any) -> MiningChain:
+def get_chain(vm: Type[BaseVM]) -> MiningChain:
+    # Genesis Block state
+    gen_state = [
+        (FUNDED_ADDRESS, {
+            "balance": DEFAULT_INITIAL_BALANCE,
+            "code": b'',
+        }),
+        (SECOND_ADDRESS, {
+            "balance": DEFAULT_INITIAL_BALANCE,
+            "code": b'',
+        }),
+    ]
 
     vm_without_pow = vm.configure(validate_seal=lambda block: None)
 
-    klass = MiningChain.configure(
-        __name__='TestChain',
-        vm_configuration=(
-            (constants.GENESIS_BLOCK_NUMBER, vm_without_pow),
-        ))
-    chain = klass.from_genesis(base_db, genesis_params, genesis_state)
-    return chain
-
-
-def get_chain(vm: Type[BaseVM]) -> MiningChain:
-    return chain_without_pow(
-        AtomicDB(),
-        vm,
-        GENESIS_PARAMS,
-        genesis_state([
-            AddressSetup(
-                address=FUNDED_ADDRESS,
-                balance=DEFAULT_INITIAL_BALANCE,
-                code=b''
-            ),
-            AddressSetup(
-                address=SECOND_ADDRESS,
-                balance=DEFAULT_INITIAL_BALANCE,
-                code=b''
-            ),
-        ])
+    chain = api.build(
+        MiningChain,
+        api.fork_at(vm_without_pow, constants.GENESIS_BLOCK_NUMBER),
+        api.disable_pow_check(),
+        api.genesis(params=GENESIS_PARAMS, state=gen_state)
     )
+
+    return chain
 
 
 def get_all_chains() -> Iterable[MiningChain]:


### PR DESCRIPTION
### What was wrong?
The current benchmarks use an impromptu API to create the chains that are used for benchmarking.

### How was it fixed?
We now have some more solid `builder tools` to create chains. These tools allow the creation of chains using a declarative, fluent API which we do use already in several tests. These `builder tools` are now integrated in `Benchmarks` for building the chains.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://timedotcom.files.wordpress.com/2017/01/cute-animal-tweet-off-zoo.jpg?quality=85)
