### PR TITLE
Move mainnet DAO fork config into mainnet configuration

### DIFF
--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -13,6 +13,7 @@ from .constants import (
     HOMESTEAD_MAINNET_BLOCK,
     SPURIOUS_DRAGON_MAINNET_BLOCK,
     DAO_FORK_MAINNET_EXTRA_DATA,
+    DAO_FORK_MAINNET_BLOCK,
 )
 from eth import constants
 
@@ -60,7 +61,7 @@ class MainnetDAOValidatorVM:
 
 
 class MainnetHomesteadVM(MainnetDAOValidatorVM, HomesteadVM):
-    pass
+    dao_fork_block_number = DAO_FORK_MAINNET_BLOCK
 
 
 MAINNET_FORK_BLOCKS = (

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -40,10 +40,8 @@ class MainnetDAOValidatorVM:
         super().validate_header(header, previous_header, check_seal)  # type: ignore
 
         # The special extra_data is set on the ten headers starting at the fork
-        extra_data_block_nums = range(
-            cls.get_dao_fork_block_number(),
-            cls.get_dao_fork_block_number() + 10,
-        )
+        dao_fork_at = cls.get_dao_fork_block_number()
+        extra_data_block_nums = range(dao_fork_at, dao_fork_at + 10)
 
         if header.block_number in extra_data_block_nums:
             if cls.support_dao_fork and header.extra_data != DAO_FORK_MAINNET_EXTRA_DATA:
@@ -64,7 +62,7 @@ class MainnetDAOValidatorVM:
 
 
 class MainnetHomesteadVM(MainnetDAOValidatorVM, HomesteadVM):
-    dao_fork_block_number = DAO_FORK_MAINNET_BLOCK
+    _dao_fork_block_number = DAO_FORK_MAINNET_BLOCK
 
 
 MAINNET_FORK_BLOCKS = (

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -40,7 +40,10 @@ class MainnetDAOValidatorVM:
         super().validate_header(header, previous_header, check_seal)  # type: ignore
 
         # The special extra_data is set on the ten headers starting at the fork
-        extra_data_block_nums = range(cls.dao_fork_block_number, cls.dao_fork_block_number + 10)
+        extra_data_block_nums = range(
+            cls.get_dao_fork_block_number(),
+            cls.get_dao_fork_block_number() + 10,
+        )
 
         if header.block_number in extra_data_block_nums:
             if cls.support_dao_fork and header.extra_data != DAO_FORK_MAINNET_EXTRA_DATA:

--- a/eth/chains/mainnet/constants.py
+++ b/eth/chains/mainnet/constants.py
@@ -1,3 +1,8 @@
+from typing import cast
+
+from eth_typing import BlockNumber
+
+
 # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
 MAINNET_CHAIN_ID = 1
 
@@ -13,7 +18,7 @@ HOMESTEAD_MAINNET_BLOCK = 1150000
 #
 # DAO Block
 #
-DAO_FORK_MAINNET_BLOCK = 1920000
+DAO_FORK_MAINNET_BLOCK = cast(BlockNumber, 1920000)
 
 DAO_FORK_MAINNET_EXTRA_DATA = b'dao-hard-fork'
 

--- a/eth/chains/mainnet/constants.py
+++ b/eth/chains/mainnet/constants.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 from eth_typing import BlockNumber
 
 
@@ -18,7 +16,7 @@ HOMESTEAD_MAINNET_BLOCK = 1150000
 #
 # DAO Block
 #
-DAO_FORK_MAINNET_BLOCK = cast(BlockNumber, 1920000)
+DAO_FORK_MAINNET_BLOCK = BlockNumber(1920000)
 
 DAO_FORK_MAINNET_EXTRA_DATA = b'dao-hard-fork'
 

--- a/eth/chains/tester/__init__.py
+++ b/eth/chains/tester/__init__.py
@@ -120,10 +120,10 @@ def _generate_vm_configuration(*fork_start_blocks: ForkStartBlocks,
             if dao_start_block is False:
                 yield (start_block, vm_class.configure(support_dao_fork=False))
             elif dao_start_block is None:
-                yield (start_block, vm_class.configure(dao_fork_block_number=start_block))
+                yield (start_block, vm_class.configure(_dao_fork_block_number=start_block))
             elif isinstance(dao_start_block, int):
                 validate_gte(dao_start_block, start_block)
-                yield (start_block, vm_class.configure(dao_fork_block_number=dao_start_block))
+                yield (start_block, vm_class.configure(_dao_fork_block_number=dao_start_block))
             else:
                 raise Exception("Invariant: unreachable code path")
         else:

--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -192,7 +192,7 @@ def _set_vm_dao_fork_block_number(dao_fork_block_number: BlockNumber,
         if _is_homestead(vm_class):
             yield fork_block, vm_class.configure(
                 support_dao_fork=True,
-                dao_fork_block_number=dao_fork_block_number,
+                _dao_fork_block_number=dao_fork_block_number,
             )
         else:
             yield fork_block, vm_class

--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -186,7 +186,7 @@ def disable_dao_fork(chain_class: BaseChain) -> type:
 
 
 @to_tuple
-def _set_vm_dao_fork_block_number(dao_fork_block_number: int,
+def _set_vm_dao_fork_block_number(dao_fork_block_number: BlockNumber,
                                   vm_configuration: VMConfiguration) -> VMConfiguration:
     for fork_block, vm_class in vm_configuration:
         if _is_homestead(vm_class):
@@ -199,7 +199,7 @@ def _set_vm_dao_fork_block_number(dao_fork_block_number: int,
 
 
 @curry
-def dao_fork_at(dao_fork_block_number: int, chain_class: BaseChain) -> type:
+def dao_fork_at(dao_fork_block_number: BlockNumber, chain_class: BaseChain) -> type:
     """
     Set the block number on which the DAO fork will happen.  Requires that a
     version of the :class:`~eth.vm.forks.homestead.HomesteadVM` is present in

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -115,7 +115,7 @@ def chain_vm_configuration(fixture):
     elif network == 'HomesteadToDaoAt5':
         HomesteadVM = BaseHomesteadVM.configure(
             support_dao_fork=True,
-            dao_fork_block_number=5,
+            _dao_fork_block_number=5,
         )
         return (
             (0, HomesteadVM),

--- a/eth/vm/forks/homestead/__init__.py
+++ b/eth/vm/forks/homestead/__init__.py
@@ -2,9 +2,6 @@ from typing import Type  # noqa: F401
 from eth.rlp.blocks import BaseBlock  # noqa: F401
 from eth.vm.state import BaseState  # noqa: F401
 
-from eth.chains.mainnet.constants import (
-    DAO_FORK_MAINNET_BLOCK
-)
 from eth.vm.forks.frontier import FrontierVM
 
 from .blocks import HomesteadBlock
@@ -18,7 +15,7 @@ from .state import HomesteadState
 
 class MetaHomesteadVM(FrontierVM):
     support_dao_fork = True
-    dao_fork_block_number = DAO_FORK_MAINNET_BLOCK
+    dao_fork_block_number = 0
 
 
 class HomesteadVM(MetaHomesteadVM):

--- a/eth/vm/forks/homestead/__init__.py
+++ b/eth/vm/forks/homestead/__init__.py
@@ -1,6 +1,8 @@
-from typing import Type  # noqa: F401
+from typing import Optional, Type  # noqa: F401
 from eth.rlp.blocks import BaseBlock  # noqa: F401
 from eth.vm.state import BaseState  # noqa: F401
+
+from eth_typing import BlockNumber
 
 from eth.vm.forks.frontier import FrontierVM
 
@@ -15,7 +17,13 @@ from .state import HomesteadState
 
 class MetaHomesteadVM(FrontierVM):
     support_dao_fork = True
-    dao_fork_block_number = 0
+    dao_fork_block_number = None  # type: Optional[BlockNumber]
+
+    @classmethod
+    def get_dao_fork_block_number(cls) -> BlockNumber:
+        if cls.dao_fork_block_number is None:
+            raise TypeError("HomesteadVM must be configured with a valid `dao_fork_block_number`")
+        return cls.dao_fork_block_number
 
 
 class HomesteadVM(MetaHomesteadVM):

--- a/eth/vm/forks/homestead/__init__.py
+++ b/eth/vm/forks/homestead/__init__.py
@@ -17,13 +17,13 @@ from .state import HomesteadState
 
 class MetaHomesteadVM(FrontierVM):
     support_dao_fork = True
-    dao_fork_block_number = None  # type: Optional[BlockNumber]
+    _dao_fork_block_number = None  # type: Optional[BlockNumber]
 
     @classmethod
     def get_dao_fork_block_number(cls) -> BlockNumber:
-        if cls.dao_fork_block_number is None:
-            raise TypeError("HomesteadVM must be configured with a valid `dao_fork_block_number`")
-        return cls.dao_fork_block_number
+        if cls._dao_fork_block_number is None:
+            raise TypeError("HomesteadVM must be configured with a valid `_dao_fork_block_number`")
+        return cls._dao_fork_block_number
 
 
 class HomesteadVM(MetaHomesteadVM):

--- a/eth/vm/forks/homestead/headers.py
+++ b/eth/vm/forks/homestead/headers.py
@@ -75,7 +75,7 @@ def configure_homestead_header(vm, **header_params):
         # get to that. Another alternative would be to do it in Block.mine(), but
         # there we'd need to manually instantiate the State and update
         # header.state_root after we're done.
-        if vm.support_dao_fork and changeset.block_number == vm.dao_fork_block_number:
+        if vm.support_dao_fork and changeset.block_number == vm.get_dao_fork_block_number():
             state = vm.state
 
             for account in dao_drain_list:

--- a/tests/core/chain-object/test_chain_reorganization.py
+++ b/tests/core/chain-object/test_chain_reorganization.py
@@ -7,9 +7,14 @@ from eth.tools.builder.chain import api
 
 @pytest.fixture(params=api.mainnet_fork_at_fns)
 def base_chain(request):
+    if request.param is api.homestead_at:
+        fork_fns = (request.param(0), api.dao_fork_at(0))
+    else:
+        fork_fns = (request.param(0),)
+
     chain = api.build(
         MiningChain,
-        request.param(0),
+        *fork_fns,
         api.disable_pow_check(),
         api.genesis(),
     )

--- a/tests/core/tester/test_generate_vm_configuration.py
+++ b/tests/core/tester/test_generate_vm_configuration.py
@@ -129,10 +129,10 @@ def test_generate_vm_configuration(args, kwargs, expected):
                 assert left_vm.support_dao_fork is False
             elif dao_start_block is None:
                 assert left_vm.support_dao_fork is True
-                assert left_vm.dao_fork_block_number == right_block
+                assert left_vm.get_dao_fork_block_number() == right_block
             else:
                 assert left_vm.support_dao_fork is True
-                assert left_vm.dao_fork_block_number == dao_start_block
+                assert left_vm.get_dao_fork_block_number() == dao_start_block
         elif right_vm == Forks.TangerineWhistle:
             assert 'TangerineWhistle' in left_vm.__name__
         elif right_vm == Forks.SpuriousDragon:

--- a/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/trinity/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -389,7 +389,7 @@ async def test_rpc_against_fixtures(chain, ipc_server, chain_fixture, fixture_da
     rpc = RPCServer(MainnetFullChain(None))
 
     setup_result, setup_error = await call_rpc(rpc, 'evm_resetToGenesisFixture', [chain_fixture])
-    assert setup_error is None and setup_result is True, "cannot load chain for %r" % fixture_data
+    assert setup_error is None and setup_result is True, "cannot load chain for {0}".format(fixture_data)  # noqa: E501
 
     await validate_accounts(rpc, chain_fixture['pre'])
 

--- a/trinity/protocol/common/boot.py
+++ b/trinity/protocol/common/boot.py
@@ -38,11 +38,11 @@ class DAOCheckBootManager(BasePeerBootManager):
                 continue
             elif not vm_class.support_dao_fork:
                 break
-            elif start_block > vm_class.dao_fork_block_number:
+            elif start_block > vm_class.get_dao_fork_block_number():
                 # VM comes after the fork, so stop checking
                 break
 
-            start_block = vm_class.dao_fork_block_number - 1
+            start_block = vm_class.get_dao_fork_block_number() - 1
 
             try:
                 headers = await self.peer.requests.get_block_headers(  # type: ignore


### PR DESCRIPTION
### What was wrong?

The default `HomesteadVM` came with the dao fork block number already set.  This didn't seem semantically correct since the block number would differ based on the chain configuration and what chain it was used in.

### How was it fixed?

Changed to have the block number configured within the context of the mainnet chain.

#### Cute Animal Picture

![21jan16_161954](https://user-images.githubusercontent.com/824194/47521471-53d12980-d850-11e8-99e1-f1616acf2e10.jpg)

