### PR TITLE
Simplify and deduplicate README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Join the chat at https://gitter.im/ethereum/py-evm](https://badges.gitter.im/ethereum/py-evm.svg)](https://gitter.im/ethereum/py-evm)
 [![Documentation Status](https://readthedocs.org/projects/py-evm/badge/?version=latest)](http://py-evm.readthedocs.io/en/latest/?badge=latest)
 
-[Documentation hosted by ReadTheDocs](http://py-evm.readthedocs.io/en/latest/)
-
 
 ## Introducing Py-EVM
 
@@ -51,95 +49,15 @@ our architecture and API choices as well as general feedback and bug finding.
 - https://medium.com/@pipermerriam/py-evm-part-1-origins-25d9ad390b
 
 
-## Development
-Py-EVM depends on a submodule of the common tests across all clients,
-so you need to clone the repo with the `--recursive` flag. Example:
+## Quickstart
 
-```sh
-git clone --recursive git@github.com:ethereum/py-evm.git
-```
+[Get started in 5 minutes](https://py-evm.readthedocs.io/en/latest/quickstart.html)
 
-Py-EVM requires Python 3. Often, the best way to guarantee a clean Python 3 environment is with [`virtualenv`](https://virtualenv.pypa.io/en/stable/), like:
+## Documentation
 
-```sh
-# once:
-$ virtualenv -p python3 venv
+Check out the [documentation on our official website](http://py-evm.readthedocs.io/en/latest/)
 
-# each session:
-$ . venv/bin/activate
-```
+## Want to help?
 
-Then install the required python packages via:
-
-```sh
-pip install -e .[dev]
-```
-
-
-### Running the tests
-
-You can run the tests with:
-
-```sh
-pytest
-```
-
-Or you can install `tox` to run the full test suite.
-
-
-### Releasing
-
-Pandoc is required for transforming the markdown README to the proper format to
-render correctly on pypi.
-
-For Debian-like systems:
-
-```
-apt install pandoc
-```
-
-Or on OSX:
-
-```sh
-brew install pandoc
-```
-
-To release a new version:
-
-```sh
-bumpversion $$VERSION_PART_TO_BUMP$$
-git push && git push --tags
-make release
-```
-
-To create a docker image:
-
-```sh
-make create-docker-image version=<version>
-```
-
-By default, this will create a new image with two tags pointing to it:
-- `ethereum/trinity:<version>` (explicit version)
-- `ethereum/trinity:latest` (latest until overwritten with a future "latest")
-
-Then, push to docker hub.
-
-```sh
-docker push ethereum/trinity:<version>
-# the following may be left out if we were pushing a patch for an older version
-docker push ethereum/trinity:latest
-```
-
-
-#### How to bumpversion
-
-The version format for this repo is `{major}.{minor}.{patch}` for stable, and
-`{major}.{minor}.{patch}-{stage}.{devnum}` for unstable (`stage` can be alpha or beta).
-
-To issue the next version in line, use bumpversion and specify which part to bump,
-like `bumpversion minor` or `bumpversion devnum`.
-
-If you are in a beta version, `bumpversion stage` will switch to a stable.
-
-To issue an unstable version when the current version is stable, specify the
-new version explicitly, like `bumpversion --new-version 4.0.0-alpha.1 devnum`
+Want to file a bug, contribute some code, or improve documentation? Excellent! Read up on our
+guidelines for [contributing](https://py-evm.readthedocs.io/en/latest/contributing.html) and then check out one of our issues that are labeled [Good First Issue](https://github.com/ethereum/py-evm/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+First+Issue%22).

--- a/README.md
+++ b/README.md
@@ -1,52 +1,50 @@
-# Python Implementation of the EVM
+# Python Implementation of the Ethereum protocol
 
 [![Join the chat at https://gitter.im/ethereum/py-evm](https://badges.gitter.im/ethereum/py-evm.svg)](https://gitter.im/ethereum/py-evm)
 [![Documentation Status](https://readthedocs.org/projects/py-evm/badge/?version=latest)](http://py-evm.readthedocs.io/en/latest/?badge=latest)
 
 
-## Introducing Py-EVM
+## Py-EVM
 
-Py-EVM is a new implementation of the Ethereum Virtual Machine written in
-python. It is currently in active development but is quickly progressing
-through the test suite provided by ethereum/tests. We have Vitalik, and the
-existing PyEthereum code to thank for the quick progress we’ve made as many
-design decisions were inspired, or even directly ported from the PyEthereum
-codebase.
+Py-EVM is a new implementation of the Ethereum protocol in Python. It contains the low level
+primitives for the existing Ethereum 1.0 chain as well as emerging support for the upcoming
+Ethereum 2.0 / Serenity spec.
 
 ### Goals
 
-Py-EVM aims to eventually become the defacto Python implementation of the EVM,
-enabling a wide array of use cases for both public and private chains. Development will focus on creating an EVM with a well defined API, friendly and
-easy to digest documentation which can be run as a fully functional mainnet
-node.
+Py-EVM aims to eventually become the defacto Python implementation of the Ethereum protocol,
+enabling a wide array of use cases for both public and private chains. 
 
 In particular Py-EVM aims to:
 
-- be an example implementation of the EVM in one of the most widely used and understood languages, Python.
-
-- deliver the low level APIs for clients to build full or light nodes on top of
+- be a reference implementation of the Ethereum 1.0 and 2.0 implementation in one of the most widely used and understood languages, Python.
 
 - be easy to understand and modifiable
 
+- have clear and simple APIs
+
+- come with solid, friendly documentation
+
+- deliver the low level primitives to build various clients on top (including *full* and *light* clients)
+
 - be highly flexible to support both research as well as alternate use cases like private chains.
 
-### Trinity
+## Trinity
 
-While Py-EVM provides the low level APIs of the EVM, it does not aim to implement a full or light node directly.
+While Py-EVM provides the low level APIs of the Ethereum protocol, it does not aim to implement a
+full or light node directly.
 
-We provide a base implementation of a full node called Trinity that is based on Py-EVM.
+### Goals
 
-In the future there may be alternative clients based on the Py-EVM.
+- provide a reference implementation for an Ethereum 1.0 node (alpha)
 
-### Step 1: Alpha Release
+- support "full" and "light" modes
 
-The plan is to begin with an MVP, alpha-level release that is suitable for
-testing purposes. We’ll be looking for early adopters to provide feedback on
-our architecture and API choices as well as general feedback and bug finding.
+- fully support mainnet as well as several testnets
 
-#### Blog posts:
+- provide a reference implementation of an Ethereum 2.0 / Serenity beacon node (pre-alpha)
 
-- https://medium.com/@pipermerriam/py-evm-part-1-origins-25d9ad390b
+- provide a reference implementation of an Ethereum 2.0 / Sereneity validator node (pre-alpha)
 
 
 ## Quickstart

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -72,37 +72,9 @@ All parameters as well as the return type of defs are expected to be typed with 
 Documentation
 ~~~~~~~~~~~~~
 
-Public APIs are expected to be annotated with docstrings as seen in the following example.
+Good documentation will lead to quicker adoption and happier users. Please check out our guide
+on `how to create documentation for the Python Ethereum ecosystem <https://github.com/ethereum/snake-charmers-tactical-manual/blob/master/documentation.md>`_.
 
-.. code:: python
-
-    def add_transaction(self,
-                        transaction: BaseTransaction,
-                        computation: BaseComputation,
-                        block: BaseBlock) -> Tuple[Block, Dict[bytes, bytes]]:
-            """
-            Add a transaction to the given block and
-            return `trie_data` to store the transaction data in chaindb in VM layer.
-
-            Update the bloom_filter, transaction trie and receipt trie roots, bloom_filter,
-            bloom, and used_gas of the block.
-
-            :param transaction: the executed transaction
-            :param computation: the Computation object with executed result
-            :param block: the Block which the transaction is added in
-
-            :return: the block and the trie_data
-            """
-
-Docstrings are written in reStructuredText and allow certain type of directives.
-
-Notice that ``:param:`` and ``:return:`` directives are being used to describe parameters and return value. Usage of ``:type:`` and ``:rtype:`` directives on the other hand is discouraged as sphinx directly reads and displays the types from the source code type definitions making any further use of ``:type:`` and ``:rtype:`` obsolete and unnecessarily verbose.
-
-Use imperative, present tense to describe APIs: “return” not “returns”
-
-One way to test if you have it right is to complete the following sentence.
-
-If you call this API it will: __________________________
 
 Pull Requests
 ~~~~~~~~~~~~~
@@ -160,3 +132,24 @@ the new version explicitly, like
 ``bumpversion --new-version 4.0.0-alpha.1 devnum``
 
 
+How to release docker images
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To create a docker image:
+
+.. code:: sh
+
+    make create-docker-image version=<version>
+
+
+By default, this will create a new image with two tags pointing to it:
+ - ``ethereum/trinity:<version>`` (explicit version)
+ - ``ethereum/trinity:latest`` (latest until overwritten with a future "latest")
+
+Then, push to docker hub:
+
+.. code:: sh
+
+    docker push ethereum/trinity:<version>
+    # the following may be left out if we were pushing a patch for an older version
+    docker push ethereum/trinity:latest

--- a/docs/guides/trinity/quickstart.rst
+++ b/docs/guides/trinity/quickstart.rst
@@ -61,8 +61,8 @@ changes need to be made to the host system apart from having ``Docker`` itself i
 
 .. note::
   While we don't officially support Windows just yet, running Trinity through ``Docker`` is a great
-  way to bypass this current limitation as Trinity can run on any system that runs ``Docker`` [with
-  support for linux containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers).
+  way to bypass this current limitation as Trinity can run on any system that runs ``Docker`` `with
+  support for linux containers <https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers>`_.
 
 Using ``Docker`` we have two different options to choose from.
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -15,13 +15,14 @@ If none of this makes sense to you yet we recommend to checkout the
 `higher level description <http://www.ethdocs.org/en/latest/introduction/what-is-ethereum.html>`_
 of the Ethereum project.
 
-Goals
------
+Py-EVM goals
+------------
 
-The main focus is to enrich the Ethereum ecosystem with a Python implementation that is:
+The main focus is to enrich the Ethereum ecosystem with a Python implementation that:
 
-* Well documented
-* Easy to understand
+* Supports Ethereum 1.0 as well as 2.0 / Serenity
+* Is well documented
+* Is easy to understand
 * Has clear APIs
 * Runs fast and resource friendly
 * Is highly flexible to support:
@@ -30,6 +31,21 @@ The main focus is to enrich the Ethereum ecosystem with a Python implementation 
   * Private chains
   * Consortium chains
   * Advanced research
+
+Trinity goals
+-------------
+
+While Py-EVM provides the low level APIs of the Ethereum protocol, it does not aim to implement a
+full or light node directly.
+
+Trinity is a refernece implementation on top of Py-EVM that aims to:
+
+* Provide a reference implementation for an Ethereum 1.0 node (alpha)
+* Support "full" and "light" modes
+* Fully support mainnet as well as several testnets
+* Provide a reference implementation of an Ethereum 2.0 / Serenity beacon node (pre-alpha)
+* Provide a reference implementation of an Ethereum 2.0 / Sereneity validator node (pre-alpha)
+
 
 .. note::
 


### PR DESCRIPTION
### What was wrong?

Our Readme feels a bit overloaded and it contains information that is better covered in the docs.

### How was it fixed?

- cleaned up Readme
- moved some things into the docs
- fixed some broken links
- updated the introduction texts

Here is how that looks like now:

![image](https://user-images.githubusercontent.com/521109/49369568-0919bb80-f6f2-11e8-8ca4-8ab17ea8be61.png)

To be honest, I could be convinced to even go a step further and remove this whole *goals* stuff and just go with a very short intro on Py-EVM and Trinity.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.oxfordmail.co.uk/resources/images/7664262/?type=responsive-gallery-fullscreen)
