### PR TITLE
Separate plugins between trinity and trinity-beacon

### DIFF
--- a/tests/trinity/integration/test_plugin_discovery.py
+++ b/tests/trinity/integration/test_plugin_discovery.py
@@ -1,5 +1,5 @@
 from trinity.plugins.registry import (
-    get_all_plugins
+    discover_plugins
 )
 # This plugin is external to this code base and installed by tox
 # In order to install it locally run:
@@ -8,5 +8,5 @@ from peer_count_reporter_plugin import PeerCountReporterPlugin
 
 
 def test_plugin_discovery():
-    plugins = [type(plugin) for plugin in get_all_plugins()]
+    plugins = [type(plugin) for plugin in discover_plugins()]
     assert PeerCountReporterPlugin in plugins

--- a/trinity/main_beacon.py
+++ b/trinity/main_beacon.py
@@ -28,6 +28,9 @@ from trinity.events import (
 from trinity.extensibility import (
     PluginManager,
 )
+from trinity.plugins.registry import (
+    BASE_PLUGINS,
+)
 from trinity.utils.ipc import (
     wait_for_ipc,
     kill_process_gracefully,
@@ -38,7 +41,7 @@ from trinity.utils.mp import (
 
 
 def main_beacon() -> None:
-    main_entry(trinity_boot)
+    main_entry(trinity_boot, BASE_PLUGINS)
 
 
 def trinity_boot(args: Namespace,

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -35,10 +35,14 @@ def is_ipython_available() -> bool:
         return True
 
 
-BUILTIN_PLUGINS = (
-    AttachPlugin() if is_ipython_available() else AttachPlugin(use_ipython=False),
-    EthstatsPlugin(),
+BASE_PLUGINS: Tuple[BasePlugin, ...] = (
+    AttachPlugin(use_ipython=is_ipython_available()),
     FixUncleanShutdownPlugin(),
+)
+
+
+ETH1_NODE_PLUGINS: Tuple[BasePlugin, ...] = (
+    EthstatsPlugin(),
     JsonRpcServerPlugin(),
     LightPeerChainBridgePlugin(),
     TxPlugin(),
@@ -52,7 +56,3 @@ def discover_plugins() -> Tuple[BasePlugin, ...]:
     return tuple(
         entry_point.load()() for entry_point in pkg_resources.iter_entry_points('trinity.plugins')
     )
-
-
-def get_all_plugins() -> Tuple[BasePlugin, ...]:
-    return BUILTIN_PLUGINS + discover_plugins()


### PR DESCRIPTION

### What was wrong?

trinity and trinity-beacon are two different pieces
of software that just share a common code base.

Hence they need to be bootstrapped with different
built-in plugins.

Relates to: #1545

### How was it fixed?

Make `setup_plugins` take an `Iterable[BasePlugin]` and separate the plugins in each bootstrapping code.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i2-prod.belfastlive.co.uk/incoming/article13738001.ece/ALTERNATES/s615/JS133171318.jpg)
