### PR TITLE
Fix bug in CREATE2 address generation + add test

### DIFF
--- a/eth/utils/address.py
+++ b/eth/utils/address.py
@@ -4,7 +4,7 @@ from eth_hash.auto import keccak
 from eth_typing import Address
 
 from eth.utils.numeric import (
-    int_to_big_endian,
+    int_to_bytes32,
 )
 
 
@@ -22,5 +22,5 @@ def generate_safe_contract_address(address: Address,
                                    salt: int,
                                    call_data: bytes) -> Address:
     return force_bytes_to_address(
-        keccak(b'\xff' + address + int_to_big_endian(salt) + keccak(call_data))
+        keccak(b'\xff' + address + int_to_bytes32(salt) + keccak(call_data))
     )

--- a/tests/core/address-utils/test_address_generation.py
+++ b/tests/core/address-utils/test_address_generation.py
@@ -1,0 +1,68 @@
+import pytest
+
+from eth_utils import (
+    decode_hex,
+    big_endian_to_int,
+    is_same_address,
+)
+from eth.utils.address import (
+    generate_safe_contract_address,
+)
+
+
+@pytest.mark.parametrize(
+    # Test cases from: https://eips.ethereum.org/EIPS/eip-1014
+    'origin, salt, code, expected',
+    (
+        (
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x00",
+            "0x4D1A2e2bB4F88F0250f26Ffff098B0b30B26BF38"
+        ),
+        (
+            "0xdeadbeef00000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "0x00",
+            "0xB928f69Bb1D91Cd65274e3c79d8986362984fDA3"
+        ),
+        (
+            "0xdeadbeef00000000000000000000000000000000",
+            "0x000000000000000000000000feed000000000000000000000000000000000000",
+            "0x00",
+            "0xD04116cDd17beBE565EB2422F2497E06cC1C9833"
+        ),
+        (
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000",
+            "0xdeadbeef",
+            "0x70f2b2914A2a4b783FaEFb75f459A580616Fcb5e"
+        ),
+        (
+            "0x00000000000000000000000000000000deadbeef",
+            "0x00000000000000000000000000000000000000000000000000000000cafebabe",
+            "0xdeadbeef",
+            "0x60f3f640a8508fC6a86d45DF051962668E1e8AC7"
+        ),
+        (
+            "0x00000000000000000000000000000000deadbeef",
+            "0x00000000000000000000000000000000000000000000000000000000cafebabe",
+            "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",  # noqa: E501
+            "0x1d8bfDC5D46DC4f61D6b6115972536eBE6A8854C"
+        ),
+        (
+            "0x0000000000000000000000000000000000000000",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "0x",
+            "0xE33C0C7F7df4809055C3ebA6c09CFe4BaF1BD9e0"
+        ),
+    )
+)
+def test_generate_safe_contract_address(origin, salt, code, expected):
+    address = generate_safe_contract_address(
+        decode_hex(origin),
+        big_endian_to_int(decode_hex(salt)),
+        decode_hex(code)
+    )
+
+    assert is_same_address(address, expected)


### PR DESCRIPTION
### What was wrong?

The generated address for the new CREATE2 opcode turned out to be wrong. By the time that I implemented it, there were no test cases so the implementation was a shot in the dark (and still kinda is, as this only partly covers what CREATE2 does).

Now we do have test cases and they discovered a bug in our implementation.

### How was it fixed?

Correctly interpret salt + add tests.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://thumbs.gfycat.com/SnappyFairCero-max-1mb.gif)
