### PR TITLE
Remove incorrect staticmethod wrapper

### DIFF
--- a/eth/tools/builder/chain/__init__.py
+++ b/eth/tools/builder/chain/__init__.py
@@ -62,7 +62,7 @@ class API:
     constantinople_at = staticmethod(constantinople_at)
 
     # iterable of the fork specific functions
-    mainnet_fork_at_fns = staticmethod(mainnet_fork_at_fns)
+    mainnet_fork_at_fns = mainnet_fork_at_fns
 
     # DAO Fork specific
     dao_fork_at = staticmethod(dao_fork_at)


### PR DESCRIPTION
### What was wrong?

The `mainnet_fork_fns` iterable on the `eth.tools.builder.api` object was incorrectly being wrapped with `staticmethod`.

### How was it fixed?

Removed the wrapper.

#### Cute Animal Picture

![slice-of-bread-cat-costume](https://user-images.githubusercontent.com/824194/49967980-996db280-fee1-11e8-969f-9dd13f2f1dbc.jpg)

