### PR TITLE
Move peer discovery into an isolated plugin

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -76,3 +76,8 @@ SEAL_CHECK_RANDOM_SAMPLE_RATE = 48
 # The amount of time that the BasePeerPool will wait for a peer to boot before
 # aborting the connection attempt.
 DEFAULT_PEER_BOOT_TIMEOUT = 20
+
+# Interval at which peer pool is checked for potential new candidates
+DISOVERY_INTERVAL = 2
+# Timeout used when fetching peer candidates from discovery
+REQUEST_PEER_CANDIDATE_TIMEOUT = 0.5

--- a/p2p/events.py
+++ b/p2p/events.py
@@ -1,4 +1,5 @@
 from typing import (
+    Tuple,
     Type,
 )
 
@@ -6,6 +7,36 @@ from lahja import (
     BaseEvent,
     BaseRequestResponseEvent,
 )
+
+
+class BaseDiscoveryServiceResponse(BaseEvent):
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+
+class PeerCandidatesResponse(BaseDiscoveryServiceResponse):
+
+    def __init__(self, candidates: Tuple[str, ...], error: Exception=None) -> None:
+        super().__init__(error)
+        self.candidates = candidates
+
+
+class PeerCandidatesRequest(BaseRequestResponseEvent[PeerCandidatesResponse]):
+
+    def __init__(self, max_candidates: int) -> None:
+        self.max_candidates = max_candidates
+
+    @staticmethod
+    def expected_response_type() -> Type[PeerCandidatesResponse]:
+        return PeerCandidatesResponse
+
+
+class RandomBootnodeRequest(BaseRequestResponseEvent[PeerCandidatesResponse]):
+
+    @staticmethod
+    def expected_response_type() -> Type[PeerCandidatesResponse]:
+        return PeerCandidatesResponse
 
 
 class PeerCountResponse(BaseEvent):

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -105,6 +105,9 @@ class Node:
         pubkey = keys.PublicKey(decode_hex(parsed.username))
         return cls(pubkey, Address(parsed.hostname, parsed.port))
 
+    def uri(self) -> str:
+        return f'enode://{self.pubkey.to_hex()}@{self.address.ip}:{self.address.tcp_port}'
+
     def __str__(self) -> str:
         return '<Node(%s@%s)>' % (self.pubkey.to_hex()[:6], self.address.ip)
 
@@ -132,6 +135,19 @@ class Node:
 
     def __hash__(self) -> int:
         return hash(self.pubkey)
+
+# TODO: check if we can make the nodes pickable and get rid of these
+# https://github.com/ethereum/py-evm/issues/1578
+
+
+def to_uris(nodes: Iterable[Node]) -> Iterator[str]:
+    for node in nodes:
+        yield node.uri()
+
+
+def from_uris(uris: Iterable[str]) -> Iterator[Node]:
+    for uri in uris:
+        yield Node.from_uri(uri)
 
 
 @total_ordering

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -52,7 +52,6 @@ class Node(BaseService):
 
         self._jsonrpc_ipc_path: Path = trinity_config.jsonrpc_ipc_path
         self._network_id = trinity_config.network_id
-        self._use_discv5 = trinity_config.use_discv5
 
         self.event_bus = event_bus
 

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -44,7 +44,6 @@ class FullNode(Node):
                 max_peers=self._max_peers,
                 bootstrap_nodes=self._bootstrap_nodes,
                 preferred_nodes=self._preferred_nodes,
-                use_discv5=self._use_discv5,
                 token=self.cancel_token,
                 event_bus=self.event_bus,
             )

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -80,7 +80,6 @@ class LightNode(Node):
                 max_peers=self._max_peers,
                 bootstrap_nodes=self._bootstrap_nodes,
                 preferred_nodes=self._preferred_nodes,
-                use_discv5=self._use_discv5,
                 token=self.cancel_token,
                 event_bus=self.event_bus,
             )

--- a/trinity/plugins/builtin/peer_discovery/plugin.py
+++ b/trinity/plugins/builtin/peer_discovery/plugin.py
@@ -1,0 +1,155 @@
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction,
+)
+import asyncio
+
+from eth_typing import (
+    BlockNumber,
+)
+from lahja import (
+    Endpoint,
+)
+
+from eth.constants import (
+    GENESIS_BLOCK_NUMBER
+)
+
+from p2p.discovery import (
+    get_v5_topic,
+    DiscoveryByTopicProtocol,
+    DiscoveryService,
+    PreferredNodeDiscoveryProtocol,
+)
+from p2p.kademlia import (
+    Address,
+)
+from p2p.protocol import (
+    Protocol,
+)
+from p2p.service import (
+    BaseService,
+)
+
+from trinity.config import (
+    BeaconAppConfig,
+    Eth1AppConfig,
+    TrinityConfig,
+)
+from trinity.db.manager import (
+    create_db_manager
+)
+from trinity.extensibility import (
+    BaseIsolatedPlugin,
+)
+from trinity.protocol.bcc.proto import (
+    BCCProtocol,
+)
+from trinity.protocol.eth.proto import (
+    ETHProtocol,
+)
+from trinity.protocol.les.proto import (
+    LESProtocolV2,
+)
+from trinity.utils.shutdown import (
+    exit_with_service_and_endpoint,
+)
+
+
+def get_protocol(trinity_config: TrinityConfig) -> Protocol:
+    # For now DiscoveryByTopicProtocol supports a single topic, so we use the latest
+    # version of our supported protocols. Maybe this could be more generic?
+    # TODO: This needs to support the beacon protocol when we have a way to
+    # check the config, if trinity is being run as a beacon node.
+
+    if trinity_config.has_app_config(BeaconAppConfig):
+        return BCCProtocol
+    else:
+        eth1_config = trinity_config.get_app_config(Eth1AppConfig)
+        if eth1_config.is_light_mode:
+            return LESProtocolV2
+        else:
+            return ETHProtocol
+
+
+def get_discv5_topic(trinity_config: TrinityConfig, protocol: Protocol):
+    db_manager = create_db_manager(trinity_config.database_ipc_path)
+    db_manager.connect()
+
+    header_db = db_manager.get_headerdb()
+    genesis_hash = header_db.get_canonical_block_hash(BlockNumber(GENESIS_BLOCK_NUMBER))
+
+    return get_v5_topic(protocol, genesis_hash)
+
+
+class DiscoveryBootstrapService(BaseService):
+    """
+    Bootstrap discovery to provide a parent ``CancellationToken``
+    """
+
+    def __init__(self, event_bus: Endpoint, trinity_config: TrinityConfig) -> None:
+        super().__init__()
+        self.event_bus = event_bus
+        self.trinity_config = trinity_config
+
+    async def _run(self) -> None:
+        external_ip = "0.0.0.0"
+        address = Address(external_ip, self.trinity_config.port, self.trinity_config.port)
+
+        if self.trinity_config.use_discv5:
+            protocol = get_protocol(self.trinity_config)
+            topic = get_discv5_topic(self.trinity_config, protocol)
+
+            discovery_protocol = DiscoveryByTopicProtocol(
+                topic,
+                self.trinity_config.nodekey,
+                address,
+                self.trinity_config.bootstrap_nodes,
+                self.cancel_token,
+            )
+        else:
+            discovery_protocol = PreferredNodeDiscoveryProtocol(
+                self.trinity_config.nodekey,
+                address,
+                self.trinity_config.bootstrap_nodes,
+                self.trinity_config.preferred_nodes,
+                self.cancel_token,
+            )
+
+        discovery_service = DiscoveryService(
+            discovery_protocol,
+            self.trinity_config.port,
+            self.event_bus,
+            self.cancel_token,
+        )
+
+        await discovery_service.run()
+
+
+class PeerDiscoveryPlugin(BaseIsolatedPlugin):
+    """
+    Continously discover other Ethereum nodes.
+    """
+
+    @property
+    def name(self) -> str:
+        return "Peer Discovery"
+
+    def on_ready(self) -> None:
+        if not self.context.args.disable_discovery:
+            self.start()
+
+    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+        arg_parser.add_argument(
+            "--disable-discovery",
+            action="store_true",
+            help="Disable peer discovery",
+        )
+
+    def do_start(self) -> None:
+        loop = asyncio.get_event_loop()
+        discovery_bootstrap = DiscoveryBootstrapService(self.event_bus, self.context.trinity_config)
+        asyncio.ensure_future(exit_with_service_and_endpoint(discovery_bootstrap, self.event_bus))
+        asyncio.ensure_future(discovery_bootstrap.run())
+        loop.run_forever()
+        loop.close()

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -18,6 +18,9 @@ from trinity.plugins.builtin.fix_unclean_shutdown.plugin import (
 from trinity.plugins.builtin.json_rpc.plugin import (
     JsonRpcServerPlugin,
 )
+from trinity.plugins.builtin.peer_discovery.plugin import (
+    PeerDiscoveryPlugin,
+)
 from trinity.plugins.builtin.tx_pool.plugin import (
     TxPlugin,
 )
@@ -38,6 +41,7 @@ def is_ipython_available() -> bool:
 BASE_PLUGINS: Tuple[BasePlugin, ...] = (
     AttachPlugin(use_ipython=is_ipython_available()),
     FixUncleanShutdownPlugin(),
+    PeerDiscoveryPlugin(),
 )
 
 


### PR DESCRIPTION
### What was wrong?

Currently the peer discovery runs in the networking process among a lot of other things. Moving it into an isolated plugin should:

- increase efficiency of syncing as the peer discovery probably takes a fair share of computing power
- increase decoupling as it breaks up the networking code into smaller pieces 
- improve reusability as the new discovery can be accessed from any other interested party since it is integrated with the event bus 

### How was it fixed?

- inverted the model in the `DiscoveryService` so that it doesn't know about the `PeerPool` and instead just exposes an API for consumers to request peer candidates from
- the API is exposed over the EventBus so that it can be requested from any other process
- created an isolated plugin to run the new discovery service in a separate process
- removed discovery code from the server where it previously lived

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pixnio.com/free-images/2018/10/03/2018-10-03-04-24-27.jpg)
