### PR TITLE
Add support for trinity-beacon command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,6 +131,9 @@ setup(
     ],
     # trinity
     entry_points={
-        'console_scripts': ['trinity=trinity:main'],
+        'console_scripts': [
+            'trinity=trinity:main',
+            'trinity-beacon=trinity:main_beacon'
+        ],
     },
 )

--- a/setup_trinity.py
+++ b/setup_trinity.py
@@ -32,6 +32,9 @@ setup(
     python_requires=">=3.6,<4",
     # trinity
     entry_points={
-        'console_scripts': ['trinity=trinity:main'],
+        'console_scripts': [
+            'trinity=trinity:main',
+            'trinity-beacon=trinity:main_beacon'
+        ],
     },
 )

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -29,3 +29,7 @@ if is_uvloop_supported():
 from .main import (  # noqa: F401
     main,
 )
+
+from .main_beacon import (  # noqa: F401
+    main_beacon,
+)

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -1,0 +1,282 @@
+from argparse import ArgumentParser, Namespace
+import logging
+import multiprocessing
+import os
+import signal
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Type,
+)
+
+from lahja import (
+    EventBus,
+    Endpoint,
+)
+
+from eth.db.backends.base import BaseDB
+
+from trinity.db.manager import get_chaindb_manager
+from trinity.exceptions import (
+    AmbigiousFileSystem,
+    MissingPath,
+)
+from trinity.initialization import (
+    initialize_data_dir,
+    is_data_dir_initialized,
+)
+from trinity.cli_parser import (
+    parser,
+    subparser,
+)
+from trinity.config import (
+    TrinityConfig,
+)
+from trinity.constants import (
+    MAINNET_NETWORK_ID,
+    MAIN_EVENTBUS_ENDPOINT,
+    ROPSTEN_NETWORK_ID,
+)
+from trinity.extensibility import (
+    BaseManagerProcessScope,
+    MainAndIsolatedProcessScope,
+    PluginManager,
+)
+from trinity.plugins.registry import (
+    get_all_plugins,
+)
+from trinity.utils.ipc import (
+    kill_process_gracefully,
+)
+from trinity.utils.logging import (
+    enable_warnings_by_default,
+    setup_log_levels,
+    setup_trinity_stderr_logging,
+    setup_trinity_file_and_queue_logging,
+    with_queued_logging,
+)
+from trinity.utils.mp import (
+    ctx,
+)
+from trinity.utils.profiling import (
+    setup_cprofiler,
+)
+from trinity.utils.version import (
+    construct_trinity_client_identifier,
+    is_prerelease,
+)
+
+
+PRECONFIGURED_NETWORKS = {MAINNET_NETWORK_ID, ROPSTEN_NETWORK_ID}
+
+
+TRINITY_HEADER = "\n".join((
+    "\n"
+    r"      ______     _       _ __       ",
+    r"     /_  __/____(_)___  (_) /___  __",
+    r"      / / / ___/ / __ \/ / __/ / / /",
+    r"     / / / /  / / / / / / /_/ /_/ / ",
+    r"    /_/ /_/  /_/_/ /_/_/\__/\__, /  ",
+    r"                           /____/   ",
+))
+
+TRINITY_AMBIGIOUS_FILESYSTEM_INFO = (
+    "Could not initialize data directory\n\n"
+    "   One of these conditions must be met:\n"
+    "   * HOME environment variable set\n"
+    "   * XDG_TRINITY_ROOT environment variable set\n"
+    "   * TRINITY_DATA_DIR environment variable set\n"
+    "   * --data-dir command line argument is passed\n"
+    "\n"
+    "   In case the data directory is outside of the trinity root directory\n"
+    "   Make sure all paths are pre-initialized as Trinity won't attempt\n"
+    "   to create directories outside of the trinity root directory\n"
+)
+
+
+BootFn = Callable[[
+    Namespace,
+    TrinityConfig,
+    Dict[str, Any],
+    PluginManager,
+    logging.handlers.QueueListener,
+    EventBus,
+    Endpoint,
+    logging.Logger
+], None]
+
+
+def main_entry(trinity_boot: BootFn) -> None:
+    event_bus = EventBus(ctx)
+    main_endpoint = event_bus.create_endpoint(MAIN_EVENTBUS_ENDPOINT)
+    main_endpoint.connect_no_wait()
+
+    plugin_manager = setup_plugins(
+        MainAndIsolatedProcessScope(event_bus, main_endpoint)
+    )
+    plugin_manager.amend_argparser_config(parser, subparser)
+    args = parser.parse_args()
+
+    if args.network_id not in PRECONFIGURED_NETWORKS:
+        raise NotImplementedError(
+            f"Unsupported network id: {args.network_id}.  Only the ropsten and mainnet "
+            "networks are supported."
+        )
+
+    has_ambigous_logging_config = (
+        args.log_levels is not None and
+        None in args.log_levels and
+        args.stderr_log_level is not None
+    )
+    if has_ambigous_logging_config:
+        parser.error(
+            "\n"
+            "Ambiguous logging configuration: The logging level for stderr was "
+            "configured with both `--stderr-log-level` and `--log-level`. "
+            "Please remove one of these flags",
+        )
+
+    if is_prerelease():
+        # this modifies the asyncio logger, but will be overridden by any custom settings below
+        enable_warnings_by_default()
+
+    stderr_logger, formatter, handler_stream = setup_trinity_stderr_logging(
+        args.stderr_log_level or (args.log_levels and args.log_levels.get(None))
+    )
+
+    if args.log_levels:
+        setup_log_levels(args.log_levels)
+
+    try:
+        trinity_config = TrinityConfig.from_parser_args(args)
+    except AmbigiousFileSystem:
+        parser.error(TRINITY_AMBIGIOUS_FILESYSTEM_INFO)
+
+    if not is_data_dir_initialized(trinity_config):
+        # TODO: this will only work as is for chains with known genesis
+        # parameters.  Need to flesh out how genesis parameters for custom
+        # chains are defined and passed around.
+        try:
+            initialize_data_dir(trinity_config)
+        except AmbigiousFileSystem:
+            parser.error(TRINITY_AMBIGIOUS_FILESYSTEM_INFO)
+        except MissingPath as e:
+            parser.error(
+                "\n"
+                f"It appears that {e.path} does not exist. "
+                "Trinity does not attempt to create directories outside of its root path. "
+                "Either manually create the path or ensure you are using a data directory "
+                "inside the XDG_TRINITY_ROOT path"
+            )
+
+    file_logger, log_queue, listener = setup_trinity_file_and_queue_logging(
+        stderr_logger,
+        formatter,
+        handler_stream,
+        trinity_config.logfile_path,
+        args.file_log_level,
+    )
+
+    display_launch_logs(trinity_config)
+
+    # compute the minimum configured log level across all configured loggers.
+    min_configured_log_level = min(
+        stderr_logger.level,
+        file_logger.level,
+        *(args.log_levels or {}).values()
+    )
+
+    extra_kwargs = {
+        'log_queue': log_queue,
+        'log_level': min_configured_log_level,
+        'profile': args.profile,
+    }
+
+    # Plugins can provide a subcommand with a `func` which does then control
+    # the entire process from here.
+    if hasattr(args, 'func'):
+        args.func(args, trinity_config)
+    else:
+        trinity_boot(
+            args,
+            trinity_config,
+            extra_kwargs,
+            plugin_manager,
+            listener,
+            event_bus,
+            main_endpoint,
+            stderr_logger,
+        )
+
+
+def setup_plugins(scope: BaseManagerProcessScope) -> PluginManager:
+    plugin_manager = PluginManager(scope)
+    # TODO: most plugins should check if they are in eth1 / eth2 context
+    # and only start when appropriate
+    plugin_manager.register(get_all_plugins())
+
+    return plugin_manager
+
+
+def display_launch_logs(trinity_config: TrinityConfig) -> None:
+    logger = logging.getLogger('trinity')
+    logger.info(TRINITY_HEADER)
+    logger.info("Started main process (pid=%d)", os.getpid())
+    logger.info(construct_trinity_client_identifier())
+    logger.info("Trinity DEBUG log file is created at %s", str(trinity_config.logfile_path))
+
+
+@setup_cprofiler('run_database_process')
+@with_queued_logging
+def run_database_process(trinity_config: TrinityConfig, db_class: Type[BaseDB]) -> None:
+    with trinity_config.process_id_file('database'):
+        base_db = db_class(db_path=trinity_config.database_dir)
+
+        manager = get_chaindb_manager(trinity_config, base_db)
+        server = manager.get_server()  # type: ignore
+
+        def _sigint_handler(*args: Any) -> None:
+            server.stop_event.set()
+
+        signal.signal(signal.SIGINT, _sigint_handler)
+
+        try:
+            server.serve_forever()
+        except SystemExit:
+            server.stop_event.set()
+            raise
+
+
+def kill_trinity_gracefully(logger: logging.Logger,
+                            processes: Iterable[multiprocessing.Process],
+                            plugin_manager: PluginManager,
+                            main_endpoint: Endpoint,
+                            event_bus: EventBus,
+                            reason: str=None) -> None:
+    # When a user hits Ctrl+C in the terminal, the SIGINT is sent to all processes in the
+    # foreground *process group*, so both our networking and database processes will terminate
+    # at the same time and not sequentially as we'd like. That shouldn't be a problem but if
+    # we keep getting unhandled BrokenPipeErrors/ConnectionResetErrors like reported in
+    # https://github.com/ethereum/py-evm/issues/827, we might want to change the networking
+    # process' signal handler to wait until the DB process has terminated before doing its
+    # thing.
+    # Notice that we still need the kill_process_gracefully() calls here, for when the user
+    # simply uses 'kill' to send a signal to the main process, but also because they will
+    # perform a non-gracefull shutdown if the process takes too long to terminate.
+
+    hint = f"({reason})" if reason else f""
+    logger.info('Shutting down Trinity %s', hint)
+    plugin_manager.shutdown_blocking()
+    main_endpoint.stop()
+    event_bus.stop()
+    for process in processes:
+        # Our sub-processes will have received a SIGINT already (see comment above), so here we
+        # wait 2s for them to finish cleanly, and if they fail we kill them for real.
+        process.join(2)
+        if process.is_alive():
+            kill_process_gracefully(process, logger)
+        logger.info('%s process (pid=%d) terminated', process.name, process.pid)
+
+    ArgumentParser().exit(message=f"Trinity shutdown complete {hint}\n")

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -1,12 +1,10 @@
 from argparse import ArgumentParser, Namespace
 import asyncio
 import logging
-import os
 import signal
 from typing import (
     Any,
     Dict,
-    Type,
 )
 
 from lahja import (
@@ -14,54 +12,34 @@ from lahja import (
     Endpoint,
 )
 
-from eth.db.backends.base import BaseDB
 from eth.db.backends.level import LevelDB
 
 from p2p.service import BaseService
 
-from trinity.db.manager import get_chaindb_manager
-from trinity.exceptions import (
-    AmbigiousFileSystem,
-    MissingPath,
-)
-from trinity.initialization import (
-    initialize_data_dir,
-    is_data_dir_initialized,
-)
-from trinity.cli_parser import (
-    parser,
-    subparser,
+from trinity.bootstrap import (
+    kill_trinity_gracefully,
+    main_entry,
+    run_database_process,
+    setup_plugins,
 )
 from trinity.config import (
     TrinityConfig,
 )
 from trinity.constants import (
-    MAINNET_NETWORK_ID,
-    MAIN_EVENTBUS_ENDPOINT,
     NETWORKING_EVENTBUS_ENDPOINT,
-    ROPSTEN_NETWORK_ID,
 )
 from trinity.events import (
     ShutdownRequest
 )
 from trinity.extensibility import (
-    BaseManagerProcessScope,
-    MainAndIsolatedProcessScope,
     PluginManager,
     SharedProcessScope,
-)
-from trinity.plugins.registry import (
-    get_all_plugins,
 )
 from trinity.utils.ipc import (
     wait_for_ipc,
     kill_process_gracefully,
 )
 from trinity.utils.logging import (
-    enable_warnings_by_default,
-    setup_log_levels,
-    setup_trinity_stderr_logging,
-    setup_trinity_file_and_queue_logging,
     with_queued_logging,
 )
 from trinity.utils.mp import (
@@ -73,140 +51,10 @@ from trinity.utils.profiling import (
 from trinity.utils.shutdown import (
     exit_signal_with_service,
 )
-from trinity.utils.version import (
-    construct_trinity_client_identifier,
-    is_prerelease,
-)
-
-
-PRECONFIGURED_NETWORKS = {MAINNET_NETWORK_ID, ROPSTEN_NETWORK_ID}
-
-
-TRINITY_HEADER = "\n".join((
-    "\n"
-    r"      ______     _       _ __       ",
-    r"     /_  __/____(_)___  (_) /___  __",
-    r"      / / / ___/ / __ \/ / __/ / / /",
-    r"     / / / /  / / / / / / /_/ /_/ / ",
-    r"    /_/ /_/  /_/_/ /_/_/\__/\__, /  ",
-    r"                           /____/   ",
-))
-
-TRINITY_AMBIGIOUS_FILESYSTEM_INFO = (
-    "Could not initialize data directory\n\n"
-    "   One of these conditions must be met:\n"
-    "   * HOME environment variable set\n"
-    "   * XDG_TRINITY_ROOT environment variable set\n"
-    "   * TRINITY_DATA_DIR environment variable set\n"
-    "   * --data-dir command line argument is passed\n"
-    "\n"
-    "   In case the data directory is outside of the trinity root directory\n"
-    "   Make sure all paths are pre-initialized as Trinity won't attempt\n"
-    "   to create directories outside of the trinity root directory\n"
-)
 
 
 def main() -> None:
-    event_bus = EventBus(ctx)
-    main_endpoint = event_bus.create_endpoint(MAIN_EVENTBUS_ENDPOINT)
-    main_endpoint.connect_no_wait()
-
-    plugin_manager = setup_plugins(
-        MainAndIsolatedProcessScope(event_bus, main_endpoint)
-    )
-    plugin_manager.amend_argparser_config(parser, subparser)
-    args = parser.parse_args()
-
-    if args.network_id not in PRECONFIGURED_NETWORKS:
-        raise NotImplementedError(
-            f"Unsupported network id: {args.network_id}.  Only the ropsten and mainnet "
-            "networks are supported."
-        )
-
-    has_ambigous_logging_config = (
-        args.log_levels is not None and
-        None in args.log_levels and
-        args.stderr_log_level is not None
-    )
-    if has_ambigous_logging_config:
-        parser.error(
-            "\n"
-            "Ambiguous logging configuration: The logging level for stderr was "
-            "configured with both `--stderr-log-level` and `--log-level`. "
-            "Please remove one of these flags",
-        )
-
-    if is_prerelease():
-        # this modifies the asyncio logger, but will be overridden by any custom settings below
-        enable_warnings_by_default()
-
-    stderr_logger, formatter, handler_stream = setup_trinity_stderr_logging(
-        args.stderr_log_level or (args.log_levels and args.log_levels.get(None))
-    )
-
-    if args.log_levels:
-        setup_log_levels(args.log_levels)
-
-    try:
-        trinity_config = TrinityConfig.from_parser_args(args)
-    except AmbigiousFileSystem:
-        parser.error(TRINITY_AMBIGIOUS_FILESYSTEM_INFO)
-
-    if not is_data_dir_initialized(trinity_config):
-        # TODO: this will only work as is for chains with known genesis
-        # parameters.  Need to flesh out how genesis parameters for custom
-        # chains are defined and passed around.
-        try:
-            initialize_data_dir(trinity_config)
-        except AmbigiousFileSystem:
-            parser.error(TRINITY_AMBIGIOUS_FILESYSTEM_INFO)
-        except MissingPath as e:
-            parser.error(
-                "\n"
-                f"It appears that {e.path} does not exist. "
-                "Trinity does not attempt to create directories outside of its root path. "
-                "Either manually create the path or ensure you are using a data directory "
-                "inside the XDG_TRINITY_ROOT path"
-            )
-
-    file_logger, log_queue, listener = setup_trinity_file_and_queue_logging(
-        stderr_logger,
-        formatter,
-        handler_stream,
-        trinity_config.logfile_path,
-        args.file_log_level,
-    )
-
-    display_launch_logs(trinity_config)
-
-    # compute the minimum configured log level across all configured loggers.
-    min_configured_log_level = min(
-        stderr_logger.level,
-        file_logger.level,
-        *(args.log_levels or {}).values()
-    )
-
-    extra_kwargs = {
-        'log_queue': log_queue,
-        'log_level': min_configured_log_level,
-        'profile': args.profile,
-    }
-
-    # Plugins can provide a subcommand with a `func` which does then control
-    # the entire process from here.
-    if hasattr(args, 'func'):
-        args.func(args, trinity_config)
-    else:
-        trinity_boot(
-            args,
-            trinity_config,
-            extra_kwargs,
-            plugin_manager,
-            listener,
-            event_bus,
-            main_endpoint,
-            stderr_logger,
-        )
+    main_entry(trinity_boot)
 
 
 def trinity_boot(args: Namespace,
@@ -226,6 +74,7 @@ def trinity_boot(args: Namespace,
 
     # First initialize the database process.
     database_server_process = ctx.Process(
+        name="DB",
         target=run_database_process,
         args=(
             trinity_config,
@@ -235,6 +84,7 @@ def trinity_boot(args: Namespace,
     )
 
     networking_process = ctx.Process(
+        name="networking",
         target=launch_node,
         args=(args, trinity_config, networking_endpoint,),
         kwargs=extra_kwargs,
@@ -258,8 +108,7 @@ def trinity_boot(args: Namespace,
     def kill_trinity_with_reason(reason: str) -> None:
         kill_trinity_gracefully(
             logger,
-            database_server_process,
-            networking_process,
+            (database_server_process, networking_process),
             plugin_manager,
             main_endpoint,
             event_bus,
@@ -282,61 +131,6 @@ def trinity_boot(args: Namespace,
         kill_trinity_with_reason("CTRL+C / Keyboard Interrupt")
 
 
-def kill_trinity_gracefully(logger: logging.Logger,
-                            database_server_process: Any,
-                            networking_process: Any,
-                            plugin_manager: PluginManager,
-                            main_endpoint: Endpoint,
-                            event_bus: EventBus,
-                            reason: str=None) -> None:
-    # When a user hits Ctrl+C in the terminal, the SIGINT is sent to all processes in the
-    # foreground *process group*, so both our networking and database processes will terminate
-    # at the same time and not sequentially as we'd like. That shouldn't be a problem but if
-    # we keep getting unhandled BrokenPipeErrors/ConnectionResetErrors like reported in
-    # https://github.com/ethereum/py-evm/issues/827, we might want to change the networking
-    # process' signal handler to wait until the DB process has terminated before doing its
-    # thing.
-    # Notice that we still need the kill_process_gracefully() calls here, for when the user
-    # simply uses 'kill' to send a signal to the main process, but also because they will
-    # perform a non-gracefull shutdown if the process takes too long to terminate.
-
-    hint = f"({reason})" if reason else f""
-    logger.info('Shutting down Trinity %s', hint)
-    plugin_manager.shutdown_blocking()
-    main_endpoint.stop()
-    event_bus.stop()
-    for name, process in [("DB", database_server_process), ("Networking", networking_process)]:
-        # Our sub-processes will have received a SIGINT already (see comment above), so here we
-        # wait 2s for them to finish cleanly, and if they fail we kill them for real.
-        process.join(2)
-        if process.is_alive():
-            kill_process_gracefully(process, logger)
-        logger.info('%s process (pid=%d) terminated', name, process.pid)
-
-    ArgumentParser().exit(message=f"Trinity shutdown complete {hint}\n")
-
-
-@setup_cprofiler('run_database_process')
-@with_queued_logging
-def run_database_process(trinity_config: TrinityConfig, db_class: Type[BaseDB]) -> None:
-    with trinity_config.process_id_file('database'):
-        base_db = db_class(db_path=trinity_config.database_dir)
-
-        manager = get_chaindb_manager(trinity_config, base_db)
-        server = manager.get_server()  # type: ignore
-
-        def _sigint_handler(*args: Any) -> None:
-            server.stop_event.set()
-
-        signal.signal(signal.SIGINT, _sigint_handler)
-
-        try:
-            server.serve_forever()
-        except SystemExit:
-            server.stop_event.set()
-            raise
-
-
 @setup_cprofiler('launch_node')
 @with_queued_logging
 def launch_node(args: Namespace, trinity_config: TrinityConfig, endpoint: Endpoint) -> None:
@@ -357,14 +151,6 @@ def launch_node(args: Namespace, trinity_config: TrinityConfig, endpoint: Endpoi
         loop.close()
 
 
-def display_launch_logs(trinity_config: TrinityConfig) -> None:
-    logger = logging.getLogger('trinity')
-    logger.info(TRINITY_HEADER)
-    logger.info("Started main process (pid=%d)", os.getpid())
-    logger.info(construct_trinity_client_identifier())
-    logger.info("Trinity DEBUG log file is created at %s", str(trinity_config.logfile_path))
-
-
 async def handle_networking_exit(service: BaseService,
                                  plugin_manager: PluginManager,
                                  endpoint: Endpoint) -> None:
@@ -372,11 +158,3 @@ async def handle_networking_exit(service: BaseService,
     async with exit_signal_with_service(service):
         await plugin_manager.shutdown()
         endpoint.stop()
-
-
-def setup_plugins(scope: BaseManagerProcessScope) -> PluginManager:
-    plugin_manager = PluginManager(scope)
-    # TODO: Implement auto-discovery of plugins based on some convention/configuration scheme
-    plugin_manager.register(get_all_plugins())
-
-    return plugin_manager

--- a/trinity/main_beacon.py
+++ b/trinity/main_beacon.py
@@ -1,0 +1,106 @@
+from argparse import ArgumentParser, Namespace
+import asyncio
+import logging
+import signal
+from typing import (
+    Any,
+    Dict,
+)
+
+from lahja import (
+    EventBus,
+    Endpoint,
+)
+
+from eth.db.backends.level import LevelDB
+
+from trinity.bootstrap import (
+    kill_trinity_gracefully,
+    main_entry,
+    run_database_process,
+)
+from trinity.config import (
+    TrinityConfig,
+)
+from trinity.events import (
+    ShutdownRequest
+)
+from trinity.extensibility import (
+    PluginManager,
+)
+from trinity.utils.ipc import (
+    wait_for_ipc,
+    kill_process_gracefully,
+)
+from trinity.utils.mp import (
+    ctx,
+)
+
+
+def main_beacon() -> None:
+    main_entry(trinity_boot)
+
+
+def trinity_boot(args: Namespace,
+                 trinity_config: TrinityConfig,
+                 extra_kwargs: Dict[str, Any],
+                 plugin_manager: PluginManager,
+                 listener: logging.handlers.QueueListener,
+                 event_bus: EventBus,
+                 main_endpoint: Endpoint,
+                 logger: logging.Logger) -> None:
+    # start the listener thread to handle logs produced by other processes in
+    # the local logger.
+    listener.start()
+
+    event_bus.start()
+
+    # First initialize the database process.
+    database_server_process = ctx.Process(
+        name="DB",
+        target=run_database_process,
+        args=(
+            trinity_config,
+            LevelDB,
+        ),
+        kwargs=extra_kwargs,
+    )
+
+    # start the processes
+    database_server_process.start()
+    logger.info("Started DB server process (pid=%d)", database_server_process.pid)
+
+    # networking process needs the IPC socket file provided by the database process
+    try:
+        wait_for_ipc(trinity_config.database_ipc_path)
+    except TimeoutError as e:
+        logger.error("Timeout waiting for database to start.  Exiting...")
+        kill_process_gracefully(database_server_process, logger)
+        ArgumentParser().error(message="Timed out waiting for database start")
+
+    def kill_trinity_with_reason(reason: str) -> None:
+        kill_trinity_gracefully(
+            logger,
+            (database_server_process,),
+            plugin_manager,
+            main_endpoint,
+            event_bus,
+            reason=reason
+        )
+
+    main_endpoint.subscribe(
+        ShutdownRequest,
+        lambda ev: kill_trinity_with_reason(ev.reason)
+    )
+
+    plugin_manager.prepare(args, trinity_config, extra_kwargs)
+
+    kill_trinity_with_reason("No beacon support yet. SOON!")
+
+    try:
+        loop = asyncio.get_event_loop()
+        loop.add_signal_handler(signal.SIGTERM, lambda: kill_trinity_with_reason("SIGTERM"))
+        loop.run_forever()
+        loop.close()
+    except KeyboardInterrupt:
+        kill_trinity_with_reason("CTRL+C / Keyboard Interrupt")


### PR DESCRIPTION
### What was wrong?

We currently do not have any bootstrapping for the beacon node.

### How was it fixed?

There are several routes we can take to add maintain an entirely different node type in the same code base.

One pragmatic solution is to maintain multiple main files and expose multiple top level commands

E.g. There would not only be `trinity` but also `trinity-beacon` (name to be discussed).

While this comes with the slight disadvantage of occuping an entirely different command, it gives us the most freedom for experimentation.

Also, it should be relatively straight forward to merge the bootstrapping at a later point in time. So this is just me trying to be pragmatic.

Steps:

1. I moved everything from `main.py` to `bootstrap.py` that I consider generic enough to be useful for any type of program that we want to support in this code base. This stuff is mostly dealing with database access (which needs to be tunneled through one process for now), setting up the event bus, plugins and logging

2. I  left the actual `trinity_boot` method to be defined by each different program. This is mainly because current Trinity uses this shared `networking` process to kickoff the actual node logic and it might be that we don't need this shared process at all for the beacon node.

3. I modified the `setup.py` and `setup_trinity.py` files to expose the other entry point as `trinity-beacon`. Currently, this just spins up the db process and then winds it down gracefully again. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uuuploads/national-geographic-traveler-photo-contest-2013/national-geographic-traveler-photo-contest-2013-1.jpg)
