### PR TITLE
Add `get_fork_version` and `get_domain` helpers

### DIFF
--- a/eth/beacon/enums.py
+++ b/eth/beacon/enums.py
@@ -1,0 +1,21 @@
+from enum import IntEnum
+
+
+class ValidatorStatusCode(IntEnum):
+    PENDING_ACTIVATION = 0
+    ACTIVE = 1
+    PENDING_EXIT = 2
+    EXITED_WITHOUT_PENALTY = 3
+    EXITED_WITH_PENALTY = 4
+
+
+class ValidatorRegistryDeltaFlag(IntEnum):
+    ACTIVATION = 0
+    EXIT = 1
+
+
+class SignatureDomain(IntEnum):
+    DOMAIN_DEPOSIT = 0
+    DOMAIN_ATTESTATION = 1
+    DOMAIN_PROPOSAL = 2
+    DOMAIN_LOGOUT = 3

--- a/eth/beacon/enums.py
+++ b/eth/beacon/enums.py
@@ -4,7 +4,7 @@ from enum import IntEnum
 class ValidatorStatusCode(IntEnum):
     PENDING_ACTIVATION = 0
     ACTIVE = 1
-    PENDING_EXIT = 2
+    ACTIVE_PENDING_EXIT = 2
     EXITED_WITHOUT_PENALTY = 3
     EXITED_WITH_PENALTY = 4
 
@@ -18,4 +18,4 @@ class SignatureDomain(IntEnum):
     DOMAIN_DEPOSIT = 0
     DOMAIN_ATTESTATION = 1
     DOMAIN_PROPOSAL = 2
-    DOMAIN_LOGOUT = 3
+    DOMAIN_EXIT = 3

--- a/eth/beacon/enums/signature_domain.py
+++ b/eth/beacon/enums/signature_domain.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 
 
-class BLSDomain(IntEnum):
+class SignatureDomain(IntEnum):
     DOMAIN_DEPOSIT = 0
     DOMAIN_ATTESTATION = 1
     DOMAIN_PROPOSAL = 2

--- a/eth/beacon/enums/signature_domain.py
+++ b/eth/beacon/enums/signature_domain.py
@@ -1,8 +1,0 @@
-from enum import IntEnum
-
-
-class SignatureDomain(IntEnum):
-    DOMAIN_DEPOSIT = 0
-    DOMAIN_ATTESTATION = 1
-    DOMAIN_PROPOSAL = 2
-    DOMAIN_LOGOUT = 3

--- a/eth/beacon/enums/special_record_types.py
+++ b/eth/beacon/enums/special_record_types.py
@@ -1,8 +1,0 @@
-from enum import IntEnum
-
-
-class SpecialRecordTypes(IntEnum):
-    VOLUNTARY_EXIT = 0
-    CASPER_SLASHING = 1
-    PROPOSER_SLASHING = 2
-    DEPOSIT_PROOF = 3

--- a/eth/beacon/enums/validator_registry_delta_flags.py
+++ b/eth/beacon/enums/validator_registry_delta_flags.py
@@ -1,6 +1,0 @@
-from enum import IntEnum
-
-
-class ValidatorRegistryDeltaFlag(IntEnum):
-    ACTIVATION = 0
-    EXIT = 1

--- a/eth/beacon/enums/validator_status_codes.py
+++ b/eth/beacon/enums/validator_status_codes.py
@@ -1,9 +1,0 @@
-from enum import IntEnum
-
-
-class ValidatorStatusCode(IntEnum):
-    PENDING_ACTIVATION = 0
-    ACTIVE = 1
-    PENDING_EXIT = 2
-    EXITED_WITHOUT_PENALTY = 3
-    EXITED_WITH_PENALTY = 4

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -156,7 +156,7 @@ def get_active_validator_indices(validators: Sequence['ValidatorRecord']) -> Tup
     """
     return tuple(
         i for i, v in enumerate(validators)
-        if v.status in [ValidatorStatusCode.ACTIVE, ValidatorStatusCode.PENDING_EXIT]
+        if v.status in [ValidatorStatusCode.ACTIVE, ValidatorStatusCode.ACTIVE_PENDING_EXIT]
     )
 
 

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -41,9 +41,11 @@ from eth.beacon.utils.random import (
 
 
 if TYPE_CHECKING:
+    from eth.beacon.enums.signature_domain import SignatureDomain  # noqa: F401
     from eth.beacon.types.attestation_records import AttestationRecord  # noqa: F401
     from eth.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
     from eth.beacon.types.states import BeaconState  # noqa: F401
+    from eth.beacon.types.fork_data import ForkData  # noqa: F401
     from eth.beacon.types.validator_records import ValidatorRecord  # noqa: F401
 
 
@@ -393,3 +395,27 @@ def get_new_validator_registry_delta_chain_tip(current_validator_registry_delta_
         # TODO: currently, we use 256-bit pubkey which is different form the spec
         pubkey.to_bytes(32, 'big')
     )
+
+
+def get_fork_version(fork_data: 'ForkData',
+                     slot: int) -> int:
+    """
+    Return the current ``fork_version`` from the given ``fork_data`` and ``slot``.
+    """
+    if slot < fork_data.fork_slot:
+        return fork_data.pre_fork_version
+    else:
+        return fork_data.post_fork_version
+
+
+def get_domain(fork_data: 'ForkData',
+               slot: int,
+               domain_type: 'SignatureDomain') -> int:
+    """
+    Return the domain number of the current fork and ``domain_type``.
+    """
+    # 2 ** 32 = 4294967296
+    return get_fork_version(
+        fork_data,
+        slot,
+    ) * 4294967296 + domain_type

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -28,7 +28,7 @@ from eth.utils.numeric import (
 )
 
 from eth.beacon.block_committees_info import BlockCommitteesInfo
-from eth.beacon.enums.validator_status_codes import (
+from eth.beacon.enums import (
     ValidatorStatusCode,
 )
 from eth.beacon.types.shard_committees import (
@@ -41,7 +41,7 @@ from eth.beacon.utils.random import (
 
 
 if TYPE_CHECKING:
-    from eth.beacon.enums.signature_domain import SignatureDomain  # noqa: F401
+    from eth.beacon.enums import SignatureDomain  # noqa: F401
     from eth.beacon.types.attestation_records import AttestationRecord  # noqa: F401
     from eth.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
     from eth.beacon.types.states import BeaconState  # noqa: F401

--- a/tests/beacon/conftest.py
+++ b/tests/beacon/conftest.py
@@ -9,7 +9,7 @@ from eth.constants import (
 import eth.utils.bls as bls
 from eth.utils.blake import blake
 
-from eth.beacon.enums.validator_status_codes import (
+from eth.beacon.enums import (
     ValidatorStatusCode,
 )
 from eth.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG

--- a/tests/beacon/helpers.py
+++ b/tests/beacon/helpers.py
@@ -1,4 +1,4 @@
-from eth.beacon.enums.validator_status_codes import (
+from eth.beacon.enums import (
     ValidatorStatusCode,
 )
 from eth.beacon.types.validator_records import (

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -503,14 +503,14 @@ def test_get_active_validator_indices(sample_validator_record_params):
     active_validator_indices = get_active_validator_indices(validators)
     assert len(active_validator_indices) == 3
 
-    # Make one validator becomes PENDING_EXIT.
+    # Make one validator becomes ACTIVE_PENDING_EXIT.
     validators[0] = validators[0].copy(
-        status=ValidatorStatusCode.PENDING_EXIT,
+        status=ValidatorStatusCode.ACTIVE_PENDING_EXIT,
     )
     active_validator_indices = get_active_validator_indices(validators)
     assert len(active_validator_indices) == 3
 
-    # Make one validator becomes PENDING_EXIT.
+    # Make one validator becomes EXITED_WITHOUT_PENALTY.
     validators[0] = validators[0].copy(
         status=ValidatorStatusCode.EXITED_WITHOUT_PENALTY,
     )
@@ -677,7 +677,7 @@ def test_get_new_validator_registry_delta_chain_tip(index,
     [
         (0, 0, 0, 0, 0),
         (0, 0, 0, 1, 0),
-        (0, 0, 20, 10, 0),
+        (0, 1, 20, 10, 0),
         (0, 1, 20, 20, 1),
         (0, 1, 10, 20, 1),
     ]

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -14,6 +14,7 @@ from eth.beacon.enums.validator_status_codes import (
     ValidatorStatusCode,
 )
 from eth.beacon.types.blocks import BaseBeaconBlock
+from eth.beacon.types.fork_data import ForkData
 from eth.beacon.types.shard_committees import ShardCommittee
 from eth.beacon.types.states import BeaconState
 from eth.beacon.types.validator_records import ValidatorRecord
@@ -24,6 +25,8 @@ from eth.beacon.helpers import (
     get_beacon_proposer_index,
     get_block_hash,
     get_effective_balance,
+    get_domain,
+    get_fork_version,
     get_hashes_from_latest_block_hashes,
     get_new_shuffling,
     get_new_validator_registry_delta_chain_tip,
@@ -661,3 +664,68 @@ def test_get_new_validator_registry_delta_chain_tip(index,
         flag=flag,
     )
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    (
+        'pre_fork_version,'
+        'post_fork_version,'
+        'fork_slot,'
+        'current_slot,'
+        'expected'
+    ),
+    [
+        (0, 0, 0, 0, 0),
+        (0, 0, 0, 1, 0),
+        (0, 0, 20, 10, 0),
+        (0, 1, 20, 20, 1),
+        (0, 1, 10, 20, 1),
+    ]
+)
+def test_get_fork_version(pre_fork_version,
+                          post_fork_version,
+                          fork_slot,
+                          current_slot,
+                          expected):
+    fork_data = ForkData(
+        pre_fork_version=pre_fork_version,
+        post_fork_version=post_fork_version,
+        fork_slot=fork_slot,
+    )
+    assert expected == get_fork_version(
+        fork_data,
+        current_slot,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        'pre_fork_version,'
+        'post_fork_version,'
+        'fork_slot,'
+        'current_slot,'
+        'domain_type,'
+        'expected'
+    ),
+    [
+        (1, 2, 20, 10, 10, 1 * 2 ** 32 + 10),
+        (1, 2, 20, 20, 11, 2 * 2 ** 32 + 11),
+        (1, 2, 10, 20, 12, 2 * 2 ** 32 + 12),
+    ]
+)
+def test_get_domain(pre_fork_version,
+                    post_fork_version,
+                    fork_slot,
+                    current_slot,
+                    domain_type,
+                    expected):
+    fork_data = ForkData(
+        pre_fork_version=pre_fork_version,
+        post_fork_version=post_fork_version,
+        fork_slot=fork_slot,
+    )
+    assert expected == get_domain(
+        fork_data=fork_data,
+        slot=current_slot,
+        domain_type=domain_type,
+    )

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -10,7 +10,7 @@ from eth.constants import (
 )
 
 
-from eth.beacon.enums.validator_status_codes import (
+from eth.beacon.enums import (
     ValidatorStatusCode,
 )
 from eth.beacon.types.blocks import BaseBeaconBlock


### PR DESCRIPTION
### What was wrong?
#1510 part 3

### How was it fixed?
1. Add `get_fork_version` and `get_domain` and tests. Spec: https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md#get_fork_version
2. Put `ValidatorStatusCode`, `ValidatorRegistryDeltaFlag`, and `SignatureDomain` in `eth/beacon/enums.py`.

#### Cute Animal Picture

![fox-in-snow](https://user-images.githubusercontent.com/9263930/49925283-63392e80-fef3-11e8-901c-d32613eeb227.jpg)

