### PR TITLE
Rework helper functions - part 2

### DIFF
--- a/eth/beacon/block_committees_info.py
+++ b/eth/beacon/block_committees_info.py
@@ -12,8 +12,7 @@ BlockCommitteesInfo = NamedTuple(
     'BlockCommitteesInfo',
     (
         ('proposer_index', int),
-        ('proposer_index_in_committee', int),
-        ('proposer_shard_id', int),
+        ('proposer_shard', int),
         ('proposer_committee_size', int),
         ('shards_committees', Tuple['ShardCommittee'])
     )

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -7,6 +7,7 @@ from typing import (
 )
 
 from eth_utils import (
+    denoms,
     to_tuple,
     ValidationError,
 )
@@ -375,7 +376,7 @@ def get_effective_balance(validator: 'ValidatorRecord', max_deposit: int) -> int
     """
     Return the effective balance (also known as "balance at stake") for the ``validator``.
     """
-    return min(validator.balance, max_deposit)
+    return min(validator.balance, max_deposit * denoms.gwei)
 
 
 def get_new_validator_registry_delta_chain_tip(current_validator_registry_delta_chain_tip: Hash32,

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -22,6 +22,9 @@ from eth.utils.bitfield import (
     get_bitfield_length,
     has_voted,
 )
+from eth.utils.blake import (
+    blake,
+)
 from eth.utils.numeric import (
     clamp,
 )
@@ -412,3 +415,29 @@ def get_attestation_participants(state: 'BeaconState',
     for bitfield_index, validator_index in enumerate(shard_committee.committee):
         if has_voted(participation_bitfield, bitfield_index):
             yield validator_index
+
+
+#
+# Misc
+#
+def get_effective_balance(validator: 'ValidatorRecord', max_deposit: int) -> int:
+    """
+    Return the effective balance (also known as "balance at stake") for the ``validator``.
+    """
+    return min(validator.balance, max_deposit)
+
+
+def get_new_validator_registry_delta_chain_tip(current_validator_registry_delta_chain_tip: Hash32,
+                                               index: int,
+                                               pubkey: int,
+                                               flag: int) -> Hash32:
+    """
+    Compute the next hash in the validator registry delta hash chain.
+    """
+    return blake(
+        current_validator_registry_delta_chain_tip +
+        flag.to_bytes(1, 'big') +
+        index.to_bytes(3, 'big') +
+        # TODO: currently, we use 256-bit pubkey which is different form the spec
+        pubkey.to_bytes(32, 'big')
+    )

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -253,7 +253,7 @@ def get_new_shuffling(*,
 
 
 #
-# Get proposer postition
+# Get proposer position
 #
 def get_block_committees_info(parent_block: 'BaseBeaconBlock',
                               state: 'BeaconState',
@@ -330,7 +330,7 @@ def get_attestation_participants(state: 'BeaconState',
                                  participation_bitfield: bytes,
                                  epoch_length: int) -> Iterable[int]:
     """
-    Return the participant indices at for the ``slot`` of shard ``shard``
+    Return the participants' indices at the ``slot`` of shard ``shard``
     from ``participation_bitfield``.
     """
     # Find the relevant committee

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -334,10 +334,10 @@ def get_new_shuffling(*,
 # Get proposer postition
 #
 def get_block_committees_info(parent_block: 'BaseBeaconBlock',
-                              crystallized_state: 'CrystallizedState',
+                              state: 'BeaconState',
                               epoch_length: int) -> BlockCommitteesInfo:
     shards_committees = get_shard_committees_at_slot(
-        crystallized_state,
+        state,
         parent_block.slot,
         epoch_length,
     )
@@ -373,3 +373,29 @@ def get_block_committees_info(parent_block: 'BaseBeaconBlock',
         proposer_committee_size=proposer_committee_size,
         shards_committees=shards_committees,
     )
+
+
+def get_beacon_proposer_index(state: 'BeaconState',
+                              slot: int,
+                              epoch_length: int) -> int:
+    """
+    Returns the beacon proposer index for the ``slot``.
+    """
+    shard_committees = get_shard_committees_at_slot(
+        state,
+        slot,
+        epoch_length,
+    )
+    try:
+        first_shard_committee = shard_committees[0]
+    except IndexError:
+        raise ValueError("shard_committees should not be empty.")
+
+    proposer_committee_size = len(first_shard_committee.committee)
+
+    if proposer_committee_size <= 0:
+        raise ValueError(
+            "The first committee should not be empty"
+        )
+
+    return first_shard_committee.committee[slot % len(first_shard_committee.committee)]

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -43,10 +43,8 @@ from eth.beacon.utils.random import (
 
 
 if TYPE_CHECKING:
-    from eth.beacon.types.active_states import ActiveState  # noqa: F401
     from eth.beacon.types.attestation_records import AttestationRecord  # noqa: F401
     from eth.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
-    from eth.beacon.types.crystallized_states import CrystallizedState  # noqa: F401
     from eth.beacon.types.states import BeaconState  # noqa: F401
     from eth.beacon.types.validator_records import ValidatorRecord  # noqa: F401
 
@@ -309,7 +307,6 @@ def get_block_committees_info(parent_block: 'BaseBeaconBlock',
         epoch_length,
     )
     """
-    FIXME
     Return the block committees and proposer info with BlockCommitteesInfo pack.
     """
     # `proposer_index_in_committee` th attester in `shard_committee`
@@ -330,13 +327,11 @@ def get_block_committees_info(parent_block: 'BaseBeaconBlock',
         proposer_committee_size
     )
 
-    # The index in CrystallizedState.validators
     proposer_index = shard_committee.committee[proposer_index_in_committee]
 
     return BlockCommitteesInfo(
         proposer_index=proposer_index,
-        proposer_index_in_committee=proposer_index_in_committee,
-        proposer_shard_id=shard_committee.shard_id,
+        proposer_shard=shard_committee.shard,
         proposer_committee_size=proposer_committee_size,
         shards_committees=shards_committees,
     )

--- a/tests/beacon/conftest.py
+++ b/tests/beacon/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import itertools
 
 from eth_utils import denoms
 
@@ -80,7 +81,7 @@ def sample_beacon_block_params(epoch_length):
         'slot': 10,
         'randao_reveal': b'\x55' * 32,
         'candidate_pow_receipt_root': b'\x55' * 32,
-        'ancestor_hashes': tuple([ZERO_HASH32 for _ in range(2 * epoch_length)]),
+        'ancestor_hashes': tuple(itertools.repeat(ZERO_HASH32, 2 * epoch_length)),
         'state_root': b'\x55' * 32,
         'attestations': (),
         'specials': (),

--- a/tests/beacon/conftest.py
+++ b/tests/beacon/conftest.py
@@ -75,12 +75,12 @@ def sample_attestation_data_params():
 
 
 @pytest.fixture
-def sample_beacon_block_params():
+def sample_beacon_block_params(epoch_length):
     return {
         'slot': 10,
         'randao_reveal': b'\x55' * 32,
         'candidate_pow_receipt_root': b'\x55' * 32,
-        'ancestor_hashes': (),
+        'ancestor_hashes': tuple([ZERO_HASH32 for _ in range(2 * epoch_length)]),
         'state_root': b'\x55' * 32,
         'attestations': (),
         'specials': (),

--- a/tests/beacon/helpers.py
+++ b/tests/beacon/helpers.py
@@ -4,9 +4,6 @@ from eth.beacon.enums.validator_status_codes import (
 from eth.beacon.types.validator_records import (
     ValidatorRecord,
 )
-from eth.constants import (
-    ZERO_HASH32,
-)
 
 
 def mock_validator_record(pubkey, max_deposit):
@@ -23,15 +20,24 @@ def mock_validator_record(pubkey, max_deposit):
 
 
 def get_pseudo_chain(length, genesis_block):
-    """Get a pseudo chain, only slot_number and parent_hash are valid.
+    """
+    Get a pseudo chain, only slot and parent_hash are valid.
     """
     blocks = []
+    ancestor_hashes_len = len(genesis_block.ancestor_hashes)
     for slot in range(length * 3):
+        if slot > 0:
+            ancestor_hashes = (
+                (blocks[slot - 1].hash, ) +
+                blocks[slot - 1].ancestor_hashes[:ancestor_hashes_len]
+            )
+        else:
+            ancestor_hashes = genesis_block.ancestor_hashes
         blocks.append(
             genesis_block.copy(
-                slot_number=slot,
-                parent_hash=blocks[slot - 1].hash if slot > 0 else ZERO_HASH32
+                slot=slot,
+                ancestor_hashes=ancestor_hashes
             )
         )
 
-    return blocks
+    return tuple(blocks)

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -3,7 +3,6 @@ import pytest
 from eth.beacon.enums.validator_status_codes import (
     ValidatorStatusCode,
 )
-from eth.beacon.types.attestation_records import AttestationRecord
 from eth.beacon.types.blocks import BaseBeaconBlock
 from eth.beacon.types.shard_committees import ShardCommittee
 from eth.beacon.types.states import BeaconState
@@ -12,14 +11,12 @@ from eth.beacon.helpers import (
     _get_element_from_recent_list,
     get_active_validator_indices,
     get_attestation_participants,
-    get_attestation_indices,
     get_beacon_proposer_index,
     get_block_hash,
     get_hashes_from_latest_block_hashes,
     get_hashes_to_sign,
     get_new_shuffling,
     _get_shard_committees_at_slot,
-    get_signed_parent_hashes,
     get_block_committees_info,
 )
 
@@ -145,7 +142,6 @@ def test_get_block_hash(
             )
 
 
-@pytest.mark.xfail(reason="Need to be fixed")
 @pytest.mark.parametrize(
     (
         'epoch_length,current_block_slot,from_slot,to_slot'
@@ -156,13 +152,13 @@ def test_get_block_hash(
     ],
 )
 def test_get_hashes_from_latest_block_hashes(
-        genesis_block,
+        sample_block,
         current_block_slot,
         from_slot,
         to_slot,
         epoch_length):
     _, latest_block_hashes = generate_mock_latest_block_hashes(
-        genesis_block,
+        sample_block,
         current_block_slot,
         epoch_length,
     )
@@ -177,12 +173,11 @@ def test_get_hashes_from_latest_block_hashes(
     assert len(result) == to_slot - from_slot + 1
 
 
-@pytest.mark.xfail(reason="Need to be fixed")
-def test_get_hashes_to_sign(genesis_block, epoch_length):
+def test_get_hashes_to_sign(sample_block, epoch_length):
     epoch_length = epoch_length
     current_block_slot = 1
     blocks, latest_block_hashes = generate_mock_latest_block_hashes(
-        genesis_block,
+        sample_block,
         current_block_slot,
         epoch_length,
     )
@@ -195,34 +190,6 @@ def test_get_hashes_to_sign(genesis_block, epoch_length):
     )
     assert len(result) == epoch_length
     assert result[-1] == block.hash
-
-
-@pytest.mark.xfail(reason="Need to be fixed")
-def test_get_new_latest_block_hashes(genesis_block,
-                                     epoch_length,
-                                     sample_attestation_record_params):
-    epoch_length = epoch_length
-    current_block_slot = 15
-    blocks, latest_block_hashes = generate_mock_latest_block_hashes(
-        genesis_block,
-        current_block_slot,
-        epoch_length,
-    )
-
-    block = blocks[current_block_slot]
-    oblique_parent_hashes = [b'\x77' * 32]
-    attestation = AttestationRecord(**sample_attestation_record_params).copy(
-        slot=10,
-        oblique_parent_hashes=oblique_parent_hashes,
-    )
-    result = get_signed_parent_hashes(
-        latest_block_hashes,
-        block,
-        attestation,
-        epoch_length,
-    )
-    assert len(result) == epoch_length
-    assert result[-1] == oblique_parent_hashes[-1]
 
 
 #
@@ -323,34 +290,6 @@ def test_get_shard_committee_for_slot(
                 slot=slot,
                 epoch_length=epoch_length,
             )
-
-
-@pytest.mark.xfail(reason="Need to be fixed")
-# @pytest.mark.parametrize(
-#     (
-#         'num_validators,'
-#         'epoch_length,min_committee_size'
-#     ),
-#     [
-#         (1000, 20, 10),
-#     ],
-# )
-def test_get_attestation_indices(genesis_crystallized_state,
-                                 sample_attestation_record_params,
-                                 epoch_length,
-                                 min_committee_size):
-    attestation = AttestationRecord(**sample_attestation_record_params)
-    attestation = attestation.copy(
-        slot=0,
-        shard_id=0,
-    )
-
-    attestation_indices = get_attestation_indices(
-        genesis_crystallized_state,
-        attestation,
-        epoch_length,
-    )
-    assert len(attestation_indices) >= min_committee_size
 
 
 #

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from eth_utils import (
+    denoms,
     ValidationError,
 )
 
@@ -609,14 +610,19 @@ def test_get_attestation_participants(
     ),
     [
         (
-            1,
+            1 * denoms.gwei,
             32,
-            1,
+            1 * denoms.gwei,
         ),
         (
-            33,
+            32 * denoms.gwei,
             32,
+            32 * denoms.gwei,
+        ),
+        (
+            33 * denoms.gwei,
             32,
+            32 * denoms.gwei,
         )
     ]
 )


### PR DESCRIPTION
### What was wrong?
#1510

### How was it fixed?
- Fix `get_shard_committees_at_slot`
    - The reason why I add `_get_shard_committees_at_slot` is for making the tests easier.
- Fix `get_block_hash`
- Add `get_beacon_proposer_index`
- Add `get_attestation_participants`
- Add `get_effective_balance`
- Add `get_new_validator_registry_delta_chain_tip`

Also, make the tests for these functions not depend on genesis state or block.

#### Cute Animal Picture
![](https://media.giphy.com/media/SiOlQGZUZYwhO/giphy.gif)
