### PR TITLE
Adjust recursion limit setting logic

### DIFF
--- a/eth/__init__.py
+++ b/eth/__init__.py
@@ -21,7 +21,8 @@ from eth.chains import (  # noqa: F401
 #
 #  Ensure we can reach 1024 frames of recursion
 #
-sys.setrecursionlimit(1024 * 10)
+EVM_RECURSION_LIMIT = 1024 * 10
+sys.setrecursionlimit(max(EVM_RECURSION_LIMIT, sys.getrecursionlimit()))
 
 
 __version__ = pkg_resources.get_distribution("py-evm").version


### PR DESCRIPTION
### What was wrong?

The way the system recursion limit was being set allowed for the recursion limit to end up being lowered.

### How was it fixed?

Adjusted to use a `max` between the desired limit and the current limit.

#### Cute Animal Picture

![hot-dog-with-mustard-dog-halloween-costume-casual-canine-1](https://user-images.githubusercontent.com/824194/49163940-6a551f80-f2eb-11e8-8e73-e76b2f490d26.jpg)

