### PR TITLE
Fix type hints

### DIFF
--- a/eth/beacon/block_proposal.py
+++ b/eth/beacon/block_proposal.py
@@ -1,6 +1,5 @@
 from typing import (
     NamedTuple,
-    Tuple,
     TYPE_CHECKING,
 )
 
@@ -18,6 +17,6 @@ BlockProposal = NamedTuple(
     (
         ('block', 'BaseBeaconBlock'),
         ('shard_id', int),
-        ('shard_block_hash', Tuple[Hash32]),
+        ('shard_block_hash', Hash32),
     )
 )


### PR DESCRIPTION
### What was wrong?
I broke the py35-lint checks... `BlockProposal.shard_block_hash` should be `Hash32`.

### How was it fixed?
Change it to `Hash32`.


#### Cute Animal Picture

    (Sorry! (and I should have rebased))
     /
😿 
