### PR TITLE
enable Constantinople fork in Ropsten chain

### DIFF
--- a/eth/chains/ropsten/__init__.py
+++ b/eth/chains/ropsten/__init__.py
@@ -3,6 +3,7 @@ from eth_utils import decode_hex
 
 from .constants import (
     BYZANTIUM_ROPSTEN_BLOCK,
+    CONSTANTINOPLE_BLOCK,
     ROPSTEN_CHAIN_ID,
     SPURIOUS_DRAGON_ROPSTEN_BLOCK,
     TANGERINE_WHISTLE_ROPSTEN_BLOCK,
@@ -14,6 +15,7 @@ from eth.rlp.headers import BlockHeader
 from eth.vm.base import BaseVM  # noqa: F401
 from eth.vm.forks import (
     ByzantiumVM,
+    ConstantinopleVM,
     SpuriousDragonVM,
     TangerineWhistleVM,
 )
@@ -24,6 +26,7 @@ ROPSTEN_VM_CONFIGURATION = (
     (TANGERINE_WHISTLE_ROPSTEN_BLOCK, TangerineWhistleVM),
     (SPURIOUS_DRAGON_ROPSTEN_BLOCK, SpuriousDragonVM),
     (BYZANTIUM_ROPSTEN_BLOCK, ByzantiumVM),
+    (CONSTANTINOPLE_BLOCK, ConstantinopleVM),
 )
 
 

--- a/eth/chains/ropsten/constants.py
+++ b/eth/chains/ropsten/constants.py
@@ -4,12 +4,6 @@ ROPSTEN_CHAIN_ID = 3
 # Fork Blocks listed in ascending order
 
 #
-# Byzantium Block
-#
-BYZANTIUM_ROPSTEN_BLOCK = 1700000
-
-
-#
 # DAO Block
 #
 DAO_FORK_ROPSTEN_BLOCK = 0
@@ -31,3 +25,15 @@ HOMESTEAD_ROPSTEN_BLOCK = 0
 # Spurious Dragon Block
 #
 SPURIOUS_DRAGON_ROPSTEN_BLOCK = 10
+
+
+#
+# Byzantium Block
+#
+BYZANTIUM_ROPSTEN_BLOCK = 1700000
+
+
+#
+# Constantinople
+#
+CONSTANTINOPLE_BLOCK = 4230000


### PR DESCRIPTION
### What was wrong?

The Constantinople fork has occured on ropsten but our `RopstenChain` was not updated.

### How was it fixed?

Updated the `RopstenChain` to include the constantinople fork 

#### Cute Animal Picture

![squirrel-in-a-pirate-costume--23988](https://user-images.githubusercontent.com/824194/47521678-db1e9d00-d850-11e8-85e1-13fd4677816f.jpg)

