### PR TITLE
Replace unicode char with three dots

### DIFF
--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -537,7 +537,7 @@ class FastChainSyncer(BaseBodyChainSyncer):
                     "bps=%-3d  "
                     "tps=%-4d  "
                     "elapsed=%0.1f  "
-                    "head=#%d (%s\u2026%s)  "
+                    "head=#%d (%s...%s)  "
                     "age=%s"
                 ),
                 stats.num_blocks,


### PR DESCRIPTION
### What was wrong?

Recent logging changes introduced a non-ascii symbol that may cause an exception if it isn't supported.

### How was it fixed?

Using `...` seams like the safer option.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.newsapi.com.au/image/v1/274d0262c6ea9573b3172d1d66432500)
