### PR TITLE
eth/vm/logic/system: fix CREATE2 failures on BadOpcode test fixture

### DIFF
--- a/eth/vm/logic/system.py
+++ b/eth/vm/logic/system.py
@@ -227,13 +227,14 @@ class Create2(CreateByzantium):
         return CreateOpcodeStackData(endowment, memory_start, memory_length, salt)
 
     def get_gas_cost(self, data: CreateOpcodeStackData) -> int:
-        return constants.GAS_SHA3WORD * ceil32(data.memory_length) // 32
+        return constants.GAS_CREATE + constants.GAS_SHA3WORD * ceil32(data.memory_length) // 32
 
     def generate_contract_address(self,
                                   stack_data: CreateOpcodeStackData,
                                   call_data: bytes,
                                   computation: BaseComputation) -> Address:
 
+        computation.state.account_db.increment_nonce(computation.msg.storage_address)
         return generate_safe_contract_address(
             computation.msg.storage_address,
             stack_data.salt,


### PR DESCRIPTION
### What was wrong?

`CREATE2` does not match the spec, [https://eips.ethereum.org/EIPS/eip-1014](EIP-1014).

PR #1181 was therefore failing fixtures.


### How was it fixed?

Use missing gas amount of 32000 (as `CREATE` does); increment nonce.


### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://1.bp.blogspot.com/_o9m_dw8cPWo/TRaosH74EBI/AAAAAAAAAHk/64RMSra7Umw/s1600/twoParrots.jpg)

Source: unknown; found [here](https://gr8poems.blogspot.com/2010/12/two-parrots.html)