### PR TITLE
Revert unintentional change to sync constant

### DIFF
--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -1,4 +1,3 @@
 # How old (in seconds) must our local head be to cause us to start with a
 # fast-sync before we switch to regular-sync.
 FAST_SYNC_CUTOFF = 60 * 60 * 24
-FAST_SYNC_CUTOFF = 60


### PR DESCRIPTION
### What was wrong?

Accidentally merged something that should not have been merged in #1553 in the sync constants.

### How was it fixed?

Reverted it.

#### Cute Animal Picture

![a086fc6aac63769c770ec8383d36fae2--animal-jam-animal-pics](https://user-images.githubusercontent.com/824194/49890837-4ec93900-fe02-11e8-842b-4b4370188523.jpg)

