### PR TITLE
Ensure state tests only run against the intended fork

### DIFF
--- a/eth/tools/fixtures/loading.py
+++ b/eth/tools/fixtures/loading.py
@@ -77,7 +77,7 @@ def load_fixture(fixture_path: str,
 def filter_fixtures(all_fixtures: Iterable[Any],
                     fixtures_base_dir: str,
                     mark_fn: Callable[[str, str], bool]=None,
-                    ignore_fn: Callable[[str, str], bool]=None) -> Any:
+                    ignore_fn: Callable[..., bool]=None) -> Any:
     """
     Helper function for filtering test fixtures.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,3 +186,7 @@ def chain_without_block_validation(
     }
     chain = klass.from_genesis(base_db, genesis_params, genesis_state)
     return chain
+
+
+def pytest_addoption(parser):
+    parser.addoption("--fork", type=str, required=False)

--- a/tox.ini
+++ b/tox.ini
@@ -36,13 +36,13 @@ commands=
     transactions: pytest {posargs:tests/json-fixtures/test_transactions.py}
     vm: pytest {posargs:tests/json-fixtures/test_virtual_machine.py}
     native-blockchain: pytest {posargs:tests/json-fixtures/test_blockchain.py}
-    native-state-frontier: pytest {posargs:tests/json-fixtures/test_state.py -k Frontier}
-    native-state-homestead: pytest {posargs:tests/json-fixtures/test_state.py -k Homestead}
-    native-state-eip150: pytest {posargs:tests/json-fixtures/test_state.py -k EIP150}
-    native-state-eip158: pytest {posargs:tests/json-fixtures/test_state.py -k EIP158}
-    native-state-byzantium: pytest {posargs:tests/json-fixtures/test_state.py -k Byzantium}
-    native-state-constantinople: pytest {posargs:tests/json-fixtures/test_state.py -k Constantinople}
-    native-state-metropolis: pytest {posargs:tests/json-fixtures/test_state.py -k Metropolis}
+    native-state-frontier: pytest {posargs:tests/json-fixtures/test_state.py --fork Frontier}
+    native-state-homestead: pytest {posargs:tests/json-fixtures/test_state.py --fork Homestead}
+    native-state-eip150: pytest {posargs:tests/json-fixtures/test_state.py --fork EIP150}
+    native-state-eip158: pytest {posargs:tests/json-fixtures/test_state.py --fork EIP158}
+    native-state-byzantium: pytest {posargs:tests/json-fixtures/test_state.py --fork Byzantium}
+    native-state-constantinople: pytest {posargs:tests/json-fixtures/test_state.py --fork Constantinople}
+    native-state-metropolis: pytest {posargs:tests/json-fixtures/test_state.py --fork Metropolis}
     lightchain_integration: pytest --integration {posargs:tests/trinity/integration/test_lightchain_integration.py}
 
 deps = .[p2p,trinity,eth-extra,test]


### PR DESCRIPTION
### What was wrong?

The statetest fixtures have different definitions
for each fork and we must ensure to only run
test against against the intended fork (e.g run
Constantinople state tests against Constantinople VM).

We can not rely on `pytest -k` matching for that
as that matches against an identification string that
includes the path and name of the test file which in
some cases also contains fork names. A test file may
be named "ConstantinopleSomething.json" but still
contains individual definitions per fork.

### How was it fixed?

Add a mechanism so that the intended fork can be passed as `--fork` and then internally filter the generated fixtures against that.

Notice that this does only apply to state tests as these are the only test files expands into multiple test cases per fork.

The following table compares the number of executed tests per fork based on this new scheme. 

| State test  | Run before | Run after |
| ------------- | ------------- | -------------|
| Frontier |1033|942
| Homestead  | 2196 | 2031 
| EIP150 |1281|1112
| EIP158  | 1177  | 1168  |
| Byzantium |4714|4714




#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img.designswan.com/2014/02/sony2014/2.jpg)
