### PR TITLE
`ethstats` plug-in: send 'uptime' to prevent "NaN%" display on dashboard

### DIFF
--- a/trinity/plugins/builtin/ethstats/ethstats_service.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_service.py
@@ -108,6 +108,7 @@ class EthstatsService(BaseService):
             await self.sleep(5)
 
     def get_node_info(self) -> EthstatsData:
+        '''Getter for data that should be sent once, on start-up.'''
         return {
             'name': self.node_id,
             'contact': self.node_contact,
@@ -121,6 +122,7 @@ class EthstatsService(BaseService):
         }
 
     def get_node_block(self) -> EthstatsData:
+        '''Getter for data that should be sent on every new chain tip change.'''
         head = self.chain.get_canonical_head()
 
         return {
@@ -133,7 +135,7 @@ class EthstatsService(BaseService):
         }
 
     async def get_node_stats(self) -> EthstatsData:
-
+        '''Getter for data that should be sent periodically.'''
         try:
             peer_count = (await self.wait(
                 self.context.event_bus.request(PeerCountRequest()),
@@ -145,6 +147,7 @@ class EthstatsService(BaseService):
 
         return {
             'active': True,
+            'uptime': 100,
             'peers': peer_count,
         }
 


### PR DESCRIPTION
### What was wrong?

If an `uptime` is not submitted, the dashboard displays `NaN%` for the node; and also `NaN%` for the averaged uptime of all tracked nodes.

### How was it fixed?

Hard-coded to "100%".

Original JS `ethstats` client keeps count of failed/total data collection/submission events, so that it can showcase downtime. We're not doing this, and perhaps shouldn't (yet) - much better things to do...

Also, the displayed uptime gradually drops for nodes that have disconnected, so this works "good enough".

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/media/B1CeupHIAAA2yjv.jpg:small)

Source: [BuzzFeed's Adorably](https://mobile.twitter.com/Adorably/status/527095681430069248); author unknown