### PR TITLE
Ensure mypy checks correctly in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,7 @@ commands=
 
 
 [common-lint]
-deps = .[lint]
+deps = .[eth,p2p,trinity,lint]
 setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
 commands=
     flake8 {toxinidir}/eth

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -2,10 +2,11 @@ from eth.chains.base import (
     BaseChain
 )
 
+from lahja import Endpoint
+
 from p2p.peer import BasePeerPool
 
 from trinity.config import TrinityConfig
-from trinity.extensibility import PluginManager
 from trinity.server import FullServer
 
 from .base import Node
@@ -15,8 +16,8 @@ class FullNode(Node):
     _chain: BaseChain = None
     _p2p_server: FullServer = None
 
-    def __init__(self, plugin_manager: PluginManager, trinity_config: TrinityConfig) -> None:
-        super().__init__(plugin_manager, trinity_config)
+    def __init__(self, event_bus: Endpoint, trinity_config: TrinityConfig) -> None:
+        super().__init__(event_bus, trinity_config)
         self._bootstrap_nodes = trinity_config.bootstrap_nodes
         self._preferred_nodes = trinity_config.preferred_nodes
         self._node_key = trinity_config.nodekey

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -5,6 +5,8 @@ from typing import (
 
 from eth_keys.datatypes import PrivateKey
 
+from lahja import Endpoint
+
 from p2p.peer import BasePeerPool
 
 from trinity.chains.light import (
@@ -12,9 +14,6 @@ from trinity.chains.light import (
 )
 from trinity.config import (
     TrinityConfig,
-)
-from trinity.extensibility import (
-    PluginManager
 )
 from trinity.nodes.base import Node
 from trinity.protocol.les.peer import LESPeerPool
@@ -32,8 +31,8 @@ class LightNode(Node):
     network_id: int = None
     nodekey: PrivateKey = None
 
-    def __init__(self, plugin_manager: PluginManager, trinity_config: TrinityConfig) -> None:
-        super().__init__(plugin_manager, trinity_config)
+    def __init__(self, event_bus: Endpoint, trinity_config: TrinityConfig) -> None:
+        super().__init__(event_bus, trinity_config)
 
         self._nodekey = trinity_config.nodekey
         self._port = trinity_config.port


### PR DESCRIPTION
### What was wrong?

As seen with #1385 and https://github.com/python/mypy/issues/5771 `mypy` currently doesn't provide us the type safety that we expect it should.

### How was it fixed?

Turns out, we didn't install all expected dependencies for the `mypy` run. That means, `mypy` was checking the source code but didn't have any of the other dependencies installed. Having the dependencies installed is important for mypy to infer the type info it needs to do its checks.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.talesbytrees.com/wp-content/uploads/Konsta_Punkka-fox.jpg)
