### PR TITLE
Use uvloop in FreeBSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ deps = {
         "web3==4.4.1",
         "lahja==0.9.0",
         "termcolor>=1.1.0,<2.0.0",
-        "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin'",
+        "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",
         "websockets==5.0.1",
     ],
     'test': [

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -13,7 +13,7 @@ except pkg_resources.DistributionNotFound:
 # This is to ensure we call setup_trace_logging() before anything else.
 import eth as _eth_module  # noqa: F401
 
-if sys.platform in {'darwin', 'linux'}:
+if sys.platform in {'darwin', 'linux'} or 'freebsd' in sys.platform:
     # Set `uvloop` as the default event loop
     import asyncio  # noqa: E402
     import uvloop  # noqa: E402


### PR DESCRIPTION
### What was wrong?
uvloop support was defined only for linux and darwin platforms

### How was it fixed?
Added FreeBSD into list

