### PR TITLE
eth-abi 1.2.2 has requirement eth-typing<2, but you'll have eth-typing 2.0.0 which is incompatible.but you'll ha…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ deps = {
     # Installing these libraries may make the evm perform better than
     # using the default fallbacks though.
     'eth-extra': [
-        "coincurve>=8.0.0,<9.0.0",
+        "coincurve>=10.0.0,<11.0.0",
         "eth-hash[pysha3];implementation_name=='cpython'",
         "eth-hash[pycryptodome];implementation_name=='pypy'",
         "plyvel==1.0.5",
@@ -40,7 +40,7 @@ deps = {
         "async-generator==1.10",
         "bloom-filter==1.3",
         "cachetools>=2.1.0,<3.0.0",
-        "coincurve>=8.0.0,<9.0.0",
+        "coincurve>=10.0.0,<11.0.0",
         "ipython>=6.2.1,<7.0.0",
         "plyvel==1.0.5",
         "web3==4.4.1",

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ deps = {
         "bumpversion>=0.5.3,<1",
         "wheel",
         "setuptools>=36.2.0",
+        "pluggy==0.7.1",
         "tox==2.7.0",
         "twine",
     ],

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ deps = {
         "bumpversion>=0.5.3,<1",
         "wheel",
         "setuptools>=36.2.0",
+        #Fixing this dependency due to: pytest 3.6.4 has requirement pluggy<0.8,>=0.5, but you'll have pluggy 0.8.0 which is incompatible.
         "pluggy==0.7.1",
         "tox==2.7.0",
         "twine",

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,8 @@ deps = {
         "setuptools>=36.2.0",
         #Fixing this dependency due to: pytest 3.6.4 has requirement pluggy<0.8,>=0.5, but you'll have pluggy 0.8.0 which is incompatible.
         "pluggy==0.7.1",
+        #Fixing this dependency due to: requests 2.20.1 has requirement idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
+        "idna==2.7",
         "tox==2.7.0",
         "twine",
     ],


### PR DESCRIPTION
https://github.com/ethereum/py-evm/issues/1484

### What was wrong?

1. pytest 3.6.4 has requirement pluggy<0.8,>=0.5, but you'll have pluggy 0.8.0 which is incompatible.
2. eth-abi 1.2.2 has requirement eth-typing<2, but you'll have eth-typing 2.0.0 which is incompatible.
3. requests 2.20.1 has requirement idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.

### How was it fixed?

1. tox was installing the latest version of pluggy 0.8 that is incompatible with pytest so pytest was not working. Fixing a version of pluggy minor to 0.8 makes pytest work without an issue for tox

2. Releasing a new version of eth-abi using eth-typing 2.0.0 (waiting for a PR in eth-abi to be ready)
3. Fixing idna to use 2.7 is fixing the issue

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://upload.wikimedia.org/wikipedia/commons/2/2b/Pomeranian_orange_sable_600.jpg)
