### PR TITLE
Always use a full chain instance in local server

### DIFF
--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -16,6 +16,7 @@ from p2p.service import (
     BaseService,
 )
 
+from trinity.chains.full import FullChain
 from trinity.db.header import (
     AsyncHeaderDB,
 )
@@ -40,6 +41,8 @@ class Node(BaseService):
     Create usable nodes by adding subclasses that define the following
     unset attributes.
     """
+    _full_chain: FullChain = None
+
     def __init__(self, event_bus: Endpoint, trinity_config: TrinityConfig) -> None:
         super().__init__()
         self.trinity_config = trinity_config
@@ -83,6 +86,13 @@ class Node(BaseService):
     @abstractmethod
     def get_chain(self) -> BaseChain:
         raise NotImplementedError("Node classes must implement this method")
+
+    def get_full_chain(self) -> FullChain:
+        if self._full_chain is None:
+            chain_class = self.chain_config.full_chain_class
+            self._full_chain = chain_class(self.db_manager.get_db())  # type: ignore
+
+        return self._full_chain
 
     @abstractmethod
     def get_peer_pool(self) -> BasePeerPool:

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -28,10 +28,7 @@ class FullNode(Node):
         return self.chain_config.full_chain_class
 
     def get_chain(self) -> FullChain:
-        if self._chain is None:
-            self._chain = self.chain_class(self.db_manager.get_db())  # type: ignore
-
-        return self._chain
+        return self.get_full_chain()
 
     def get_p2p_server(self) -> FullServer:
         if self._p2p_server is None:
@@ -39,7 +36,7 @@ class FullNode(Node):
             self._p2p_server = FullServer(
                 privkey=self._node_key,
                 port=self._node_port,
-                chain=self.get_chain(),
+                chain=self.get_full_chain(),
                 chaindb=manager.get_chaindb(),  # type: ignore
                 headerdb=self.headerdb,
                 base_db=manager.get_db(),  # type: ignore

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -4,6 +4,9 @@ from typing import (
 )
 
 from eth_keys.datatypes import PrivateKey
+from eth_utils import (
+    ValidationError,
+)
 
 from lahja import Endpoint
 
@@ -56,7 +59,10 @@ class LightNode(Node):
         if self._chain is None:
             if self.chain_class is None:
                 raise AttributeError("LightNode subclass must set chain_class")
-            self._chain = self.chain_class(self.headerdb, peer_chain=self._peer_chain)
+            elif self._peer_chain is None:
+                raise ValidationError("peer chain is not initialized!")
+            else:
+                self._chain = self.chain_class(self.headerdb, peer_chain=self._peer_chain)
 
         return self._chain
 
@@ -66,7 +72,7 @@ class LightNode(Node):
             self._p2p_server = LightServer(
                 privkey=self._nodekey,
                 port=self._port,
-                chain=self.get_chain(),
+                chain=self.get_full_chain(),
                 chaindb=manager.get_chaindb(),  # type: ignore
                 headerdb=self.headerdb,
                 base_db=manager.get_db(),  # type: ignore


### PR DESCRIPTION
### What was wrong?

Can't get block body from light peers.

An initialization cycle was introduced by [this line](https://github.com/ethereum/py-evm/commit/75be226ddd2da06066f1c7a3b7fe0e3826e201a9#diff-49f4c2ce3b6081ee05a5a002420f0446R70), which causes `_peer_chain` to be `None` in the `LightDispatchChain`, which prevents the light dispatch chain from making any requests to peers

(Symptom is something like: `None object doesn't have attribute coro_get_block_by_header`)

### How was it fixed?

Always use a full chain instance in the server, even a `LightServer`. It should always be asking for data locally, instead of trying to ask other peers.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://thumbpress.com/wp-content/uploads/2011/12/Cute-Christmas-Animals-38.jpg)