### PR TITLE
Fix sync mode naming: change all of the SYNC_FULL to SYNC_FAST

### DIFF
--- a/scripts/db-shell.py
+++ b/scripts/db-shell.py
@@ -16,6 +16,7 @@ from trinity.config import TrinityConfig
 from trinity.constants import (
     MAINNET_NETWORK_ID,
     ROPSTEN_NETWORK_ID,
+    SYNC_FAST,
     SYNC_FULL,
     SYNC_LIGHT,
 )
@@ -30,9 +31,13 @@ if __name__ == '__main__':
     network_id = MAINNET_NETWORK_ID
     if args.ropsten:
         network_id = ROPSTEN_NETWORK_ID
-    sync_mode = SYNC_FULL
-    if args.light:
+
+    if args.full:
+        sync_mode = SYNC_FULL
+    elif args.light:
         sync_mode = SYNC_LIGHT
+    else:
+        sync_mode = SYNC_FAST
 
     cfg = TrinityConfig(network_id, sync_mode=sync_mode)
     chaindb = ChainDB(LevelDB(cfg.database_dir))

--- a/tests/trinity/core/config/test_trinity_config_object.py
+++ b/tests/trinity/core/config/test_trinity_config_object.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+import pytest
+
+from eth_utils import (
+    decode_hex,
+)
+
+from eth_keys import keys
+
+from trinity.utils.chains import (
+    get_data_dir_for_network_id,
+    get_local_data_dir,
+    get_nodekey_path,
+)
+from trinity.config import (
+    TrinityConfig,
+    DATABASE_DIR_NAME,
+)
+from trinity.utils.filesystem import (
+    is_under_path,
+)
+
+
+def test_chain_config_computed_properties(xdg_trinity_root):
+    data_dir = get_local_data_dir('muffin', xdg_trinity_root)
+    chain_config = TrinityConfig(network_id=1234, data_dir=data_dir)
+
+    assert chain_config.network_id == 1234
+    assert chain_config.data_dir == data_dir
+    assert chain_config.database_dir == data_dir / DATABASE_DIR_NAME / "fast"
+    assert chain_config.nodekey_path == get_nodekey_path(data_dir)
+
+
+def test_chain_config_computed_properties_custom_xdg(tmpdir, xdg_trinity_root):
+    alt_xdg_root = tmpdir.mkdir('trinity-custom')
+    assert not is_under_path(alt_xdg_root, xdg_trinity_root)
+
+    data_dir = get_data_dir_for_network_id(1, alt_xdg_root)
+    chain_config = TrinityConfig(trinity_root_dir=alt_xdg_root, network_id=1)
+
+    assert chain_config.network_id == 1
+    assert chain_config.data_dir == data_dir
+    assert chain_config.database_dir == data_dir / DATABASE_DIR_NAME / "fast"
+    assert chain_config.nodekey_path == get_nodekey_path(data_dir)
+
+
+def test_chain_config_explicit_properties():
+    chain_config = TrinityConfig(
+        network_id=1,
+        data_dir='./data-dir',
+        nodekey_path='./nodekey'
+    )
+
+    assert chain_config.data_dir == Path('./data-dir').resolve()
+    assert chain_config.nodekey_path == Path('./nodekey').resolve()
+
+
+NODEKEY = '0xd18445cc77139cd8e09110e99c9384f0601bd2dfa5b230cda917df7e56b69949'
+
+
+@pytest.fixture
+def nodekey_bytes():
+    _nodekey_bytes = decode_hex(NODEKEY)
+    return _nodekey_bytes
+
+
+@pytest.fixture
+def nodekey_path(tmpdir, nodekey_bytes):
+    nodekey_file = tmpdir.mkdir('temp-nodekey-dir').join('nodekey')
+    nodekey_file.write_binary(nodekey_bytes)
+
+    return str(nodekey_file)
+
+
+def test_chain_config_nodekey_loading(nodekey_bytes, nodekey_path):
+    chain_config = TrinityConfig(
+        network_id=1,
+        nodekey_path=nodekey_path,
+    )
+
+    assert chain_config.nodekey.to_bytes() == nodekey_bytes
+
+
+@pytest.mark.parametrize('as_bytes', (True, False))
+def test_chain_config_explictely_provided_nodekey(nodekey_bytes, as_bytes):
+    chain_config = TrinityConfig(
+        network_id=1,
+        nodekey=nodekey_bytes if as_bytes else keys.PrivateKey(nodekey_bytes),
+    )
+
+    assert chain_config.nodekey.to_bytes() == nodekey_bytes

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -16,6 +16,7 @@ from trinity import __version__
 from trinity.constants import (
     MAINNET_NETWORK_ID,
     ROPSTEN_NETWORK_ID,
+    SYNC_FAST,
     SYNC_FULL,
     SYNC_LIGHT,
 )
@@ -244,8 +245,8 @@ network_parser.add_argument(
 mode_parser = syncing_parser.add_mutually_exclusive_group()
 mode_parser.add_argument(
     '--sync-mode',
-    choices={SYNC_LIGHT, SYNC_FULL},
-    default=SYNC_FULL,
+    choices={SYNC_LIGHT, SYNC_FAST, SYNC_FULL},
+    default=SYNC_FAST,
 )
 mode_parser.add_argument(
     '--light',  # TODO: consider --sync-mode like geth.

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -33,6 +33,7 @@ from trinity.constants import (
     DEFAULT_PREFERRED_NODES,
     MAINNET_NETWORK_ID,
     ROPSTEN_NETWORK_ID,
+    SYNC_FAST,
     SYNC_FULL,
     SYNC_LIGHT,
 )
@@ -212,7 +213,7 @@ class TrinityConfig:
                  nodekey_path: str=None,
                  logfile_path: str=None,
                  nodekey: PrivateKey=None,
-                 sync_mode: str=SYNC_FULL,
+                 sync_mode: str=SYNC_FAST,
                  port: int=30303,
                  use_discv5: bool = False,
                  preferred_nodes: Tuple[KademliaNode, ...]=None,
@@ -375,7 +376,9 @@ class TrinityConfig:
 
         This is resolved relative to the ``data_dir``
         """
-        if self.sync_mode == SYNC_FULL:
+        if self.sync_mode == SYNC_FAST:
+            return self.data_dir / DATABASE_DIR_NAME / "fast"
+        elif self.sync_mode == SYNC_FULL:
             return self.data_dir / DATABASE_DIR_NAME / "full"
         elif self.sync_mode == SYNC_LIGHT:
             return self.data_dir / DATABASE_DIR_NAME / "light"

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -18,6 +18,7 @@ ASSETS_DIR = Path(__file__).parent / "assets"
 
 # sync modes
 SYNC_FULL = 'full'
+SYNC_FAST = 'fast'
 SYNC_LIGHT = 'light'
 
 # lahja endpoint names


### PR DESCRIPTION
### What was wrong?

We need to fix an internal naming issue where we refer to our fast sync using `SYNC_FULL`. This should be renamed to `SYNC_FAST`, and use the fast terminology in place of full everywhere that is currently used.

Issue Reference: https://github.com/ethereum/py-evm/issues/1480

### How was it fixed?

Change the name from `SYNC_FULL` to `SYNC_FAST`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/profile_images/962170088941019136/lgpCD8X4_400x400.jpg)
