### PR TITLE
Just for fun: Minor speedup on CodeStream.

### DIFF
--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -15,12 +15,16 @@ from eth.vm import opcode_values
 class CodeStream(object):
     stream = None
     depth_processed = None
+    _len = None
+    _value = None
 
     logger = logging.getLogger('eth.vm.CodeStream')
 
     def __init__(self, code_bytes: bytes) -> None:
         validate_is_bytes(code_bytes, title="CodeStream bytes")
         self.stream = io.BytesIO(code_bytes)
+        self._value = code_bytes
+        self._len = len(code_bytes)
         self.invalid_positions = set()  # type: Set[int]
         self.depth_processed = 0
 
@@ -28,7 +32,7 @@ class CodeStream(object):
         return self.stream.read(size)
 
     def __len__(self) -> int:
-        return len(self.stream.getvalue())
+        return self._len
 
     def __iter__(self) -> 'CodeStream':
         return self
@@ -37,7 +41,7 @@ class CodeStream(object):
         return self.next()
 
     def __getitem__(self, i: int) -> int:
-        return self.stream.getvalue()[i]
+        return self._value[i]
 
     def next(self) -> int:
         next_opcode_as_byte = self.read(1)

--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -77,7 +77,7 @@ class CodeStream(object):
     invalid_positions = None
 
     def is_valid_opcode(self, position: int) -> bool:
-        if position >= len(self):
+        if position >= self._length_cache:
             return False
         if position in self.invalid_positions:
             return False

--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -15,16 +15,16 @@ from eth.vm import opcode_values
 class CodeStream(object):
     stream = None
     depth_processed = None
-    _len = None
-    _value = None
+    _length_cache = None
+    _raw_code_bytes = None
 
     logger = logging.getLogger('eth.vm.CodeStream')
 
     def __init__(self, code_bytes: bytes) -> None:
         validate_is_bytes(code_bytes, title="CodeStream bytes")
         self.stream = io.BytesIO(code_bytes)
-        self._value = code_bytes
-        self._len = len(code_bytes)
+        self._raw_code_bytes = code_bytes
+        self._length_cache = len(code_bytes)
         self.invalid_positions = set()  # type: Set[int]
         self.depth_processed = 0
 
@@ -32,7 +32,7 @@ class CodeStream(object):
         return self.stream.read(size)
 
     def __len__(self) -> int:
-        return self._len
+        return self._length_cache
 
     def __iter__(self) -> 'CodeStream':
         return self
@@ -41,7 +41,7 @@ class CodeStream(object):
         return self.next()
 
     def __getitem__(self, i: int) -> int:
-        return self._value[i]
+        return self._raw_code_bytes[i]
 
     def next(self) -> int:
         next_opcode_as_byte = self.read(1)


### PR DESCRIPTION
### What was wrong?

Nothing really, I actually was curious what numba @jit would do in terms of VM speed on all the function of `arithmetic.py` - it had no effect. Then ended up finding this, and seems to be faster, Interested to find if this is just a margin of error (I gave it x3 runs each) ?

Before:
```
------------------------------------------------------------------------------------------------------------------------------------------------
|       Total       |    389.244     |     12504      |       -        |      9012      |         -          | 2,337,825,400  |       -        |
|        Avg        |     4.990      |      160       |     32.124     |      116       |       23.153       |   29,972,121   | 6,006,064.601  |
================================================================================================================================================


```

After:
```

------------------------------------------------------------------------------------------------------------------------------------------------
|       Total       |    366.143     |     12504      |       -        |      9012      |         -          | 2,337,825,400  |       -        |
|        Avg        |     4.694      |      160       |     34.151     |      116       |       24.613       |   29,972,121   | 6,385,013.504  |
================================================================================================================================================

```

### How was it fixed?

Basically caching len & value[x] instead of getvalue[i].

#### Cute Animal Picture

![](https://static.boredpanda.com/blog/wp-content/uploads/2016/05/cute-baby-foxes-cubs-17-574436be67482__880.jpg)
