### PR TITLE
Option to ignore duplicates in OrderedTaskPreparation

### DIFF
--- a/tests/trinity/utils/test_ordered_task_preparation.py
+++ b/tests/trinity/utils/test_ordered_task_preparation.py
@@ -203,6 +203,21 @@ async def test_no_prereq_tasks():
 
 
 @pytest.mark.asyncio
+async def test_ignore_duplicates():
+    ti = OrderedTaskPreparation(NoPrerequisites, identity, lambda x: x - 1)
+    ti.set_finished_dependency(1)
+    ti.register_tasks((2, ))
+    # this will ignore the 2 task:
+    ti.register_tasks((2, 3), ignore_duplicates=True)
+    # this will be completely ignored:
+    ti.register_tasks((2, 3), ignore_duplicates=True)
+
+    # with no prerequisites, tasks are *immediately* finished, as long as they are in order
+    finished = await wait(ti.ready_tasks())
+    assert finished == (2, 3)
+
+
+@pytest.mark.asyncio
 async def test_register_out_of_order():
     ti = OrderedTaskPreparation(OnePrereq, identity, lambda x: x - 1, accept_dangling_tasks=True)
     ti.set_finished_dependency(1)


### PR DESCRIPTION
### What was wrong?

Some use cases are totally fine with duplicates in `OrderedTaskPreparation`, but they have a bit of boilerplate to overcome the dups.

### How was it fixed?

Add option to drop duplicates when registering tasks.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://theawesomedaily.com/wp-content/uploads/2014/10/cute-animals-twins-14.jpg)