### PR TITLE
Colorize shell output based on log level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ deps = {
         "plyvel==1.0.5",
         "web3==4.4.1",
         "lahja==0.9.0",
+        "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin'",
         "websockets==5.0.1",
     ],

--- a/trinity/utils/logging.py
+++ b/trinity/utils/logging.py
@@ -28,6 +28,11 @@ from eth.tools.logging import (
     TraceLogger,
 )
 
+from trinity.utils.shellart import (
+    bold_red,
+    bold_yellow,
+)
+
 if TYPE_CHECKING:
     from multiprocessing import Queue  # noqa: F401
 
@@ -42,7 +47,13 @@ class TrinityLogFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         record.shortname = record.name.split('.')[-1]  # type: ignore
-        return super().format(record)
+
+        if record.levelno >= logging.ERROR:
+            return bold_red(super().format(record))
+        elif record.levelno >= logging.WARNING:
+            return bold_yellow(super().format(record))
+        else:
+            return super().format(record)
 
 
 class HasTraceLogger:

--- a/trinity/utils/shellart.py
+++ b/trinity/utils/shellart.py
@@ -1,0 +1,19 @@
+from termcolor import (
+    colored
+)
+
+
+def bold_green(txt: str) -> str:
+    return colored(txt, 'green', attrs=['bold'])
+
+
+def bold_red(txt: str) -> str:
+    return colored(txt, 'red', attrs=['bold'])
+
+
+def bold_yellow(txt: str) -> str:
+    return colored(txt, 'yellow', attrs=['bold'])
+
+
+def bold_white(txt: str) -> str:
+    return colored(txt, 'white', attrs=['bold'])


### PR DESCRIPTION
### What was wrong?

Do you spot the `ERROR` in here?

![image](https://user-images.githubusercontent.com/521109/46766603-bbc93100-cce2-11e8-9b91-dceb9cd1a629.png)

Me, neither!

### How was it fixed?

Colors! :rainbow: 

![image](https://user-images.githubusercontent.com/521109/46766558-9cca9f00-cce2-11e8-8e49-1627f9d00193.png)

With this change, everything worse than `ERROR` is printed bold and red and everything worse than `WARNING` (but less bad than `ERROR`) is printed bold and yellow.

Notice that this copies the `shellart` util that we already use in the benchmark to Trinity because there doesn't seem to be a common space to share between both projects and the file is simple and small enough that I think the copy is ok.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTsPvm-5V30vS78wqTPwlvVzpq4X_qshIonI6Csy80CzcGNAj9B)
