### PR TITLE
[WIP] Extend round trip API to GetBlockBodies LES protocol command

### DIFF
--- a/trinity/protocol/les/exchanges.py
+++ b/trinity/protocol/les/exchanges.py
@@ -11,20 +11,27 @@ from eth.rlp.headers import BlockHeader
 from trinity.protocol.common.exchanges import (
     BaseExchange,
 )
+# Q: What is the order to imports?  and why sometimes new line between imports and sometimes not?
+from trinity.protocol.common.types import BlockBodyBundles
+from trinity.rlp.block_body import BlockBody
 from trinity.utils.les import (
     gen_request_id,
 )
 
 from .normalizers import (
     BlockHeadersNormalizer,
+    GetBlockBodiesNormalizer,
 )
 from .requests import (
     GetBlockHeadersRequest,
+    GetBlockBodiesRequest,
 )
 from .trackers import (
     GetBlockHeadersTracker,
+    GetBlockBodiesTracker,
 )
 from .validators import (
+    GetBlockBodiesValidator,
     GetBlockHeadersValidator,
     match_payload_request_id,
 )
@@ -53,6 +60,28 @@ class GetBlockHeadersExchange(LESExchange[Tuple[BlockHeader, ...]]):
 
         command_args = original_request_args + (gen_request_id(),)
         request = self.request_class(*command_args)  # type: ignore
+
+        return await self.get_result(
+            request,
+            self._normalizer,
+            validator,
+            match_payload_request_id,
+            timeout,
+        )
+
+# Q: Where can I find the correct signature for this class?
+class GetBlockBodiesExchange(LESExchange[Tuple[BlockBody, ...]]):
+    _normalizer = GetBlockBodiesNormalizer()
+    request_class = GetBlockBodiesRequest
+    tracker_class = GetBlockBodiesTracker
+
+    async def __call__(self,  # type: ignore
+                       headers: Tuple[BlockHeader, ...],
+                       timeout: float = None) -> BlockBodyBundles:
+        validator = GetBlockBodiesValidator(headers)
+
+        block_hashes = tuple(header.hash for header in headers)
+        request = self.request_class(block_hashes, gen_request_id())
 
         return await self.get_result(
             request,

--- a/trinity/protocol/les/exchanges.py
+++ b/trinity/protocol/les/exchanges.py
@@ -11,9 +11,7 @@ from eth.rlp.headers import BlockHeader
 from trinity.protocol.common.exchanges import (
     BaseExchange,
 )
-# Q: What is the order to imports?  and why sometimes new line between imports and sometimes not?
 from trinity.protocol.common.types import BlockBodyBundles
-from trinity.rlp.block_body import BlockBody
 from trinity.utils.les import (
     gen_request_id,
 )
@@ -69,8 +67,8 @@ class GetBlockHeadersExchange(LESExchange[Tuple[BlockHeader, ...]]):
             timeout,
         )
 
-# Q: Where can I find the correct signature for this class?
-class GetBlockBodiesExchange(LESExchange[Tuple[BlockBody, ...]]):
+
+class GetBlockBodiesExchange(LESExchange[BlockBodyBundles]):
     _normalizer = GetBlockBodiesNormalizer()
     request_class = GetBlockBodiesRequest
     tracker_class = GetBlockBodiesTracker

--- a/trinity/protocol/les/handlers.py
+++ b/trinity/protocol/les/handlers.py
@@ -2,10 +2,17 @@ from trinity.protocol.common.handlers import (
     BaseChainExchangeHandler,
 )
 
-from .exchanges import GetBlockHeadersExchange
+from .exchanges import (
+    GetBlockBodiesExchange,
+    GetBlockHeadersExchange,
+)
 
 
-class LESExchangeHandler(BaseChainExchangeHandler):
+class ETHExchangeHandler(BaseChainExchangeHandler):
     _exchange_config = {
+        'get_block_bodies': GetBlockBodiesExchange,
         'get_block_headers': GetBlockHeadersExchange,
     }
+
+    # These are needed only to please mypy.
+    get_block_bodies: GetBlockBodiesExchange

--- a/trinity/protocol/les/handlers.py
+++ b/trinity/protocol/les/handlers.py
@@ -8,7 +8,7 @@ from .exchanges import (
 )
 
 
-class ETHExchangeHandler(BaseChainExchangeHandler):
+class LESExchangeHandler(BaseChainExchangeHandler):
     _exchange_config = {
         'get_block_bodies': GetBlockBodiesExchange,
         'get_block_headers': GetBlockHeadersExchange,

--- a/trinity/protocol/les/normalizers.py
+++ b/trinity/protocol/les/normalizers.py
@@ -8,13 +8,22 @@ from typing import (
 from eth.rlp.headers import BlockHeader
 
 from trinity.protocol.common.normalizers import BaseNormalizer
+from trinity.rlp.block_body import BlockBody
 
 TResult = TypeVar('TResult')
 LESNormalizer = BaseNormalizer[Dict[str, Any], TResult]
 
 
+# Q: Shouldn't this be named GetBlockHeadersNormalizer?
 class BlockHeadersNormalizer(LESNormalizer[Tuple[BlockHeader, ...]]):
     @staticmethod
     def normalize_result(message: Dict[str, Any]) -> Tuple[BlockHeader, ...]:
         result = message['headers']
+        return result
+
+
+class GetBlockBodiesNormalizer(LESNormalizer[Tuple[BlockBody, ...]]):
+    @staticmethod
+    def normalize_result(message: Dict[str, Any]) -> Tuple[BlockBody, ...]:
+        result = message['bodies']
         return result

--- a/trinity/protocol/les/normalizers.py
+++ b/trinity/protocol/les/normalizers.py
@@ -5,6 +5,12 @@ from typing import (
     TypeVar,
 )
 
+from cytoolz import compose
+
+from eth.db.trie import make_trie_root_and_nodes
+from eth_hash.auto import keccak
+import rlp
+
 from eth.rlp.headers import BlockHeader
 
 from trinity.protocol.common.normalizers import BaseNormalizer

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -45,8 +45,9 @@ class HeaderRequest(BaseHeaderRequest):
         self.reverse = reverse
         self.request_id = request_id
 
+LESRequest = BaseRequest[Dict[str, Any]]
 
-class GetBlockHeadersRequest(BaseRequest[Dict[str, Any]]):
+class GetBlockHeadersRequest(LESRequest):
     cmd_type = GetBlockHeaders
     response_type = BlockHeaders
 
@@ -67,7 +68,7 @@ class GetBlockHeadersRequest(BaseRequest[Dict[str, Any]]):
         }
 
 
-class GetBlockBodiesRequest(BaseRequest[Tuple[Hash32, ...]]):
+class GetBlockBodiesRequest(LESRequest):
     cmd_type = GetBlockBodies
     response_type = BlockBodies
 

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -1,9 +1,13 @@
 from typing import (
     Any,
     Dict,
+    Tuple,
 )
 
-from eth_typing import BlockIdentifier
+from eth_typing import (
+    BlockIdentifier,
+    Hash32,
+)
 
 from p2p.protocol import BaseRequest
 
@@ -16,6 +20,8 @@ from .commands import (
     BlockHeaders,
     GetBlockHeaders,
     GetBlockHeadersQuery,
+    BlockBodies,
+    GetBlockBodies,
 )
 
 
@@ -58,4 +64,17 @@ class GetBlockHeadersRequest(BaseRequest[Dict[str, Any]]):
                 skip,
                 reverse,
             ),
+        }
+
+
+class GetBlockBodiesRequest(BaseRequest[Tuple[Hash32, ...]]):
+    cmd_type = GetBlockBodies
+    response_type = BlockBodies
+
+    def __init__(self,
+                 block_hashes: Tuple[Hash32, ...],
+                 request_id: int) -> None:
+        self.command_payload = {
+            'request_id': request_id,
+            'block_hashes': block_hashes,
         }

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -45,7 +45,9 @@ class HeaderRequest(BaseHeaderRequest):
         self.reverse = reverse
         self.request_id = request_id
 
+
 LESRequest = BaseRequest[Dict[str, Any]]
+
 
 class GetBlockHeadersRequest(LESRequest):
     cmd_type = GetBlockHeaders

--- a/trinity/protocol/les/trackers.py
+++ b/trinity/protocol/les/trackers.py
@@ -6,10 +6,12 @@ from typing import (
 from eth.rlp.headers import BlockHeader
 
 from trinity.protocol.common.trackers import BasePerformanceTracker
+from trinity.rlp.block_body import BlockBody
 from trinity.utils.headers import sequence_builder
 
 from .requests import (
     GetBlockHeadersRequest,
+    GetBlockBodiesRequest,
 )
 
 
@@ -36,4 +38,22 @@ class GetBlockHeadersTracker(BaseGetBlockHeadersTracker):
         return len(result)
 
     def _get_result_item_count(self, result: Tuple[BlockHeader, ...]) -> int:
+        return len(result)
+
+
+BaseGetBlockBodiesTracker = BasePerformanceTracker[
+    GetBlockBodiesRequest,
+    Tuple[BlockBody, ...],
+]
+
+
+# Q: Where can I find the signature for this class?
+class GetBlockBodiesTracker(BaseGetBlockBodiesTracker):
+    def _get_request_size(self, request: GetBlockBodiesRequest) -> Optional[int]:
+        return len(request.command_payload['block_hashes'])
+
+    def _get_result_size(self, result: Tuple[BlockBody, ...]) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: Tuple[BlockBody, ...]) -> int:
         return len(result)

--- a/trinity/protocol/les/trackers.py
+++ b/trinity/protocol/les/trackers.py
@@ -6,7 +6,7 @@ from typing import (
 from eth.rlp.headers import BlockHeader
 
 from trinity.protocol.common.trackers import BasePerformanceTracker
-from trinity.rlp.block_body import BlockBody
+from trinity.protocol.common.types import BlockBodyBundles
 from trinity.utils.headers import sequence_builder
 
 from .requests import (
@@ -43,17 +43,16 @@ class GetBlockHeadersTracker(BaseGetBlockHeadersTracker):
 
 BaseGetBlockBodiesTracker = BasePerformanceTracker[
     GetBlockBodiesRequest,
-    Tuple[BlockBody, ...],
+    BlockBodyBundles,
 ]
 
 
-# Q: Where can I find the signature for this class?
 class GetBlockBodiesTracker(BaseGetBlockBodiesTracker):
     def _get_request_size(self, request: GetBlockBodiesRequest) -> Optional[int]:
         return len(request.command_payload['block_hashes'])
 
-    def _get_result_size(self, result: Tuple[BlockBody, ...]) -> int:
+    def _get_result_size(self, result: BlockBodyBundles) -> int:
         return len(result)
 
-    def _get_result_item_count(self, result: Tuple[BlockBody, ...]) -> int:
+    def _get_result_item_count(self, result: BlockBodyBundles) -> int:
         return len(result)

--- a/trinity/protocol/les/validators.py
+++ b/trinity/protocol/les/validators.py
@@ -1,20 +1,47 @@
 from typing import (
     Any,
     Dict,
+    Tuple,
 )
+
+from eth.rlp.headers import BlockHeader
 
 from eth_utils import (
     ValidationError,
 )
 
 from trinity.protocol.common.validators import (
+    BaseValidator,
     BaseBlockHeadersValidator,
 )
+from trinity.protocol.common.types import BlockBodyBundles
+
 from . import constants
 
 
 class GetBlockHeadersValidator(BaseBlockHeadersValidator):
     protocol_max_request_size = constants.MAX_HEADERS_FETCH
+
+
+class GetBlockBodiesValidator(BaseValidator[BlockBodyBundles]):
+    def __init__(self, headers: Tuple[BlockHeader, ...]) -> None:
+        self.headers = headers
+
+    def validate_result(self, response: BlockBodyBundles) -> None:
+        expected_keys = {
+            (header.transaction_root, header.uncles_hash)
+            for header in self.headers
+        }
+        actual_keys = {
+            (txn_root, uncles_hash)
+            for body, (txn_root, trie_data), uncles_hash
+            in response
+        }
+        unexpected_keys = actual_keys.difference(expected_keys)
+        if unexpected_keys:
+            raise ValidationError(
+                "Got {0} unexpected block bodies".format(len(unexpected_keys))
+            )
 
 
 def match_payload_request_id(request: Dict[str, Any], response: Dict[str, Any]) -> None:

--- a/trinity/protocol/les/validators.py
+++ b/trinity/protocol/les/validators.py
@@ -39,9 +39,7 @@ class GetBlockBodiesValidator(BaseValidator[BlockBodyBundles]):
         }
         unexpected_keys = actual_keys.difference(expected_keys)
         if unexpected_keys:
-            raise ValidationError(
-                "Got {0} unexpected block bodies".format(len(unexpected_keys))
-            )
+            raise ValidationError(f"Got {len(unexpected_keys)} unexpected block bodies")
 
 
 def match_payload_request_id(request: Dict[str, Any], response: Dict[str, Any]) -> None:


### PR DESCRIPTION
### What was wrong?
The following LES command pair does not have a round trip API available to it.

 * [ ]  `GetBlockBodies -> BlockBodies`

### How was it fixed?

Use and/or extend the existing Handler/Manager pattern to implement round trip APIs for these command pairs. At minimum each of these should be tested at the Request level and the Peer level. Feel free to borrow patterns and test cases from the existing tests.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/depkqo9etrq11.png)
