### PR TITLE
Memory db to level db

### DIFF
--- a/scripts/benchmark/utils/chain_plumbing.py
+++ b/scripts/benchmark/utils/chain_plumbing.py
@@ -2,11 +2,9 @@ from pathlib import (
     Path,
 )
 import tempfile
-
 from typing import (
     Any,
     Dict,
-    Generator,
     Iterable,
     Tuple,
     Type,
@@ -90,9 +88,8 @@ DEFAULT_GENESIS_STATE = [
 GenesisState = Iterable[Tuple[Address, Dict[str, Any]]]
 
 
-def get_chain(vm: Type[BaseVM], genesis_state: GenesisState) -> Generator[MiningChain, None, None]:
+def get_chain(vm: Type[BaseVM], genesis_state: GenesisState) -> Iterable[MiningChain]:
 
-    # Chain uses LevelDB
     with tempfile.TemporaryDirectory() as temp_dir:
         level_db_obj = LevelDB(Path(temp_dir))
         level_db_chain = build(
@@ -106,5 +103,4 @@ def get_chain(vm: Type[BaseVM], genesis_state: GenesisState) -> Generator[Mining
 
 def get_all_chains(genesis_state: GenesisState=DEFAULT_GENESIS_STATE) -> Iterable[MiningChain]:
     for vm in ALL_VM:
-        chain = get_chain(vm, genesis_state)
-        yield next(chain)
+        yield from get_chain(vm, genesis_state)


### PR DESCRIPTION
### What was wrong?
Currently, all our benchmarks run against the `MemoryDB`. Unfortunately, that means we are missing out to measure pretty much all optimizations that are about reducing the number of hits to read/write to the database.

In other words, if some optimizations save e.g. two hits to the DB we will barely see any difference in the benchmarks as data updates in-memory are just super fast compared to the actual cost when we hit the disk (which will be the case with something like `LevelDB`.

Issue : #1359 

### How was it fixed?
While creating the chains, for each benchmark the chains were created one with `MemoryDB` and one with `LevelDB` in `chain_plumbing.py` which is the base for all the benchmarks.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/g4xLVP_eFec/maxresdefault.jpg)
