### PR TITLE
Update mypy to 0.630

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ deps = {
     ],
     'lint': [
         "flake8==3.5.0",
-        "mypy==0.620",
+        "mypy==0.630",
     ],
     'benchmark': [
         "termcolor>=1.1.0,<2.0.0",


### PR DESCRIPTION
### What was wrong?

Mypy is still on 0.620

### How was it fixed?

Updated to 0.630

New features: http://mypy-lang.blogspot.com/2018/09/mypy-0630-released.html

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://4.bp.blogspot.com/-v8TlvRU7jfA/UFeIT8K5avI/AAAAAAAAAJ8/lVlGmmrEYPI/s1600/BWPA+Deer+Watermarked+LR-29155.jpg)
