### PR TITLE
If peer disconnects during boot, don't add to pool

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -841,7 +841,10 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             await peer.disconnect(DisconnectReason.timeout)
             return
         else:
-            self._add_peer(peer, buffer.get_messages())
+            if peer.is_operational:
+                self._add_peer(peer, buffer.get_messages())
+            else:
+                self.logger.debug('%s disconnected during boot-up, not adding to pool', peer)
 
     def _add_peer(self,
                   peer: BasePeer,


### PR DESCRIPTION
### What was wrong?

Fixes #1455 

(Well, it doesn't fix the issue the way that 1455 originally asked to, but I would rather prevent the problem than do occasional cleanups after an unknown problem occurs)

### How was it fixed?

Identify if a peer has disconnected during the boot up process, and if so, don't add it to the pool.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://littlepenguinboots.files.wordpress.com/2018/03/oie_jpg1-e1520651543261.png)