### PR TITLE
Ensure ethstats plugin handles incorrect server responses

### DIFF
--- a/trinity/plugins/builtin/ethstats/ethstats_client.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_client.py
@@ -59,7 +59,7 @@ class EthstatsClient(BaseService):
             try:
                 message: EthstatsMessage = self.deserialize_message(json_string)
             except EthstatsException as e:
-                self.logger.info('Cannot parse message from server: %s' % e)
+                self.logger.warning('Cannot parse message from server: %s' % e)
                 return
 
             await self.recv_queue.put(message)
@@ -83,6 +83,9 @@ class EthstatsClient(BaseService):
             raw_message = json.loads(json_string)
         except json.decoder.JSONDecodeError as e:
             raise EthstatsException('Received incorrect JSON: %s' % e)
+
+        if isinstance(raw_message, str):
+            raise EthstatsException(f'Received invalid payload: {raw_message}')
 
         try:
             payload = raw_message['emit']


### PR DESCRIPTION
### What was wrong?

When the ethstats plugin connects without secret we get a string response instead of the expected JSON object. This then further leads to a `TypeError` if we try to access an attribute on that string.

### How was it fixed?

Check if `raw_message` is a string and raise an exception. Also ensure ethstats errors are logged as `warning` not `info`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.animalslook.com/media/these-15-amazing-wildlife-photographs-will-make-you-laugh-till-your-stomach-hurts/these-15-amazing-wildlife-photographs-will-make-you-laugh-till-your-stomach-hurts-4.jpg)
