### PR TITLE
Rename _start/_stop/_run_/_cleanup to use do_ prefix

### DIFF
--- a/p2p/DEVELOPMENT.md
+++ b/p2p/DEVELOPMENT.md
@@ -26,7 +26,7 @@ library.
 
 ```Python
 class Node(BaseService):
-    async def _run(self):
+    async def do_run(self):
         self.discovery = DiscoveryService(token=self.cancel_token)
         self.run_daemon(self.discovery)
         self.run_task(self.discovery.bootstrap())

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -956,7 +956,7 @@ class DiscoveryService(BaseService):
         self.port = port
         self._lookup_running = asyncio.Lock()
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         await self._start_udp_listener()
         connect_loop_sleep = 2
         self.run_task(self.proto.bootstrap())
@@ -1004,7 +1004,7 @@ class DiscoveryService(BaseService):
             finally:
                 self._last_lookup = time.time()
 
-    async def _cleanup(self) -> None:
+    async def do_cleanup(self) -> None:
         await self.proto.stop()
 
 

--- a/p2p/nat.py
+++ b/p2p/nat.py
@@ -69,7 +69,7 @@ class UPnPService(BaseService):
         self.port = port
         self._mapping: PortMapping = None  # when called externally, this never returns None
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         """Run an infinite loop refreshing our NAT port mapping.
 
         On every iteration we configure the port mapping with a lifetime of 30 minutes and then
@@ -85,7 +85,7 @@ class UPnPService(BaseService):
             except Exception:
                 self.logger.exception("Failed to setup NAT portmap")
 
-    async def _cleanup(self) -> None:
+    async def do_cleanup(self) -> None:
         pass
 
     async def add_nat_portmap(self) -> str:

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -150,7 +150,7 @@ class BasePeerBootManager(BaseService):
         super().__init__(peer.cancel_token)
         self.peer = peer
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         pass
 
 
@@ -351,10 +351,10 @@ class BasePeer(BaseService):
     def is_closing(self) -> bool:
         return self.writer.transport.is_closing()
 
-    async def _cleanup(self) -> None:
+    async def do_cleanup(self) -> None:
         self.close()
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         # The `boot` process is run in the background to allow the `run` loop
         # to continue so that all of the Peer APIs can be used within the
         # `boot` task.
@@ -860,7 +860,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             for msg in msgs:
                 subscriber.add_msg(msg)
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         # FIXME: PeerPool should probably no longer be a BaseService, but for now we're keeping it
         # so in order to ensure we cancel all peers when we terminate.
         if self.event_bus is not None:
@@ -875,7 +875,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             peer.disconnect(DisconnectReason.client_quitting) for peer in peers if peer.is_running
         ])
 
-    async def _cleanup(self) -> None:
+    async def do_cleanup(self) -> None:
         await self.stop_all_peers()
 
     async def connect(self, remote: Node) -> BasePeer:

--- a/tests/p2p/test_service.py
+++ b/tests/p2p/test_service.py
@@ -10,7 +10,7 @@ class ParentService(BaseService):
     be triggered.
     """
 
-    async def _run(self):
+    async def do_run(self):
         self.daemon = WaitService(token=self.cancel_token)
         self.run_daemon(self.daemon)
         await self.cancel_token.wait()
@@ -18,7 +18,7 @@ class ParentService(BaseService):
 
 class WaitService(BaseService):
 
-    async def _run(self):
+    async def do_run(self):
         await self.cancel_token.wait()
 
 

--- a/tests/trinity/core/peer_helpers.py
+++ b/tests/trinity/core/peer_helpers.py
@@ -130,5 +130,5 @@ class MockPeerPoolWithConnectedPeers(ETHPeerPool):
         for peer in peers:
             self.connected_nodes[peer.remote] = peer
 
-    async def _run(self) -> None:
-        raise NotImplementedError("This is a mock PeerPool implementation, you must not _run() it")
+    async def do_run(self) -> None:
+        raise NotImplementedError("This is a mock PeerPool implementation, you must not run it")

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -123,7 +123,7 @@ class Node(BaseService):
             BroadcastConfig(internal=True),
         )
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         await self.event_bus.wait_for_connection()
         self.notify_resource_available()
         self.run_daemon_task(self.handle_network_id_requests())

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -47,9 +47,9 @@ class LightNode(Node):
             token=self.cancel_token,
         )
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         self.run_daemon(self._peer_chain)
-        await super()._run()
+        await super().do_run()
 
     def get_chain(self) -> LightDispatchChain:
         if self._chain is None:

--- a/trinity/plugins/builtin/ethstats/ethstats_client.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_client.py
@@ -46,7 +46,7 @@ class EthstatsClient(BaseService):
         self.send_queue: asyncio.Queue[EthstatsMessage] = asyncio.Queue()
         self.recv_queue: asyncio.Queue[EthstatsMessage] = asyncio.Queue()
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         await self.wait_first(
             self.send_handler(),
             self.recv_handler(),

--- a/trinity/plugins/builtin/ethstats/ethstats_service.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_service.py
@@ -61,7 +61,7 @@ class EthstatsService(BaseService):
 
         self.chain = self.get_chain()
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         while self.is_operational:
             try:
                 self.logger.info('Connecting to %s...' % self.server_url)

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -103,7 +103,7 @@ class EthstatsPlugin(BaseIsolatedPlugin):
 
         self.start()
 
-    def _start(self) -> None:
+    def do_start(self) -> None:
         service = EthstatsService(
             self.context,
             self.server_url,

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -44,7 +44,7 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
             help="Disables the JSON-RPC Server",
         )
 
-    def _start(self) -> None:
+    def do_start(self) -> None:
         db_manager = create_db_manager(self.context.trinity_config.database_ipc_path)
         db_manager.connect()
 

--- a/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
@@ -150,7 +150,7 @@ class LightPeerChainEventBusHandler(BaseService):
         self.chain = chain
         self.event_bus = event_bus
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         self.logger.info("Running LightPeerChainEventBusHandler")
 
         self.run_daemon_task(self.handle_get_blockheader_by_hash_requests())

--- a/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
@@ -57,12 +57,12 @@ class LightPeerChainBridgePlugin(BaseAsyncStopPlugin):
             self.chain = event.resource
             self.start()
 
-    def _start(self) -> None:
+    def do_start(self) -> None:
         chain = cast(LightDispatchChain, self.chain)
         self.handler = LightPeerChainEventBusHandler(chain._peer_chain, self.context.event_bus)
         asyncio.ensure_future(self.handler.run())
 
-    async def _stop(self) -> None:
+    async def do_stop(self) -> None:
         # This isn't really needed for the standard shutdown case as the LightPeerChain will
         # automatically shutdown whenever the `CancelToken` it was chained with is triggered.
         # It may still be useful to stop the LightPeerChain Bridge plugin individually though.

--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -78,7 +78,7 @@ class TxPlugin(BaseAsyncStopPlugin):
         if all((self.peer_pool is not None, self.chain is not None, self.is_enabled)):
             self.start()
 
-    def _start(self) -> None:
+    def do_start(self) -> None:
         if isinstance(self.chain, BaseMainnetChain):
             validator = DefaultTransactionValidator(self.chain, BYZANTIUM_MAINNET_BLOCK)
         elif isinstance(self.chain, BaseRopstenChain):
@@ -91,7 +91,7 @@ class TxPlugin(BaseAsyncStopPlugin):
         self.tx_pool = TxPool(self.peer_pool, validator, self.cancel_token)
         asyncio.ensure_future(self.tx_pool.run())
 
-    async def _stop(self) -> None:
+    async def do_stop(self) -> None:
         # This isn't really needed for the standard shutdown case as the TxPool will automatically
         # shutdown whenever the `CancelToken` it was chained with is triggered. It may still be
         # useful to stop the TxPool plugin individually though.

--- a/trinity/plugins/builtin/tx_pool/pool.py
+++ b/trinity/plugins/builtin/tx_pool/pool.py
@@ -67,7 +67,7 @@ class TxPool(BaseService, PeerSubscriber):
     # now.
     msg_queue_maxsize: int = 2000
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         self.logger.info("Running Tx Pool")
 
         with self.subscribe(self._peer_pool):
@@ -122,5 +122,5 @@ class TxPool(BaseService, PeerSubscriber):
         for val in txs:
             self._bloom.add(self._construct_bloom_entry(peer, val))
 
-    async def _cleanup(self) -> None:
+    async def do_cleanup(self) -> None:
         self.logger.info("Stopping Tx Pool...")

--- a/trinity/protocol/common/boot.py
+++ b/trinity/protocol/common/boot.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 class DAOCheckBootManager(BasePeerBootManager):
     peer: 'BaseChainPeer'
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         try:
             await self.ensure_same_side_on_dao_fork()
         except DAOForkCheckFailure as err:

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -118,7 +118,7 @@ class ResponseCandidateStream(
     #
     # Service API
     #
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         self.logger.debug("Launching %r", self)
 
         with self.subscribe_peer(self._peer):
@@ -176,7 +176,7 @@ class ResponseCandidateStream(
     def _is_pending(self) -> bool:
         return self.pending_request is not None
 
-    async def _cleanup(self) -> None:
+    async def do_cleanup(self) -> None:
         if self.pending_request is not None:
             self.logger.debug("Stream %r shutting down, cancelling the pending request", self)
             _, future = self.pending_request

--- a/trinity/protocol/common/monitors.py
+++ b/trinity/protocol/common/monitors.py
@@ -75,7 +75,7 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
         for new_tip_event in self._subscriber_notices:
             new_tip_event.set()
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         self.run_daemon_task(self._handle_msg_loop())
         with self.subscribe(self._peer_pool):
             await self.wait(self.events.cancelled.wait())

--- a/trinity/protocol/common/servers.py
+++ b/trinity/protocol/common/servers.py
@@ -47,7 +47,7 @@ class BaseRequestServer(BaseService, PeerSubscriber):
         super().__init__(token)
         self._peer_pool = peer_pool
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         self.run_daemon_task(self._handle_msg_loop())
         with self.subscribe(self._peer_pool):
             await self.events.cancelled.wait()

--- a/trinity/rpc/ipc.py
+++ b/trinity/rpc/ipc.py
@@ -140,7 +140,7 @@ class IPCServer(BaseService):
         self.rpc = rpc
         self.ipc_path = ipc_path
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         self.server = await asyncio.start_unix_server(
             connection_handler(self.rpc.execute, self.cancel_token),
             str(self.ipc_path),
@@ -150,7 +150,7 @@ class IPCServer(BaseService):
         self.logger.info('IPC started at: %s', self.ipc_path.resolve())
         await self.cancel_token.wait()
 
-    async def _cleanup(self) -> None:
+    async def do_cleanup(self) -> None:
         self.server.close()
         await self.server.wait_closed()
         self.ipc_path.unlink()

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -144,7 +144,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
             self._tcp_listener.close()
             await self._tcp_listener.wait_closed()
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         self.logger.info("Running server...")
         mapped_external_ip = await self.upnp_service.add_nat_portmap()
         if mapped_external_ip is None:
@@ -185,7 +185,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
         self.syncer = self._make_syncer()
         await self.syncer.run()
 
-    async def _cleanup(self) -> None:
+    async def do_cleanup(self) -> None:
         self.logger.info("Closing server...")
         await self._close_tcp_listener()
 

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -109,7 +109,7 @@ class BaseHeaderChainSyncer(BaseService):
     def tip_monitor_class(self) -> Type[BaseChainTipMonitor]:
         pass
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         self.run_daemon(self._tip_monitor)
         if self.peer_pool.event_bus is not None:
             self.run_daemon_task(self.handle_sync_status_requests())
@@ -204,7 +204,7 @@ class PeerHeaderSyncer(BaseService):
         else:
             return self._target_header_hash
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         await self.events.cancelled.wait()
 
     async def next_header_batch(self) -> AsyncIterator[Tuple[BlockHeader, ...]]:

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -163,9 +163,9 @@ class BaseBodyChainSyncer(BaseHeaderChainSyncer, PeerSubscriber):
         buffer_size = MAX_BODIES_FETCH * REQUEST_BUFFER_MULTIPLIER
         self._block_body_tasks = TaskQueue(buffer_size, attrgetter('block_number'))
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         with self.subscribe(self.peer_pool):
-            await super()._run()
+            await super().do_run()
 
     async def _assign_body_download_to_peers(self) -> None:
         """
@@ -372,7 +372,7 @@ class FastChainSyncer(BaseBodyChainSyncer):
             dependency_extractor=attrgetter('parent_hash'),
         )
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         head = await self.wait(self.db.coro_get_canonical_head())
         self._block_persist_tracker.set_finished_dependency(head)
         self.run_daemon_task(self._launch_prerequisite_tasks())
@@ -380,7 +380,7 @@ class FastChainSyncer(BaseBodyChainSyncer):
         self.run_daemon_task(self._assign_body_download_to_peers())
         self.run_daemon_task(self._persist_ready_blocks())
         self.run_daemon_task(self._display_stats())
-        await super()._run()
+        await super().do_run()
 
     def register_peer(self, peer: BasePeer) -> None:
         # when a new peer is added to the pool, add it to the idle peer lists
@@ -740,13 +740,13 @@ class RegularChainSyncer(BaseBodyChainSyncer):
             dependency_extractor=attrgetter('parent_hash'),
         )
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         head = await self.wait(self.db.coro_get_canonical_head())
         self._block_import_tracker.set_finished_dependency(head)
         self.run_daemon_task(self._launch_prerequisite_tasks())
         self.run_daemon_task(self._assign_body_download_to_peers())
         self.run_daemon_task(self._import_ready_blocks())
-        await super()._run()
+        await super().do_run()
 
     def register_peer(self, peer: BasePeer) -> None:
         # when a new peer is added to the pool, add it to the idle peer list

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -35,7 +35,7 @@ class FullNodeSyncer(BaseService):
         self.base_db = base_db
         self.peer_pool = peer_pool
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         head = await self.wait(self.chaindb.coro_get_canonical_head())
         # We're still too slow at block processing, so if our local head is older than
         # FAST_SYNC_CUTOFF we first do a fast-sync run to catch up with the rest of the network.

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -137,7 +137,7 @@ class StateDownloader(BaseService, PeerSubscriber):
                 # retry after a timeout.
                 pass
 
-    async def _cleanup(self) -> None:
+    async def do_cleanup(self) -> None:
         self._nodes_cache_dir.cleanup()
 
     async def request_nodes(self, node_keys: Iterable[Hash32]) -> None:
@@ -235,7 +235,7 @@ class StateDownloader(BaseService, PeerSubscriber):
             next_timeout = self.request_tracker.get_next_timeout()
             await self.sleep(next_timeout - time.time())
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         """Fetch all trie nodes starting from self.root_hash, and store them in self.db.
 
         Raises OperationCancelled if we're interrupted before that is completed.

--- a/trinity/sync/light/chain.py
+++ b/trinity/sync/light/chain.py
@@ -8,9 +8,9 @@ class LightChainSyncer(BaseHeaderChainSyncer):
 
     tip_monitor_class = LightChainTipMonitor
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         self.run_task(self._persist_headers())
-        await super()._run()
+        await super().do_run()
 
     async def _persist_headers(self) -> None:
         while self.is_operational:

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -117,7 +117,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
     # to be handled by the chain syncer), so our queue should never grow too much.
     msg_queue_maxsize = 500
 
-    async def _run(self) -> None:
+    async def do_run(self) -> None:
         with self.subscribe(self.peer_pool):
             while self.is_operational:
                 peer, cmd, msg = await self.wait(self.msg_queue.get())


### PR DESCRIPTION
### What was wrong?

We had a bunch of methods that we called `_<something>` not because they are considered private but mainly because `<something>` already exist where `<something>` calls `_<something>` behind the scenes (after performing other work).

These methods are meant to be overwritten and hence in the classical sense of OOP can not be considered private anyway (e.g. could not be private in most statically typed languages).

Also this has proven to be problematic for the documentation because private methods are by default not included in the generated docs (righfully so).

### How was it fixed?

Changed `_` prefix to `do_` prefix

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://mymodernmet.com/wp/wp-content/uploads/archive/YXgc7XPC9L3x4dNplf5L_1082020962.jpeg)
