### PR TITLE
Clarify local plugin install

### DIFF
--- a/docs/guides/trinity/writing_plugins.rst
+++ b/docs/guides/trinity/writing_plugins.rst
@@ -333,3 +333,9 @@ for a deeper explanation.
 
 A plugin where the ``setup.py`` file is configured as described can be installed by
 ``pip install <package-name>``` and immediately becomes available as a plugin in Trinity.
+
+.. note::
+
+  Plugins installed from a local directory (instead of the pypi registry), such as the sample
+  plugin described in this article, must be installed with the ``-e`` parameter (Example:
+  ``pip install -e ./trinity-external-plugins/examples/peer_count_reporter``)


### PR DESCRIPTION
### What was wrong?

The "Writing Plugins" guide did not mention that plugins that are installed from a local directory need to be installed with `-e` parameter

### How was it fixed?

Added a note section to explain it.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/c8/3d/0f/c83d0fbec1519cf32ade02da86050002.jpg)
