### PR TITLE
Pretty hash display utility

### DIFF
--- a/tests/trinity/core/utils/test_humanize.py
+++ b/tests/trinity/core/utils/test_humanize.py
@@ -44,7 +44,7 @@ def test_humanize_elapsed(seconds, expected):
 @pytest.mark.parametrize(
     'hash32,expected',
     (
-        (bytes(range(32)), '000102..1d1e1f'),
+        (bytes(range(32)), '0001..1e1f'),
     )
 )
 def test_humanize_hash(hash32, expected):

--- a/tests/trinity/core/utils/test_humanize.py
+++ b/tests/trinity/core/utils/test_humanize.py
@@ -1,6 +1,6 @@
 import pytest
 
-from trinity.utils.humanize import humanize_elapsed
+from trinity.utils.humanize import humanize_elapsed, humanize_hash
 
 
 SECOND = 1
@@ -39,3 +39,13 @@ WEEK = 7 * DAY
 def test_humanize_elapsed(seconds, expected):
     actual = humanize_elapsed(seconds)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'hash32,expected',
+    (
+        (bytes(range(32)), '000102..1d1e1f'),
+    )
+)
+def test_humanize_hash(hash32, expected):
+    assert humanize_hash(hash32) == expected

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -65,7 +65,7 @@ from trinity.utils.datastructures import (
     TaskQueue,
 )
 from trinity.utils.ema import EMA
-from trinity.utils.humanize import humanize_elapsed
+from trinity.utils.humanize import humanize_elapsed, humanize_hash
 from trinity.utils.timer import Timer
 
 # (ReceiptBundle, (Receipt, (root_hash, receipt_trie_data))
@@ -537,7 +537,7 @@ class FastChainSyncer(BaseBodyChainSyncer):
                     "bps=%-3d  "
                     "tps=%-4d  "
                     "elapsed=%0.1f  "
-                    "head=#%d (%s...%s)  "
+                    "head=#%d %s  "
                     "age=%s"
                 ),
                 stats.num_blocks,
@@ -546,8 +546,7 @@ class FastChainSyncer(BaseBodyChainSyncer):
                 stats.transactions_per_second,
                 stats.elapsed,
                 stats.latest_head.block_number,
-                stats.latest_head.hex_hash[2:6],
-                stats.latest_head.hex_hash[-4:],
+                humanize_hash(stats.latest_head.hash),
                 humanize_elapsed(head_age),
             )
 

--- a/trinity/utils/humanize.py
+++ b/trinity/utils/humanize.py
@@ -1,5 +1,7 @@
 from typing import Iterator
 
+from eth_typing import Hash32
+
 
 def humanize_elapsed(seconds: int) -> str:
     return ''.join(_humanize_elapsed(seconds))
@@ -44,3 +46,12 @@ def _humanize_elapsed(seconds: int) -> Iterator[str]:
             return
 
         remainder %= duration
+
+
+DISPLAY_HASH_BYTES = 3
+
+
+def humanize_hash(value: Hash32) -> str:
+    head = value[:DISPLAY_HASH_BYTES]
+    tail = value[-1 * DISPLAY_HASH_BYTES:]
+    return f"{head.hex()}..{tail.hex()}"

--- a/trinity/utils/humanize.py
+++ b/trinity/utils/humanize.py
@@ -48,7 +48,7 @@ def _humanize_elapsed(seconds: int) -> Iterator[str]:
         remainder %= duration
 
 
-DISPLAY_HASH_BYTES = 3
+DISPLAY_HASH_BYTES = 2
 
 
 def humanize_hash(value: Hash32) -> str:


### PR DESCRIPTION
### What was wrong?

We're likely to write little bits of hash display code here and there. Better to have a common utility.

Inspired by https://github.com/ethereum/py-evm/pull/1392#discussion_r240773225

### How was it fixed?

Decided to keep it super simple by only supporting the long form.

The short form seems just so short to implement, that it's better not to worry about the utility, like:

```py
f"{header.hash[:4].hex()}"
```

I don't feel super strongly though.

#### Cute Animal Picture

![screenshot_2018-12-13_15-25-22](https://user-images.githubusercontent.com/205327/49973811-63353080-feeb-11e8-8909-8165087b7d9c.png)
_"hash browns"_