### PR TITLE
Support light client header validation during sync

### DIFF
--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -56,6 +56,9 @@ from eth.vm.computation import (
 from trinity.sync.light.service import (
     BaseLightPeerChain,
 )
+from trinity.utils.async_dispatch import (
+    async_method,
+)
 
 from .base import BaseAsyncChain
 
@@ -250,16 +253,4 @@ class LightDispatchChain(BaseAsyncChain):
     def validate_uncles(self, block: BaseBlock) -> None:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
-    def validate_chain(
-            self,
-            parent: BlockHeader,
-            chain: Tuple[BlockHeader, ...],
-            seal_check_random_sample_rate: int = 1) -> None:
-        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
-
-    async def coro_validate_chain(
-            self,
-            parent: BlockHeader,
-            chain: Tuple[BlockHeader, ...],
-            seal_check_random_sample_rate: int = 1) -> None:
-        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+    coro_validate_chain = async_method('validate_chain')


### PR DESCRIPTION
### What was wrong?

The light client couldn't validate header chains, in sync or async contexts.

Interestingly, it appears that our light sync is not currently running full header validations :(

On the up-side, we will be getting those for "free" in #1392 (which is where this PR was stripped from)

### How was it fixed?

- Move `validate_chain` to a classmethod on the base class
- Inherit `validate_chain` in the light chain
- Add the async call using `async_method("validate_chain")`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.mnn.com/assets/images/2016/09/Formosan-rock-monkeys-inspect-ears.jpg.1000x0_q80_crop-smart.jpg)
