### PR TITLE
New SeededAtomicDB: in-memory atomic, backed by read-only DB

### DIFF
--- a/tests/database/test_base_atomic_db.py
+++ b/tests/database/test_base_atomic_db.py
@@ -2,14 +2,17 @@ import pytest
 
 from eth_utils import ValidationError
 
-from eth.db.atomic import AtomicDB
+from eth.db.atomic import AtomicDB, SeededAtomicDB
 from eth.db.backends.level import LevelDB
 
 
-@pytest.fixture(params=['atomic', 'level'])
+@pytest.fixture(params=['atomic', 'seeded', 'level'])
 def atomic_db(request, tmpdir):
     if request.param == 'atomic':
         return AtomicDB()
+    elif request.param == 'seeded':
+        read_db = LevelDB(db_path=tmpdir.mkdir("level_db_path"))
+        return SeededAtomicDB(read_db)
     elif request.param == 'level':
         return LevelDB(db_path=tmpdir.mkdir("level_db_path"))
     else:

--- a/tests/database/test_seeded_atomic_db.py
+++ b/tests/database/test_seeded_atomic_db.py
@@ -1,0 +1,117 @@
+import pytest
+
+from eth.db.atomic import SeededAtomicDB
+
+
+@pytest.fixture
+def atomic_db(base_db):
+    return SeededAtomicDB(base_db)
+
+
+def test_seeded_atomic_db_with_set_and_get(base_db, atomic_db):
+    with atomic_db.atomic_batch() as db:
+        db.set(b'key-1', b'value-1')
+        db.set(b'key-2', b'value-2')
+        assert db.get(b'key-1') == b'value-1'
+        assert db.get(b'key-2') == b'value-2'
+
+        # keys should not be set in base db.
+        assert b'key-1' not in base_db
+        assert b'key-2' not in base_db
+
+    # keys should never be set in base db.
+    assert b'key-1' not in base_db
+    assert b'key-2' not in base_db
+
+    # but they should be set in the in-memory DB
+    assert atomic_db.get(b'key-1') == b'value-1'
+    assert atomic_db.get(b'key-2') == b'value-2'
+
+
+def test_seeded_atomic_db_with_set_and_get_unbatched(base_db, atomic_db):
+    atomic_db.set(b'key-1', b'value-1')
+    assert atomic_db.get(b'key-1') == b'value-1'
+    atomic_db.set(b'key-2', b'value-2')
+    assert atomic_db.get(b'key-2') == b'value-2'
+
+    # keys should never be set in base db.
+    assert b'key-1' not in base_db
+    assert b'key-2' not in base_db
+
+
+def test_seeded_atomic_db_with_set_and_delete(base_db, atomic_db):
+    base_db[b'key-1'] = b'origin'
+
+    with atomic_db.atomic_batch() as db:
+        db.delete(b'key-1')
+
+        assert b'key-1' not in db
+        with pytest.raises(KeyError):
+            assert db[b'key-1']
+
+        # key should still be in base db
+        assert b'key-1' in base_db
+
+    # key should never be removed from base db
+    assert b'key-1' in base_db
+
+    with pytest.raises(KeyError):
+        atomic_db[b'key-1']
+
+
+def test_seeded_atomic_db_with_set_and_delete_unbatched(base_db, atomic_db):
+    base_db[b'key-1'] = b'origin'
+
+    atomic_db.delete(b'key-1')
+
+    assert b'key-1' not in atomic_db
+    with pytest.raises(KeyError):
+        assert atomic_db[b'key-1']
+
+    # key should never be removed from base atomic_db
+    assert b'key-1' in base_db
+
+
+def test_seeded_atomic_db_with_exception(base_db, atomic_db):
+    base_db.set(b'key-1', b'value-1')
+
+    try:
+        with atomic_db.atomic_batch() as db:
+            db.set(b'key-1', b'new-value-1')
+            db.set(b'key-2', b'value-2')
+            raise Exception
+    except Exception:
+        pass
+
+    assert base_db.get(b'key-1') == b'value-1'
+    assert atomic_db.get(b'key-1') == b'value-1'
+
+    with pytest.raises(KeyError):
+        base_db[b'key-2']
+    with pytest.raises(KeyError):
+        atomic_db[b'key-2']
+
+
+def test_seeded_atomic_db_with_exception_across_contexts(base_db, atomic_db):
+    base_db[b'key-1'] = b'origin-1'
+    base_db[b'key-2'] = b'origin-2'
+
+    try:
+        with atomic_db.atomic_batch() as db:
+            db[b'key-1'] = b'value-1'
+            raise Exception('throw')
+    except Exception:
+        pass
+
+    assert base_db[b'key-1'] == b'origin-1'
+    assert atomic_db[b'key-1'] == b'origin-1'
+    assert base_db[b'key-2'] == b'origin-2'
+    assert atomic_db[b'key-2'] == b'origin-2'
+
+    with atomic_db.atomic_batch() as db:
+        db[b'key-2'] = b'value-2'
+
+    assert base_db[b'key-1'] == b'origin-1'
+    assert atomic_db[b'key-1'] == b'origin-1'
+    assert base_db[b'key-2'] == b'origin-2'  # base db never updates
+    assert atomic_db[b'key-2'] == b'value-2'


### PR DESCRIPTION
### What was wrong?

I wanted to load a LevelDB database from disk into an in-memory Chain DB, and guarantee that it could not be modified. It is relatively straightforward to implement, but I wanted to test that everything worked as expected, and make it available for re-use.

(This was inspired by working on an integration test for #1392 which includes ~1k blocks that should be loaded from disk, but not modified)

### How was it fixed?

Added a `SeededAtomicDB`, which is a tiny deviation from `AtomicDB`: all changes go into a `BatchDB` which is never committed. So it looks as if all changes are made, but the underlying is never changed.

I'll include an example case in a new PR that updates the `tests/trinity/core/p2p-proto/test_sync.py` to use a prebuilt chain with the `SeededAtomicDB` (lightchain integration could use the same tool). This will shave a few seconds off of the sync tests (and make it feasible to use ~1k real headers with PoW seals in a header skeleton test).

Thoughts on a better name? Some alternatives, plus things I don't like about them:
- `PreloadedAtomicDB` (close 2nd to Seeded, I could be convinced)
- `ReadThroughAtomicDB` (wordy)
- `EphemeralDB` (not clear from the name how it's different from MemoryDB)
- `DiskReadMemoryWriteDB` (the DB doesn't actually enforce the read db is on disk)
- `LockedAtomicDB` (locked implies you can't write, but you can)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/W8h4VdLI1UA/maxresdefault.jpg)
