### PR TITLE
Fix incorrect parameter to get_chain

### DIFF
--- a/scripts/benchmark/utils/chain_plumbing.py
+++ b/scripts/benchmark/utils/chain_plumbing.py
@@ -95,5 +95,5 @@ def get_chain(vm: Type[BaseVM], genesis_state: GenesisState) -> MiningChain:
 
 def get_all_chains(genesis_state: GenesisState=DEFAULT_GENESIS_STATE) -> Iterable[MiningChain]:
     for vm in ALL_VM:
-        chain = get_chain(vm, DEFAULT_GENESIS_STATE)
+        chain = get_chain(vm, genesis_state)
         yield chain


### PR DESCRIPTION
### What was wrong?

Accidentially passed wrong value for `genesis_state` in `get_chain`

### How was it fixed?

Changed passed parameter.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://data.whicdn.com/images/13931474/large.jpg)
