### PR TITLE
Use 99th percentile and standard deviation to dynamically tune peer timeout

### DIFF
--- a/tests/trinity/core/utils/test_percentile.py
+++ b/tests/trinity/core/utils/test_percentile.py
@@ -1,43 +1,19 @@
+import pytest
+
 from trinity.utils.percentile import Percentile
-import random
 
 
-def test_percentile_basics():
-    percentile = Percentile(percentile=0.5, window_size=5)
-    percentile.update(5)
-    percentile.update(4)
-    percentile.update(6)
-    percentile.update(3)
-    percentile.update(7)
+@pytest.mark.parametrize(
+    'data,percentile,window_size,expected',
+    (
+        (range(6), 0.2, 6, 1),
+        (range(11), 0.4, 11, 4),
+        (range(11), 0.2, 6, 6),
+    ),
+)
+def test_percentile_class(data, percentile, window_size, expected):
+    percentile = Percentile(percentile=percentile, window_size=window_size)
+    for value in data:
+        percentile.update(value)
 
-    assert percentile.num_above == 0
-    assert percentile.num_below == 0
-    assert percentile.window == [3, 4, 5, 6, 7]
-
-    percentile.update(5.5)
-
-    assert percentile.num_above == 1
-    assert percentile.num_below == 0
-    assert percentile.window == [3, 4, 5, 5.5, 6]
-
-    percentile.update(4.5)
-    percentile.update(4.6)
-
-    assert percentile.num_above == 2
-    assert percentile.num_below == 1
-    assert percentile.window == [4, 4.5, 4.6, 5, 5.5]
-
-    percentile.update(1)
-
-    assert percentile.num_above == 2
-    assert percentile.num_below == 2
-    assert percentile.window == [4, 4.5, 4.6, 5, 5.5]
-
-
-def test_percentile_with_random():
-    percentile = Percentile(percentile=0.9, window_size=50)
-    for _ in range(1000):
-        percentile.update(random.random() * 10)
-
-    value = percentile.value
-    assert abs(value - 9) < 0.5
+    assert percentile.value == expected

--- a/tests/trinity/core/utils/test_percentile.py
+++ b/tests/trinity/core/utils/test_percentile.py
@@ -1,0 +1,43 @@
+from trinity.utils.percentile import Percentile
+import random
+
+
+def test_percentile_basics():
+    percentile = Percentile(percentile=0.5, window_size=5)
+    percentile.update(5)
+    percentile.update(4)
+    percentile.update(6)
+    percentile.update(3)
+    percentile.update(7)
+
+    assert percentile.num_above == 0
+    assert percentile.num_below == 0
+    assert percentile.window == [3, 4, 5, 6, 7]
+
+    percentile.update(5.5)
+
+    assert percentile.num_above == 1
+    assert percentile.num_below == 0
+    assert percentile.window == [3, 4, 5, 5.5, 6]
+
+    percentile.update(4.5)
+    percentile.update(4.6)
+
+    assert percentile.num_above == 2
+    assert percentile.num_below == 1
+    assert percentile.window == [4, 4.5, 4.6, 5, 5.5]
+
+    percentile.update(1)
+
+    assert percentile.num_above == 2
+    assert percentile.num_below == 2
+    assert percentile.window == [4, 4.5, 4.6, 5, 5.5]
+
+
+def test_percentile_with_random():
+    percentile = Percentile(percentile=0.9, window_size=50)
+    for _ in range(1000):
+        percentile.update(random.random() * 10)
+
+    value = percentile.value
+    assert abs(value - 9) < 0.5

--- a/tests/trinity/core/utils/test_standard_deviation.py
+++ b/tests/trinity/core/utils/test_standard_deviation.py
@@ -1,0 +1,21 @@
+import pytest
+
+from trinity.utils.stddev import StandardDeviation
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    (
+        ((4, 2, 5, 8, 6), 2.23606),
+        ((1.5, 1.8, 7, 1.2, 1.35), 2.4863),
+        ((2, 2, 2, 2, 2), 0),
+        ((1, 3, 5, 7, 9), 3.1622),
+    ),
+)
+def test_standard_deviation(data, expected):
+    stddev = StandardDeviation()
+
+    for value in data:
+        stddev.update(value)
+
+    assert abs(stddev.value - expected) < 0.01

--- a/tests/trinity/core/utils/test_standard_deviation.py
+++ b/tests/trinity/core/utils/test_standard_deviation.py
@@ -10,10 +10,11 @@ from trinity.utils.stddev import StandardDeviation
         ((1.5, 1.8, 7, 1.2, 1.35), 2.4863),
         ((2, 2, 2, 2, 2), 0),
         ((1, 3, 5, 7, 9), 3.1622),
+        ((100, 200, 300, 400, 500, 1, 3, 5, 7, 9), 3.1622),
     ),
 )
 def test_standard_deviation(data, expected):
-    stddev = StandardDeviation()
+    stddev = StandardDeviation(window_size=5)
 
     for value in data:
         stddev.update(value)

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -79,10 +79,7 @@ class ResponseCandidateStream(
         To mark a response as valid, use `complete_request`. After that call, payload
         candidates will stop arriving.
         """
-        if timeout is None:
-            outer_timeout = self.response_timeout
-        else:
-            outer_timeout = timeout
+        outer_timeout = self.response_timeout if timeout is None else timeout
 
         start_at = time.perf_counter()
 
@@ -106,7 +103,7 @@ class ResponseCandidateStream(
                 rtt_99th = tracker.round_trip_99th.value
                 rtt_stddev = tracker.round_trip_stddev.value
             except ValueError:
-                inner_timeout = self.response_timeout
+                inner_timeout = outer_timeout
             else:
                 inner_timeout = rtt_99th + 3 * rtt_stddev
 

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -80,26 +80,45 @@ class ResponseCandidateStream(
         candidates will stop arriving.
         """
         if timeout is None:
-            timeout = self.response_timeout
+            outer_timeout = self.response_timeout
+        else:
+            outer_timeout = timeout
 
         start_at = time.perf_counter()
 
         # The _lock ensures that we never have two concurrent requests to a
         # single peer for a single command pair in flight.
         try:
-            await self.wait(self._lock.acquire(), timeout=timeout)
+            await self.wait(self._lock.acquire(), timeout=outer_timeout)
         except TimeoutError:
             raise AlreadyWaiting(
                 f"Timed out waiting for {self.response_msg_name} request lock "
                 f"or peer: {self._peer}"
             )
 
+        if timeout is not None or tracker.total_msgs < 20:
+            inner_timeout = outer_timeout
+        else:
+            # We compute a timeout based on the historical performance
+            # of the peer defined as three standard deviations above
+            # the response time for the 99th percentile of requests.
+            try:
+                rtt_99th = tracker.round_trip_99th.value
+                rtt_stddev = tracker.round_trip_stddev.value
+            except ValueError:
+                inner_timeout = self.response_timeout
+            else:
+                inner_timeout = rtt_99th + 3 * rtt_stddev
+
         try:
             self._request(request)
             while self._is_pending():
-                timeout_remaining = max(0, timeout - (time.perf_counter() - start_at))
+                timeout_remaining = max(0, outer_timeout - (time.perf_counter() - start_at))
+
+                payload_timeout = min(inner_timeout, timeout_remaining)
+
                 try:
-                    yield await self._get_payload(timeout_remaining)
+                    yield await self._get_payload(payload_timeout)
                 except TimeoutError:
                     tracker.record_timeout()
                     raise

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -101,7 +101,7 @@ class ResponseCandidateStream(
                 try:
                     yield await self._get_payload(timeout_remaining)
                 except TimeoutError:
-                    tracker.record_timeout(timeout)
+                    tracker.record_timeout()
                     raise
         finally:
             self._lock.release()

--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -1,3 +1,4 @@
 # How old (in seconds) must our local head be to cause us to start with a
 # fast-sync before we switch to regular-sync.
 FAST_SYNC_CUTOFF = 60 * 60 * 24
+FAST_SYNC_CUTOFF = 60

--- a/trinity/utils/percentile.py
+++ b/trinity/utils/percentile.py
@@ -1,43 +1,22 @@
 import bisect
+import collections
 import math
-from typing import List, Union
-
-from eth_utils.toolz import tail, take
+from typing import List, Union, Deque
 
 
 class Percentile:
     """
-    Keeps track of an approximation for a specific percentile value for a
-    streaming data set with unknown size using a constant size storage.
+    Tracks a specific percentile across a window of recent data.
 
     https://en.wikipedia.org/wiki/Percentile
-
-    This is done by maintaining a *window* of values around where the target
-    percentile *should* be as well as counters for the number of values that
-    are above/below the window.
-
-    The accuracy of the percentile value is a function of how evenly
-    distributed the streaming data set is.  A data set who's value are
-    rarandomly distributed will produce a more accurate approximation where as
-    a fully sorted data set will result in larger margins of error.
     """
     def __init__(self, percentile: float, window_size: int) -> None:
         if percentile < 0 or percentile > 1:
             raise ValueError("Invalid: percentile must be in the range [0, 1]")
-        self.num_below = 0
-        self.num_above = 0
         self.window: List[Union[int, float]] = []
+        self.history: Deque[Union[int, float]] = collections.deque()
         self.percentile = percentile
         self.window_size = window_size
-        self.is_outside_window = False
-
-    @property
-    def _percentile_idx(self) -> float:
-        """
-        The *float* index in our window where our percentile value is located.
-        """
-        sample_size = self.num_below + len(self.window) + self.num_above
-        return sample_size * self.percentile - self.num_below
 
     @property
     def value(self) -> float:
@@ -45,88 +24,30 @@ class Percentile:
         The current approximation for the tracked percentile.
         """
         if not self.window:
-            raise ValueError("No sampled data")
+            raise ValueError("No data for percentile calculation")
 
-        percentile_idx = self._percentile_idx
+        idx = (len(self.window) - 1) * self.percentile
+        if int(idx) == idx:
+            return self.window[int(idx)]
 
-        # Edge cases where our window is outside of the target percentile and
-        # thus we've lost precision.
-        if percentile_idx < 0:
-            return self.window[0]
-        elif percentile_idx > len(self.window) - 1:
-            return self.window[-1]
+        left = int(math.floor(idx))
+        right = int(math.ceil(idx))
 
-        if percentile_idx == int(percentile_idx):
-            # If we are *exactly* on one of the window values return it.
-            return self.window[int(percentile_idx)]
-        else:
-            # If we are *between* two values then return the *porportional*
-            # value that would fall between the two bounds assuming an even
-            # distribution.
-            left_value = self.window[int(math.floor(percentile_idx))]
-            right_value = self.window[int(math.ceil(percentile_idx))]
-            delta = right_value - left_value
-            position = percentile_idx % 1
-            return left_value + delta * position
+        left_part = self.window[int(left)] * (right - idx)
+        right_part = self.window[int(right)] * (idx - left)
+
+        return left_part + right_part
 
     def update(self, value: Union[int, float]) -> None:
-        # We only want to insert the value into our window in the event that it
-        # is:
-        #
-        # 1) within the current bounds of the window
-        # 2) our window is not full
-        # 3) our percentile is located somewhere outside of our window and
-        #    thus we want to expand our window to allow it to move towards where
-        #    the accurate percentile is located.
-        should_insert_in_window = (
-            self.is_outside_window or
-            len(self.window) < self.window_size or
-            self.window[0] <= value <= self.window[-1]
-        )
+        bisect.insort(self.window, value)
+        self.history.append(value)
 
-        if should_insert_in_window:
-            bisect.insort(self.window, value)
-        elif value < self.window[0]:
-            self.num_below += 1
-            return
-        elif value > self.window[-1]:
-            self.num_above += 1
-            return
-        else:
-            raise Exception("Invariant")
-
-        percentile_idx = self._percentile_idx
-        actual_middle_idx = (len(self.window) + 1) / 2
-
-        # Record whether our percentile is within our window or if it has
-        # strayed beyond our tracked window.
-        if percentile_idx < 0:
-            self.is_outside_window = True
-            # values is *above* the target percentile
-        elif percentile_idx > self.window_size:
-            self.is_outside_window = True
-            # values is *below* the target percentile
-        else:
-            self.is_outside_window = False
-
-        # Discard values from either end of our window to get down to the
-        # correctly sized window.
-        if len(self.window) > self.window_size:
-            num_to_discard = len(self.window) - self.window_size
-
-            if actual_middle_idx > percentile_idx:
-                self.num_above += num_to_discard
-                self.window = list(take(self.window_size, self.window))
-            elif actual_middle_idx < percentile_idx:
-                self.num_below += num_to_discard
-                self.window = list(tail(self.window_size, self.window))
-            elif num_to_discard > 1:
-                num_to_trim = num_to_discard // 2
-                self.num_above += num_to_trim
-                self.num_below += num_to_trim
-                self.window = self.window[num_to_trim:-1 * num_to_trim]
-            else:
-                # in the case that the middle of the window is *exactly* in the
-                # right place we allow our window to grow beyond `window_size`
-                # temporarily.
-                pass
+        while len(self.history) > self.window_size:
+            to_discard = self.history.popleft()
+            window_idx = bisect.bisect_left(self.window, to_discard)
+            discarded = self.window.pop(window_idx)
+            if discarded != to_discard:
+                raise ValueError(
+                    "The value popped from the `window` does not match the "
+                    "expected value"
+                )

--- a/trinity/utils/percentile.py
+++ b/trinity/utils/percentile.py
@@ -1,0 +1,131 @@
+import bisect
+import math
+
+from eth_utils.toolz import tail, take
+
+
+class Percentile:
+    """
+    Keeps track of an approximation for a specific percentile value for a
+    streaming data set with unknown size using a constant size storage.
+
+    https://en.wikipedia.org/wiki/Percentile
+
+    This is done by maintaining a *window* of values around where the target
+    percentile *should* be as well as counters for the number of values that
+    are above/below the window.
+
+    The accuracy of the percentile value is a function of how evenly
+    distributed the streaming data set is.  A data set who's value are
+    rarandomly distributed will produce a more accurate approximation where as
+    a fully sorted data set will result in larger margins of error.
+    """
+    def __init__(self, percentile: float, window_size: int) -> None:
+        if percentile < 0 or percentile > 1:
+            raise ValueError("Invalid: percentile must be in the range [0, 1]")
+        self.num_below = 0
+        self.num_above = 0
+        self.window = []
+        self.percentile = percentile
+        self.window_size = window_size
+        self.is_outside_window = False
+
+    @property
+    def _percentile_idx(self) -> float:
+        """
+        The *float* index in our window where our percentile value is located.
+        """
+        sample_size = self.num_below + len(self.window) + self.num_above
+        return sample_size * self.percentile - self.num_below
+
+    @property
+    def value(self) -> float:
+        """
+        The current approximation for the tracked percentile.
+        """
+        if not self.window:
+            raise ValueError("No sampled data")
+
+        percentile_idx = self._percentile_idx
+
+        # Edge cases where our window is outside of the target percentile and
+        # thus we've lost precision.
+        if percentile_idx < 0:
+            return self.window[0]
+        elif percentile_idx > len(self.window) - 1:
+            return self.window[-1]
+
+        if percentile_idx == int(percentile_idx):
+            # If we are *exactly* on one of the window values return it.
+            return self.window[int(percentile_idx)]
+        else:
+            # If we are *between* two values then return the *porportional*
+            # value that would fall between the two bounds assuming an even
+            # distribution.
+            left_value = self.window[int(math.floor(percentile_idx))]
+            right_value = self.window[int(math.ceil(percentile_idx))]
+            delta = right_value - left_value
+            position = percentile_idx % 1
+            return left_value + delta * position
+
+    def update(self, value):
+        # We only want to insert the value into our window in the event that it
+        # is:
+        #
+        # 1) within the current bounds of the window
+        # 2) our window is not full
+        # 3) our percentile is located somewhere outside of our window and
+        #    thus we want to expand our window to allow it to move towards where
+        #    the accurate percentile is located.
+        should_insert_in_window = (
+            self.is_outside_window or
+            len(self.window) < self.window_size or
+            self.window[0] <= value <= self.window[-1]
+        )
+
+        if should_insert_in_window:
+            bisect.insort(self.window, value)
+        elif value < self.window[0]:
+            self.num_below += 1
+            return
+        elif value > self.window[-1]:
+            self.num_above += 1
+            return
+        else:
+            raise Exception("Invariant")
+
+        percentile_idx = self._percentile_idx
+        actual_middle_idx = (len(self.window) + 1) / 2
+
+        # Record whether our percentile is within our window or if it has
+        # strayed beyond our tracked window.
+        if percentile_idx < 0:
+            self.is_outside_window = True
+            # values is *above* the target percentile
+        elif percentile_idx > self.window_size:
+            self.is_outside_window = True
+            # values is *below* the target percentile
+        else:
+            self.is_outside_window = False
+
+        # Discard values from either end of our window to get down to the
+        # correctly sized window.
+        if len(self.window) > self.window_size:
+            num_to_discard = len(self.window) - self.window_size
+
+            if actual_middle_idx > percentile_idx:
+                self.num_above += num_to_discard
+                self.window = list(take(self.window_size, self.window))
+            elif actual_middle_idx < percentile_idx:
+                self.num_below += num_to_discard
+                self.window = list(tail(self.window_size, self.window))
+            elif num_to_discard > 1:
+                num_to_trim = num_to_discard // 2
+                self.num_above += num_to_trim
+                self.num_below += num_to_trim
+                self.window = self.window[num_to_trim:-1 * num_to_trim]
+            else:
+                # in the case that the middle of the window is *exactly* in the
+                # right place we allow our window to grow beyond `window_size`
+                # temporarily.
+                pass

--- a/trinity/utils/percentile.py
+++ b/trinity/utils/percentile.py
@@ -1,5 +1,6 @@
 import bisect
 import math
+from typing import List, Union
 
 from eth_utils.toolz import tail, take
 
@@ -25,7 +26,7 @@ class Percentile:
             raise ValueError("Invalid: percentile must be in the range [0, 1]")
         self.num_below = 0
         self.num_above = 0
-        self.window = []
+        self.window: List[Union[int, float]] = []
         self.percentile = percentile
         self.window_size = window_size
         self.is_outside_window = False
@@ -68,7 +69,7 @@ class Percentile:
             position = percentile_idx % 1
             return left_value + delta * position
 
-    def update(self, value):
+    def update(self, value: Union[int, float]) -> None:
         # We only want to insert the value into our window in the event that it
         # is:
         #

--- a/trinity/utils/percentile.py
+++ b/trinity/utils/percentile.py
@@ -6,7 +6,7 @@ from typing import List, Union, Deque
 
 class Percentile:
     """
-    Tracks a specific percentile across a window of recent data.
+    Track a specific percentile across a window of recent data.
 
     https://en.wikipedia.org/wiki/Percentile
     """

--- a/trinity/utils/stddev.py
+++ b/trinity/utils/stddev.py
@@ -1,4 +1,5 @@
 import math
+from typing import Union
 
 
 class StandardDeviation:
@@ -7,18 +8,18 @@ class StandardDeviation:
 
     Tracks standard deviation on a stream of data.
     """
-    def __init__(self):
+    def __init__(self) -> None:
         self.num_values = 0
-        self.sum_of_values = 0
-        self.sum_of_squared_values = 0
+        self.sum_of_values = 0.0
+        self.sum_of_squared_values = 0.0
 
-    def update(self, value):
+    def update(self, value: Union[int, float]) -> None:
         self.num_values += 1
         self.sum_of_values += value
         self.sum_of_squared_values += value ** 2
 
     @property
-    def value(self):
+    def value(self) -> float:
         if self.num_values < 2:
             raise ValueError("No data")
 

--- a/trinity/utils/stddev.py
+++ b/trinity/utils/stddev.py
@@ -1,5 +1,6 @@
+import collections
 import math
-from typing import Union
+from typing import Union, Deque
 
 
 class StandardDeviation:
@@ -8,22 +9,27 @@ class StandardDeviation:
 
     Tracks standard deviation on a stream of data.
     """
-    def __init__(self) -> None:
-        self.num_values = 0
-        self.sum_of_values = 0.0
-        self.sum_of_squared_values = 0.0
+    def __init__(self, window_size: int) -> None:
+        self.window: Deque[Union[int, float]] = collections.deque()
+        self.window_size = window_size
 
     def update(self, value: Union[int, float]) -> None:
-        self.num_values += 1
-        self.sum_of_values += value
-        self.sum_of_squared_values += value ** 2
+        self.window.append(value)
+
+        while len(self.window) > self.window_size:
+            self.window.popleft()
 
     @property
     def value(self) -> float:
-        if self.num_values < 2:
+        num_values = len(self.window)
+
+        if num_values < 2:
             raise ValueError("No data")
 
+        sum_of_values = sum(self.window)
+        sum_of_squared_values = sum(item * item for item in self.window)
+
         return math.sqrt(
-            (self.num_values * self.sum_of_squared_values - self.sum_of_values ** 2) /
-            (self.num_values * (self.num_values - 1))
+            (num_values * sum_of_squared_values - sum_of_values ** 2) /
+            (num_values * (num_values - 1))
         )

--- a/trinity/utils/stddev.py
+++ b/trinity/utils/stddev.py
@@ -1,0 +1,28 @@
+import math
+
+
+class StandardDeviation:
+    """
+    https://stackoverflow.com/questions/5543651/computing-standard-deviation-in-a-stream
+
+    Tracks standard deviation on a stream of data.
+    """
+    def __init__(self):
+        self.num_values = 0
+        self.sum_of_values = 0
+        self.sum_of_squared_values = 0
+
+    def update(self, value):
+        self.num_values += 1
+        self.sum_of_values += value
+        self.sum_of_squared_values += value ** 2
+
+    @property
+    def value(self):
+        if self.num_values < 2:
+            raise ValueError("No data")
+
+        return math.sqrt(
+            (self.num_values * self.sum_of_squared_values - self.sum_of_values ** 2) /
+            (self.num_values * (self.num_values - 1))
+        )


### PR DESCRIPTION
### What was wrong?

I wanted to *tune* our timeouts based on historical peer performance.

A simple standard for setting timeouts is to use something like N standard deviations above the Xth percentile for response time.  Under generally *normally* distributed data this should yield a number for which the majority of requests will complete within fine tuned to the peer's historical performance.

### How was it fixed?

- Implemented a percentile tracker which approximates the desired percentile using a constant size memory footprint and added it to the stats that we track about peer performance.
- Implemented a standard deviation tracker which approximates the standard deviation of response times using a constant memory footprint.
- Modified the `trinity.protocol.common.manager.Managers` to take advantage of this data and set the default timeout to be `3` standard deviations above the 99th percentile of response times (once we have at least 20 data points).

> I also removed the updating of the EMA when tracking timeouts because this was polluting the statistics.  Since we already track number of timeouts it seems appropriate.

```
   DEBUG  12-05 13:11:48           ETHPeerPool  == Peer details ==
   DEBUG  12-05 13:11:48           ETHPeerPool  ETHPeer <Node(0x5669@127.0.0.1)>: uptime=0:00:05:40, received_msgs=5643, most_received=Transactions (cmd_id=18)(5110)
   DEBUG  12-05 13:11:48           ETHPeerPool      BlockBodies: msgs=52  items=566004  rtt=1.01/2.42/1.35  ips=10811.93193/9904.51206  timeouts=0  quality=82
   DEBUG  12-05 13:11:48           ETHPeerPool      BlockHeaders: msgs=43  items=8066  rtt=0.15/2.39/1.00  ips=1247.68185/3543.64275  timeouts=0  quality=88
   DEBUG  12-05 13:11:48           ETHPeerPool      NodeData: None
   DEBUG  12-05 13:11:48           ETHPeerPool      Receipts: msgs=69  items=322855  rtt=0.79/1.37/1.34  ips=5942.61693/6070.33386  timeouts=0  quality=19
   DEBUG  12-05 13:11:48           ETHPeerPool  ETHPeer <Node(0x4792@51.255.77.90)>: uptime=0:00:01:07, received_msgs=2809, most_received=Transactions (cmd_id=18)(2779)
   DEBUG  12-05 13:11:48           ETHPeerPool      BlockBodies: msgs=4  items=20774  rtt=2.56/16.76/4.13  ips=2031.83861/484.39878  timeouts=0  quality=17
   DEBUG  12-05 13:11:48           ETHPeerPool      BlockHeaders: msgs=1  items=2  rtt=0.47/19.02/0.47  ips=4.24773/0.21239  timeouts=0  quality=5
   DEBUG  12-05 13:11:48           ETHPeerPool      NodeData: None
   DEBUG  12-05 13:11:48           ETHPeerPool      Receipts: msgs=10  items=46893  rtt=1.56/12.60/2.71  ips=3006.86708/1341.48419  timeouts=0  quality=7
   DEBUG  12-05 13:11:48           ETHPeerPool  ETHPeer <Node(0x1a88@35.240.140.112)>: uptime=0:00:00:15, received_msgs=85, most_received=Transactions (cmd_id=18)(79)
   DEBUG  12-05 13:11:48           ETHPeerPool      BlockBodies: msgs=1  items=1994  rtt=0.77/19.04/0.77  ips=2601.65025/130.08251  timeouts=0  quality=5
   DEBUG  12-05 13:11:48           ETHPeerPool      BlockHeaders: msgs=1  items=2  rtt=1.51/19.08/1.51  ips=1.32354/0.06618  timeouts=0  quality=5
   DEBUG  12-05 13:11:48           ETHPeerPool      NodeData: None
   DEBUG  12-05 13:11:48           ETHPeerPool      Receipts: msgs=1  items=4851  rtt=1.52/19.08/1.52  ips=3182.11566/159.10578  timeouts=0  quality=1
   DEBUG  12-05 13:11:48           ETHPeerPool  == End peer details ==
```

#### Cute Animal Picture

![funny christmas dog](https://user-images.githubusercontent.com/824194/49541211-5717f600-f88f-11e8-95a5-bb2028762b94.jpg)

