### PR TITLE
Log when fast-sync has finished

### DIFF
--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -256,9 +256,9 @@ class PeerHeaderSyncer(BaseService):
                             head.block_number - MAX_REORG_DEPTH
                         )
                         self.logger.debug(
-                            "All %d headers redundant, head at #%d, fetching from #%d",
+                            "All %d headers redundant, head at %s, fetching from #%d",
                             len(all_headers),
-                            head.block_number,
+                            head,
                             start_at,
                         )
                         continue

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -467,8 +467,8 @@ class FastChainSyncer(BaseBodyChainSyncer):
                 last_head = head
 
                 self.logger.info(
-                    "Advanced by %d blocks in %0.1f seconds, new head: #%d",
-                    block_num_change, timer.pop_elapsed(), head.block_number)
+                    "Advanced by %d blocks in %0.1f seconds, new head: %s",
+                    block_num_change, timer.pop_elapsed(), head)
 
     async def _persist_ready_blocks(self) -> None:
         """
@@ -793,10 +793,10 @@ class RegularChainSyncer(BaseBodyChainSyncer):
 
             head = await self.wait(self.db.coro_get_canonical_head())
             self.logger.info(
-                "Synced chain segment with %d blocks in %.2f seconds, new head: #%d",
+                "Synced chain segment with %d blocks in %.2f seconds, new head: %s",
                 len(completed_headers),
                 timer.elapsed,
-                head.block_number,
+                head,
             )
 
     async def _import_blocks(self, headers: Tuple[BlockHeader, ...]) -> None:

--- a/trinity/sync/light/chain.py
+++ b/trinity/sync/light/chain.py
@@ -21,7 +21,7 @@ class LightChainSyncer(BaseHeaderChainSyncer):
 
             head = await self.wait(self.db.coro_get_canonical_head())
             self.logger.info(
-                "Imported %d headers in %0.2f seconds, new head: #%d",
-                len(headers), timer.elapsed, head.block_number)
+                "Imported %d headers in %0.2f seconds, new head: %s",
+                len(headers), timer.elapsed, head)
 
             self.header_queue.complete(batch_id, headers)


### PR DESCRIPTION
### What was wrong?

We currently do not log when the fast-sync has finished. Two reasons to have this:

1. Achieve symmetry (we do log when fast sync begins)
2. Have it easier to grep the logs to see if a fast-sync finished or not

### How was it fixed?

Add a `info` log when the fast sync has finished.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://lionaroundwriting.files.wordpress.com/2013/07/studious-gorilla.jpg)
