### PR TITLE
Fix wrong types

### DIFF
--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -2,10 +2,11 @@ from eth.chains.base import (
     BaseChain
 )
 
+from lahja import Endpoint
+
 from p2p.peer import BasePeerPool
 
 from trinity.config import TrinityConfig
-from trinity.extensibility import PluginManager
 from trinity.server import FullServer
 
 from .base import Node
@@ -15,8 +16,8 @@ class FullNode(Node):
     _chain: BaseChain = None
     _p2p_server: FullServer = None
 
-    def __init__(self, plugin_manager: PluginManager, trinity_config: TrinityConfig) -> None:
-        super().__init__(plugin_manager, trinity_config)
+    def __init__(self, event_bus: Endpoint, trinity_config: TrinityConfig) -> None:
+        super().__init__(event_bus, trinity_config)
         self._bootstrap_nodes = trinity_config.bootstrap_nodes
         self._preferred_nodes = trinity_config.preferred_nodes
         self._node_key = trinity_config.nodekey

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -5,6 +5,8 @@ from typing import (
 
 from eth_keys.datatypes import PrivateKey
 
+from lahja import Endpoint
+
 from p2p.peer import BasePeerPool
 
 from trinity.chains.light import (
@@ -12,9 +14,6 @@ from trinity.chains.light import (
 )
 from trinity.config import (
     TrinityConfig,
-)
-from trinity.extensibility import (
-    PluginManager
 )
 from trinity.nodes.base import Node
 from trinity.protocol.les.peer import LESPeerPool
@@ -32,8 +31,8 @@ class LightNode(Node):
     network_id: int = None
     nodekey: PrivateKey = None
 
-    def __init__(self, plugin_manager: PluginManager, trinity_config: TrinityConfig) -> None:
-        super().__init__(plugin_manager, trinity_config)
+    def __init__(self, event_bus: Endpoint, trinity_config: TrinityConfig) -> None:
+        super().__init__(event_bus, trinity_config)
 
         self._nodekey = trinity_config.nodekey
         self._port = trinity_config.port


### PR DESCRIPTION
### What was wrong?

Type hints were wrong.

What is super weird about it: Somehow, `mypy` inside `tox` did not catch this. Running the same `mypy` command outside of `tox` (with the same `mypy` version) caught this though.

```
$ tox -e py36-lint
py36-lint develop-inst-nodeps: /home/cburgdorf/Documents/hacking/ef/py-evm
py36-lint installed: asn1crypto==0.24.0,cffi==1.11.5,cryptography==2.3.1,cytoolz==0.9.0.1,eth-bloom==1.0.1,eth-hash==0.2.0,eth-keys==0.2.0b3,eth-typing==1.3.0,eth-utils==1.2.2,flake8==3.5.0,idna==2.7,lru-dict==1.1.6,mccabe==0.6.1,mypy==0.630,mypy-extensions==0.4.1,py-ecc==1.4.3,-e git+https://github.com/ethereum/py-evm.git@cafd4a6b9bf11bc69178331d73c20bdc24fec3b9#egg=py_evm,pycodestyle==2.3.1,pycparser==2.19,pyethash==0.1.27,pyflakes==1.6.0,rlp==1.0.3,six==1.11.0,toolz==0.9.0,trie==1.3.8,typed-ast==1.1.0
py36-lint runtests: PYTHONHASHSEED='1314036567'
py36-lint runtests: commands[0] | flake8 /home/cburgdorf/Documents/hacking/ef/py-evm/eth
py36-lint runtests: commands[1] | flake8 /home/cburgdorf/Documents/hacking/ef/py-evm/tests
py36-lint runtests: commands[2] | flake8 /home/cburgdorf/Documents/hacking/ef/py-evm/p2p
py36-lint runtests: commands[3] | flake8 /home/cburgdorf/Documents/hacking/ef/py-evm/trinity
py36-lint runtests: commands[4] | flake8 /home/cburgdorf/Documents/hacking/ef/py-evm/scripts
py36-lint runtests: commands[5] | mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics scripts/benchmark
py36-lint runtests: commands[6] | mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p p2p -p trinity
_____________________________________________________________________________________________________ summary _____________________________________________________________________________________________________
  py36-lint: commands succeeded
  congratulations :)
(venv) cburgdorf at craftbot in ~/Documents/hacking/ef/py-evm on (HEAD detached at upstream/master)
$ mypy --version
mypy 0.630
$ mypy --follow-imports=silent --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p p2p -p trinity
trinity/nodes/light.py:36: error: Argument 1 to "__init__" of "Node" has incompatible type "PluginManager"; expected "Endpoint"
trinity/nodes/full.py:19: error: Argument 1 to "__init__" of "Node" has incompatible type "PluginManager"; expected "Endpoint"

```

### How was it fixed?

Use correct types.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.topdesignmag.com/wp-content/uploads/2012/03/You_Mean_Me_by_Lady-Tori-500x493.jpg)
