### PR TITLE
Resolve dangling future in ResponseCandidateStream

### DIFF
--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -206,6 +206,12 @@ class ResponseCandidateStream(
                     self,
                 )
 
+    def __del__(self) -> None:
+        if self.pending_request is not None:
+            _, future = self.pending_request
+            if future.cancel():
+                self.logger.debug("Forcefully cancelled a pending response in %s", self)
+
     def deregister_peer(self, peer: BasePeer) -> None:
         if self.pending_request is not None:
             self.logger.debug("Peer stream %r shutting down, cancelling the pending request", self)


### PR DESCRIPTION
### What was wrong?

Occasionally, during shutdown, the `ResponseCandidateStream` would set an exception on the pending request, only to emit an asyncio "never gathered" exception, due to random service shutdown ordering.

### How was it fixed?

Just before the RCS is garbage collected, cancel any futures that were uncollected.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/4452555264/h36AE9F4A/)
