### PR TITLE
Per block transition and attestation

### DIFF
--- a/eth/beacon/aggregation.py
+++ b/eth/beacon/aggregation.py
@@ -1,0 +1,79 @@
+from typing import (
+    Iterable,
+    Tuple,
+)
+from cytoolz import (
+    pipe
+)
+
+
+from eth_typing import (
+    Hash32,
+)
+
+from eth.utils import bls
+from eth.utils.bitfield import (
+    set_voted,
+)
+from eth.utils.blake import blake
+
+
+def create_signing_message(slot: int,
+                           parent_hashes: Iterable[Hash32],
+                           shard_id: int,
+                           shard_block_hash: Hash32,
+                           justified_slot: int) -> bytes:
+    """
+    Return the signining message for attesting.
+    """
+    # TODO: Will be updated with SSZ encoded attestation.
+    return blake(
+        slot.to_bytes(8, byteorder='big') +
+        b''.join(parent_hashes) +
+        shard_id.to_bytes(2, byteorder='big') +
+        shard_block_hash +
+        justified_slot.to_bytes(8, 'big')
+    )
+
+
+def verify_votes(
+        message: bytes,
+        votes: Iterable[Tuple[int, bytes, int]]) -> Tuple[Tuple[bytes, ...], Tuple[int, ...]]:
+    """
+    Verify the given votes.
+
+    vote: (committee_index, sig, public_key)
+    """
+    sigs_with_committe_info = tuple(
+        (sig, committee_index)
+        for (committee_index, sig, public_key)
+        in votes
+        if bls.verify(message, public_key, sig)
+    )
+    try:
+        sigs, committee_indices = zip(*sigs_with_committe_info)
+    except ValueError:
+        sigs = tuple()
+        committee_indices = tuple()
+
+    return sigs, committee_indices
+
+
+def aggregate_votes(bitfield: bytes,
+                    sigs: Iterable[bytes],
+                    voting_sigs: Iterable[bytes],
+                    voting_committee_indices: Iterable[int]) -> Tuple[bytes, Tuple[int]]:
+    """
+    Aggregate the votes.
+    """
+    # Update the bitfield and append the signatures
+    sigs = tuple(sigs) + tuple(voting_sigs)
+    bitfield = pipe(
+        bitfield,
+        *(
+            set_voted(index=committee_index)
+            for committee_index in voting_committee_indices
+        )
+    )
+
+    return bitfield, bls.aggregate_sigs(sigs)

--- a/eth/beacon/block_committees_info.py
+++ b/eth/beacon/block_committees_info.py
@@ -1,6 +1,6 @@
 from typing import (
-    Iterable,
     NamedTuple,
+    Tuple,
     TYPE_CHECKING,
 )
 
@@ -15,6 +15,6 @@ BlockCommitteesInfo = NamedTuple(
         ('proposer_index_in_committee', int),
         ('proposer_shard_id', int),
         ('proposer_committee_size', int),
-        ('shards_and_committees', Iterable['ShardAndCommittee'])
+        ('shards_and_committees', Tuple['ShardAndCommittee'])
     )
 )

--- a/eth/beacon/block_committees_info.py
+++ b/eth/beacon/block_committees_info.py
@@ -1,0 +1,47 @@
+from typing import (
+    Iterable,
+    TYPE_CHECKING,
+)
+
+if TYPE_CHECKING:
+    from eth.beacon.types.shard_and_committees import ShardAndCommittee  # noqa: F401
+
+
+class BlockCommitteesInfo:
+    _proposer_index = None  # validator index
+    _proposer_index_in_committee = None
+    _proposer_shard_id = None
+    _proposer_committee_size = None
+    _shards_and_committees = None
+
+    def __init__(self,
+                 proposer_index: int,
+                 proposer_index_in_committee: int,
+                 proposer_shard_id: int,
+                 proposer_committee_size: int,
+                 shards_and_committees: Iterable['ShardAndCommittee']) -> None:
+        self._proposer_index = proposer_index
+        self._proposer_index_in_committee = proposer_index_in_committee
+        self._proposer_shard_id = proposer_shard_id
+        self._proposer_committee_size = proposer_committee_size
+        self._shards_and_committees = shards_and_committees
+
+    @property
+    def proposer_index(self) -> int:
+        return self._proposer_index
+
+    @property
+    def proposer_index_in_committee(self) -> int:
+        return self._proposer_index_in_committee
+
+    @property
+    def proposer_shard_id(self) -> int:
+        return self._proposer_shard_id
+
+    @property
+    def proposer_committee_size(self) -> int:
+        return self._proposer_committee_size
+
+    @property
+    def shards_and_committees(self) -> Iterable['ShardAndCommittee']:
+        return self._shards_and_committees

--- a/eth/beacon/block_committees_info.py
+++ b/eth/beacon/block_committees_info.py
@@ -1,5 +1,6 @@
 from typing import (
     Iterable,
+    NamedTuple,
     TYPE_CHECKING,
 )
 
@@ -7,41 +8,13 @@ if TYPE_CHECKING:
     from eth.beacon.types.shard_and_committees import ShardAndCommittee  # noqa: F401
 
 
-class BlockCommitteesInfo:
-    _proposer_index = None  # validator index
-    _proposer_index_in_committee = None
-    _proposer_shard_id = None
-    _proposer_committee_size = None
-    _shards_and_committees = None
-
-    def __init__(self,
-                 proposer_index: int,
-                 proposer_index_in_committee: int,
-                 proposer_shard_id: int,
-                 proposer_committee_size: int,
-                 shards_and_committees: Iterable['ShardAndCommittee']) -> None:
-        self._proposer_index = proposer_index
-        self._proposer_index_in_committee = proposer_index_in_committee
-        self._proposer_shard_id = proposer_shard_id
-        self._proposer_committee_size = proposer_committee_size
-        self._shards_and_committees = shards_and_committees
-
-    @property
-    def proposer_index(self) -> int:
-        return self._proposer_index
-
-    @property
-    def proposer_index_in_committee(self) -> int:
-        return self._proposer_index_in_committee
-
-    @property
-    def proposer_shard_id(self) -> int:
-        return self._proposer_shard_id
-
-    @property
-    def proposer_committee_size(self) -> int:
-        return self._proposer_committee_size
-
-    @property
-    def shards_and_committees(self) -> Iterable['ShardAndCommittee']:
-        return self._shards_and_committees
+BlockCommitteesInfo = NamedTuple(
+    'BlockCommitteesInfo',
+    (
+        ('proposer_index', int),
+        ('proposer_index_in_committee', int),
+        ('proposer_shard_id', int),
+        ('proposer_committee_size', int),
+        ('shards_and_committees', Iterable['ShardAndCommittee'])
+    )
+)

--- a/eth/beacon/block_proposal.py
+++ b/eth/beacon/block_proposal.py
@@ -1,0 +1,23 @@
+from typing import (
+    NamedTuple,
+    Tuple,
+    TYPE_CHECKING,
+)
+
+from eth.constants import (
+    Hash32,
+)
+
+if TYPE_CHECKING:
+    from eth.beacon.types.blocks import AttestationRecord  # noqa: F401
+    from eth.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
+
+
+BlockProposal = NamedTuple(
+    'BlockProposal',
+    (
+        ('block', 'BaseBeaconBlock'),
+        ('shard_id', int),
+        ('shard_block_hash', Tuple[Hash32]),
+    )
+)

--- a/eth/beacon/db/chain.py
+++ b/eth/beacon/db/chain.py
@@ -73,6 +73,10 @@ class BaseBeaconChainDB(ABC):
         pass
 
     @abstractmethod
+    def get_canonical_block_hash_by_slot(self, slot: int) -> Hash32:
+        pass
+
+    @abstractmethod
     def get_canonical_head(self) -> BaseBeaconBlock:
         pass
 
@@ -195,7 +199,7 @@ class BeaconChainDB(BaseBeaconChainDB):
 
     def get_canonical_block_by_slot(self, slot: int) -> BaseBeaconBlock:
         """
-        Return the block header with the given slot in the canonical chain.
+        Return the block with the given slot in the canonical chain.
 
         Raise BlockNotFound if there's no block with the given slot in the
         canonical chain.
@@ -207,9 +211,25 @@ class BeaconChainDB(BaseBeaconChainDB):
             cls,
             db: BaseDB,
             slot: int) -> BaseBeaconBlock:
-        validate_slot(slot)
-        canonical_block_hash = cls._get_canonical_block_hash(db, slot)
+        canonical_block_hash = cls._get_canonical_block_hash_by_slot(db, slot)
         return cls._get_block_by_hash(db, canonical_block_hash)
+
+    def get_canonical_block_hash_by_slot(self, slot: int) -> Hash32:
+        """
+        Return the block hash with the given slot in the canonical chain.
+
+        Raise BlockNotFound if there's no block with the given slot in the
+        canonical chain.
+        """
+        return self._get_canonical_block_hash_by_slot(self.db, slot)
+
+    @classmethod
+    def _get_canonical_block_hash_by_slot(
+            cls,
+            db: BaseDB,
+            slot: int) -> Hash32:
+        validate_slot(slot)
+        return cls._get_canonical_block_hash(db, slot)    
 
     def get_canonical_head(self) -> BaseBeaconBlock:
         """

--- a/eth/beacon/db/chain.py
+++ b/eth/beacon/db/chain.py
@@ -229,7 +229,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             db: BaseDB,
             slot: int) -> Hash32:
         validate_slot(slot)
-        return cls._get_canonical_block_hash(db, slot)    
+        return cls._get_canonical_block_hash(db, slot)
 
     def get_canonical_head(self) -> BaseBeaconBlock:
         """

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -435,7 +435,7 @@ def aggregate_attestation_record(last_justified_slot: int,
         block.slot_number,
         parent_hashes,
         proposer_attestation.shard_id,
-        block.shard_block_hash,
+        proposer_attestation.shard_block_hash,
         last_justified_slot,
     )
 

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -439,7 +439,7 @@ def aggregate_attestation_record(last_justified_slot: int,
         block.shard_block_hash,
         last_justified_slot,
     )
-    
+
     bitfield, sigs = aggregate_votes(
         message,
         votes,
@@ -475,7 +475,7 @@ def aggregate_votes(message: bytes,
     bitfield = pipe(
         bitfield,
         *(
-            functools.partial(set_voted, index=committee_index)
+            set_voted(index=committee_index)
             for committee_index in committee_indices
         )
     )

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -1,4 +1,3 @@
-import functools
 from itertools import (
     repeat,
 )

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -45,7 +45,7 @@ def _get_element_from_recent_list(
         target_slot: int,
         slot_relative_position: int) -> Any:
     """
-    Returns the element from ``target_list`` by the ``target_slot`` number,
+    Return the element from ``target_list`` by the ``target_slot`` number,
     where the the element should be at ``target_slot - slot_relative_position``th
     element of the given ``target_list``.
     """
@@ -75,7 +75,7 @@ def get_block_hash(
         slot: int,
         cycle_length: int) -> Hash32:
     """
-    Returns the blockhash from ``ActiveState.recent_block_hashes`` by
+    Return the blockhash from ``ActiveState.recent_block_hashes`` by
     ``current_block_slot_number``.
     """
     if len(recent_block_hashes) != cycle_length * 2:
@@ -192,7 +192,7 @@ def get_attestation_indices(crystallized_state: 'CrystallizedState',
                             attestation: 'AttestationRecord',
                             cycle_length: int) -> Iterable[int]:
     """
-    Returns committee of the given attestation.
+    Return committee of the given attestation.
     """
     shard_id = attestation.shard_id
 
@@ -231,7 +231,7 @@ def _get_shuffling_committee_slot_portions(
         min_committee_size: int,
         shard_count: int) -> Tuple[int, int]:
     """
-    Returns committees number per slot and slots number per committee.
+    Return committees number per slot and slots number per committee.
     """
     # If there are enough active validators to form committees for every slot
     if active_validators_size >= cycle_length * min_committee_size:
@@ -279,7 +279,7 @@ def get_new_shuffling(*,
                       min_committee_size: int,
                       shard_count: int) -> Iterable[Iterable[ShardAndCommittee]]:
     """
-    Returns shuffled ``shard_and_committee_for_slots`` (``[[ShardAndCommittee]]``) of
+    Return shuffled ``shard_and_committee_for_slots`` (``[[ShardAndCommittee]]``) of
     the given active ``validators``.
 
     Two-dimensional:
@@ -356,7 +356,7 @@ def get_block_committees_info(parent_block: 'BaseBeaconBlock',
         cycle_length,
     )
     """
-    Returns the proposer index in committee and the ``shard_id``.
+    Return the block committees and proposer info with BlockCommitteesInfo pack.
     """
     # `proposer_index_in_committee` th attester in `shard_and_committee`
     # is the proposer of the parent block.

--- a/eth/beacon/state_machines/base.py
+++ b/eth/beacon/state_machines/base.py
@@ -433,7 +433,7 @@ class BeaconStateMachine(BaseBeaconStateMachine):
         """
         Return the initial attestation by the block proposer.
 
-        The proposer broadcasts zir attestation with the proposed block.
+        The proposer broadcasts their attestation with the proposed block.
         """
         block_committees_info = get_block_committees_info(
             block,
@@ -499,9 +499,8 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     #
     # Attestation validation
     #
-    @classmethod
-    def validate_attestation(cls,
-                             block: BaseBeaconBlock,
+    @staticmethod
+    def validate_attestation(block: BaseBeaconBlock,
                              parent_block: BaseBeaconBlock,
                              crystallized_state: CrystallizedState,
                              active_state: ActiveState,

--- a/eth/beacon/state_machines/base.py
+++ b/eth/beacon/state_machines/base.py
@@ -4,6 +4,8 @@ from abc import (
 import logging
 from typing import (
     Iterable,
+    Sequence,
+    Tuple,
     Type,
 )
 
@@ -12,6 +14,7 @@ from eth_typing import (
 )
 from eth_utils import (
     to_tuple,
+    ValidationError,
 )
 
 
@@ -21,12 +24,29 @@ from eth.constants import (
 from eth.exceptions import (
     BlockNotFound,
 )
+from eth.utils.blake import blake
+from eth.utils import bls
+from eth.utils.bitfield import (
+    get_bitfield_length,
+    get_empty_bitfield,
+    has_voted,
+    set_voted,
+)
 from eth.utils.datatypes import (
     Configurable,
 )
 
 from eth.beacon.db.chain import BaseBeaconChainDB
+from eth.beacon.helpers import (
+    get_attestation_indices,
+    get_hashes_to_sign,
+    get_new_recent_block_hashes,
+    get_block_committees_info,
+    get_signed_parent_hashes,
+)
 from eth.beacon.types.active_states import ActiveState
+from eth.beacon.types.attestation_records import AttestationRecord  # noqa: F401
+
 from eth.beacon.types.blocks import BaseBeaconBlock
 from eth.beacon.types.crystallized_states import CrystallizedState
 from eth.beacon.state_machines.configs import BeaconConfig  # noqa: F401
@@ -42,6 +62,7 @@ class BaseBeaconStateMachine(Configurable, ABC):
     block_class = None  # type: Type[BaseBeaconBlock]
     crystallized_state_class = None  # type: Type[CrystallizedState]
     active_state_class = None  # type: Type[ActiveState]
+    attestation_record_class = None  # type: Type[AttestationRecord]
 
     # TODO: Add abstractmethods
 
@@ -55,9 +76,17 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     _crytallized_state = None  # type: CrystallizedState
     _active_state = None  # type: ActiveState
 
-    def __init__(self, chaindb: BaseBeaconChainDB, block: BaseBeaconBlock) -> None:
+    def __init__(self, chaindb: BaseBeaconChainDB, block: BaseBeaconBlock=None) -> None:
         self.chaindb = chaindb
-        self.block = self.get_block_class().from_block(block)
+        if self.block is None:
+            # Build a child block of current head
+            head = self.chaindb.get_canonical_head()
+            self.block = self.get_block_class().from_block(block).copy(
+                slot_number=head.slot_number + 1,
+                parent_hash=head.hash,
+            )
+        else:
+            self.block = self.get_block_class().from_block(block)
 
     #
     # Logging
@@ -193,9 +222,562 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     def get_active_state_class(cls) -> Type[ActiveState]:
         """
         Return the :class:`~eth.beacon.types.active_states.ActiveState` class that this
-        StateMachine uses for crystallized_state.
+        StateMachine uses for active_state.
         """
         if cls.active_state_class is None:
             raise AttributeError("No `active_state_class` has been set for this StateMachine")
         else:
             return cls.active_state_class
+
+    #
+    # AttestationRecord
+    #
+    @classmethod
+    def get_attestation_record_class(cls) -> Type[AttestationRecord]:
+        """
+        Return the :class:`~eth.beacon.types.attestation_records.AttestationRecord` class that this
+        StateMachine uses for the current fork version.
+        """
+        if cls.attestation_record_class is None:
+            raise AttributeError("No `attestation_record_class` has been set for this StateMachine")
+        else:
+            return cls.attestation_record_class
+
+    @classmethod
+    def create_signing_message(cls,
+                               slot: int,
+                               parent_hashes: Iterable[Hash32],
+                               shard_id: int,
+                               shard_block_hash: Hash32,
+                               justified_slot: int) -> bytes:
+        # TODO: will be updated to hashed encoded attestation
+        return blake(
+            slot.to_bytes(8, byteorder='big') +
+            b''.join(parent_hashes) +
+            shard_id.to_bytes(2, byteorder='big') +
+            shard_block_hash +
+            justified_slot.to_bytes(8, 'big')
+        )
+
+    #
+    # Import block API
+    #
+    def import_block(
+            self,
+            block: BaseBeaconBlock) -> Tuple[BaseBeaconBlock, CrystallizedState, ActiveState]:
+        """
+        Import the given block to the chain.
+        """
+        processing_block = self.get_block_class().from_block(block)
+        processing_block, processed_crystallized_state, processed_active_state = self.process_block(
+            self.crystallized_state,
+            self.active_state,
+            processing_block,
+            self.chaindb,
+            self.config,
+        )
+
+        # Validate state roots
+        self.validate_state_roots(
+            processed_crystallized_state.hash,
+            processed_active_state.hash,
+            block,
+        )
+
+        self.block = processing_block
+        self._update_the_states(processed_crystallized_state, processed_active_state)
+        # TODO: persist states in BeaconChain if needed
+
+        return self.block, self.crystallized_state, self.active_state
+
+    #
+    # Process block APIs
+    #
+    @classmethod
+    def process_block(
+            cls,
+            crystallized_state: CrystallizedState,
+            active_state: ActiveState,
+            block: BaseBeaconBlock,
+            chaindb: BaseBeaconChainDB,
+            config: BeaconConfig) -> Tuple[BaseBeaconBlock, CrystallizedState, ActiveState]:
+        """
+        Process ``block`` and return the new crystallized state and active state.
+        """
+        # Process per block state changes (ActiveState)
+        processing_active_state = cls.compute_per_block_transtion(
+            crystallized_state,
+            active_state,
+            block,
+            chaindb,
+            config.CYCLE_LENGTH,
+        )
+
+        # Process per cycle state changes (CrystallizedState and ActiveState)
+        processed_crystallized_state, processed_active_state = cls.compute_cycle_transitions(
+            crystallized_state,
+            processing_active_state,
+        )
+
+        # Return the copy
+        result_block = block.copy()
+        return result_block, processed_crystallized_state, processed_active_state
+
+    @classmethod
+    def compute_per_block_transtion(cls,
+                                    crystallized_state: CrystallizedState,
+                                    active_state: ActiveState,
+                                    block: BaseBeaconBlock,
+                                    chaindb: BaseBeaconChainDB,
+                                    cycle_length: int) -> ActiveState:
+        """
+        Process ``block`` and return the new ActiveState.
+
+
+        TODO: It doesn't match the latest spec.
+        There will be more fields need to be updated in ActiveState.
+        """
+        parent_block = chaindb.get_block_by_hash(block.parent_hash)
+        recent_block_hashes = get_new_recent_block_hashes(
+            active_state.recent_block_hashes,
+            parent_block.slot_number,
+            block.slot_number,
+            block.parent_hash
+        )
+
+        if parent_block.parent_hash != GENESIS_PARENT_HASH:
+            cls.validate_parent_block_proposer(
+                crystallized_state,
+                block,
+                parent_block,
+                cycle_length,
+            )
+        cls.validate_randao_reveal()
+
+        for attestation in block.attestations:
+            cls.validate_attestation(
+                block,
+                parent_block,
+                crystallized_state,
+                active_state,
+                attestation,
+                chaindb,
+                cycle_length,
+            )
+
+        return active_state.copy(
+            recent_block_hashes=recent_block_hashes,
+            pending_attestations=(
+                active_state.pending_attestations + block.attestations
+            ),
+        )
+
+    @classmethod
+    def compute_cycle_transitions(
+            cls,
+            crystallized_state: CrystallizedState,
+            active_state: ActiveState) -> Tuple[CrystallizedState, ActiveState]:
+        # TODO: it's a stub
+        return crystallized_state, active_state
+
+    #
+    #
+    # Proposer APIs
+    #
+    #
+    def propose_block(
+        self,
+        crystallized_state: CrystallizedState,
+        active_state: ActiveState,
+        block: BaseBeaconBlock,
+        shard_id: int,
+        shard_block_hash: Hash32,
+        chaindb: BaseBeaconBlock,
+        config: BeaconConfig,
+        private_key: int
+    ) -> Tuple[BaseBeaconBlock, CrystallizedState, ActiveState, 'AttestationRecord']:
+        """
+        Propose the given block.
+        """
+        block, post_crystallized_state, post_active_state = self.process_block(
+            crystallized_state,
+            active_state,
+            block,
+            chaindb,
+            config,
+        )
+
+        # Set state roots
+        block.copy(
+            crystallized_state_root=post_crystallized_state.hash,
+            active_state_root=post_active_state,
+        )
+
+        proposer_attestation = self.attest_proposed_block(
+            post_crystallized_state,
+            post_active_state,
+            block,
+            shard_id,
+            shard_block_hash,
+            chaindb,
+            config.CYCLE_LENGTH,
+            private_key,
+        )
+        return block, post_crystallized_state, post_active_state, proposer_attestation
+
+    def _update_the_states(self,
+                           crystallized_state: CrystallizedState,
+                           active_state: ActiveState) -> None:
+        self._crytallized_state = crystallized_state
+        self._active_state = active_state
+
+    def attest_proposed_block(self,
+                              post_crystallized_state: CrystallizedState,
+                              post_active_state: ActiveState,
+                              block: BaseBeaconBlock,
+                              shard_id: int,
+                              shard_block_hash: Hash32,
+                              chaindb: BaseBeaconBlock,
+                              cycle_length: int,
+                              private_key: int) -> 'AttestationRecord':
+        """
+        Return the initial attestation by the block proposer.
+
+        The proposer broadcasts zir attestation with the proposed block.
+        """
+        block_committees_info = get_block_committees_info(
+            block,
+            post_crystallized_state,
+            cycle_length,
+        )
+        # Vote
+        attester_bitfield = set_voted(
+            get_empty_bitfield(block_committees_info.proposer_committee_size),
+            block_committees_info.proposer_index_in_committee,
+        )
+
+        # Get justified_slot and justified_block_hash
+        justified_slot = post_crystallized_state.last_justified_slot
+        justified_block_hash = chaindb.get_canonical_block_by_slot(justified_slot).hash
+
+        # Get signing message and sign it
+        parent_hashes = get_hashes_to_sign(
+            post_active_state.recent_block_hashes,
+            block,
+            cycle_length,
+        )
+        message = self.create_signing_message(
+            block.slot_number,
+            parent_hashes,
+            shard_id,
+            shard_block_hash,
+            justified_slot,
+        )
+        sigs = [
+            bls.sign(
+                message,
+                private_key,
+            )
+        ]
+        aggregate_sig = bls.aggregate_sigs(sigs)
+
+        return self.get_attestation_record_class()(
+            slot=block.slot_number,
+            shard_id=shard_id,
+            oblique_parent_hashes=(),
+            shard_block_hash=shard_block_hash,
+            attester_bitfield=attester_bitfield,
+            justified_slot=justified_slot,
+            justified_block_hash=justified_block_hash,
+            aggregate_sig=aggregate_sig,
+        )
+
+    @classmethod
+    def aggregate_attestation_record(cls,
+                                     crystallized_state: CrystallizedState,
+                                     active_state: ActiveState,
+                                     block: BaseBeaconBlock,
+                                     votes: Iterable[Tuple[int, bytes, int]],
+                                     proposer_attestation: 'AttestationRecord',
+                                     cycle_length: int) -> 'AttestationRecord':
+        """
+        Aggregate the votes.
+
+        TODO: Write tests
+        """
+        # Get signing message
+        parent_hashes = get_hashes_to_sign(
+            active_state.recent_block_hashes,
+            block,
+            cycle_length,
+        )
+        message = cls.create_signing_message(
+            block.slot_number,
+            parent_hashes,
+            proposer_attestation.shard_id,
+            block.shard_block_hash,
+            crystallized_state.last_justified_slot,
+        )
+        # Update the bitfield and append the signatures
+        bitfield = proposer_attestation.bitfield
+        sigs = []
+        for (committee_index, sig, public_key) in votes:
+            if bls.verify(message, public_key, sig):
+                bitfield = set_voted(bitfield, committee_index)
+                sigs.append(sig)
+
+        return proposer_attestation.copy(
+            bitfield=bitfield,
+            sigs=bls.aggregate_sigs(sigs),
+        )
+
+    #
+    #
+    # Validation
+    #
+    #
+
+    #
+    # Parent block proposer validation
+    #
+    @classmethod
+    def validate_parent_block_proposer(cls,
+                                       crystallized_state: CrystallizedState,
+                                       block: BaseBeaconBlock,
+                                       parent_block: BaseBeaconBlock,
+                                       cycle_length: int) -> None:
+        if block.slot_number == 0:
+            return
+
+        block_committees_info = get_block_committees_info(
+            parent_block,
+            crystallized_state,
+            cycle_length,
+        )
+
+        if len(block.attestations) == 0:
+            raise ValidationError(
+                "block.attestations should not be an empty list"
+            )
+        attestation = block.attestations[0]
+
+        is_proposer_attestation = (
+            attestation.shard_id == block_committees_info.proposer_shard_id and
+            attestation.slot == parent_block.slot_number and
+            has_voted(
+                attestation.attester_bitfield,
+                block_committees_info.proposer_index_in_committee
+            )
+        )
+        if not is_proposer_attestation:
+            raise ValidationError(
+                "Proposer of parent block should be one of the attesters in block.attestions[0]:\n"
+                "\tExpected: proposer index in committee: %d, shard_id: %d, slot: %d\n"
+                "\tFound: shard_id: %d, slot: %d, voted: %s" % (
+                    block_committees_info.proposer_index_in_committee,
+                    block_committees_info.proposer_shard_id,
+                    parent_block.slot_number,
+                    attestation.shard_id,
+                    attestation.slot,
+                    has_voted(
+                        attestation.attester_bitfield,
+                        block_committees_info.proposer_index_in_committee,
+                    ),
+                )
+            )
+
+    #
+    # Randao reveal validation
+    #
+    @classmethod
+    def validate_randao_reveal(cls) -> None:
+        # TODO: it's a stub
+        return
+
+    #
+    # Attestation validation
+    #
+    @classmethod
+    def validate_attestation(cls,
+                             block: BaseBeaconBlock,
+                             parent_block: BaseBeaconBlock,
+                             crystallized_state: CrystallizedState,
+                             active_state: ActiveState,
+                             attestation: 'AttestationRecord',
+                             chaindb: BaseBeaconChainDB,
+                             cycle_length: int) -> None:
+        """
+        Validate the given ``attestation``.
+
+        Raise ``ValidationError`` if it's invalid.
+        """
+        cls.validate_slot(
+            parent_block,
+            attestation,
+            cycle_length,
+        )
+
+        cls.validate_justified(
+            crystallized_state,
+            attestation,
+            chaindb,
+        )
+
+        attestation_indices = get_attestation_indices(
+            crystallized_state,
+            attestation,
+            cycle_length,
+        )
+
+        cls.validate_bitfield(attestation, attestation_indices)
+
+        cls.validate_version(crystallized_state, attestation)
+
+        parent_hashes = get_signed_parent_hashes(
+            active_state.recent_block_hashes,
+            block,
+            attestation,
+            cycle_length,
+        )
+        cls.validate_aggregate_sig(
+            crystallized_state,
+            attestation,
+            attestation_indices,
+            parent_hashes,
+        )
+
+    @classmethod
+    def validate_slot(cls,
+                      parent_block: BaseBeaconBlock,
+                      attestation: 'AttestationRecord',
+                      cycle_length: int) -> None:
+        """
+        Validate ``slot`` field.
+
+        Raise ``ValidationError`` if it's invalid.
+        """
+        if attestation.slot > parent_block.slot_number:
+            raise ValidationError(
+                "Attestation slot number too high:\n"
+                "\tFound: %s Needed less than or equal to %s" %
+                (attestation.slot, parent_block.slot_number)
+            )
+        if attestation.slot < max(parent_block.slot_number - cycle_length + 1, 0):
+            raise ValidationError(
+                "Attestation slot number too low:\n"
+                "\tFound: %s, Needed greater than or equalt to: %s" %
+                (
+                    attestation.slot,
+                    max(parent_block.slot_number - cycle_length + 1, 0)
+                )
+            )
+
+    @classmethod
+    def validate_justified(cls,
+                           crystallized_state: CrystallizedState,
+                           attestation: 'AttestationRecord',
+                           chaindb: BaseBeaconChainDB) -> None:
+        """
+        Validate ``justified_slot`` and ``justified_block_hash`` fields.
+
+        Raise ``ValidationError`` if it's invalid.
+        """
+        if attestation.justified_slot > crystallized_state.last_justified_slot:
+            raise ValidationError(
+                "attestation.justified_slot %s should be equal to or earlier than"
+                " crystallized_state.last_justified_slot %s" % (
+                    attestation.justified_slot,
+                    crystallized_state.last_justified_slot,
+                )
+            )
+
+        justified_block = chaindb.get_block_by_hash(attestation.justified_block_hash)
+        if justified_block is None:
+            raise ValidationError(
+                "justified_block_hash %s is not in the canonical chain" %
+                attestation.justified_block_hash
+            )
+        if justified_block.slot_number != attestation.justified_slot:
+            raise ValidationError(
+                "justified_slot %s doesn't match justified_block_hash" % attestation.justified_slot
+            )
+
+    @classmethod
+    def validate_bitfield(cls,
+                          attestation: 'AttestationRecord',
+                          attestation_indices: Sequence[int]) -> None:
+        """
+        Validate ``attester_bitfield`` field.
+
+        Raise ``ValidationError`` if it's invalid.
+        """
+        if len(attestation.attester_bitfield) != get_bitfield_length(len(attestation_indices)):
+            raise ValidationError(
+                "Attestation has incorrect bitfield length. Found: %s, Expected: %s" %
+                (len(attestation.attester_bitfield), get_bitfield_length(len(attestation_indices)))
+            )
+
+        # check if end bits are zero
+        last_bit = len(attestation_indices)
+        if last_bit % 8 != 0:
+            for i in range(8 - last_bit % 8):
+                if has_voted(attestation.attester_bitfield, last_bit + i):
+                    raise ValidationError("Attestation has non-zero trailing bits")
+
+    @classmethod
+    def validate_aggregate_sig(cls,
+                               crystallized_state: CrystallizedState,
+                               attestation: 'AttestationRecord',
+                               attestation_indices: Iterable[int],
+                               parent_hashes: Iterable[Hash32]) -> None:
+        """
+        Validate ``aggregate_sig`` field.
+
+        Raise ``ValidationError`` if it's invalid.
+        """
+        pub_keys = [
+            crystallized_state.validators[validator_index].pubkey
+            for committee_index, validator_index in enumerate(attestation_indices)
+            if has_voted(attestation.attester_bitfield, committee_index)
+        ]
+
+        message = cls.create_signing_message(
+            attestation.slot,
+            parent_hashes,
+            attestation.shard_id,
+            attestation.shard_block_hash,
+            attestation.justified_slot,
+        )
+        if not bls.verify(message, bls.aggregate_pubs(pub_keys), attestation.aggregate_sig):
+            raise ValidationError("Attestation aggregate signature fails")
+
+    @classmethod
+    def validate_version(cls,
+                         crystallized_state: CrystallizedState,
+                         attestation: 'AttestationRecord') -> None:
+        # TODO: it's a stub
+        return
+
+    #
+    # State roots validation
+    #
+    @classmethod
+    def validate_state_roots(cls,
+                             crystallized_state_root: Hash32,
+                             active_state_root: Hash32,
+                             block: BaseBeaconBlock) -> None:
+        """
+        Validate block ``crystallized_state_root`` and ``active_state_root`` fields.
+
+        Raise ``ValidationError`` if it's invalid.
+        """
+        if crystallized_state_root != block.crystallized_state_root:
+            raise ValidationError(
+                "Crystallized state root incorrect. Found: %s, Expected: %s" %
+                (crystallized_state_root, block.crystallized_state_root)
+            )
+        if active_state_root != block.active_state_root:
+            raise ValidationError(
+                "Active state root incorrect. Found: %s, Expected: %s" %
+                (active_state_root, block.active_state_root)
+            )

--- a/eth/beacon/state_machines/base.py
+++ b/eth/beacon/state_machines/base.py
@@ -31,10 +31,12 @@ from eth.utils.datatypes import (
     Configurable,
 )
 
+from eth.beacon.aggregation import (
+    create_signing_message,
+)
 from eth.beacon.block_proposal import BlockProposal
 from eth.beacon.db.chain import BaseBeaconChainDB
 from eth.beacon.helpers import (
-    create_signing_message,
     get_block_committees_info,
     get_hashes_to_sign,
     get_new_recent_block_hashes,

--- a/eth/beacon/state_machines/base.py
+++ b/eth/beacon/state_machines/base.py
@@ -85,10 +85,10 @@ class BeaconStateMachine(BaseBeaconStateMachine):
         self.chaindb = chaindb
         if block is None:
             # Build a child block of current head
-            head = self.chaindb.get_canonical_head()
-            self.block = self.get_block_class()(*block).copy(
-                slot_number=head.slot_number + 1,
-                parent_hash=head.hash,
+            head_block = self.chaindb.get_canonical_head()
+            self.block = self.get_block_class()(*head_block).copy(
+                slot_number=head_block.slot_number + 1,
+                parent_hash=head_block.hash,
             )
         else:
             self.block = self.get_block_class()(*block)

--- a/eth/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth/beacon/state_machines/forks/serenity/__init__.py
@@ -15,7 +15,7 @@ from .crystallized_states import SerenityCrystallizedState
 from .configs import SERENITY_CONFIG
 
 
-class SerenityBeaconStateMachine(BeaconStateMachine):
+class SerenityStateMachine(BeaconStateMachine):
     # fork name
     fork = 'serenity'  # type: str
 

--- a/eth/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth/beacon/state_machines/forks/serenity/__init__.py
@@ -2,12 +2,14 @@
 from typing import Type  # noqa: F401
 
 from eth.beacon.types.active_states import ActiveState  # noqa: F401
+from eth.beacon.types.attestation_records import AttestationRecord  # noqa: F401
 from eth.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
 from eth.beacon.types.crystallized_states import CrystallizedState  # noqa: F401
 
 from eth.beacon.state_machines.base import BeaconStateMachine
 
 from .active_states import SerenityActiveState
+from .attestation_records import SerenityAttestationRecord
 from .blocks import SerenityBeaconBlock
 from .crystallized_states import SerenityCrystallizedState
 from .configs import SERENITY_CONFIG
@@ -21,4 +23,5 @@ class SerenityBeaconStateMachine(BeaconStateMachine):
     block_class = SerenityBeaconBlock  # type: Type[BaseBeaconBlock]
     crystallized_state_class = SerenityCrystallizedState  # type: Type[CrystallizedState]
     active_state_class = SerenityActiveState  # type: Type[ActiveState]
+    attestation_record_class = SerenityAttestationRecord  # type: Type[AttestationRecord]
     config = SERENITY_CONFIG

--- a/eth/beacon/state_machines/forks/serenity/attestation_records.py
+++ b/eth/beacon/state_machines/forks/serenity/attestation_records.py
@@ -1,0 +1,5 @@
+from eth.beacon.types.attestation_records import AttestationRecord
+
+
+class SerenityAttestationRecord(AttestationRecord):
+    pass

--- a/eth/beacon/state_machines/forks/serenity/blocks.py
+++ b/eth/beacon/state_machines/forks/serenity/blocks.py
@@ -2,14 +2,4 @@ from eth.beacon.types.blocks import BaseBeaconBlock
 
 
 class SerenityBeaconBlock(BaseBeaconBlock):
-    @classmethod
-    def from_block(cls, block):
-        return cls(
-            parent_hash=block.parent_hash,
-            slot_number=block.slot_number,
-            randao_reveal=block.randao_reveal,
-            attestations=block.attestations,
-            pow_chain_ref=block.pow_chain_ref,
-            active_state_root=block.active_state_root,
-            crystallized_state_root=block.crystallized_state_root,
-        )
+    pass

--- a/eth/beacon/state_machines/validation.py
+++ b/eth/beacon/state_machines/validation.py
@@ -86,7 +86,6 @@ def validate_parent_block_proposer(crystallized_state: 'CrystallizedState',
 #
 # Attestation validation
 #
-
 def validate_attestation(
         block: BaseBeaconBlock,
         parent_block: BaseBeaconBlock,

--- a/eth/beacon/state_machines/validation.py
+++ b/eth/beacon/state_machines/validation.py
@@ -19,8 +19,10 @@ from eth.utils.bitfield import (
     has_voted,
 )
 
-from eth.beacon.helpers import (
+from eth.beacon.aggregation import (
     create_signing_message,
+)
+from eth.beacon.helpers import (
     get_attestation_indices,
     get_block_committees_info,
     get_signed_parent_hashes,

--- a/eth/beacon/state_machines/validation.py
+++ b/eth/beacon/state_machines/validation.py
@@ -1,0 +1,209 @@
+from typing import (
+    Iterable,
+    Sequence,
+)
+
+from eth_typing import (
+    Hash32
+)
+from eth_utils import (
+    ValidationError,
+)
+
+from eth.utils import bls
+from eth.utils.bitfield import (
+    get_bitfield_length,
+    has_voted,
+)
+
+from eth.beacon.helpers import (
+    create_signing_message,
+    get_block_committees_info,
+)
+
+from eth.beacon.db.chain import BaseBeaconChainDB  # noqa: F401
+from eth.beacon.types.attestation_records import AttestationRecord  # noqa: F401
+from eth.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
+from eth.beacon.types.crystallized_states import CrystallizedState  # noqa: F401
+
+
+#
+# Parent block proposer validation
+#
+def validate_parent_block_proposer(crystallized_state: 'CrystallizedState',
+                                   block: 'BaseBeaconBlock',
+                                   parent_block: 'BaseBeaconBlock',
+                                   cycle_length: int) -> None:
+    if block.slot_number == 0:
+        return
+
+    block_committees_info = get_block_committees_info(
+        parent_block,
+        crystallized_state,
+        cycle_length,
+    )
+
+    try:
+        attestation = block.attestations[0]
+    except IndexError:
+        raise ValidationError(
+            "block.attestations should not be an empty list"
+        )
+
+    is_proposer_attestation = (
+        attestation.shard_id == block_committees_info.proposer_shard_id and
+        attestation.slot == parent_block.slot_number and
+        has_voted(
+            attestation.attester_bitfield,
+            block_committees_info.proposer_index_in_committee
+        )
+    )
+    if not is_proposer_attestation:
+        raise ValidationError(
+            "Proposer of parent block should be one of the attesters in block.attestions[0]:\n"
+            "\tExpected: proposer index in committee: %d, shard_id: %d, slot: %d\n"
+            "\tFound: shard_id: %d, slot: %d, voted: %s" % (
+                block_committees_info.proposer_index_in_committee,
+                block_committees_info.proposer_shard_id,
+                parent_block.slot_number,
+                attestation.shard_id,
+                attestation.slot,
+                has_voted(
+                    attestation.attester_bitfield,
+                    block_committees_info.proposer_index_in_committee,
+                ),
+            )
+        )
+
+
+#
+# Attestation validation
+#
+def validate_slot(parent_block: 'BaseBeaconBlock',
+                  attestation: 'AttestationRecord',
+                  cycle_length: int) -> None:
+    """
+    Validate ``slot`` field.
+
+    Raise ``ValidationError`` if it's invalid.
+    """
+    if attestation.slot > parent_block.slot_number:
+        raise ValidationError(
+            "Attestation slot number too high:\n"
+            "\tFound: %s Needed less than or equal to %s" %
+            (attestation.slot, parent_block.slot_number)
+        )
+    if attestation.slot < max(parent_block.slot_number - cycle_length + 1, 0):
+        raise ValidationError(
+            "Attestation slot number too low:\n"
+            "\tFound: %s, Needed greater than or equalt to: %s" %
+            (
+                attestation.slot,
+                max(parent_block.slot_number - cycle_length + 1, 0)
+            )
+        )
+
+
+def validate_justified(crystallized_state: 'CrystallizedState',
+                       attestation: 'AttestationRecord',
+                       chaindb: 'BaseBeaconChainDB') -> None:
+    """
+    Validate ``justified_slot`` and ``justified_block_hash`` fields.
+
+    Raise ``ValidationError`` if it's invalid.
+    """
+    if attestation.justified_slot > crystallized_state.last_justified_slot:
+        raise ValidationError(
+            "attestation.justified_slot %s should be equal to or earlier than"
+            " crystallized_state.last_justified_slot %s" % (
+                attestation.justified_slot,
+                crystallized_state.last_justified_slot,
+            )
+        )
+
+    justified_block = chaindb.get_block_by_hash(attestation.justified_block_hash)
+    if justified_block is None:
+        raise ValidationError(
+            "justified_block_hash %s is not in the canonical chain" %
+            attestation.justified_block_hash
+        )
+    if justified_block.slot_number != attestation.justified_slot:
+        raise ValidationError(
+            "justified_slot %s doesn't match justified_block_hash" % attestation.justified_slot
+        )
+
+
+def validate_bitfield(attestation: 'AttestationRecord',
+                      attestation_indices: Sequence[int]) -> None:
+    """
+    Validate ``attester_bitfield`` field.
+
+    Raise ``ValidationError`` if it's invalid.
+    """
+    if len(attestation.attester_bitfield) != get_bitfield_length(len(attestation_indices)):
+        raise ValidationError(
+            "Attestation has incorrect bitfield length. Found: %s, Expected: %s" %
+            (len(attestation.attester_bitfield), get_bitfield_length(len(attestation_indices)))
+        )
+
+    # check if end bits are zero
+    last_bit = len(attestation_indices)
+    if last_bit % 8 != 0:
+        for i in range(8 - last_bit % 8):
+            if has_voted(attestation.attester_bitfield, last_bit + i):
+                raise ValidationError("Attestation has non-zero trailing bits")
+
+
+def validate_version(crystallized_state: 'CrystallizedState',
+                     attestation: 'AttestationRecord') -> None:
+    # TODO: it's a stub
+    pass
+
+
+def validate_aggregate_sig(crystallized_state: 'CrystallizedState',
+                           attestation: 'AttestationRecord',
+                           attestation_indices: Iterable[int],
+                           parent_hashes: Iterable[Hash32]) -> None:
+    """
+    Validate ``aggregate_sig`` field.
+
+    Raise ``ValidationError`` if it's invalid.
+    """
+    pub_keys = [
+        crystallized_state.validators[validator_index].pubkey
+        for committee_index, validator_index in enumerate(attestation_indices)
+        if has_voted(attestation.attester_bitfield, committee_index)
+    ]
+
+    message = create_signing_message(
+        attestation.slot,
+        parent_hashes,
+        attestation.shard_id,
+        attestation.shard_block_hash,
+        attestation.justified_slot,
+    )
+    if not bls.verify(message, bls.aggregate_pubs(pub_keys), attestation.aggregate_sig):
+        raise ValidationError("Attestation aggregate signature fails")
+
+
+#
+# State roots validation
+#
+def validate_state_roots(crystallized_state_root: Hash32,
+                         active_state_root: Hash32,
+                         block: 'BaseBeaconBlock') -> None:
+    """
+    Validate block ``crystallized_state_root`` and ``active_state_root`` fields.
+
+    Raise ``ValidationError`` if it's invalid.
+    """
+    if crystallized_state_root != block.crystallized_state_root:
+        raise ValidationError(
+            "Crystallized state root incorrect. Found: %s, Expected: %s" %
+            (crystallized_state_root, block.crystallized_state_root)
+        )
+    if active_state_root != block.active_state_root:
+        raise ValidationError(
+            "Active state root incorrect. Found: %s, Expected: %s" %
+            (active_state_root, block.active_state_root)
+        )

--- a/eth/beacon/state_machines/validation.py
+++ b/eth/beacon/state_machines/validation.py
@@ -95,7 +95,8 @@ def validate_attestation(
         recent_block_hashes: Iterable[Hash32],
         attestation: 'AttestationRecord',
         chaindb: BaseBeaconChainDB,
-        cycle_length: int) -> None:
+        cycle_length: int,
+        is_validating_signatures: bool=True) -> None:
     """
     Validate the given ``attestation``.
 
@@ -124,18 +125,19 @@ def validate_attestation(
     # TODO: implement versioning
     validate_version(crystallized_state, attestation)
 
-    parent_hashes = get_signed_parent_hashes(
-        recent_block_hashes,
-        block,
-        attestation,
-        cycle_length,
-    )
-    validate_aggregate_sig(
-        crystallized_state,
-        attestation,
-        attestation_indices,
-        parent_hashes,
-    )
+    if is_validating_signatures:
+        parent_hashes = get_signed_parent_hashes(
+            recent_block_hashes,
+            block,
+            attestation,
+            cycle_length,
+        )
+        validate_aggregate_sig(
+            crystallized_state,
+            attestation,
+            attestation_indices,
+            parent_hashes,
+        )
 
 
 def validate_slot(parent_block: 'BaseBeaconBlock',

--- a/eth/utils/bitfield.py
+++ b/eth/utils/bitfield.py
@@ -17,6 +17,7 @@ def has_voted(bitfield: bytes, index: int) -> bool:
     return bool(bitfield[index // 8] & (128 >> (index % 8)))
 
 
+@curry
 def set_voted(bitfield: bytes, index: int) -> bytes:
     byte_index = index // 8
     bit_index = index % 8

--- a/eth/utils/numeric.py
+++ b/eth/utils/numeric.py
@@ -1,6 +1,10 @@
 import functools
 import itertools
 
+from cytoolz import (
+    curry,
+)
+
 from eth.constants import (
     UINT_255_MAX,
     UINT_256_MAX,
@@ -71,3 +75,19 @@ def get_highest_bit_index(value):
         if not value:
             return bit_length
         value >>= 1
+
+
+@curry
+def clamp(inclusive_lower_bound: int,
+          inclusive_upper_bound: int,
+          value: int) -> int:
+    """
+    Bound the given ``value`` between ``inclusive_lower_bound`` and
+    ``inclusive_upper_bound``.
+    """
+    if value <= inclusive_lower_bound:
+        return inclusive_lower_bound
+    elif value >= inclusive_upper_bound:
+        return inclusive_upper_bound
+    else:
+        return value

--- a/tests/beacon/state_machines/conftest.py
+++ b/tests/beacon/state_machines/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from eth.beacon.db.chain import BeaconChainDB
 from eth.beacon.state_machines.configs import BeaconConfig
 from eth.beacon.state_machines.forks.serenity import (
-    SerenityBeaconStateMachine,
+    SerenityStateMachine,
 )
 
 
@@ -32,8 +32,8 @@ def config(base_reward_quotient,
 
 @pytest.fixture
 def fixture_sm_class(config):
-    return SerenityBeaconStateMachine.configure(
-        __name__='SerenityBeaconStateMachineForTesting',
+    return SerenityStateMachine.configure(
+        __name__='SerenityStateMachineForTesting',
         config=config,
     )
 

--- a/tests/beacon/state_machines/conftest.py
+++ b/tests/beacon/state_machines/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+
+from eth.beacon.state_machines.configs import BeaconConfig
+
+
+@pytest.fixture
+def config(base_reward_quotient,
+           default_end_dynasty,
+           deposit_size,
+           cycle_length,
+           min_committee_size,
+           min_dynasty_length,
+           shard_count,
+           slot_duration,
+           sqrt_e_drop_time):
+    return BeaconConfig(
+        BASE_REWARD_QUOTIENT=base_reward_quotient,
+        DEFAULT_END_DYNASTY=default_end_dynasty,
+        DEPOSIT_SIZE=deposit_size,
+        CYCLE_LENGTH=cycle_length,
+        MIN_COMMITTEE_SIZE=min_committee_size,
+        MIN_DYNASTY_LENGTH=min_dynasty_length,
+        SHARD_COUNT=shard_count,
+        SLOT_DURATION=slot_duration,
+        SQRT_E_DROP_TIME=sqrt_e_drop_time,
+    )

--- a/tests/beacon/state_machines/conftest.py
+++ b/tests/beacon/state_machines/conftest.py
@@ -1,6 +1,10 @@
 import pytest
 
+from eth.beacon.db.chain import BeaconChainDB
 from eth.beacon.state_machines.configs import BeaconConfig
+from eth.beacon.state_machines.forks.serenity import (
+    SerenityBeaconStateMachine,
+)
 
 
 @pytest.fixture
@@ -24,3 +28,23 @@ def config(base_reward_quotient,
         SLOT_DURATION=slot_duration,
         SQRT_E_DROP_TIME=sqrt_e_drop_time,
     )
+
+
+@pytest.fixture
+def fixture_sm_class(config):
+    return SerenityBeaconStateMachine.configure(
+        __name__='SerenityBeaconStateMachineForTesting',
+        config=config,
+    )
+
+
+@pytest.fixture
+def initial_chaindb(base_db,
+                    genesis_block,
+                    genesis_crystallized_state,
+                    genesis_active_state):
+    chaindb = BeaconChainDB(base_db)
+    chaindb.persist_block(genesis_block)
+    chaindb.persist_crystallized_state(genesis_crystallized_state)
+    chaindb.persist_active_state(genesis_active_state, genesis_crystallized_state.hash)
+    return chaindb

--- a/tests/beacon/state_machines/test_block_validation.py
+++ b/tests/beacon/state_machines/test_block_validation.py
@@ -1,0 +1,308 @@
+import pytest
+
+from eth_utils import (
+    ValidationError,
+)
+
+from eth.constants import (
+    ZERO_HASH32,
+)
+from eth.utils.bitfield import (
+    get_empty_bitfield,
+    set_voted,
+)
+
+from eth.beacon.block_proposal import BlockProposal
+from eth.beacon.state_machines.validation import (
+    validate_aggregate_sig,
+    validate_attestation,
+    validate_bitfield,
+    validate_justified,
+    validate_slot,
+)
+
+
+from eth.beacon.helpers import (
+    get_attestation_indices,
+    get_block_committees_info,
+    get_new_recent_block_hashes,
+    get_signed_parent_hashes,
+)
+
+
+@pytest.fixture
+def attestation_validation_fixture(fixture_sm_class,
+                                   initial_chaindb,
+                                   genesis_block,
+                                   privkeys):
+    # NOTE: Copied from `test_proposer.py`, might need to refactor it.
+
+    chaindb = initial_chaindb
+
+    # Propose a block
+    block_1_shell = genesis_block.copy(
+        parent_hash=genesis_block.hash,
+        slot_number=genesis_block.slot_number + 1,
+    )
+    sm = fixture_sm_class(chaindb, block_1_shell)
+
+    # The proposer of block_1
+    block_committees_info = (
+        get_block_committees_info(
+            block_1_shell,
+            sm.crystallized_state,
+            sm.config.CYCLE_LENGTH,
+        )
+    )
+    # public_key = sm.crystallized_state.validators[block_committees_info.proposer_index].pubkey
+    private_key = privkeys[block_committees_info.proposer_index]
+    block_proposal = BlockProposal(
+        block=block_1_shell,
+        shard_id=block_committees_info.proposer_shard_id,
+        shard_block_hash=ZERO_HASH32,
+    )
+
+    (block_1, post_crystallized_state, post_active_state, proposer_attestation) = (
+        sm.propose_block(
+            crystallized_state=sm.crystallized_state,
+            active_state=sm.active_state,
+            block_proposal=block_proposal,
+            chaindb=sm.chaindb,
+            config=sm.config,
+            private_key=private_key,
+        )
+    )
+
+    # Block 2
+    # Manually update state for testing
+    sm._update_the_states(post_crystallized_state, post_active_state)
+
+    # Validate the attestation
+    block_2_shell = block_1.copy(
+        parent_hash=block_1.hash,
+        slot_number=block_1.slot_number + 1,
+        attestations=[proposer_attestation],
+    )
+    recent_block_hashes = get_new_recent_block_hashes(
+        sm.active_state.recent_block_hashes,
+        block_1.slot_number,
+        block_2_shell.slot_number,
+        block_1.hash
+    )
+    filled_active_state = sm.active_state.copy(
+        recent_block_hashes=recent_block_hashes,
+    )
+
+    return (
+        post_crystallized_state,
+        filled_active_state,
+        proposer_attestation,
+        block_2_shell,
+        block_1,
+        sm.chaindb
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,cycle_length,'
+        'min_committee_size,shard_count'
+    ),
+    [
+        (100, 50, 10, 10),
+    ],
+)
+def test_validate_attestation_valid(attestation_validation_fixture, cycle_length):
+    (
+        crystallized_state,
+        active_state,
+        attestation,
+        block,
+        parent_block,
+        chaindb,
+    ) = attestation_validation_fixture
+
+    validate_attestation(
+        block,
+        parent_block,
+        crystallized_state,
+        active_state.recent_block_hashes,
+        attestation,
+        chaindb,
+        cycle_length,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,cycle_length,'
+        'min_committee_size,shard_count,'
+        'attestation_slot'
+    ),
+    [
+        (100, 50, 10, 10, 2),
+        (100, 50, 10, 10, -1),
+    ],
+)
+def test_validate_slot(attestation_validation_fixture, cycle_length, attestation_slot):
+    (
+        _,
+        _,
+        attestation,
+        _,
+        parent_block,
+        _,
+    ) = attestation_validation_fixture
+
+    attestation = attestation.copy(
+        slot=attestation_slot,
+    )
+    with pytest.raises(ValidationError):
+        validate_slot(
+            parent_block=parent_block,
+            attestation=attestation,
+            cycle_length=cycle_length,
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,cycle_length,'
+        'min_committee_size,shard_count,'
+    ),
+    [
+        (100, 50, 10, 10),
+    ],
+)
+def test_validate_justified(attestation_validation_fixture):
+    (
+        crystallized_state,
+        _,
+        attestation,
+        _,
+        _,
+        chaindb,
+    ) = attestation_validation_fixture
+
+    # Case 1: attestation.justified_slot > crystallized_state.last_justified_slot
+    attestation_case_1 = attestation.copy(
+        justified_slot=crystallized_state.last_justified_slot + 1
+    )
+    with pytest.raises(ValidationError):
+        validate_justified(
+            crystallized_state,
+            attestation_case_1,
+            chaindb,
+        )
+
+    # Case 2: justified_block_hash is not in canonical chain
+    attestation_case_2 = attestation.copy(
+        justified_block_hash=b'\x11' * 32
+    )
+    with pytest.raises(ValidationError):
+        validate_justified(
+            crystallized_state,
+            attestation_case_2,
+            chaindb,
+        )
+
+    # Case 3: justified_slot doesn't match justified_block_hash
+    attestation_case_3 = attestation.copy(
+        justified_slot=attestation.justified_slot - 1
+    )
+    with pytest.raises(ValidationError):
+        validate_justified(
+            crystallized_state,
+            attestation_case_3,
+            chaindb,
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,cycle_length,'
+        'min_committee_size,shard_count'
+    ),
+    [
+        (100, 50, 10, 10),
+    ],
+)
+def test_validate_bitfield(attestation_validation_fixture, cycle_length):
+    (
+        crystallized_state,
+        _,
+        attestation,
+        _,
+        _,
+        _,
+    ) = attestation_validation_fixture
+
+    attestation_indices = get_attestation_indices(
+        crystallized_state,
+        attestation,
+        cycle_length,
+    )
+
+    # Case 1: Attestation has incorrect bitfield length
+    attestation_case_1 = attestation.copy(
+        attester_bitfield=get_empty_bitfield(10),
+    )
+    with pytest.raises(ValidationError):
+        validate_bitfield(
+            attestation_case_1,
+            attestation_indices
+        )
+
+    # Case 2: End bits are not all zero
+    last_bit = len(attestation_indices)
+    attestation_case_2 = attestation.copy(
+        attester_bitfield=set_voted(attestation.attester_bitfield, last_bit),
+    )
+    with pytest.raises(ValidationError):
+        validate_bitfield(
+            attestation_case_2,
+            attestation_indices
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,cycle_length,'
+        'min_committee_size,shard_count'
+    ),
+    [
+        (100, 50, 10, 10),
+    ],
+)
+def test_validate_attestation_aggregate_sig(attestation_validation_fixture, cycle_length):
+    (
+        crystallized_state,
+        active_state,
+        attestation,
+        block,
+        _,
+        _
+    ) = attestation_validation_fixture
+
+    attestation_indices = get_attestation_indices(
+        crystallized_state,
+        attestation,
+        cycle_length,
+    )
+    parent_hashes = get_signed_parent_hashes(
+        active_state.recent_block_hashes,
+        block,
+        attestation,
+        cycle_length,
+    )
+
+    attestation = attestation.copy(
+        aggregate_sig=[0, 0]
+    )
+    with pytest.raises(ValidationError):
+        validate_aggregate_sig(
+            crystallized_state,
+            attestation,
+            attestation_indices,
+            parent_hashes,
+        )

--- a/tests/beacon/state_machines/test_proposer.py
+++ b/tests/beacon/state_machines/test_proposer.py
@@ -4,6 +4,7 @@ from eth.constants import (
     ZERO_HASH32,
 )
 
+from eth.beacon.block_proposal import BlockProposal
 from eth.beacon.helpers import (
     get_block_committees_info,
     get_new_recent_block_hashes,
@@ -46,14 +47,17 @@ def test_propose_block_and_validate_attestation(fixture_sm_class,
     )
     # public_key = sm.crystallized_state.validators[block_committees_info.proposer_index].pubkey
     private_key = privkeys[block_committees_info.proposer_index]
+    block_proposal = BlockProposal(
+        block=block_1_shell,
+        shard_id=block_committees_info.proposer_shard_id,
+        shard_block_hash=ZERO_HASH32,
+    )
 
     (block_1, post_crystallized_state, post_active_state, proposer_attestation) = (
         sm.propose_block(
             crystallized_state=sm.crystallized_state,
             active_state=sm.active_state,
-            block=block_1_shell,
-            shard_id=block_committees_info.proposer_shard_id,
-            shard_block_hash=ZERO_HASH32,
+            block_proposal=block_proposal,
             chaindb=sm.chaindb,
             config=sm.config,
             private_key=private_key,

--- a/tests/beacon/state_machines/test_proposer.py
+++ b/tests/beacon/state_machines/test_proposer.py
@@ -26,10 +26,10 @@ from eth.beacon.state_machines.validation import (
         (1000, 20, 10, 100),
     ]
 )
-def test_propose_block_and_validate_attestation(fixture_sm_class,
-                                                initial_chaindb,
-                                                genesis_block,
-                                                privkeys):
+def test_propose_block(fixture_sm_class,
+                       initial_chaindb,
+                       genesis_block,
+                       privkeys):
     chaindb = initial_chaindb
 
     # Propose a block
@@ -39,7 +39,9 @@ def test_propose_block_and_validate_attestation(fixture_sm_class,
     )
     sm = fixture_sm_class(chaindb, block_1_shell)
 
+    #
     # The proposer of block_1
+    #
     block_committees_info = (
         get_block_committees_info(
             block_1_shell,
@@ -94,7 +96,9 @@ def test_propose_block_and_validate_attestation(fixture_sm_class,
         block_committees_info.proposer_index_in_committee
     )
 
+    #
     # The proposer of block_2
+    #
     block_committees_info = (
         get_block_committees_info(
             block_2_shell,

--- a/tests/beacon/state_machines/test_proposer.py
+++ b/tests/beacon/state_machines/test_proposer.py
@@ -9,38 +9,9 @@ from eth.beacon.helpers import (
     get_new_recent_block_hashes,
 )
 
-
-@pytest.mark.parametrize(
-    (
-        'num_validators,'
-        'cycle_length,min_committee_size,shard_count'
-    ),
-    [
-        (1000, 20, 10, 100),
-    ]
+from eth.beacon.state_machines.validation import (
+    validate_parent_block_proposer,
 )
-def test_import_block_one(fixture_sm_class,
-                          initial_chaindb,
-                          genesis_block):
-    chaindb = initial_chaindb
-
-    # Create the first block
-    block_1_shell = genesis_block.copy(
-        parent_hash=genesis_block.hash,
-        slot_number=genesis_block.slot_number + 1,
-    )
-    sm = fixture_sm_class(chaindb, block_1_shell)
-    active_state_1 = sm.compute_per_block_transtion(
-        sm.crystallized_state,
-        sm.active_state,
-        block_1_shell,
-        sm.chaindb,
-        sm.config,
-    )
-    block_1 = block_1_shell.copy(
-        active_state_root=active_state_1.hash,
-    )
-    sm.import_block(block_1)
 
 
 @pytest.mark.parametrize(
@@ -55,7 +26,7 @@ def test_import_block_one(fixture_sm_class,
 def test_propose_block_and_validate_attestation(fixture_sm_class,
                                                 initial_chaindb,
                                                 genesis_block,
-                                                keymap):
+                                                privkeys):
     chaindb = initial_chaindb
 
     # Propose a block
@@ -73,8 +44,8 @@ def test_propose_block_and_validate_attestation(fixture_sm_class,
             sm.config.CYCLE_LENGTH,
         )
     )
-    public_key = sm.crystallized_state.validators[block_committees_info.proposer_index].pubkey
-    private_key = keymap[public_key]
+    # public_key = sm.crystallized_state.validators[block_committees_info.proposer_index].pubkey
+    private_key = privkeys[block_committees_info.proposer_index]
 
     (block_1, post_crystallized_state, post_active_state, proposer_attestation) = (
         sm.propose_block(
@@ -88,6 +59,13 @@ def test_propose_block_and_validate_attestation(fixture_sm_class,
             private_key=private_key,
         )
     )
+    expect_block_1 = block_1_shell.copy(
+        active_state_root=post_active_state.hash,
+        crystallized_state_root=post_crystallized_state.hash,
+    )
+    assert block_1.hash == expect_block_1.hash
+
+    # Manually update state for testing
     sm._update_the_states(post_crystallized_state, post_active_state)
 
     # Validate the attestation
@@ -117,7 +95,7 @@ def test_propose_block_and_validate_attestation(fixture_sm_class,
     )
 
     # Validate the parent block proposer
-    sm.validate_parent_block_proposer(
+    validate_parent_block_proposer(
         sm.crystallized_state,
         block_2_shell,
         block_1,

--- a/tests/beacon/state_machines/test_proposer.py
+++ b/tests/beacon/state_machines/test_proposer.py
@@ -1,0 +1,149 @@
+import pytest
+
+from eth.constants import (
+    ZERO_HASH32,
+)
+from eth.beacon.state_machines.forks.serenity import (
+    SerenityBeaconStateMachine,
+)
+from eth.beacon.db.chain import BeaconChainDB
+
+from eth.beacon.helpers import (
+    get_block_committees_info,
+    get_new_recent_block_hashes,
+)
+
+
+@pytest.fixture
+def fixture_sm_class(config):
+    return SerenityBeaconStateMachine.configure(
+        __name__='SerenityBeaconStateMachineForTesting',
+        config=config,
+    )
+
+
+@pytest.fixture
+def initial_chaindb(base_db,
+                    genesis_block,
+                    genesis_crystallized_state,
+                    genesis_active_state):
+    chaindb = BeaconChainDB(base_db)
+    chaindb.persist_block(genesis_block)
+    chaindb.persist_crystallized_state(genesis_crystallized_state)
+    chaindb.persist_active_state(genesis_active_state, genesis_crystallized_state.hash)
+    return chaindb
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'cycle_length,min_committee_size,shard_count'
+    ),
+    [
+        (1000, 20, 10, 100),
+    ]
+)
+def test_import_block_one(fixture_sm_class,
+                          initial_chaindb,
+                          genesis_block):
+    chaindb = initial_chaindb
+
+    # Create the first block
+    block_1_shell = genesis_block.copy(
+        parent_hash=genesis_block.hash,
+        slot_number=genesis_block.slot_number + 1,
+    )
+    sm = fixture_sm_class(chaindb, block_1_shell)
+    active_state_1 = sm.compute_per_block_transtion(
+        sm.crystallized_state,
+        sm.active_state,
+        block_1_shell,
+        sm.chaindb,
+        sm.config,
+    )
+    block_1 = block_1_shell.copy(
+        active_state_root=active_state_1.hash,
+    )
+    sm.import_block(block_1)
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'cycle_length,min_committee_size,shard_count'
+    ),
+    [
+        (1000, 20, 10, 100),
+    ]
+)
+def test_propose_block_and_validate_attestation(fixture_sm_class,
+                                                initial_chaindb,
+                                                genesis_block,
+                                                keymap):
+    chaindb = initial_chaindb
+
+    # Propose a block
+    block_1_shell = genesis_block.copy(
+        parent_hash=genesis_block.hash,
+        slot_number=genesis_block.slot_number + 1,
+    )
+    sm = fixture_sm_class(chaindb, block_1_shell)
+
+    # The proposer of block_1
+    block_committees_info = (
+        get_block_committees_info(
+            block_1_shell,
+            sm.crystallized_state,
+            sm.config.CYCLE_LENGTH,
+        )
+    )
+    public_key = sm.crystallized_state.validators[block_committees_info.proposer_index].pubkey
+    private_key = keymap[public_key]
+
+    (block_1, post_crystallized_state, post_active_state, proposer_attestation) = (
+        sm.propose_block(
+            crystallized_state=sm.crystallized_state,
+            active_state=sm.active_state,
+            block=block_1_shell,
+            shard_id=block_committees_info.proposer_shard_id,
+            shard_block_hash=ZERO_HASH32,
+            chaindb=sm.chaindb,
+            config=sm.config,
+            private_key=private_key,
+        )
+    )
+    sm._update_the_states(post_crystallized_state, post_active_state)
+
+    # Validate the attestation
+    block_2_shell = block_1.copy(
+        parent_hash=block_1.hash,
+        slot_number=block_1.slot_number + 1,
+        attestations=[proposer_attestation],
+    )
+    recent_block_hashes = get_new_recent_block_hashes(
+        sm.active_state.recent_block_hashes,
+        block_1.slot_number,
+        block_2_shell.slot_number,
+        block_1.hash
+    )
+    filled_active_state = sm.active_state.copy(
+        recent_block_hashes=recent_block_hashes,
+    )
+
+    sm.validate_attestation(
+        block_2_shell,
+        block_1,
+        sm.crystallized_state,
+        filled_active_state,
+        proposer_attestation,
+        sm.chaindb,
+        sm.config.CYCLE_LENGTH,
+    )
+
+    # Validate the parent block proposer
+    sm.validate_parent_block_proposer(
+        sm.crystallized_state,
+        block_2_shell,
+        block_1,
+        sm.config.CYCLE_LENGTH,
+    )

--- a/tests/beacon/state_machines/test_proposer.py
+++ b/tests/beacon/state_machines/test_proposer.py
@@ -4,12 +4,14 @@ from eth.constants import (
     ZERO_HASH32,
 )
 
+from eth.utils.bitfield import (
+    has_voted,
+)
+
 from eth.beacon.block_proposal import BlockProposal
 from eth.beacon.helpers import (
     get_block_committees_info,
-    get_new_recent_block_hashes,
 )
-
 from eth.beacon.state_machines.validation import (
     validate_parent_block_proposer,
 )
@@ -45,7 +47,6 @@ def test_propose_block_and_validate_attestation(fixture_sm_class,
             sm.config.CYCLE_LENGTH,
         )
     )
-    # public_key = sm.crystallized_state.validators[block_committees_info.proposer_index].pubkey
     private_key = privkeys[block_committees_info.proposer_index]
     block_proposal = BlockProposal(
         block=block_1_shell,
@@ -69,33 +70,15 @@ def test_propose_block_and_validate_attestation(fixture_sm_class,
     )
     assert block_1.hash == expect_block_1.hash
 
-    # Manually update state for testing
-    sm._update_the_states(post_crystallized_state, post_active_state)
+    # Persist block_1
+    sm.import_block(block_1)
+    sm.chaindb.persist_block(block_1)
 
     # Validate the attestation
     block_2_shell = block_1.copy(
         parent_hash=block_1.hash,
         slot_number=block_1.slot_number + 1,
-        attestations=[proposer_attestation],
-    )
-    recent_block_hashes = get_new_recent_block_hashes(
-        sm.active_state.recent_block_hashes,
-        block_1.slot_number,
-        block_2_shell.slot_number,
-        block_1.hash
-    )
-    filled_active_state = sm.active_state.copy(
-        recent_block_hashes=recent_block_hashes,
-    )
-
-    sm.validate_attestation(
-        block_2_shell,
-        block_1,
-        sm.crystallized_state,
-        filled_active_state,
-        proposer_attestation,
-        sm.chaindb,
-        sm.config.CYCLE_LENGTH,
+        attestations=(proposer_attestation, ),
     )
 
     # Validate the parent block proposer
@@ -105,3 +88,39 @@ def test_propose_block_and_validate_attestation(fixture_sm_class,
         block_1,
         sm.config.CYCLE_LENGTH,
     )
+
+    assert has_voted(
+        proposer_attestation.attester_bitfield,
+        block_committees_info.proposer_index_in_committee
+    )
+
+    # The proposer of block_2
+    block_committees_info = (
+        get_block_committees_info(
+            block_2_shell,
+            sm.crystallized_state,
+            sm.config.CYCLE_LENGTH,
+        )
+    )
+    private_key = privkeys[block_committees_info.proposer_index]
+    block_proposal = BlockProposal(
+        block=block_2_shell,
+        shard_id=block_committees_info.proposer_shard_id,
+        shard_block_hash=ZERO_HASH32,
+    )
+
+    (block_2, post_crystallized_state, post_active_state, proposer_attestation) = (
+        sm.propose_block(
+            crystallized_state=sm.crystallized_state,
+            active_state=sm.active_state,
+            block_proposal=block_proposal,
+            chaindb=sm.chaindb,
+            config=sm.config,
+            private_key=private_key,
+        )
+    )
+    expect_block_2 = block_2_shell.copy(
+        active_state_root=post_active_state.hash,
+        crystallized_state_root=post_crystallized_state.hash,
+    )
+    assert block_2.hash == expect_block_2.hash

--- a/tests/beacon/state_machines/test_proposer.py
+++ b/tests/beacon/state_machines/test_proposer.py
@@ -3,35 +3,11 @@ import pytest
 from eth.constants import (
     ZERO_HASH32,
 )
-from eth.beacon.state_machines.forks.serenity import (
-    SerenityBeaconStateMachine,
-)
-from eth.beacon.db.chain import BeaconChainDB
 
 from eth.beacon.helpers import (
     get_block_committees_info,
     get_new_recent_block_hashes,
 )
-
-
-@pytest.fixture
-def fixture_sm_class(config):
-    return SerenityBeaconStateMachine.configure(
-        __name__='SerenityBeaconStateMachineForTesting',
-        config=config,
-    )
-
-
-@pytest.fixture
-def initial_chaindb(base_db,
-                    genesis_block,
-                    genesis_crystallized_state,
-                    genesis_active_state):
-    chaindb = BeaconChainDB(base_db)
-    chaindb.persist_block(genesis_block)
-    chaindb.persist_crystallized_state(genesis_crystallized_state)
-    chaindb.persist_active_state(genesis_active_state, genesis_crystallized_state.hash)
-    return chaindb
 
 
 @pytest.mark.parametrize(

--- a/tests/beacon/state_machines/test_state_machines.py
+++ b/tests/beacon/state_machines/test_state_machines.py
@@ -1,20 +1,16 @@
 from eth.constants import (
     ZERO_HASH32,
 )
+
 from eth.beacon.state_machines.forks.serenity import (
     SerenityBeaconStateMachine,
 )
-from eth.beacon.db.chain import BeaconChainDB
 
 
-def test_state_machine(base_db,
+def test_state_machine(initial_chaindb,
                        genesis_block,
-                       genesis_crystallized_state,
-                       genesis_active_state):
-    chaindb = BeaconChainDB(base_db)
-    chaindb.persist_block(genesis_block)
-    chaindb.persist_crystallized_state(genesis_crystallized_state)
-    chaindb.persist_active_state(genesis_active_state, genesis_crystallized_state.hash)
+                       genesis_crystallized_state):
+    chaindb = initial_chaindb
 
     block_1 = genesis_block.copy(
         parent_hash=genesis_block.hash,

--- a/tests/beacon/state_machines/test_state_machines.py
+++ b/tests/beacon/state_machines/test_state_machines.py
@@ -80,7 +80,7 @@ def test_import_block_one(fixture_sm_class,
         slot_number=genesis_block.slot_number + 1,
     )
     sm = fixture_sm_class(chaindb, block_1_shell)
-    active_state_1 = sm.compute_per_block_transtion(
+    active_state_1 = sm.compute_per_block_transition(
         sm.crystallized_state,
         sm.active_state,
         block_1_shell,

--- a/tests/beacon/state_machines/test_state_machines.py
+++ b/tests/beacon/state_machines/test_state_machines.py
@@ -9,6 +9,20 @@ from eth.beacon.state_machines.forks.serenity import (
 )
 
 
+def test_state_machine_canonical(initial_chaindb,
+                                 genesis_block,
+                                 genesis_crystallized_state,
+                                 genesis_active_state):
+    chaindb = initial_chaindb
+    sm = SerenityStateMachine(chaindb)
+    assert sm.block == genesis_block.copy(
+        slot_number=genesis_block.slot_number + 1,
+        parent_hash=genesis_block.hash
+    )
+    assert sm.crystallized_state == genesis_crystallized_state
+    assert sm.active_state == genesis_active_state
+
+
 def test_state_machine(initial_chaindb,
                        genesis_block,
                        genesis_crystallized_state):

--- a/tests/beacon/state_machines/test_state_machines.py
+++ b/tests/beacon/state_machines/test_state_machines.py
@@ -1,9 +1,11 @@
+import pytest
+
 from eth.constants import (
     ZERO_HASH32,
 )
 
 from eth.beacon.state_machines.forks.serenity import (
-    SerenityBeaconStateMachine,
+    SerenityStateMachine,
 )
 
 
@@ -34,10 +36,48 @@ def test_state_machine(initial_chaindb,
         active_state_root=b'\x33' * 32,
     )
 
-    sm = SerenityBeaconStateMachine(chaindb, block_3)
+    sm = SerenityStateMachine(chaindb, block_3)
 
     assert sm.crystallized_state == genesis_crystallized_state
-    expect = [ZERO_HASH32] * (sm.config.CYCLE_LENGTH * 2 - 2) + \
+    expect = tuple(
+        [ZERO_HASH32] * (sm.config.CYCLE_LENGTH * 2 - 2) +
         [genesis_block.hash] + [block_1.hash]
-    expect = tuple(expect)
+    )
     assert sm.active_state.recent_block_hashes == expect
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'cycle_length,min_committee_size,shard_count'
+    ),
+    [
+        (1000, 20, 10, 100),
+    ]
+)
+def test_import_block_one(fixture_sm_class,
+                          initial_chaindb,
+                          genesis_block):
+    chaindb = initial_chaindb
+
+    # Create the first block
+    block_1_shell = genesis_block.copy(
+        parent_hash=genesis_block.hash,
+        slot_number=genesis_block.slot_number + 1,
+    )
+    sm = fixture_sm_class(chaindb, block_1_shell)
+    active_state_1 = sm.compute_per_block_transtion(
+        sm.crystallized_state,
+        sm.active_state,
+        block_1_shell,
+        sm.chaindb,
+        sm.config,
+    )
+    block_1 = block_1_shell.copy(
+        active_state_root=active_state_1.hash,
+    )
+    _, _, active_state = sm.import_block(block_1)
+    expect = tuple(
+        [ZERO_HASH32] * (sm.config.CYCLE_LENGTH * 2 - 1) + [genesis_block.hash]
+    )
+    assert active_state.recent_block_hashes == expect

--- a/tests/beacon/test_aggregation.py
+++ b/tests/beacon/test_aggregation.py
@@ -1,0 +1,68 @@
+import pytest
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
+
+from eth.utils import bls
+from eth.utils.bitfield import (
+    get_empty_bitfield,
+    has_voted,
+)
+from eth.beacon.aggregation import (
+    aggregate_votes,
+    verify_votes,
+)
+
+
+@settings(max_examples=1)
+@given(random=st.randoms())
+@pytest.mark.parametrize(
+    (
+        'votes_count'
+    ),
+    [
+        (0),
+        (9),
+    ],
+)
+def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
+    bit_count = 10
+    pre_bitfield = get_empty_bitfield(bit_count)
+    pre_sigs = ()
+
+    random_votes = random.sample([i for i in range(bit_count)], votes_count)
+    message = b'hello'
+
+    # Get votes: (committee_index, sig, public_key)
+    votes = [
+        (committee_index, bls.sign(message, privkeys[committee_index]), pubkeys[committee_index])
+        for committee_index in random_votes
+    ]
+
+    # Verify
+    sigs, committee_indices = verify_votes(message, votes)
+
+    # Aggregate the votes
+    bitfield, sigs = aggregate_votes(
+        bitfield=pre_bitfield,
+        sigs=pre_sigs,
+        voting_sigs=sigs,
+        voting_committee_indices=committee_indices
+    )
+
+    try:
+        _, _, pubs = zip(*votes)
+    except ValueError:
+        pubs = ()
+
+    voted_index = [
+        committee_index
+        for committee_index in random_votes
+        if has_voted(bitfield, committee_index)
+    ]
+    assert len(voted_index) == len(votes)
+
+    aggregated_pubs = bls.aggregate_pubs(pubs)
+    assert bls.verify(message, aggregated_pubs, sigs)

--- a/tests/beacon/test_aggregation.py
+++ b/tests/beacon/test_aggregation.py
@@ -32,7 +32,7 @@ def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
     pre_bitfield = get_empty_bitfield(bit_count)
     pre_sigs = ()
 
-    random_votes = random.sample([i for i in range(bit_count)], votes_count)
+    random_votes = random.sample(range(bit_count), votes_count)
     message = b'hello'
 
     # Get votes: (committee_index, sig, public_key)

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -11,10 +11,7 @@ from eth.beacon.helpers import (
     get_new_shuffling,
     get_shards_and_committees_for_slot,
     get_signed_parent_hashes,
-    get_proposer_position,
-)
-from eth.utils.blake import (
-    blake,
+    get_block_committees_info,
 )
 
 from tests.beacon.helpers import (
@@ -163,7 +160,7 @@ def test_get_hashes_to_sign(genesis_block, cycle_length):
         cycle_length,
     )
     assert len(result) == cycle_length
-    assert result[-1] == blake(block.hash)
+    assert result[-1] == block.hash
 
 
 def test_get_new_recent_block_hashes(genesis_block,
@@ -347,13 +344,13 @@ def test_get_new_shuffling_handles_shard_wrap(genesis_validators,
         ([], 1, ValueError()),
     ],
 )
-def test_get_proposer_position(monkeypatch,
-                               genesis_block,
-                               genesis_crystallized_state,
-                               committee,
-                               parent_block_number,
-                               result_proposer_index_in_committee,
-                               cycle_length):
+def test_get_block_committees_info(monkeypatch,
+                                   genesis_block,
+                                   genesis_crystallized_state,
+                                   committee,
+                                   parent_block_number,
+                                   result_proposer_index_in_committee,
+                                   cycle_length):
     from eth.beacon import helpers
 
     def mock_get_shards_and_committees_for_slot(parent_block,
@@ -376,16 +373,18 @@ def test_get_proposer_position(monkeypatch,
 
     if isinstance(result_proposer_index_in_committee, Exception):
         with pytest.raises(ValueError):
-            get_proposer_position(
+            get_block_committees_info(
                 parent_block,
                 genesis_crystallized_state,
                 cycle_length,
             )
     else:
-        proposer_index_in_committee, _ = get_proposer_position(
+        block_committees_info = get_block_committees_info(
             parent_block,
             genesis_crystallized_state,
             cycle_length,
         )
-
-        assert proposer_index_in_committee == result_proposer_index_in_committee
+        assert (
+            block_committees_info.proposer_index_in_committee ==
+            result_proposer_index_in_committee
+        )

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -1,6 +1,9 @@
-import random
-
 import pytest
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
 
 from eth.utils import bls
 from eth.utils.bitfield import (
@@ -20,6 +23,7 @@ from eth.beacon.helpers import (
     get_shards_and_committees_for_slot,
     get_signed_parent_hashes,
     get_block_committees_info,
+    verify_votes,
 )
 
 from tests.beacon.helpers import (
@@ -398,18 +402,18 @@ def test_get_block_committees_info(monkeypatch,
         )
 
 
+@settings(max_examples=1)
+@given(random=st.randoms())
 @pytest.mark.parametrize(
     (
         'votes_count'
     ),
     [
         (0),
-        (1),
-        (5),
         (9),
     ],
 )
-def test_aggregate_votes(votes_count, privkeys, pubkeys):
+def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
     bit_count = 10
     pre_bitfield = get_empty_bitfield(bit_count)
     pre_sigs = ()
@@ -417,16 +421,21 @@ def test_aggregate_votes(votes_count, privkeys, pubkeys):
     random_votes = random.sample([i for i in range(bit_count)], votes_count)
     message = b'hello'
 
-    # (committee_index, sig, public_key)
+    # Get votes: (committee_index, sig, public_key)
     votes = [
         (committee_index, bls.sign(message, privkeys[committee_index]), pubkeys[committee_index])
         for committee_index in random_votes
     ]
+
+    # Verify
+    sigs, committee_indices = verify_votes(message, votes)
+
+    # Aggregate the votes
     bitfield, sigs = aggregate_votes(
-        message,
-        votes,
-        pre_bitfield,
-        pre_sigs,
+        bitfield=pre_bitfield,
+        sigs=pre_sigs,
+        voting_sigs=sigs,
+        voting_committee_indices=committee_indices
     )
 
     try:
@@ -434,7 +443,12 @@ def test_aggregate_votes(votes_count, privkeys, pubkeys):
     except ValueError:
         pubs = ()
 
+    voted_index = [
+        committee_index
+        for committee_index in random_votes
+        if has_voted(bitfield, committee_index)
+    ]
+    assert len(voted_index) == len(votes)
+
     aggregated_pubs = bls.aggregate_pubs(pubs)
-    for committee_index in random_votes:
-        if has_voted(bitfield, committee_index):
-            assert bls.verify(message, aggregated_pubs, sigs)
+    assert bls.verify(message, aggregated_pubs, sigs)

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -1,15 +1,5 @@
 import pytest
-from hypothesis import (
-    given,
-    settings,
-    strategies as st,
-)
 
-from eth.utils import bls
-from eth.utils.bitfield import (
-    get_empty_bitfield,
-    has_voted,
-)
 from eth.beacon.types.attestation_records import AttestationRecord
 from eth.beacon.types.shard_and_committees import ShardAndCommittee
 from eth.beacon.helpers import (

--- a/tests/core/bitfield-utils/test_bitfields.py
+++ b/tests/core/bitfield-utils/test_bitfields.py
@@ -140,7 +140,7 @@ def test_or_bitfields():
 @given(st.integers(1, 1000))
 def test_set_vote_and_has_vote(bit_count):
     bitfield = get_empty_bitfield(bit_count)
-    index = random.choice([i for i in range(bit_count)])
+    index = random.choice(range(bit_count))
     bitfield = set_voted(bitfield, index)
     assert has_voted(bitfield, index)
 
@@ -150,7 +150,7 @@ def test_set_vote_and_has_vote(bit_count):
 def test_has_voted_random(votes_count):
     bit_count = 1000
     bitfield = get_empty_bitfield(bit_count)
-    random_votes = random.sample([i for i in range(bit_count)], votes_count)
+    random_votes = random.sample(range(bit_count), votes_count)
 
     for index in random_votes:
         bitfield = set_voted(bitfield, index)


### PR DESCRIPTION
Apologize for the fat PR. 🙈 

### What was wrong?
#1381 - StateMachine - per block transition and attestation

### How was it fixed?


#### Follow [the beacon chain spec - Per-block processing section](https://github.com/ethereum/eth2.0-specs/blob/fe74c7e299ff90d56f4099733754c0e94e645ccc/specs/beacon-chain.md#per-block-processing) **except**:
1. No `update_ancestor_hashes`  design in this PR
2. No RANDAO reveal design in this PR
3. No versioning design in this PR

#### Modifications:
1. `helpers.py`
	1. Bugfix `get_hashes_to_sign` - shouldn’t re-hash the latest hash
	2. Remove multiple slots per committee option: https://github.com/ethereum/eth2.0-specs/pull/62
	3. Rename `get_proposer_position` to `get_block_committees_info`, it will return `BlockCommitteesInfo` as a simple structure of the committee information context.
2. `eth.beacon.state_machines.base.py`
	1. **Import block APIs**
		1. Import the given block into state machine
		2. Call process APIs; if valid, update the states in memory
	2. **Process block APIs** (all are classmethods)
		1. Pure functions for processing a block
		2. `compute_per_block_transtion`: compute for every block, will return the updated `active_state`. 
			1. Validate the `validate_parent_block_proposer` and `attestations`
			2. Return the new `active_state`
		3. (TODO in other PRs) `compute_cycle_transitions`: compute the cycle transitions. (`CYCLE_LENGTH = 64 slots`), will return the updated `crystallized_state` and `active_state`.
	3. **Proposer APIs** 
		1.  Proposer story, please see `test_propose_block_and_validate_attestation` tests:
			 1. The block proposer of slot 1:
				 1. Creates a block and process the block `B1`.
					 * Note: no shard block validation currently, so I just set `shard_block_hash=ZERO_HASH32`.
				 2. Attests the block and create an `AttestationRecord` of `B1`
				 3. Broadcasts `B1` **and the attestation record of  `B1`.**
			 2. The other attesters validate `B1`.
				 * If it's valid, sign the same message.
			 3. The next block proposer or other nodes collect  the votes
				* Aggregate the signatures and build attestation record.
				* Broadcast the attestation record.
			 4. The block proposer of slot 2:
				 1. Create a block `B2` with the aggregated attestation records
				 2. Attests the block and create an `AttestationRecord`
				 3. Broadcasts `B2` **and the attestation record of  `B2`.**
                          (Continue)
	4. **Validation APIs** (all are classmethods)
		1. proposer validation 
		2. attestation validation


#### TODO
- Add tests for validation APIs
- Add tests for aggregate signature
- Add test for multiple attestations and multiple blocks.
- Add assertions in the current tests.
- Too many arguments passing! 
	* Yep I see > 6 is a bad signal. I’d prefer to keep using pure function in processing the block, so need to refactor it.
	* FYI: The only reason why Proposer APIs are not classmethods is because it calls `self.get_attestation_record_class()`, any other way to avoid it?

@djrtwo: the proposer logic is partially from old `mock_make_attestations` and partially something new, could you verify the description above? Thanks!


#### Cute Animal Picture
Cat-sper!
![caspercat_by_steve_begin](https://user-images.githubusercontent.com/9263930/46867673-67e05880-ce58-11e8-9e32-fa167fe9b671.jpg)
