### PR TITLE
Limit the max open files of state sync cache db

### DIFF
--- a/eth/db/backends/level.py
+++ b/eth/db/backends/level.py
@@ -28,7 +28,9 @@ class LevelDB(BaseAtomicDB):
     logger = logging.getLogger("eth.db.backends.LevelDB")
 
     # Creates db as a class variable to avoid level db lock error
-    def __init__(self, db_path: Path = None) -> None:
+    def __init__(self,
+                 db_path: Path=None,
+                 max_open_files: int=None) -> None:
         if not db_path:
             raise TypeError("Please specifiy a valid path for your database.")
         try:
@@ -39,7 +41,12 @@ class LevelDB(BaseAtomicDB):
                 "LevelDB requires the plyvel library which is not available for import."
             )
         self.db_path = db_path
-        self.db = plyvel.DB(str(db_path), create_if_missing=True, error_if_exists=False)
+        self.db = plyvel.DB(
+            str(db_path),
+            create_if_missing=True,
+            error_if_exists=False,
+            max_open_files=max_open_files
+        )
 
     def __getitem__(self, key: bytes) -> bytes:
         v = self.db.get(key)

--- a/trinity/utils/os.py
+++ b/trinity/utils/os.py
@@ -1,0 +1,9 @@
+import resource
+
+
+def get_open_fd_limit() -> int:
+    """
+    Return the OS soft limit of open file descriptors per process.
+    """
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    return soft_limit


### PR DESCRIPTION
### What was wrong?

As described in #1479, currently, with the state sync, it can happen that the caching db consumes too many open file descriptors so that the process exceeds the maximum number of open file descriptors that the OS can handle.

### How was it fixed?

Let the state sync cache db consume only half of the available open file descriptors. This is somewhat expired by what `geth` does but not entirely the same. I didn't feel comfortable copying an approach which wasn't triggered by an immediate need to solve it that way.

The chosen approach here seems simple enough to try out.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img.designswan.com/2014/07/cano/7.jpg)
