### PR TITLE
Teach TrinityConfig to handle sub configs

### DIFF
--- a/tests/trinity/core/configuration/test_trinity_config_object.py
+++ b/tests/trinity/core/configuration/test_trinity_config_object.py
@@ -15,6 +15,7 @@ from trinity.utils.chains import (
 )
 from trinity.config import (
     TrinityConfig,
+    BeaconAppConfig,
     DATABASE_DIR_NAME,
 )
 from trinity.utils.filesystem import (
@@ -90,3 +91,12 @@ def test_trinity_config_explictely_provided_nodekey(nodekey_bytes, as_bytes):
     )
 
     assert trinity_config.nodekey.to_bytes() == nodekey_bytes
+
+
+def test_trinity_config_sub_configs():
+    trinity_config = TrinityConfig(network_id=1)
+    trinity_config.initialize_app_configs(None, (BeaconAppConfig,))
+
+    assert trinity_config.has_app_config(BeaconAppConfig)
+    beacon_config = trinity_config.get_app_config(BeaconAppConfig)
+    assert type(beacon_config) is BeaconAppConfig

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -32,6 +32,7 @@ from trinity.cli_parser import (
     subparser,
 )
 from trinity.config import (
+    BaseAppConfig,
     TrinityConfig,
 )
 from trinity.constants import (
@@ -106,7 +107,9 @@ BootFn = Callable[[
 ], None]
 
 
-def main_entry(trinity_boot: BootFn, plugins: Iterable[BasePlugin]) -> None:
+def main_entry(trinity_boot: BootFn,
+               plugins: Iterable[BasePlugin],
+               sub_configs: Iterable[Type[BaseAppConfig]]) -> None:
     event_bus = EventBus(ctx)
     main_endpoint = event_bus.create_endpoint(MAIN_EVENTBUS_ENDPOINT)
     main_endpoint.connect_no_wait()
@@ -149,7 +152,7 @@ def main_entry(trinity_boot: BootFn, plugins: Iterable[BasePlugin]) -> None:
         setup_log_levels(args.log_levels)
 
     try:
-        trinity_config = TrinityConfig.from_parser_args(args)
+        trinity_config = TrinityConfig.from_parser_args(args, sub_configs)
     except AmbigiousFileSystem:
         parser.error(TRINITY_AMBIGIOUS_FILESYSTEM_INFO)
 

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -25,6 +25,7 @@ from trinity.bootstrap import (
 )
 from trinity.config import (
     TrinityConfig,
+    Eth1AppConfig,
 )
 from trinity.constants import (
     NETWORKING_EVENTBUS_ENDPOINT,
@@ -65,7 +66,7 @@ def get_all_plugins() -> Iterable[BasePlugin]:
 
 
 def main() -> None:
-    main_entry(trinity_boot, get_all_plugins())
+    main_entry(trinity_boot, get_all_plugins(), (Eth1AppConfig,))
 
 
 def trinity_boot(args: Namespace,
@@ -147,7 +148,7 @@ def trinity_boot(args: Namespace,
 def launch_node(args: Namespace, trinity_config: TrinityConfig, endpoint: Endpoint) -> None:
     with trinity_config.process_id_file('networking'):
 
-        NodeClass = trinity_config.node_class
+        NodeClass = trinity_config.get_app_config(Eth1AppConfig).node_class
         node = NodeClass(endpoint, trinity_config)
         loop = node.get_event_loop()
 

--- a/trinity/main_beacon.py
+++ b/trinity/main_beacon.py
@@ -21,6 +21,7 @@ from trinity.bootstrap import (
 )
 from trinity.config import (
     TrinityConfig,
+    BeaconAppConfig
 )
 from trinity.events import (
     ShutdownRequest
@@ -41,7 +42,7 @@ from trinity.utils.mp import (
 
 
 def main_beacon() -> None:
-    main_entry(trinity_boot, BASE_PLUGINS)
+    main_entry(trinity_boot, BASE_PLUGINS, (BeaconAppConfig,))
 
 
 def trinity_boot(args: Namespace,

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -4,6 +4,7 @@ from argparse import (
 )
 import asyncio
 
+from trinity.config import Eth1AppConfig
 from trinity.chains.base import BaseAsyncChain
 from trinity.db.manager import (
     create_db_manager
@@ -47,15 +48,16 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
         db_manager.connect()
 
         trinity_config = self.context.trinity_config
+        eth1_app_config = self.context.trinity_config.get_app_config(Eth1AppConfig)
         chain_config = trinity_config.get_chain_config()
 
         chain: BaseAsyncChain
 
-        if self.context.trinity_config.is_light_mode:
+        if eth1_app_config.is_light_mode:
             header_db = db_manager.get_headerdb()  # type: ignore
             event_bus_light_peer_chain = EventBusLightPeerChain(self.context.event_bus)
             chain = chain_config.light_chain_class(header_db, peer_chain=event_bus_light_peer_chain)
-        elif trinity_config.is_full_mode:
+        elif eth1_app_config.is_full_mode:
             db = db_manager.get_db()  # type: ignore
             chain = chain_config.full_chain_class(db)
         else:


### PR DESCRIPTION
### What was wrong?

As we aim to support more and more node types using one common `TrinityConfig` becomes seems to become less sustainable as it would mean that e.g. we need to add things for the beacon node into the `TrinityConfig` that will just be noise for other node types. In language theory speak, that would lower the cohesion of the `TrinityConfig`which is a bad thing.

### How was it fixed?

Related discussion: https://github.com/ethereum/py-evm/pull/1556#discussion_r240014047

1.This introduces a concept of sub configurations which need to be derived from `BaseSubConfig`. 

```python
class BaseSubConfig:

    def __init__(self, args: argparse.Namespace, base_config: TrinityConfig) -> None:
        self.args = args
        self.base_config = base_config
```

2. `TrinityConfig.from_parser_args` now accepts an additional `Iterable[BaseSubConfig` to bootstrap any number of given sub configs.

3. `TrinityConfig` now has APIs `has_sub_config()` and `get_sub_config` to work with sub configs 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.dailymail.co.uk/i/pix/2011/04/04/article-0-0B78E26500000578-768_964x660.jpg)
