### PR TITLE
Ensure network connection is closed when handshake with peer fails

### DIFF
--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -57,8 +57,16 @@ async def handshake(
     use_eip8 = False
     initiator = HandshakeInitiator(remote, privkey, use_eip8, token)
     reader, writer = await initiator.connect()
-    aes_secret, mac_secret, egress_mac, ingress_mac = await _handshake(
-        initiator, reader, writer, token)
+    try:
+        aes_secret, mac_secret, egress_mac, ingress_mac = await _handshake(
+            initiator, reader, writer, token)
+    except Exception:
+        if not reader.at_eof():
+            reader.feed_eof()
+        writer.close()
+        await asyncio.sleep(0)
+        raise
+
     return aes_secret, mac_secret, egress_mac, ingress_mac, reader, writer
 
 

--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -61,6 +61,10 @@ async def handshake(
         aes_secret, mac_secret, egress_mac, ingress_mac = await _handshake(
             initiator, reader, writer, token)
     except Exception:
+        # Note: This is one of two places where we manually handle closing the
+        # reader/writer connection pair in the event of an error during the
+        # peer connection and handshake process.
+        # See `p2p.peer.handshake` for the other.
         if not reader.at_eof():
             reader.feed_eof()
         writer.close()

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -132,6 +132,10 @@ async def handshake(remote: Node, factory: 'BasePeerFactory') -> 'BasePeer':
         await peer.do_p2p_handshake()
         await peer.do_sub_proto_handshake()
     except Exception:
+        # Note: This is one of two places where we manually handle closing the
+        # reader/writer connection pair in the event of an error during the
+        # peer connection and handshake process.
+        # See `p2p.auth.handshake` for the other.
         if not reader.at_eof():
             reader.feed_eof()
         writer.close()


### PR DESCRIPTION
fixes #1403 

### What was wrong?

As part of our peer connection logic we initiate a low level connection, then create a `Peer` instance, then perform a handshake, followed by starting the peer service.  If anything goes wrong before the service starts, the connection will be left open causing these warnings.

### How was it fixed?

wrapped the handshake step in a `try/except` which closes the connection in the event of an error.

#### Cute Animal Picture

![bearlive05_04](https://user-images.githubusercontent.com/824194/48675567-9e745780-eb17-11e8-8043-cca824fbaecb.jpg)

