### PR TITLE
Add `compute_cycle_transitions`

### DIFF
--- a/eth/beacon/state_machines/base.py
+++ b/eth/beacon/state_machines/base.py
@@ -385,6 +385,11 @@ class BeaconStateMachine(BaseBeaconStateMachine):
                 block,
             )
 
+            # TODO: it's a STUB before we implement compute_per_cycle_transition
+            crystallized_state = crystallized_state.copy(
+                last_state_recalc=crystallized_state.last_state_recalc + cls.config.CYCLE_LENGTH
+            )
+
             if cls.ready_for_dynasty_transition(crystallized_state, block):
                 crystallized_state = cls.compute_dynasty_transition(
                     crystallized_state,
@@ -409,10 +414,10 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     # Crosslinks
     #
     @classmethod
-    def compute_crosslinks(cls,
-                           crystallized_state: CrystallizedState,
-                           active_state: ActiveState,
-                           block: BaseBeaconBlock) -> Tuple['CrosslinkRecord', ...]:
+    def update_crosslinks(cls,
+                          crystallized_state: CrystallizedState,
+                          active_state: ActiveState,
+                          block: BaseBeaconBlock) -> Tuple['CrosslinkRecord', ...]:
         # TODO
         return ()
 

--- a/eth/beacon/state_machines/base.py
+++ b/eth/beacon/state_machines/base.py
@@ -385,11 +385,6 @@ class BeaconStateMachine(BaseBeaconStateMachine):
                 block,
             )
 
-            # TODO: it's a STUB before we implement compute_per_cycle_transition
-            crystallized_state = crystallized_state.copy(
-                last_state_recalc=crystallized_state.last_state_recalc + cls.config.CYCLE_LENGTH
-            )
-
             if cls.ready_for_dynasty_transition(crystallized_state, block):
                 crystallized_state = cls.compute_dynasty_transition(
                     crystallized_state,
@@ -407,7 +402,11 @@ class BeaconStateMachine(BaseBeaconStateMachine):
         """
         Initialize a new cycle.
         """
-        # TODO
+        # TODO: it's a STUB before we implement compute_per_cycle_transition
+        crystallized_state = crystallized_state.copy(
+            last_state_recalc=crystallized_state.last_state_recalc + cls.config.CYCLE_LENGTH
+        )
+
         return crystallized_state, active_state
 
     #

--- a/eth/beacon/types/crystallized_states.py
+++ b/eth/beacon/types/crystallized_states.py
@@ -106,7 +106,7 @@ class CrystallizedState(rlp.Serializable):
         )
 
     @property
-    def total_deposits(self) -> int:
+    def total_balance(self) -> int:
         return sum(
             self.validators[index].balance
             for index in self.active_validator_indices

--- a/tests/beacon/state_machines/test_block_validation.py
+++ b/tests/beacon/state_machines/test_block_validation.py
@@ -70,7 +70,6 @@ def attestation_validation_fixture(fixture_sm_class,
             active_state=sm.active_state,
             block_proposal=block_proposal,
             chaindb=sm.chaindb,
-            config=sm.config,
             private_key=private_key,
         )
     )

--- a/tests/beacon/state_machines/test_proposer.py
+++ b/tests/beacon/state_machines/test_proposer.py
@@ -62,7 +62,6 @@ def test_propose_block(fixture_sm_class,
             active_state=sm.active_state,
             block_proposal=block_proposal,
             chaindb=sm.chaindb,
-            config=sm.config,
             private_key=private_key,
         )
     )
@@ -119,7 +118,6 @@ def test_propose_block(fixture_sm_class,
             active_state=sm.active_state,
             block_proposal=block_proposal,
             chaindb=sm.chaindb,
-            config=sm.config,
             private_key=private_key,
         )
     )

--- a/tests/beacon/test_genesis_helpers.py
+++ b/tests/beacon/test_genesis_helpers.py
@@ -28,7 +28,7 @@ def test_get_genesis_crystallized_state(genesis_validators,
         shard_count,
     )
     len_shard_and_committee_for_slots = cycle_length * 2
-    total_deposits = deposit_size * len(genesis_validators)
+    total_balance = deposit_size * len(genesis_validators)
 
     assert crystallized_state.validators == genesis_validators
     assert crystallized_state.last_state_recalc == 0
@@ -43,7 +43,7 @@ def test_get_genesis_crystallized_state(genesis_validators,
         assert crosslink.hash == ZERO_HASH32
         assert crosslink.slot == 0
         assert crosslink.dynasty == 0
-    assert crystallized_state.total_deposits == total_deposits
+    assert crystallized_state.total_balance == total_balance
     assert crystallized_state.dynasty_seed == init_shuffling_seed
     assert crystallized_state.dynasty_start == 0
 

--- a/tests/beacon/types/test_crystallized_state.py
+++ b/tests/beacon/types/test_crystallized_state.py
@@ -85,10 +85,10 @@ def test_num_crosslink_records(expected,
         (20),
     ]
 )
-def test_total_deposits(num_active_validators,
-                        deposit_size,
-                        default_end_dynasty,
-                        empty_crystallized_state):
+def test_total_balance(num_active_validators,
+                       deposit_size,
+                       default_end_dynasty,
+                       empty_crystallized_state):
     start_dynasty = 10
     active_validators = [
         mock_validator_record(
@@ -115,8 +115,8 @@ def test_total_deposits(num_active_validators,
 
     assert len(crystallized_state.active_validator_indices) == len(active_validators)
 
-    expected_total_deposits = deposit_size * num_active_validators
-    assert crystallized_state.total_deposits == expected_total_deposits
+    expected_total_balance = deposit_size * num_active_validators
+    assert crystallized_state.total_balance == expected_total_balance
 
 
 def test_hash(sample_crystallized_state_params):


### PR DESCRIPTION
### What was wrong?
#1381

Before adding the [whole cycle transition process](https://github.com/ethereum/eth2.0-specs/blob/master/specs/beacon-chain.md#state-recalculations-every-cycle_length-slots), first, adding `compute_cycle_transitions`.

### How was it fixed?
1. `compute_cycle_transitions` does two things:
    1. Check if `block.slot_number >= crystallized_state.last_state_recalc + config.CYCLE_LENGTH`; if yes: 
        - Call `compute_per_cycle_transition` (a.k.a. `initialize_new_cycle` in `beacon_chain` repo) to compute new cycle and get updated states.
            - TODO in other PRs: `compute_crosslinks` will call `compute_crosslinks` and `apply_rewards_and_penalties`.
        - Check if it's ready for dynasty transition.
            - If yes, call `compute_dynasty_transition`
    2. Return the updated states.
2. Renamed `total_deposits` to `total_balance` as the latest spec.


#### Cute Animal Picture

![512px-cheney s_dogs_dressed_for_halloween_by david bohrer](https://user-images.githubusercontent.com/9263930/47006094-bac35400-d167-11e8-9f27-e45ee2d8b2b7.jpg)
