### PR TITLE
Improve logging output during chain sync

### DIFF
--- a/tests/trinity/core/humanize-utils/test_humanize_elapsed.py
+++ b/tests/trinity/core/humanize-utils/test_humanize_elapsed.py
@@ -1,0 +1,41 @@
+import pytest
+
+from trinity.utils.humanize import humanize_elapsed
+
+
+SECOND = 1
+MINUTE = 60
+HOUR = 60 * 60
+DAY = 24 * HOUR
+YEAR = 365 * DAY
+MONTH = YEAR // 12
+WEEK = 7 * DAY
+
+
+@pytest.mark.parametrize(
+    'seconds,expected',
+    (
+        (0, '0s'),
+        (1, '1s'),
+        (60, '1m'),
+        (61, '1m1s'),
+        (119, '1m59s'),
+        (HOUR, '1h'),
+        (HOUR + 1, '1h0m1s'),
+        (HOUR + MINUTE + 1, '1h1m1s'),
+        (DAY + HOUR, '1d1h'),
+        (DAY + HOUR + MINUTE, '1d1h1m'),
+        (DAY + MINUTE, '1d0h1m'),
+        (DAY + MINUTE + 1, '1d0h1m'),
+        (WEEK + DAY + HOUR, '1w1d1h'),
+        (WEEK + DAY + HOUR + MINUTE, '1w1d1h'),
+        (WEEK + DAY + HOUR + SECOND, '1w1d1h'),
+        (MONTH + WEEK + DAY, '1m1w1d'),
+        (MONTH + WEEK + DAY + HOUR, '1m1w1d'),
+        (YEAR + MONTH + WEEK, '1y1m1w'),
+        (YEAR + MONTH + WEEK + DAY, '1y1m1w'),
+    ),
+)
+def test_humanize_elapsed(seconds, expected):
+    actual = humanize_elapsed(seconds)
+    assert actual == expected

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -4,15 +4,14 @@ from typing import (
     Generic,
     Optional,
     TypeVar,
-    Union,
 )
 
-from eth_utils import ValidationError
 
 from p2p.protocol import (
     BaseRequest,
 )
 
+from trinity.utils.ema import EMA
 from trinity.utils.logging import HasTraceLogger
 from .constants import ROUND_TRIP_TIMEOUT
 from .types import (
@@ -21,39 +20,6 @@ from .types import (
 
 
 TRequest = TypeVar('TRequest', bound=BaseRequest[Any])
-
-
-class EMA:
-    """
-    Represents an exponential moving average.
-    https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
-
-    Smoothing factor, or "alpha" of the exponential moving average.
-
-    - Closer to 0 gives you smoother, slower-to-update, data
-    - Closer to 1 gives you choppier, quicker-to-update, data
-
-    .. note::
-
-        A smoothing factor of 1 would completely ignore history whereas 0 would
-        completely ignore new data
-
-
-    The initial value is the starting value for the EMA
-    """
-    def __init__(self, initial_value: float, smoothing_factor: float) -> None:
-        self._value = initial_value
-        if 0 < smoothing_factor < 1:
-            self._alpha = smoothing_factor
-        else:
-            raise ValidationError("Smoothing factor of EMA must be between 0 and 1")
-
-    def update(self, scalar: Union[int, float]) -> None:
-        self._value = (self._value * (1 - self._alpha)) + (scalar * self._alpha)
-
-    @property
-    def value(self) -> float:
-        return self._value
 
 
 class BasePerformanceTracker(ABC, HasTraceLogger, Generic[TRequest, TResult]):

--- a/trinity/utils/ema.py
+++ b/trinity/utils/ema.py
@@ -1,0 +1,36 @@
+from typing import Union
+
+from eth_utils import ValidationError
+
+
+class EMA:
+    """
+    Represents an exponential moving average.
+    https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+
+    Smoothing factor, or "alpha" of the exponential moving average.
+
+    - Closer to 0 gives you smoother, slower-to-update, data
+    - Closer to 1 gives you choppier, quicker-to-update, data
+
+    .. note::
+
+        A smoothing factor of 1 would completely ignore history whereas 0 would
+        completely ignore new data
+
+
+    The initial value is the starting value for the EMA
+    """
+    def __init__(self, initial_value: float, smoothing_factor: float) -> None:
+        self._value = initial_value
+        if 0 < smoothing_factor < 1:
+            self._alpha = smoothing_factor
+        else:
+            raise ValidationError("Smoothing factor of EMA must be between 0 and 1")
+
+    def update(self, scalar: Union[int, float]) -> None:
+        self._value = (self._value * (1 - self._alpha)) + (scalar * self._alpha)
+
+    @property
+    def value(self) -> float:
+        return self._value

--- a/trinity/utils/humanize.py
+++ b/trinity/utils/humanize.py
@@ -1,0 +1,46 @@
+from typing import Iterator
+
+
+def humanize_elapsed(seconds: int) -> str:
+    return ''.join(_humanize_elapsed(seconds))
+
+
+SECOND = 1
+MINUTE = 60
+HOUR = 60 * 60
+DAY = 24 * HOUR
+YEAR = 365 * DAY
+MONTH = YEAR // 12
+WEEK = 7 * DAY
+
+
+UNITS = (
+    (YEAR, 'y'),
+    (MONTH, 'm'),
+    (WEEK, 'w'),
+    (DAY, 'd'),
+    (HOUR, 'h'),
+    (MINUTE, 'm'),
+    (SECOND, 's'),
+)
+
+
+def _humanize_elapsed(seconds: int) -> Iterator[str]:
+    if not seconds:
+        yield '0s'
+
+    num_display_units = 0
+    remainder = seconds
+
+    for duration, unit in UNITS:
+        if not remainder:
+            break
+        if remainder >= duration or num_display_units:
+            num = remainder // duration
+            yield f"{num}{unit}"
+            num_display_units += 1
+
+        if num_display_units >= 3:
+            return
+
+        remainder %= duration


### PR DESCRIPTION
fixes #1423 

### What was wrong?

The logging output during chain sync didn't expose certain valuable metrics.

### How was it fixed?

Improved logging output to explose;

- num blocks
- num transactions
- EMA of blocks-per-second
- EMA of transactions-per-second
- elapsed time since last logging message
- head block number and hash (first and last 4 hex digits)
- age of head block in a terse format

```
    INFO  11-19 11:39:40       FastChainSyncer  blks=326   txs=193    bps=62   tps=73    elapsed=5.0  head=#267756 (566e…b671)  age=3y1m4w
    INFO  11-19 11:39:46       FastChainSyncer  blks=284   txs=287    bps=62   tps=72    elapsed=5.6  head=#268040 (9dba…a01c)  age=3y1m4w
    INFO  11-19 11:39:51       FastChainSyncer  blks=330   txs=396    bps=62   tps=72    elapsed=5.0  head=#268370 (148f…eeb7)  age=3y1m4w
    INFO  11-19 11:39:58       FastChainSyncer  blks=471   txs=426    bps=62   tps=72    elapsed=7.3  head=#268841 (0fb0…62ff)  age=3y1m4w
    INFO  11-19 11:40:05       FastChainSyncer  blks=512   txs=409    bps=62   tps=71    elapsed=7.3  head=#269353 (7183…2934)  age=3y1m4w
    INFO  11-19 11:40:13       FastChainSyncer  blks=512   txs=1255   bps=63   tps=76    elapsed=7.4  head=#269865 (ca52…3ed0)  age=3y1m4w
    INFO  11-19 11:40:19       FastChainSyncer  blks=457   txs=644    bps=63   tps=77    elapsed=6.3  head=#270322 (78e6…df28)  age=3y1m4w
    INFO  11-19 11:40:25       FastChainSyncer  blks=431   txs=306    bps=63   tps=76    elapsed=6.2  head=#270753 (6fa5…a516)  age=3y1m4w
    INFO  11-19 11:40:31       FastChainSyncer  blks=440   txs=303    bps=64   tps=74    elapsed=6.2  head=#271193 (8367…6aa2)  age=3y1m4w
    INFO  11-19 11:40:38       FastChainSyncer  blks=420   txs=287    bps=64   tps=73    elapsed=6.4  head=#271613 (78a7…099e)  age=3y1m4w
```

#### Cute Animal Picture

![s-l1000](https://user-images.githubusercontent.com/824194/48727665-1a41d300-ebf0-11e8-9a53-b118daeeb382.jpg)

