### PR TITLE
fix broken implementation of version string

### DIFF
--- a/trinity/utils/version.py
+++ b/trinity/utils/version.py
@@ -15,7 +15,7 @@ def construct_trinity_client_identifier() -> str:
         "Trinity/"
         f"{__version__}/"
         f"{sys.platform}/"
-        f"{sys.implementation}"
+        f"{sys.implementation.name}"
         f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     )
 


### PR DESCRIPTION
### What was wrong?

Version string was being created as:

```
Trinity/eth-0.2.0a33/linux/namespace(_multiarch='x86_64-linux-gnu', cache_tag='cpython-36', hexversion=50726384, name='cpython', version=sys.version_info(major=3, minor=6, micro=5, releaselevel='final', serial=0))3.6.5
```


### How was it fixed?

Fixed the missing `.name` property in the f-string.

#### Cute Animal Picture

![635807717385032176-1043691390_omg](https://user-images.githubusercontent.com/824194/47578317-52facf00-d906-11e8-8680-cae7be290127.jpg)

