### PR TITLE
Refactor EVM stack to store only int

### DIFF
--- a/eth/validation.py
+++ b/eth/validation.py
@@ -167,9 +167,7 @@ def validate_uint256(value, title="Value"):
 
 
 def validate_stack_item(value):
-    if isinstance(value, bytes) and len(value) <= 32:
-        return
-    elif isinstance(value, int) and 0 <= value <= UINT_256_MAX:
+    if isinstance(value, int) and 0 <= value <= UINT_256_MAX:
         return
     raise ValidationError(
         "Invalid Stack Item: Must be either a length 32 byte "

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -291,17 +291,25 @@ class BaseComputation(Configurable, ABC):
         """
         return self._gas_meter.refund_gas(amount)
 
-    def stack_pop(self, num_items=1, type_hint=None):
+    def stack_pop_ints(self, num_items=1):
         """
         Pop and return a number of items equal to ``num_items`` from the stack.
-        ``type_hint`` can be either ``'uint256'`` or ``'bytes'``.  The return value
-        will be an ``int`` or ``bytes`` type depending on the value provided for
-        the ``type_hint``.
+        The return value will be ``int`` type.
 
         Raise `eth.exceptions.InsufficientStack` if there are not enough items on
         the stack.
         """
-        return self._stack.pop(num_items, type_hint)
+        return self._stack.pop_ints(num_items)
+
+    def stack_pop_bytes(self, num_items=1):
+        """
+        Pop and return a number of items equal to ``num_items`` from the stack.
+        The return value will be ``bytes`` type.
+
+        Raise `eth.exceptions.InsufficientStack` if there are not enough items on
+        the stack.
+        """
+        return self._stack.pop_bytes(num_items)
 
     def stack_push(self, value):
         """

--- a/eth/vm/forks/constantinople/storage.py
+++ b/eth/vm/forks/constantinople/storage.py
@@ -1,6 +1,3 @@
-from eth.constants import (
-    UINT256
-)
 from eth.vm.forks.constantinople import (
     constants
 )
@@ -11,7 +8,7 @@ from eth.utils.hexadecimal import (
 
 
 def sstore_eip1283(computation):
-    slot, value = computation.stack_pop(num_items=2, type_hint=UINT256)
+    slot, value = computation.stack_pop_ints(num_items=2)
 
     current_value = computation.state.account_db.get_storage(
         address=computation.msg.storage_address,

--- a/eth/vm/logic/arithmetic.py
+++ b/eth/vm/logic/arithmetic.py
@@ -15,7 +15,7 @@ def add(computation):
     """
     Addition
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(num_items=2)
 
     result = (left + right) & constants.UINT_256_MAX
 
@@ -26,7 +26,7 @@ def addmod(computation):
     """
     Modulo Addition
     """
-    left, right, mod = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    left, right, mod = computation.stack_pop_ints(num_items=3)
 
     if mod == 0:
         result = 0
@@ -40,7 +40,7 @@ def sub(computation):
     """
     Subtraction
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(num_items=2)
 
     result = (left - right) & constants.UINT_256_MAX
 
@@ -51,7 +51,7 @@ def mod(computation):
     """
     Modulo
     """
-    value, mod = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    value, mod = computation.stack_pop_ints(num_items=2)
 
     if mod == 0:
         result = 0
@@ -67,7 +67,7 @@ def smod(computation):
     """
     value, mod = map(
         unsigned_to_signed,
-        computation.stack_pop(num_items=2, type_hint=constants.UINT256),
+        computation.stack_pop_ints(num_items=2),
     )
 
     pos_or_neg = -1 if value < 0 else 1
@@ -84,7 +84,7 @@ def mul(computation):
     """
     Multiplication
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(num_items=2)
 
     result = (left * right) & constants.UINT_256_MAX
 
@@ -95,7 +95,7 @@ def mulmod(computation):
     """
     Modulo Multiplication
     """
-    left, right, mod = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    left, right, mod = computation.stack_pop_ints(num_items=3)
 
     if mod == 0:
         result = 0
@@ -108,7 +108,7 @@ def div(computation):
     """
     Division
     """
-    numerator, denominator = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    numerator, denominator = computation.stack_pop_ints(num_items=2)
 
     if denominator == 0:
         result = 0
@@ -124,7 +124,7 @@ def sdiv(computation):
     """
     numerator, denominator = map(
         unsigned_to_signed,
-        computation.stack_pop(num_items=2, type_hint=constants.UINT256),
+        computation.stack_pop_ints(num_items=2),
     )
 
     pos_or_neg = -1 if numerator * denominator < 0 else 1
@@ -142,7 +142,7 @@ def exp(computation, gas_per_byte):
     """
     Exponentiation
     """
-    base, exponent = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    base, exponent = computation.stack_pop_ints(num_items=2)
 
     bit_size = exponent.bit_length()
     byte_size = ceil8(bit_size) // 8
@@ -166,7 +166,7 @@ def signextend(computation):
     """
     Signed Extend
     """
-    bits, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    bits, value = computation.stack_pop_ints(num_items=2)
 
     if bits <= 31:
         testbit = bits * 8 + 7
@@ -185,7 +185,7 @@ def shl(computation):
     """
     Bitwise left shift
     """
-    shift_length, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    shift_length, value = computation.stack_pop_ints(num_items=2)
 
     if shift_length >= 256:
         result = 0
@@ -199,7 +199,7 @@ def shr(computation):
     """
     Bitwise right shift
     """
-    shift_length, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    shift_length, value = computation.stack_pop_ints(num_items=2)
 
     if shift_length >= 256:
         result = 0
@@ -213,7 +213,7 @@ def sar(computation):
     """
     Arithmetic bitwise right shift
     """
-    shift_length, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    shift_length, value = computation.stack_pop_ints(num_items=2)
     value = unsigned_to_signed(value)
 
     if shift_length >= 256:

--- a/eth/vm/logic/block.py
+++ b/eth/vm/logic/block.py
@@ -1,8 +1,5 @@
-from eth import constants
-
-
 def blockhash(computation):
-    block_number = computation.stack_pop(type_hint=constants.UINT256)
+    block_number, = computation.stack_pop_ints()
 
     block_hash = computation.state.get_ancestor_hash(block_number)
 

--- a/eth/vm/logic/call.py
+++ b/eth/vm/logic/call.py
@@ -140,8 +140,8 @@ class Call(BaseCall):
         return transfer_gas_fee + create_gas_fee
 
     def get_call_params(self, computation):
-        gas = computation.stack_pop(type_hint=constants.UINT256)
-        to = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+        gas, = computation.stack_pop_ints()
+        to = force_bytes_to_address(next(computation.stack_pop_bytes()))
 
         (
             value,
@@ -149,7 +149,7 @@ class Call(BaseCall):
             memory_input_size,
             memory_output_start_position,
             memory_output_size,
-        ) = computation.stack_pop(num_items=5, type_hint=constants.UINT256)
+        ) = computation.stack_pop_ints(num_items=5)
 
         return (
             gas,
@@ -171,8 +171,8 @@ class CallCode(BaseCall):
         return constants.GAS_CALLVALUE if value else 0
 
     def get_call_params(self, computation):
-        gas = computation.stack_pop(type_hint=constants.UINT256)
-        code_address = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+        gas, = computation.stack_pop_ints()
+        code_address = force_bytes_to_address(next(computation.stack_pop_bytes()))
 
         (
             value,
@@ -180,7 +180,7 @@ class CallCode(BaseCall):
             memory_input_size,
             memory_output_start_position,
             memory_output_size,
-        ) = computation.stack_pop(num_items=5, type_hint=constants.UINT256)
+        ) = computation.stack_pop_ints(num_items=5)
 
         to = computation.msg.storage_address
         sender = computation.msg.storage_address
@@ -208,15 +208,15 @@ class DelegateCall(BaseCall):
         return 0
 
     def get_call_params(self, computation):
-        gas = computation.stack_pop(type_hint=constants.UINT256)
-        code_address = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+        gas, = computation.stack_pop_ints()
+        code_address = force_bytes_to_address(next(computation.stack_pop_bytes()))
 
         (
             memory_input_start_position,
             memory_input_size,
             memory_output_start_position,
             memory_output_size,
-        ) = computation.stack_pop(num_items=4, type_hint=constants.UINT256)
+        ) = computation.stack_pop_ints(num_items=4)
 
         to = computation.msg.storage_address
         sender = computation.msg.sender
@@ -321,15 +321,15 @@ class CallEIP161(CallEIP150):
 #
 class StaticCall(CallEIP161):
     def get_call_params(self, computation):
-        gas = computation.stack_pop(type_hint=constants.UINT256)
-        to = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+        gas, = computation.stack_pop_ints()
+        to = force_bytes_to_address(next(computation.stack_pop_bytes()))
 
         (
             memory_input_start_position,
             memory_input_size,
             memory_output_start_position,
             memory_output_size,
-        ) = computation.stack_pop(num_items=4, type_hint=constants.UINT256)
+        ) = computation.stack_pop_ints(num_items=4)
 
         return (
             gas,

--- a/eth/vm/logic/comparison.py
+++ b/eth/vm/logic/comparison.py
@@ -10,7 +10,7 @@ def lt(computation):
     """
     Lesser Comparison
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(num_items=2)
 
     if left < right:
         result = 1
@@ -24,7 +24,7 @@ def gt(computation):
     """
     Greater Comparison
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(num_items=2)
 
     if left > right:
         result = 1
@@ -40,7 +40,7 @@ def slt(computation):
     """
     left, right = map(
         unsigned_to_signed,
-        computation.stack_pop(num_items=2, type_hint=constants.UINT256),
+        computation.stack_pop_ints(num_items=2),
     )
 
     if left < right:
@@ -57,7 +57,7 @@ def sgt(computation):
     """
     left, right = map(
         unsigned_to_signed,
-        computation.stack_pop(num_items=2, type_hint=constants.UINT256),
+        computation.stack_pop_ints(num_items=2),
     )
 
     if left > right:
@@ -72,7 +72,7 @@ def eq(computation):
     """
     Equality
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(num_items=2)
 
     if left == right:
         result = 1
@@ -86,7 +86,7 @@ def iszero(computation):
     """
     Not
     """
-    value = computation.stack_pop(type_hint=constants.UINT256)
+    value, = computation.stack_pop_ints()
 
     if value == 0:
         result = 1
@@ -100,7 +100,7 @@ def and_op(computation):
     """
     Bitwise And
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(num_items=2)
 
     result = left & right
 
@@ -111,7 +111,7 @@ def or_op(computation):
     """
     Bitwise Or
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(num_items=2)
 
     result = left | right
 
@@ -122,7 +122,7 @@ def xor(computation):
     """
     Bitwise XOr
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(num_items=2)
 
     result = left ^ right
 
@@ -133,7 +133,7 @@ def not_op(computation):
     """
     Not
     """
-    value = computation.stack_pop(type_hint=constants.UINT256)
+    value, = computation.stack_pop_ints()
 
     result = constants.UINT_256_MAX - value
 
@@ -144,7 +144,7 @@ def byte_op(computation):
     """
     Bitwise And
     """
-    position, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    position, value = computation.stack_pop_ints(num_items=2)
 
     if position >= 32:
         result = 0

--- a/eth/vm/logic/context.py
+++ b/eth/vm/logic/context.py
@@ -12,7 +12,7 @@ from eth.utils.numeric import (
 
 
 def balance(computation):
-    addr = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    addr = force_bytes_to_address(next(computation.stack_pop_bytes()))
     balance = computation.state.account_db.get_balance(addr)
     computation.stack_push(balance)
 
@@ -37,7 +37,7 @@ def calldataload(computation):
     """
     Load call data into memory.
     """
-    start_position = computation.stack_pop(type_hint=constants.UINT256)
+    start_position, = computation.stack_pop_ints()
 
     value = computation.msg.data[start_position:start_position + 32]
     padded_value = value.ljust(32, b'\x00')
@@ -56,7 +56,7 @@ def calldatacopy(computation):
         mem_start_position,
         calldata_start_position,
         size,
-    ) = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    ) = computation.stack_pop_ints(num_items=3)
 
     computation.extend_memory(mem_start_position, size)
 
@@ -81,7 +81,7 @@ def codecopy(computation):
         mem_start_position,
         code_start_position,
         size,
-    ) = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    ) = computation.stack_pop_ints(num_items=3)
 
     computation.extend_memory(mem_start_position, size)
 
@@ -106,19 +106,19 @@ def gasprice(computation):
 
 
 def extcodesize(computation):
-    account = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    account = force_bytes_to_address(next(computation.stack_pop_bytes()))
     code_size = len(computation.state.account_db.get_code(account))
 
     computation.stack_push(code_size)
 
 
 def extcodecopy(computation):
-    account = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    account = force_bytes_to_address(next(computation.stack_pop_bytes()))
     (
         mem_start_position,
         code_start_position,
         size,
-    ) = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    ) = computation.stack_pop_ints(num_items=3)
 
     computation.extend_memory(mem_start_position, size)
 
@@ -143,7 +143,7 @@ def extcodehash(computation):
     Return the code hash for a given address.
     EIP: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1052.md
     """
-    account = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    account = force_bytes_to_address(next(computation.stack_pop_bytes()))
     account_db = computation.state.account_db
 
     if not account_db.account_exists(account):
@@ -162,7 +162,7 @@ def returndatacopy(computation):
         mem_start_position,
         returndata_start_position,
         size,
-    ) = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    ) = computation.stack_pop_ints(num_items=3)
 
     if returndata_start_position + size > len(computation.return_data):
         raise OutOfBoundsRead(

--- a/eth/vm/logic/flow.py
+++ b/eth/vm/logic/flow.py
@@ -1,4 +1,3 @@
-from eth import constants
 from eth.exceptions import (
     InvalidJumpDestination,
     InvalidInstruction,
@@ -14,7 +13,7 @@ def stop(computation):
 
 
 def jump(computation):
-    jump_dest = computation.stack_pop(type_hint=constants.UINT256)
+    jump_dest, = computation.stack_pop_ints()
 
     computation.code.pc = jump_dest
 
@@ -28,7 +27,7 @@ def jump(computation):
 
 
 def jumpi(computation):
-    jump_dest, check_value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    jump_dest, check_value = computation.stack_pop_ints(num_items=2)
 
     if check_value:
         computation.code.pc = jump_dest

--- a/eth/vm/logic/logging.py
+++ b/eth/vm/logic/logging.py
@@ -9,14 +9,14 @@ def log_XX(computation, topic_count):
     if topic_count < 0 or topic_count > 4:
         raise TypeError("Invalid log topic size.  Must be 0, 1, 2, 3, or 4")
 
-    mem_start_position, size = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    mem_start_position, size = computation.stack_pop_ints(num_items=2)
 
     if not topic_count:
         topics = []  # type: List[int]
     elif topic_count > 1:
-        topics = computation.stack_pop(num_items=topic_count, type_hint=constants.UINT256)
+        topics = computation.stack_pop_ints(num_items=topic_count)
     else:
-        topics = [computation.stack_pop(num_items=topic_count, type_hint=constants.UINT256)]
+        topics = [computation.stack_pop_ints(num_items=topic_count)]
 
     data_gas_cost = constants.GAS_LOGDATA * size
     topic_gas_cost = constants.GAS_LOGTOPIC * topic_count

--- a/eth/vm/logic/memory.py
+++ b/eth/vm/logic/memory.py
@@ -1,9 +1,6 @@
-from eth import constants
-
-
 def mstore(computation):
-    start_position = computation.stack_pop(type_hint=constants.UINT256)
-    value = computation.stack_pop(type_hint=constants.BYTES)
+    start_position, = computation.stack_pop_ints()
+    value, = computation.stack_pop_bytes()
 
     padded_value = value.rjust(32, b'\x00')
     normalized_value = padded_value[-32:]
@@ -14,8 +11,8 @@ def mstore(computation):
 
 
 def mstore8(computation):
-    start_position = computation.stack_pop(type_hint=constants.UINT256)
-    value = computation.stack_pop(type_hint=constants.BYTES)
+    start_position, = computation.stack_pop_ints()
+    value, = computation.stack_pop_bytes()
 
     padded_value = value.rjust(1, b'\x00')
     normalized_value = padded_value[-1:]
@@ -26,7 +23,7 @@ def mstore8(computation):
 
 
 def mload(computation):
-    start_position = computation.stack_pop(type_hint=constants.UINT256)
+    start_position, = computation.stack_pop_ints()
 
     computation.extend_memory(start_position, 32)
 

--- a/eth/vm/logic/sha3.py
+++ b/eth/vm/logic/sha3.py
@@ -7,7 +7,7 @@ from eth.utils.numeric import (
 
 
 def sha3(computation):
-    start_position, size = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    start_position, size = computation.stack_pop_ints(num_items=2, type_hint=constants.UINT256)
 
     computation.extend_memory(start_position, size)
 

--- a/eth/vm/logic/stack.py
+++ b/eth/vm/logic/stack.py
@@ -1,10 +1,8 @@
 import functools
 
-from eth import constants
-
 
 def pop(computation):
-    computation.stack_pop(type_hint=constants.ANY)
+    computation.stack_pop_ints()
 
 
 def push_XX(computation, size):

--- a/eth/vm/logic/storage.py
+++ b/eth/vm/logic/storage.py
@@ -6,7 +6,7 @@ from eth.utils.hexadecimal import (
 
 
 def sstore(computation):
-    slot, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    slot, value = computation.stack_pop_ints(num_items=2)
 
     current_value = computation.state.account_db.get_storage(
         address=computation.msg.storage_address,
@@ -50,7 +50,7 @@ def sstore(computation):
 
 
 def sload(computation):
-    slot = computation.stack_pop(type_hint=constants.UINT256)
+    slot, = computation.stack_pop_ints()
 
     value = computation.state.account_db.get_storage(
         address=computation.msg.storage_address,

--- a/eth/vm/logic/system.py
+++ b/eth/vm/logic/system.py
@@ -32,7 +32,7 @@ from .call import max_child_gas_eip150
 
 
 def return_op(computation: BaseComputation) -> None:
-    start_position, size = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    start_position, size = computation.stack_pop_ints(num_items=2)
 
     computation.extend_memory(start_position, size)
 
@@ -42,7 +42,7 @@ def return_op(computation: BaseComputation) -> None:
 
 
 def revert(computation: BaseComputation) -> None:
-    start_position, size = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    start_position, size = computation.stack_pop_ints(num_items=2)
 
     computation.extend_memory(start_position, size)
 
@@ -52,13 +52,13 @@ def revert(computation: BaseComputation) -> None:
 
 
 def selfdestruct(computation: BaseComputation) -> None:
-    beneficiary = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    beneficiary = force_bytes_to_address(next(computation.stack_pop_bytes()))
     _selfdestruct(computation, beneficiary)
     raise Halt('SELFDESTRUCT')
 
 
 def selfdestruct_eip150(computation: BaseComputation) -> None:
-    beneficiary = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    beneficiary = force_bytes_to_address(next(computation.stack_pop_bytes()))
     if not computation.state.account_db.account_exists(beneficiary):
         computation.consume_gas(
             constants.GAS_SELFDESTRUCT_NEWACCOUNT,
@@ -68,7 +68,7 @@ def selfdestruct_eip150(computation: BaseComputation) -> None:
 
 
 def selfdestruct_eip161(computation: BaseComputation) -> None:
-    beneficiary = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    beneficiary = force_bytes_to_address(next(computation.stack_pop_bytes()))
     is_dead = (
         not computation.state.account_db.account_exists(beneficiary) or
         computation.state.account_db.account_is_empty(beneficiary)
@@ -142,10 +142,7 @@ class Create(Opcode):
         return contract_address
 
     def get_stack_data(self, computation: BaseComputation) -> CreateOpcodeStackData:
-        endowment, memory_start, memory_length = computation.stack_pop(
-            num_items=3,
-            type_hint=constants.UINT256,
-        )
+        endowment, memory_start, memory_length = computation.stack_pop_ints(num_items=3)
 
         return CreateOpcodeStackData(endowment, memory_start, memory_length)
 
@@ -220,10 +217,7 @@ class Create2(CreateByzantium):
 
     def get_stack_data(self, computation: BaseComputation) -> CreateOpcodeStackData:
 
-        endowment, memory_start, memory_length, salt = computation.stack_pop(
-            num_items=4,
-            type_hint=constants.UINT256,
-        )
+        endowment, memory_start, memory_length, salt = computation.stack_pop_ints(num_items=4)
 
         return CreateOpcodeStackData(endowment, memory_start, memory_length, salt)
 

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -105,7 +105,7 @@ def test_add(vm_class, val1, val2, expected):
     computation.stack_push(val2)
     computation.opcodes[opcode_values.ADD](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result, = computation.stack_pop_ints()
 
     assert result == expected
 
@@ -126,7 +126,7 @@ def test_mul(vm_class, val1, val2, expected):
     computation.stack_push(val2)
     computation.opcodes[opcode_values.MUL](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result, = computation.stack_pop_ints()
 
     assert result == expected
 
@@ -152,7 +152,7 @@ def test_exp(vm_class, base, exponent, expected):
     computation.stack_push(base)
     computation.opcodes[opcode_values.EXP](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result, = computation.stack_pop_ints()
 
     assert result == expected
 
@@ -235,7 +235,7 @@ def test_shl(vm_class, val1, val2, expected):
     computation.stack_push(decode_hex(val2))
     computation.opcodes[opcode_values.SHL](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result, = computation.stack_pop_ints()
 
     assert encode_hex(pad32(int_to_big_endian(result))) == expected
 
@@ -318,7 +318,7 @@ def test_shr(vm_class, val1, val2, expected):
     computation.stack_push(decode_hex(val2))
     computation.opcodes[opcode_values.SHR](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result, = computation.stack_pop_ints()
     assert encode_hex(pad32(int_to_big_endian(result))) == expected
 
 
@@ -431,7 +431,7 @@ def test_sar(vm_class, val1, val2, expected):
     computation.stack_push(decode_hex(val2))
     computation.opcodes[opcode_values.SAR](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result, = computation.stack_pop_ints()
     assert encode_hex(pad32(int_to_big_endian(result))) == expected
 
 
@@ -462,7 +462,7 @@ def test_extcodehash(vm_class, address, expected):
     computation.stack_push(decode_hex(address))
     computation.opcodes[opcode_values.EXTCODEHASH](computation)
 
-    result = computation.stack_pop(type_hint=constants.BYTES)
+    result, = computation.stack_pop_bytes()
     assert encode_hex(pad32(result)) == expected
 
 

--- a/tests/core/validation/test_validation.py
+++ b/tests/core/validation/test_validation.py
@@ -302,9 +302,9 @@ def test_validate_uint256(value, is_valid):
     "value,is_valid",
     (
         ('a', False),
-        (b'', True),
-        (b'a', True),
-        (b'10010010010010010010010010010010', True),
+        (b'', False),
+        (b'a', False),
+        (b'10010010010010010010010010010010', False),
         (b'100100100100100100100100100100100', False),
         (-1, False),
         (0, True),


### PR DESCRIPTION
### What was wrong?
EVM stack (`eth.vm.stack`) previously stored items of both `int` and `bytes`. This causes typing issues and morevover `bytes` data can be converted to `int`, and that would be a better design. This is because while popping the data, we can be sure of only 1 type(`int`), instead of `union of int and bytes`.


### How was it fixed?
Stack was made sure that it stored only items of the type `int`. Data of type `bytes` were converted to `int` and then stored in the stack. Also instead of having a single `pop` function, 2 functions `pop_ints` and `pop_bytes` were introduced, and they are used instead of the traditional `pop` function.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i1.ytimg.com/vi/TvqSBu69ur8/hqdefault.jpg)
