### PR TITLE
Add warning regarding `fork` and asyncio

### DIFF
--- a/trinity/utils/mp.py
+++ b/trinity/utils/mp.py
@@ -13,6 +13,8 @@ from typing import (
 from types import TracebackType
 
 
+# WARNING: Think twice before experimenting with `fork`. The `fork` method does not work well with
+# asyncio yet. This might change with Python 3.8 (See https://bugs.python.org/issue22087#msg318140)
 MP_CONTEXT = os.environ.get('TRINITY_MP_CONTEXT', 'spawn')
 
 


### PR DESCRIPTION
### What was wrong?

I've spent hours lately debugging weird multiprocessing issues that turned out to be caused by the fact that Pythons **default** method to spawn processes on Unix (`fork`) just doesn't work well yet with `asyncio`.

This doesn't seem to be well documented yet but it is [well](https://bugs.python.org/issue21998#msg325820) [known](https://bugs.python.org/issue22087#msg318140) among the Python team. This may be fixed with Python 3.8.

### How was it fixed?

I added a warning at the place where we define `spawn` as our process launch method because every know and then we may wonder why we use `spawn` and attempt to change it. This might save us some painful debugging hours.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://tailandfur.com/wp-content/uploads/2014/09/beautiful-and-cute-animals-wallpaper-56.jpg)
