### PR TITLE
Remove obsolete hack

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -780,17 +780,12 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         self.event_bus = event_bus
 
     async def handle_peer_count_requests(self) -> None:
-        async def f() -> None:
-            # FIXME: There must be a way to cancel event_bus.stream() when our token is triggered,
-            # but for the time being we just wrap everything in self.wait().
-            async for req in self.event_bus.stream(PeerCountRequest):
+        async for req in self.event_bus.stream(PeerCountRequest):
                 # We are listening for all `PeerCountRequest` events but we ensure to only send a
                 # `PeerCountResponse` to the callsite that made the request.  We do that by
                 # retrieving a `BroadcastConfig` from the request via the
                 # `event.broadcast_config()` API.
                 self.event_bus.broadcast(PeerCountResponse(len(self)), req.broadcast_config())
-
-        await self.wait(f())
 
     def __len__(self) -> int:
         return len(self.connected_nodes)


### PR DESCRIPTION
## DO NOT MERGE BEFORE #1331 landed

### What was wrong?

There's a hack in `PeerPool` that can be removed as soon as #1331 lands which updates to `lahja` `0.9.0` which makes this hack obsolete.

### How was it fixed?

Removed hack.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
