### PR TITLE
client/server naming seems swapped in sync test

### DIFF
--- a/tests/trinity/core/p2p-proto/test_sync.py
+++ b/tests/trinity/core/p2p-proto/test_sync.py
@@ -51,8 +51,8 @@ async def test_fast_syncer(request, event_loop, chaindb_fresh, chaindb_20):
     asyncio.ensure_future(server.run())
     server_request_handler = ETHRequestServer(FakeAsyncChainDB(chaindb_20.db), server_peer_pool)
     asyncio.ensure_future(server_request_handler.run())
-    server_peer.logger.info("%s is serving 20 blocks", server_peer)
-    client_peer.logger.info("%s is syncing up 20", client_peer)
+    client_peer.logger.info("%s is serving 20 blocks", client_peer)
+    server_peer.logger.info("%s is syncing up 20 blocks", server_peer)
 
     def finalizer():
         event_loop.run_until_complete(server.cancel())
@@ -133,8 +133,8 @@ async def test_regular_syncer(request, event_loop, chaindb_fresh, chaindb_20):
     asyncio.ensure_future(server.run())
     server_request_handler = ETHRequestServer(FakeAsyncChainDB(chaindb_20.db), server_peer_pool)
     asyncio.ensure_future(server_request_handler.run())
-    server_peer.logger.info("%s is serving 20 blocks", server_peer)
-    client_peer.logger.info("%s is syncing up 20", client_peer)
+    client_peer.logger.info("%s is serving 20 blocks", client_peer)
+    server_peer.logger.info("%s is syncing up 20 blocks", server_peer)
 
     def finalizer():
         event_loop.run_until_complete(asyncio.gather(
@@ -173,8 +173,8 @@ async def test_light_syncer(request, event_loop, chaindb_fresh, chaindb_20):
     asyncio.ensure_future(server.run())
     server_request_handler = LightRequestServer(FakeAsyncHeaderDB(chaindb_20.db), server_peer_pool)
     asyncio.ensure_future(server_request_handler.run())
-    server_peer.logger.info("%s is serving 20 blocks", server_peer)
-    client_peer.logger.info("%s is syncing up 20", client_peer)
+    client_peer.logger.info("%s is serving 20 blocks", client_peer)
+    server_peer.logger.info("%s is syncing up 20 blocks", server_peer)
 
     def finalizer():
         event_loop.run_until_complete(asyncio.gather(


### PR DESCRIPTION
### What was wrong?

Every time I read the sync tests I get lost, and one reason is that I think the peers are named backwards. `client_peer` is the one that has access to all the data, and `server_peer` is the one with a fresh database (based on inspecting `peer.head_td`, for example).

That leads to some weird backwards-looking logs. Also notice that the server's peer pool includes the `server_peer`, which seems backwards to me: shouldn't the `client_peer` be there?

### How was it fixed?

I fixed the particular logs I'm looking at, but I'm still confused. `get_directly_linked_peers()` makes it look like `alice` should have the fresh/empty DB, but it's actually getting the populated one. Are we returning alice/bob backwards? Stepping in a couple levels to the utilities shows that it *thinks* it's returning Alice first. I didn't have a chance to debug further.

I won't have a chance to dig further, and this seems like a step in the right direction (the logs were clearly incorrect before). We'll either come back to this, or it will be resolved naturally when #1535 is finished.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQKI_IcqbTp9TjHd-NXJbii5Bbw6OVc2emZy9zpHr52D6wQU44eEw)