### PR TITLE
Fix warnings when printing Trinity cli header

### DIFF
--- a/trinity/main.py
+++ b/trinity/main.py
@@ -81,15 +81,15 @@ from trinity.utils.version import (
 PRECONFIGURED_NETWORKS = {MAINNET_NETWORK_ID, ROPSTEN_NETWORK_ID}
 
 
-TRINITY_HEADER = (
+TRINITY_HEADER = "\n".join((
     "\n"
-    "      ______     _       _ __       \n"
-    "     /_  __/____(_)___  (_) /___  __\n"
-    "      / / / ___/ / __ \/ / __/ / / /\n"
-    "     / / / /  / / / / / / /_/ /_/ / \n"
-    "    /_/ /_/  /_/_/ /_/_/\__/\__, /  \n"
-    "                           /____/   "
-)
+    r"      ______     _       _ __       ",
+    r"     /_  __/____(_)___  (_) /___  __",
+    r"      / / / ___/ / __ \/ / __/ / / /",
+    r"     / / / /  / / / / / / /_/ /_/ / ",
+    r"    /_/ /_/  /_/_/ /_/_/\__/\__, /  ",
+    r"                           /____/   ",
+))
 
 TRINITY_AMBIGIOUS_FILESYSTEM_INFO = (
     "Could not initialize data directory\n\n"


### PR DESCRIPTION
### What was wrong?

The ASCII "trinity" header that is printed out when running the trinity command uses forward slashes.  These cause warnings because python thinks they are supposed to be escape sequences.

### How was it fixed?

Update header to use raw strings.

#### Cute Animal Picture

![awesomelycute-com-2607](https://user-images.githubusercontent.com/824194/47524999-68fe8600-d859-11e8-8bae-de2f7725a37f.jpg)

