### PR TITLE
Making RocksDB installation Global

### DIFF
--- a/.circleci/install_rocksdb.sh
+++ b/.circleci/install_rocksdb.sh
@@ -20,4 +20,10 @@ if [ ! -f "/usr/lib/librocksdb.so.5" ]; then
 fi
 if [ ! -f "/usr/lib/librocksdb.so" ]; then
   ln -fs /home/circleci/rocksdb/librocksdb.so.5.8.8 /usr/lib/librocksdb.so
-fi  
+fi
+
+# globally install headers
+if [ ! -d "/usr/include/rocksdb" ]; then
+  sudo mkdir -p /usr/include/rocksdb/
+  ln -fs /home/circleci/rocksdb /usr/include/rocksdb
+fi


### PR DESCRIPTION
### What was wrong?
RocksDB header files (`slice.h`) were not accessible globally


### How was it fixed?
Creating a link to `~/rocksdb/include` at `/usr/include`, should solve the issue.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.pixelstalk.net/wp-content/uploads/2016/03/Background-cute-animal-wallpaper.jpg)
