### PR TITLE
test_trinity_cli: Add Trinity attach web3 interaction test.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ deps = {
     ],
     'test': [
         "hypothesis==3.69.5",
+        "pexpect>=4.6, <5",
         # pinned to <3.7 until async fixtures work again
         # https://github.com/pytest-dev/pytest-asyncio/issues/89
         "pytest>=3.6,<3.7",

--- a/tests/trinity/integration/test_trinity_cli.py
+++ b/tests/trinity/integration/test_trinity_cli.py
@@ -1,3 +1,5 @@
+import sys
+import pexpect
 import pytest
 
 from trinity.tools.async_process_runner import AsyncProcessRunner
@@ -107,6 +109,34 @@ async def test_light_boot(async_process_runner, command):
         "Started networking process",
         "IPC started at",
     })
+
+
+@pytest.mark.parametrize(
+    'command',
+    (
+        ('trinity', ),
+    )
+)
+@pytest.mark.asyncio
+async def test_web3(command, async_process_runner):
+    await async_process_runner.run(command, timeout_sec=30)
+    assert await contains_all(async_process_runner.stderr, {
+        "Started DB server process",
+        "Started networking process",
+        "IPC started at",
+    })
+
+    attached_trinity = pexpect.spawn('trinity', ['attach'], logfile=sys.stdout)
+    try:
+        attached_trinity.expect("An instance of Web3 connected to the running chain")
+        attached_trinity.sendline("w3.net.version")
+        attached_trinity.expect("'1'")
+        attached_trinity.sendline("w3")
+        attached_trinity.expect("web3.main.Web3")
+    except pexpect.TIMEOUT:
+        raise Exception("Trinity attach timeout")
+    finally:
+        attached_trinity.close()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?

Trinity attach interaction test did not work properly.

### How was it fixed?

The test attaches to running Trinity and interacts with the console using pexpect module.
Test verifies that the w3 object is available reads network version.

Based on Christoph Burgdorf's [christoph.burgdorf (at) gmail.com] test skeleton.

Fixes: https://github.com/ethereum/py-evm/issues/1472

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.drapiezniki.pl/Photos/bobr.jpg)
