### PR TITLE
Migrate util usage to eth_utils

### DIFF
--- a/eth/consensus/pow.py
+++ b/eth/consensus/pow.py
@@ -14,6 +14,7 @@ from eth_typing import (
     Hash32
 )
 from eth_utils import (
+    big_endian_to_int,
     ValidationError,
 )
 
@@ -21,9 +22,6 @@ from eth_hash.auto import keccak
 
 from eth.utils.hexadecimal import (
     encode_hex,
-)
-from eth.utils.numeric import (
-    big_endian_to_int,
 )
 from eth.validation import (
     validate_length,

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -19,7 +19,10 @@ from trie import (
 )
 
 from eth_hash.auto import keccak
-from eth_utils import encode_hex
+from eth_utils import (
+    encode_hex,
+    int_to_big_endian,
+)
 
 from eth.constants import (
     BLANK_ROOT_HASH,
@@ -44,9 +47,6 @@ from eth.validation import (
 )
 from eth.tools.logging import (
     TraceLogger
-)
-from eth.utils.numeric import (
-    int_to_big_endian,
 )
 from eth.utils.padding import (
     pad32,

--- a/eth/precompiles/ecadd.py
+++ b/eth/precompiles/ecadd.py
@@ -4,6 +4,8 @@ from py_ecc import (
 
 from eth_utils import (
     ValidationError,
+    big_endian_to_int,
+    int_to_big_endian,
 )
 
 from eth import constants
@@ -13,10 +15,6 @@ from eth.exceptions import (
 )
 from eth.utils.bn128 import (
     validate_point,
-)
-from eth.utils.numeric import (
-    big_endian_to_int,
-    int_to_big_endian,
 )
 from eth.utils.padding import (
     pad32,

--- a/eth/precompiles/ecmul.py
+++ b/eth/precompiles/ecmul.py
@@ -3,6 +3,8 @@ from py_ecc import (
 )
 
 from eth_utils import (
+    big_endian_to_int,
+    int_to_big_endian,
     ValidationError,
 )
 
@@ -13,10 +15,6 @@ from eth.exceptions import (
 )
 from eth.utils.bn128 import (
     validate_point,
-)
-from eth.utils.numeric import (
-    big_endian_to_int,
-    int_to_big_endian,
 )
 from eth.utils.padding import (
     pad32,

--- a/eth/precompiles/ecpairing.py
+++ b/eth/precompiles/ecpairing.py
@@ -7,6 +7,7 @@ from py_ecc import (
 )
 
 from eth_utils import (
+    big_endian_to_int,
     ValidationError,
 )
 
@@ -17,9 +18,6 @@ from eth.exceptions import (
 )
 from eth.utils.bn128 import (
     validate_point,
-)
-from eth.utils.numeric import (
-    big_endian_to_int,
 )
 from eth.utils.padding import (
     pad32,

--- a/eth/precompiles/ecrecover.py
+++ b/eth/precompiles/ecrecover.py
@@ -4,6 +4,7 @@ from eth_keys.exceptions import (
 )
 
 from eth_utils import (
+    big_endian_to_int,
     ValidationError,
 )
 
@@ -15,9 +16,6 @@ from eth.validation import (
     validate_lte,
 )
 
-from eth.utils.numeric import (
-    big_endian_to_int,
-)
 from eth.utils.padding import (
     pad32,
     pad32r,

--- a/eth/precompiles/modexp.py
+++ b/eth/precompiles/modexp.py
@@ -1,9 +1,12 @@
+from eth_utils import (
+    big_endian_to_int,
+    int_to_big_endian,
+)
+
 from eth import constants
 
 from eth.utils.numeric import (
-    big_endian_to_int,
     get_highest_bit_index,
-    int_to_big_endian,
 )
 from eth.utils.padding import (
     pad32r,

--- a/eth/precompiles/modexp.py
+++ b/eth/precompiles/modexp.py
@@ -122,7 +122,13 @@ def modexp(computation):
     result = _modexp(computation.msg.data)
 
     _, _, modulus_length = _extract_lengths(computation.msg.data)
-    result_bytes = zpad_left(int_to_big_endian(result), to_size=modulus_length)
+
+    # Modulo 0 is undefined, return zero
+    # https://math.stackexchange.com/questions/516251/why-is-n-mod-0-undefined
+    result_bytes = b'' if modulus_length == 0 else zpad_left(
+        int_to_big_endian(result),
+        to_size=modulus_length
+    )
 
     computation.output = result_bytes
     return computation

--- a/eth/utils/numeric.py
+++ b/eth/utils/numeric.py
@@ -1,21 +1,11 @@
 import functools
 import itertools
-import math
 
 from eth.constants import (
     UINT_255_MAX,
     UINT_256_MAX,
     UINT_256_CEILING,
 )
-
-
-def int_to_big_endian(value: int) -> bytes:
-    byte_length = math.ceil(value.bit_length() / 8)
-    return (value).to_bytes(byte_length, byteorder='big')
-
-
-def big_endian_to_int(value: bytes) -> int:
-    return int.from_bytes(value, byteorder='big')
 
 
 def int_to_bytes32(value):

--- a/eth/utils/transactions.py
+++ b/eth/utils/transactions.py
@@ -7,11 +7,11 @@ from eth_keys.exceptions import (
 )
 
 from eth_utils import (
+    int_to_big_endian,
     ValidationError,
 )
 from eth.utils.numeric import (
     is_even,
-    int_to_big_endian,
 )
 
 

--- a/eth/vm/forks/spurious_dragon/transactions.py
+++ b/eth/vm/forks/spurious_dragon/transactions.py
@@ -1,3 +1,7 @@
+from eth_utils import (
+    int_to_big_endian,
+)
+
 import rlp
 
 from eth.vm.forks.homestead.transactions import (
@@ -5,9 +9,6 @@ from eth.vm.forks.homestead.transactions import (
     HomesteadUnsignedTransaction,
 )
 
-from eth.utils.numeric import (
-    int_to_big_endian,
-)
 from eth.utils.transactions import (
     create_transaction_signature,
     extract_chain_id,

--- a/eth/vm/stack.py
+++ b/eth/vm/stack.py
@@ -1,5 +1,9 @@
 import logging
 
+from eth_utils import (
+    int_to_big_endian,
+    big_endian_to_int,
+)
 from eth import constants
 from eth.exceptions import (
     InsufficientStack,
@@ -7,11 +11,6 @@ from eth.exceptions import (
 )
 from eth.validation import (
     validate_stack_item,
-)
-
-from eth.utils.numeric import (
-    int_to_big_endian,
-    big_endian_to_int,
 )
 
 from typing import (  # noqa: F401


### PR DESCRIPTION
### What was wrong?

Came across this while working on something else. Seems we had some helpers in `eth.utils.numeric` that we also have in `eth_utils`. Guess those were in place from a time where `eth_utils did not exist or at least did not have these methods.

### How was it fixed?

Migrated to `eth_utils`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://wallup.net/wp-content/uploads/2016/01/106129-animals-Corgi-puppies.jpg)
