### PR TITLE
Cleanup classifiers and add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
     keywords='ethereum blockchain evm',
     packages=find_packages(exclude=["tests", "tests.*"]),
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',

--- a/setup_trinity.py
+++ b/setup_trinity.py
@@ -23,12 +23,13 @@ setup(
     keywords='ethereum blockchain evm trinity',
     packages=[],
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3.6',
     ],
+    python_requires=">=3.6,<4"
     # trinity
     entry_points={
         'console_scripts': ['trinity=trinity:main'],


### PR DESCRIPTION
### What was wrong?

Outdated info in `setup.py`. Also pip should prevent people from trying to install Trinity on Python versions below `3.6`.

Related: https://github.com/ethereum/snake-charmers-internal-handbook/issues/3

### How was it fixed?

Magic!

I believe that the `python_requires` change does only affect people who try to install Trinity from pypi as anyone else who would `pip install -e [trinity]` directly from the repository root, would hit the `setup.py` file instead of the `setup_trinity.py` file.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://s.yimg.com/ny/api/res/1.2/V1D8mYd3y0HWVMVZvdRfMA--~A/YXBwaWQ9aGlnaGxhbmRlcjtzbT0xO3c9MTI4MDtoPTk2MA--/http://media.zenfs.com/en/homerun/feed_manager_auto_publish_494/a3bc374da27e1f40e9638d8570265f1d)
