### PR TITLE
Emit better balance diffs when comparing accounts

### DIFF
--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -78,7 +78,7 @@ def verify_account_db(expected_state: AccountState, account_db: BaseAccountDB) -
                         'balance',
                         actual_value,
                         expected_value,
-                        expected_value - actual_value,
+                        actual_value - expected_value,
                     )
                 )
             else:


### PR DESCRIPTION
Instead of emitting expected - actual, emit actual - expected.

Rationale (by @veox):

> For example, as things stand, if a fixture-expected value is 1000, and
> the actual produced by py-evm is 500, the printed message will show a
> delta of 500 - that is, a net positive, whereas what truly happened is
> py-evm having produced a value that's too low. This is confusing: say, a
> miner's account balance showing "Delta: 500" makes one think that the
> miner received 500 wei more than expected (which is not true).

Reference:
- https://github.com/ethereum/py-evm/pull/1181#issuecomment-445986061
- https://github.com/ethereum/py-evm/pull/1573#issuecomment-446404858

#### Cute Animal Picture

![babyhawk](https://user-images.githubusercontent.com/466333/49840362-ed548c00-fd67-11e8-9bb5-b5e38ded399e.jpg)
