### PR TITLE
Use similar log formatting in pytest & trinity cli

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 addopts= --showlocals
 python_paths= .
 xfail_strict=true
+log_format = %(levelname)8s  %(asctime)s  %(filename)20s  %(message)s
+log_date_format = %m-%d %H:%M:%S


### PR DESCRIPTION
### What was wrong?

I got stuck on debugging longer than necessary, because timestamp was
missing from the default pytest log format.

### How was it fixed?

Add timestamp, and other features that make pytest similar to the trinity logging format

#### Cute Animal Picture

![get it, logs?](https://i.chzbgr.com/full/4796425216/h96168346/)
