### PR TITLE
Fix and improve logging output

### DIFF
--- a/tests/trinity/integration/test_trinity_cli.py
+++ b/tests/trinity/integration/test_trinity_cli.py
@@ -87,7 +87,7 @@ async def test_txpool_deactivated(async_process_runner, command):
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",
-        "The transaction pool is not yet available in light mode",
+        "Transaction pool not available in light mode",
     })
 
 

--- a/trinity/events.py
+++ b/trinity/events.py
@@ -4,4 +4,6 @@ from lahja import (
 
 
 class ShutdownRequest(BaseEvent):
-    pass
+
+    def __init__(self, reason: str="") -> None:
+        self.reason = reason

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -64,9 +64,9 @@ class PluginContext:
         self.args: Namespace = None
         self.trinity_config: TrinityConfig = None
 
-    def shutdown_host(self) -> None:
+    def shutdown_host(self, reason: str) -> None:
         self.event_bus.broadcast(
-            ShutdownRequest(),
+            ShutdownRequest(reason),
             BroadcastConfig(filter_endpoint=MAIN_EVENTBUS_ENDPOINT)
         )
 

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -81,14 +81,14 @@ class EthstatsPlugin(BaseIsolatedPlugin):
             self.logger.error(
                 'You must provide ethstats server url using the `--ethstats-server-url`'
             )
-            self.context.shutdown_host()
+            self.context.shutdown_host("Missing EthStats Server URL")
             return
 
         if not args.ethstats_server_secret:
             self.logger.error(
                 'You must provide ethstats server secret using `--ethstats-server-secret`'
             )
-            self.context.shutdown_host()
+            self.context.shutdown_host("Missing EthStats Server Secret")
             return
 
         if (args.ethstats_server_url):

--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -62,8 +62,9 @@ class TxPlugin(BaseAsyncStopPlugin):
         unsupported = self.context.args.tx_pool and light_mode
 
         if unsupported:
-            self.logger.error('The transaction pool is not yet available in light mode')
-            self.context.shutdown_host()
+            unsupported_msg = "Transaction pool not available in light mode"
+            self.logger.error(unsupported_msg)
+            self.context.shutdown_host(unsupported_msg)
 
         self.event_bus.subscribe(ResourceAvailableEvent, self.handle_event)
 


### PR DESCRIPTION
### What was wrong?

1. Trinity always prints `Keyboard Interrupt: Stopping` on shutdown even if the shutdown was not initiated by a `KeyboardInterrupt`
2. The `message` parameter to `kill_trinity_gracefully` was never used and hence removed

### How was it fixed?

1. Trinity now prints the reason for the shutdown next to the `Shutting down Trinity` as well as next to the `Trinity shutdown complete` message, making it more obvious to the user why Trinity was shutdown
2. `message` parameter was removed

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://oddstuffmagazine.com/wp-content/uploads/2012/08/1439.jpg)
