### PR TITLE
Chain tip monitor

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -113,7 +113,7 @@ async def handshake(remote: Node, factory: 'BasePeerFactory') -> 'BasePeer':
          writer
          ) = await auth.handshake(remote, factory.privkey, factory.cancel_token)
     except (ConnectionRefusedError, OSError) as e:
-        raise UnreachablePeer() from e
+        raise UnreachablePeer(f"Can't reach {remote!r}") from e
     connection = PeerConnection(
         reader=reader,
         writer=writer,

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -105,6 +105,11 @@ class BaseService(ABC, CancellableMixin):
             self.logger.debug("%s finished: %s", self, e)
         except Exception:
             self.logger.exception("Unexpected error in %r, exiting", self)
+        else:
+            if self.is_cancelled:
+                self.logger.debug("%s cancelled, cleaning up...", self)
+            else:
+                self.logger.debug("%s had nothing left to do, ceasing operation...", self)
         finally:
             # Trigger our cancel token to ensure all pending asyncio tasks and background
             # coroutines started by this service exit cleanly.

--- a/trinity/protocol/common/monitors.py
+++ b/trinity/protocol/common/monitors.py
@@ -76,7 +76,7 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
             new_tip_event.set()
 
     async def _run(self) -> None:
-        self.run_task(self._handle_msg_loop())
+        self.run_daemon_task(self._handle_msg_loop())
         with self.subscribe(self._peer_pool):
             await self.wait(self.events.cancelled.wait())
 

--- a/trinity/protocol/common/monitors.py
+++ b/trinity/protocol/common/monitors.py
@@ -1,0 +1,93 @@
+import asyncio
+from contextlib import contextmanager
+from typing import (
+    AsyncIterator,
+    Iterator,
+    Set,
+)
+
+from cancel_token import CancelToken
+from eth_utils import ValidationError
+
+from p2p.exceptions import NoConnectedPeers
+from p2p.peer import BasePeer, PeerSubscriber
+from p2p.service import BaseService
+
+from trinity.protocol.common.peer import BaseChainPeer, BaseChainPeerPool
+from trinity.protocol.eth import commands
+
+
+class BaseChainTipMonitor(BaseService, PeerSubscriber):
+    """
+    Monitor for potential changes to the tip of the chain: a new peer or a new block
+
+    Subclass must specify :attr:`subscription_msg_types`
+    """
+
+    def __init__(
+            self,
+            peer_pool: BaseChainPeerPool,
+            token: CancelToken = None) -> None:
+        super().__init__(token)
+        self._peer_pool = peer_pool
+        # There is one event for each subscriber, each one gets set any time new tip info arrives
+        self._subscriber_notices: Set[asyncio.Event] = set()
+
+    async def wait_tip_info(self) -> AsyncIterator[BaseChainPeer]:
+        """
+        This iterator waits until there is potentially new tip information.
+        New tip information means a new peer connected or a new block arrived.
+        Then it yields the peer with the highest total difficulty.
+        It continues indefinitely, until this service is cancelled.
+        """
+        if self.is_cancelled:
+            raise ValidationError("%s is cancelled, new tip info is impossible", self)
+        elif not self.is_running:
+            await self.events.started.wait()
+
+        with self._subscriber() as new_tip_event:
+            while self.is_operational:
+                try:
+                    highest_td_peer = self._peer_pool.highest_td_peer
+                except NoConnectedPeers:
+                    # no peers are available right now, skip the new tip info yield
+                    continue
+                else:
+                    yield highest_td_peer
+
+                await self.wait(new_tip_event.wait())
+                new_tip_event.clear()
+
+    @property
+    def msg_queue_maxsize(self) -> int:
+        # This is a rather arbitrary value, but when the sync is operating normally we never see
+        # the msg queue grow past a few hundred items, so this should be a reasonable limit for
+        # now.
+        return 2000
+
+    def register_peer(self, peer: BasePeer) -> None:
+        self._notify_tip()
+
+    async def _handle_msg_loop(self) -> None:
+        while self.is_operational:
+            peer, cmd, msg = await self.wait(self.msg_queue.get())
+            if isinstance(cmd, commands.NewBlock):
+                self._notify_tip()
+
+    def _notify_tip(self) -> None:
+        for new_tip_event in self._subscriber_notices:
+            new_tip_event.set()
+
+    async def _run(self) -> None:
+        self.run_task(self._handle_msg_loop())
+        with self.subscribe(self._peer_pool):
+            await self.wait(self.events.cancelled.wait())
+
+    @contextmanager
+    def _subscriber(self) -> Iterator[asyncio.Event]:
+        new_tip_event = asyncio.Event()
+        self._subscriber_notices.add(new_tip_event)
+        try:
+            yield new_tip_event
+        finally:
+            self._subscriber_notices.remove(new_tip_event)

--- a/trinity/protocol/common/monitors.py
+++ b/trinity/protocol/common/monitors.py
@@ -23,6 +23,10 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
 
     Subclass must specify :attr:`subscription_msg_types`
     """
+    # This is a rather arbitrary value, but when the sync is operating normally we never see
+    # the msg queue grow past a few hundred items, so this should be a reasonable limit for
+    # now.
+    msg_queue_maxsize = 2000
 
     def __init__(
             self,
@@ -57,13 +61,6 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
 
                 await self.wait(new_tip_event.wait())
                 new_tip_event.clear()
-
-    @property
-    def msg_queue_maxsize(self) -> int:
-        # This is a rather arbitrary value, but when the sync is operating normally we never see
-        # the msg queue grow past a few hundred items, so this should be a reasonable limit for
-        # now.
-        return 2000
 
     def register_peer(self, peer: BasePeer) -> None:
         self._notify_tip()

--- a/trinity/protocol/common/monitors.py
+++ b/trinity/protocol/common/monitors.py
@@ -14,7 +14,6 @@ from p2p.peer import BasePeer, PeerSubscriber
 from p2p.service import BaseService
 
 from trinity.protocol.common.peer import BaseChainPeer, BaseChainPeerPool
-from trinity.protocol.eth import commands
 
 
 class BaseChainTipMonitor(BaseService, PeerSubscriber):
@@ -66,9 +65,10 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
         self._notify_tip()
 
     async def _handle_msg_loop(self) -> None:
+        new_tip_types = tuple(self.subscription_msg_types)
         while self.is_operational:
             peer, cmd, msg = await self.wait(self.msg_queue.get())
-            if isinstance(cmd, commands.NewBlock):
+            if isinstance(cmd, new_tip_types):
                 self._notify_tip()
 
     def _notify_tip(self) -> None:

--- a/trinity/protocol/common/monitors.py
+++ b/trinity/protocol/common/monitors.py
@@ -55,7 +55,7 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
                     highest_td_peer = self._peer_pool.highest_td_peer
                 except NoConnectedPeers:
                     # no peers are available right now, skip the new tip info yield
-                    continue
+                    pass
                 else:
                     yield highest_td_peer
 

--- a/trinity/protocol/eth/monitors.py
+++ b/trinity/protocol/eth/monitors.py
@@ -1,0 +1,6 @@
+from trinity.protocol.common.monitors import BaseChainTipMonitor
+from trinity.protocol.eth import commands
+
+
+class ETHChainTipMonitor(BaseChainTipMonitor):
+    subscription_msg_types = {commands.NewBlock}

--- a/trinity/protocol/les/monitors.py
+++ b/trinity/protocol/les/monitors.py
@@ -1,0 +1,6 @@
+from trinity.protocol.common.monitors import BaseChainTipMonitor
+from trinity.protocol.les import commands
+
+
+class LightChainTipMonitor(BaseChainTipMonitor):
+    subscription_msg_types = {commands.Announce}

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -51,6 +51,11 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
     # the latest header hash of the peer on the current sync
     header_queue: TaskQueue[BlockHeader]
 
+    # This is a rather arbitrary value, but when the sync is operating normally we never see
+    # the msg queue grow past a few hundred items, so this should be a reasonable limit for
+    # now.
+    msg_queue_maxsize = 2000
+
     def __init__(self,
                  chain: AsyncChain,
                  db: AsyncHeaderDB,
@@ -69,13 +74,6 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
         # small enough to avoid wasteful over-requests before post-processing can happen
         max_pending_headers = ETHPeer.max_headers_fetch * 8
         self.header_queue = TaskQueue(max_pending_headers, attrgetter('block_number'))
-
-    @property
-    def msg_queue_maxsize(self) -> int:
-        # This is a rather arbitrary value, but when the sync is operating normally we never see
-        # the msg queue grow past a few hundred items, so this should be a reasonable limit for
-        # now.
-        return 2000
 
     def get_target_header_hash(self) -> Hash32:
         if self._peer_header_syncer is None and self._last_target_header_hash is None:

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -109,7 +109,7 @@ class BaseHeaderChainSyncer(BaseService, PeerSubscriber):
 
     async def _run(self) -> None:
         self.run_daemon(self._tip_monitor)
-        self.run_task(self._handle_msg_loop())
+        self.run_daemon_task(self._handle_msg_loop())
         with self.subscribe(self.peer_pool):
             try:
                 async for highest_td_peer in self._tip_monitor.wait_tip_info():


### PR DESCRIPTION
### What was wrong?

Sometimes a class wants to know if there is a chance of a new tip (based on a new peer or a new block).  Previously the best way to do it was to become a `PeerSubscriber`. That adds a lot of extra code overhead.

### How was it fixed?

Added a new tip monitor class. When you want to act on potentially new tip info, simply do:
```py
tip_monitor = ETHChainTipMonitor(...)
asyncio.ensure_future(tip_monitor.run())

async for highest_td_peer in tip_monitor.wait_tip_info():
    do_something_with_new_tip(highest_td_peer)
```

Pulled out of #1353 -- with a few random logging improvements.

The `highest_td_peer` getting returned is a little weird here. It is the closest implementation to the old way of doing things. One alternative would be to return the peer that provided the new tip info. I kept the current implementation, because it shouldn't be hard to change later. Knowing what other context we want to use it in might help design a better API, at that point. I'm open to suggestions, of course.

Note that it doesn't significantly reduce the size of the syncing clients yet, but it will as part of #1353 -- when the `BaseHeaderChainSyncer` will not have to be a `PeerSubscriber` anymore, so can drop several methods.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.heroviral.com/wp-content/uploads/2015/12/http-distractify-media-prod.cdn_.bingo-1483192-980x-719x1024.jpg)
