### PR TITLE
Suppress ImportWarning messages

### DIFF
--- a/eth/_warnings.py
+++ b/eth/_warnings.py
@@ -1,0 +1,10 @@
+from contextlib import contextmanager
+import warnings
+
+
+# TODO: drop once https://github.com/cython/cython/issues/1720 is resolved
+@contextmanager
+def catch_and_ignore_import_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=ImportWarning)
+        yield

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -29,18 +29,6 @@ from eth_typing import (
     Hash32,
 )
 
-from eth_utils import (
-    to_set,
-    ValidationError,
-)
-from eth_utils.toolz import (
-    assoc,
-    compose,
-    groupby,
-    iterate,
-    take,
-)
-
 from eth.db.backends.base import BaseAtomicDB
 from eth.db.chain import (
     BaseChainDB,
@@ -100,6 +88,20 @@ from eth.utils.hexadecimal import (
 from eth.utils.rlp import (
     validate_imported_block_unchanged,
 )
+
+from eth._warnings import catch_and_ignore_import_warning
+with catch_and_ignore_import_warning():
+    from eth_utils import (
+        to_set,
+        ValidationError,
+    )
+    from eth_utils.toolz import (
+        assoc,
+        compose,
+        groupby,
+        iterate,
+        take,
+    )
 
 if TYPE_CHECKING:
     from eth.vm.base import BaseVM  # noqa: F401

--- a/eth/constants.py
+++ b/eth/constants.py
@@ -2,7 +2,10 @@ from eth_typing import (
     Address,
     Hash32
 )
-from eth_utils import denoms
+
+from eth._warnings import catch_and_ignore_import_warning
+with catch_and_ignore_import_warning():
+    from eth_utils import denoms
 
 
 ANY = 'any'

--- a/eth/db/backends/level.py
+++ b/eth/db/backends/level.py
@@ -17,8 +17,11 @@ from .base import (
     BaseDB,
 )
 
+from eth._warnings import catch_and_ignore_import_warning
+
 if TYPE_CHECKING:
-    import plyvel  # noqa: F401
+    with catch_and_ignore_import_warning():
+        import plyvel  # noqa: F401
 
 
 class LevelDB(BaseAtomicDB):
@@ -29,7 +32,8 @@ class LevelDB(BaseAtomicDB):
         if not db_path:
             raise TypeError("Please specifiy a valid path for your database.")
         try:
-            import plyvel  # noqa: F811
+            with catch_and_ignore_import_warning():
+                import plyvel  # noqa: F811
         except ImportError:
             raise ImportError(
                 "LevelDB requires the plyvel library which is not available for import."

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -13,21 +13,9 @@ from typing import (
     TYPE_CHECKING,
 )
 
-import rlp
-
-from trie import (
-    HexaryTrie,
-)
-
 from eth_typing import (
     BlockNumber,
     Hash32
-)
-
-from eth_utils import (
-    to_list,
-    to_tuple,
-    ValidationError,
 )
 
 from eth_hash.auto import keccak
@@ -57,6 +45,17 @@ from eth.utils.hexadecimal import (
 from eth.validation import (
     validate_word,
 )
+from eth._warnings import catch_and_ignore_import_warning
+with catch_and_ignore_import_warning():
+    import rlp
+    from trie import (
+        HexaryTrie,
+    )
+    from eth_utils import (
+        to_list,
+        to_tuple,
+        ValidationError,
+    )
 
 if TYPE_CHECKING:
     from eth.rlp.blocks import (  # noqa: F401

--- a/p2p/nat.py
+++ b/p2p/nat.py
@@ -18,7 +18,10 @@ from p2p.exceptions import (
 )
 import netifaces
 from p2p.service import BaseService
-import upnpclient
+
+from eth._warnings import catch_and_ignore_import_warning
+with catch_and_ignore_import_warning():
+    import upnpclient
 
 
 # UPnP discovery can take a long time, so use a loooong timeout here.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ deps = {
         "web3==4.4.1",
         "lahja==0.9.0",
         "termcolor>=1.1.0,<2.0.0",
-        "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin'",
+        "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",
         "websockets==5.0.1",
     ],
     'test': [

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -16,7 +16,11 @@ import eth as _eth_module  # noqa: F401
 if sys.platform in {'darwin', 'linux'} or 'freebsd' in sys.platform:
     # Set `uvloop` as the default event loop
     import asyncio  # noqa: E402
-    import uvloop  # noqa: E402
+
+    from eth._warnings import catch_and_ignore_import_warning
+    with catch_and_ignore_import_warning():
+        import uvloop  # noqa: E402
+
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 from .main import (  # noqa: F401

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -13,7 +13,7 @@ except pkg_resources.DistributionNotFound:
 # This is to ensure we call setup_trace_logging() before anything else.
 import eth as _eth_module  # noqa: F401
 
-if sys.platform in {'darwin', 'linux'}:
+if sys.platform in {'darwin', 'linux'} or 'freebsd' in sys.platform:
     # Set `uvloop` as the default event loop
     import asyncio  # noqa: E402
     import uvloop  # noqa: E402


### PR DESCRIPTION
This commit fixes ImportWarning-s issue (#1402, #1370). As mentioned in referred issue, this is a Cython bug fixed in master and not yet available. We can't fix it in py-evm modules.
A suggested [workaround](https://bugs.launchpad.net/lxml/+bug/1732505/comments/4) was used.