### PR TITLE
Require parameters to be passed as keyword arguments for long function signatures

### DIFF
--- a/eth/vm/forks/byzantium/transactions.py
+++ b/eth/vm/forks/byzantium/transactions.py
@@ -10,7 +10,7 @@ from eth.utils.transactions import (
 
 class ByzantiumTransaction(SpuriousDragonTransaction):
     @classmethod
-    def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):
+    def create_unsigned_transaction(cls, *, nonce, gas_price, gas, to, value, data):
         return ByzantiumUnsignedTransaction(nonce, gas_price, gas, to, value, data)
 
 

--- a/eth/vm/forks/constantinople/transactions.py
+++ b/eth/vm/forks/constantinople/transactions.py
@@ -10,7 +10,7 @@ from eth.utils.transactions import (
 
 class ConstantinopleTransaction(ByzantiumTransaction):
     @classmethod
-    def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):
+    def create_unsigned_transaction(cls, *, nonce, gas_price, gas, to, value, data):
         return ConstantinopleUnsignedTransaction(nonce, gas_price, gas, to, value, data)
 
 

--- a/eth/vm/forks/frontier/transactions.py
+++ b/eth/vm/forks/frontier/transactions.py
@@ -76,7 +76,7 @@ class FrontierTransaction(BaseTransaction):
         ))
 
     @classmethod
-    def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):
+    def create_unsigned_transaction(cls, *, nonce, gas_price, gas, to, value, data):
         return FrontierUnsignedTransaction(nonce, gas_price, gas, to, value, data)
 
 

--- a/eth/vm/forks/homestead/transactions.py
+++ b/eth/vm/forks/homestead/transactions.py
@@ -40,7 +40,7 @@ class HomesteadTransaction(FrontierTransaction):
         ))
 
     @classmethod
-    def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):
+    def create_unsigned_transaction(cls, *, nonce, gas_price, gas, to, value, data):
         return HomesteadUnsignedTransaction(nonce, gas_price, gas, to, value, data)
 
 

--- a/eth/vm/forks/spurious_dragon/transactions.py
+++ b/eth/vm/forks/spurious_dragon/transactions.py
@@ -32,7 +32,7 @@ class SpuriousDragonTransaction(HomesteadTransaction):
             ))
 
     @classmethod
-    def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):
+    def create_unsigned_transaction(cls, *, nonce, gas_price, gas, to, value, data):
         return SpuriousDragonUnsignedTransaction(nonce, gas_price, gas, to, value, data)
 
     @property

--- a/eth/vm/logic/call.py
+++ b/eth/vm/logic/call.py
@@ -244,16 +244,26 @@ class CallEIP150(Call):
     def compute_msg_gas(self, computation, gas, to, value):
         extra_gas = self.compute_msg_extra_gas(computation, gas, to, value)
         return compute_eip150_msg_gas(
-            computation, gas, extra_gas, value, self.mnemonic,
-            constants.GAS_CALLSTIPEND)
+            computation=computation,
+            gas=gas,
+            extra_gas=extra_gas,
+            value=value,
+            mnemonic=self.mnemonic,
+            callstipend=constants.GAS_CALLSTIPEND
+        )
 
 
 class CallCodeEIP150(CallCode):
     def compute_msg_gas(self, computation, gas, to, value):
         extra_gas = self.compute_msg_extra_gas(computation, gas, to, value)
         return compute_eip150_msg_gas(
-            computation, gas, extra_gas, value, self.mnemonic,
-            constants.GAS_CALLSTIPEND)
+            computation=computation,
+            gas=gas,
+            extra_gas=extra_gas,
+            value=value,
+            mnemonic=self.mnemonic,
+            callstipend=constants.GAS_CALLSTIPEND
+        )
 
 
 class DelegateCallEIP150(DelegateCall):
@@ -261,14 +271,20 @@ class DelegateCallEIP150(DelegateCall):
         extra_gas = self.compute_msg_extra_gas(computation, gas, to, value)
         callstipend = 0
         return compute_eip150_msg_gas(
-            computation, gas, extra_gas, value, self.mnemonic, callstipend)
+            computation=computation,
+            gas=gas,
+            extra_gas=extra_gas,
+            value=value,
+            mnemonic=self.mnemonic,
+            callstipend=callstipend
+        )
 
 
 def max_child_gas_eip150(gas):
     return gas - (gas // 64)
 
 
-def compute_eip150_msg_gas(computation, gas, extra_gas, value, mnemonic, callstipend):
+def compute_eip150_msg_gas(*, computation, gas, extra_gas, value, mnemonic, callstipend):
     if computation.get_gas_remaining() < extra_gas:
         # It feels wrong to raise an OutOfGas exception outside of GasMeter,
         # but I don't see an easy way around it.

--- a/scripts/benchmark/utils/tx.py
+++ b/scripts/benchmark/utils/tx.py
@@ -30,6 +30,12 @@ def new_transaction(
     """
     nonce = vm.state.account_db.get_nonce(from_)
     tx = vm.create_unsigned_transaction(
-        nonce=nonce, gas_price=gas_price, gas=gas, to=to, value=amount, data=data)
+        nonce=nonce,
+        gas_price=gas_price,
+        gas=gas,
+        to=to,
+        value=amount,
+        data=data,
+    )
 
     return tx.as_signed_transaction(private_key)

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -39,7 +39,13 @@ def new_transaction(
     """
     nonce = vm.state.account_db.get_nonce(from_)
     tx = vm.create_unsigned_transaction(
-        nonce=nonce, gas_price=gas_price, gas=gas, to=to, value=amount, data=data)
+        nonce=nonce,
+        gas_price=gas_price,
+        gas=gas,
+        to=to,
+        value=amount,
+        data=data,
+    )
     if private_key:
         return tx.as_signed_transaction(private_key, chain_id=1)
     else:

--- a/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -215,7 +215,7 @@ async def assert_rpc_result(rpc, method, params, expected):
     return result
 
 
-async def validate_account_attribute(fixture_key, rpc_method, rpc, state, addr, at_block):
+async def validate_account_attribute(*, fixture_key, rpc_method, rpc, state, addr, at_block):
     state_result, state_error = await call_rpc(rpc, rpc_method, [addr, at_block])
     assert state_result == state[fixture_key], "Invalid state - %s" % state_error
 
@@ -231,12 +231,12 @@ async def validate_account_state(rpc, state, addr, at_block):
     standardized_state = fixture_state_in_rpc_format(state)
     for fixture_key, rpc_method in RPC_STATE_LOOKUPS:
         await validate_account_attribute(
-            fixture_key,
-            rpc_method,
-            rpc,
-            standardized_state,
-            addr,
-            at_block
+            fixture_key=fixture_key,
+            rpc_method=rpc_method,
+            rpc=rpc,
+            state=standardized_state,
+            addr=addr,
+            at_block=at_block
         )
     for key in state['storage']:
         position = '0x0' if key == '0x' else key


### PR DESCRIPTION
### What was wrong?
There are lots of places in the codebase with either classes or functions which take 6+ parameters. In these cases, calling these using positional arguments can be both error prone as well as hard to read.

* Errors arise when arguments are accidentally called in the wrong order.
* Difficult readability comes when it's not clear what each parameter actually means since sometimes multiple parameters might be called with the same constant value `f(b'', b'')`.


### How was it fixed?
PEP3102 introduces a new syntax for requiring certain arguments to be called as keyword arguments. Based on the above format the function signatures and the way in which they were called throughout the system were changed. The functions which were changed are as follows
>evm/vm/logic/call.py
>272:def compute_eip150_msg_gas(computation, gas, extra_gas, value, mnemonic, callstipend):
>
>tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
>131:def validate_account_attribute(fixture_key, rpc_method, rpc, state, addr, at_block):
>
>evm/vm/forks/byzantium/transactions.py
>13:    def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):
>
>evm/vm/forks/frontier/transactions.py
>79:    def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):
>
>evm/vm/forks/homestead/transactions.py
>43:    def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):
>
>evm/vm/forks/spurious_dragon/transactions.py
>35:    def create_unsigned_transaction(cls, nonce, gas_price, gas, to, value, data):


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://imgs.abduzeedo.com/files/articles/baby-animals/Baby-Animals-011.jpg)
