### PR TITLE
[WIP] broadcast new peer and chain tip events

### DIFF
--- a/p2p/events.py
+++ b/p2p/events.py
@@ -1,11 +1,23 @@
 from typing import (
     Type,
+    TYPE_CHECKING,
 )
 
 from lahja import (
     BaseEvent,
     BaseRequestResponseEvent,
 )
+
+if TYPE_CHECKING:
+    from p2p.peer import BasePeer
+
+
+class PeerConnectedEvent(BaseEvent):
+    """
+    Broadcasted when a new peer of any kind connects to the peer pool.
+    """
+    def __init__(self, peer: 'BasePeer'):
+        self.peer = peer
 
 
 class PeerCountResponse(BaseEvent):

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -86,6 +86,7 @@ from .constants import (
 )
 
 from .events import (
+    PeerConnectedEvent,
     PeerCountRequest,
     PeerCountResponse,
 )
@@ -864,6 +865,8 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             peer.add_subscriber(subscriber)
             for msg in msgs:
                 subscriber.add_msg(msg)
+        if self.event_bus is not None:
+            self.event_bus.broadcast(PeerConnectedEvent(peer))
 
     async def _run(self) -> None:
         # FIXME: PeerPool should probably no longer be a BaseService, but for now we're keeping it

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -1,0 +1,11 @@
+from p2p.peer import PeerMessage
+
+from trinity.extensibility.events import BaseEvent
+
+
+class NewChainTipEvent(BaseEvent):
+    """
+    Broadcasted when a new tip (in regular or light protocol) is received from a peer.
+    """
+    def __init__(self, peer_message: PeerMessage) -> None:
+        self.peer_message = peer_message


### PR DESCRIPTION
### What was wrong?

Plugins will probably be interested in new tip events as well. The newest tip monitor class isn't suited for plugin usage.


### How was it fixed?

Broadcast events when a new peer joins the pool, and when a new eth block is received (via regular or light protocol)

Builds on #1374 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://i.imgur.com/rGQ1GBo.jpg)
