### PR TITLE
Add support for different trinity root dirs

### DIFF
--- a/tests/trinity/conftest.py
+++ b/tests/trinity/conftest.py
@@ -15,6 +15,7 @@ from eth.chains import (
 
 from trinity.constants import (
     NETWORKING_EVENTBUS_ENDPOINT,
+    APP_NAME_ETH1,
 )
 from trinity.chains.coro import (
     AsyncChainMixin,
@@ -53,7 +54,7 @@ def xdg_trinity_root(monkeypatch, tmpdir):
     dir_path = tmpdir.mkdir('trinity')
     monkeypatch.setenv('XDG_TRINITY_ROOT', str(dir_path))
 
-    assert not is_under_path(os.path.expandvars('$HOME'), get_xdg_trinity_root())
+    assert not is_under_path(os.path.expandvars('$HOME'), get_xdg_trinity_root(APP_NAME_ETH1))
 
     return Path(str(dir_path))
 

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -109,6 +109,7 @@ BootFn = Callable[[
 
 def main_entry(trinity_boot: BootFn,
                plugins: Iterable[BasePlugin],
+               app_name: str,
                sub_configs: Iterable[Type[BaseAppConfig]]) -> None:
     event_bus = EventBus(ctx)
     main_endpoint = event_bus.create_endpoint(MAIN_EVENTBUS_ENDPOINT)
@@ -152,7 +153,7 @@ def main_entry(trinity_boot: BootFn,
         setup_log_levels(args.log_levels)
 
     try:
-        trinity_config = TrinityConfig.from_parser_args(args, sub_configs)
+        trinity_config = TrinityConfig.from_parser_args(args, app_name, sub_configs)
     except AmbigiousFileSystem:
         parser.error(TRINITY_AMBIGIOUS_FILESYSTEM_INFO)
 

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -35,6 +35,7 @@ from p2p.constants import (
 )
 
 from trinity.constants import (
+    APP_NAME_ETH1,
     ASSETS_DIR,
     DEFAULT_PREFERRED_NODES,
     MAINNET_NETWORK_ID,
@@ -216,6 +217,7 @@ class TrinityConfig:
 
     def __init__(self,
                  network_id: int,
+                 app_name: str = APP_NAME_ETH1,
                  genesis_config: Dict[str, Any]=None,
                  max_peers: int=25,
                  trinity_root_dir: str=None,
@@ -228,6 +230,7 @@ class TrinityConfig:
                  use_discv5: bool = False,
                  preferred_nodes: Tuple[KademliaNode, ...]=None,
                  bootstrap_nodes: Tuple[KademliaNode, ...]=None) -> None:
+        self.app_name = app_name
         self.network_id = network_id
         self.max_peers = max_peers
         self.sync_mode = sync_mode
@@ -330,7 +333,7 @@ class TrinityConfig:
         if self._trinity_root_dir is not None:
             return self._trinity_root_dir
         else:
-            return get_xdg_trinity_root()
+            return get_xdg_trinity_root(self.app_name)
 
     @trinity_root_dir.setter
     def trinity_root_dir(self, value: str) -> None:
@@ -348,7 +351,7 @@ class TrinityConfig:
         if self._trinity_root_dir is not None:
             return self._trinity_root_dir
         else:
-            return get_xdg_trinity_root()
+            return get_xdg_trinity_root(self.app_name)
 
     @trinity_root_dir.setter
     def trinity_root_dir(self, value: str) -> None:
@@ -452,6 +455,7 @@ class TrinityConfig:
     @classmethod
     def from_parser_args(cls,
                          parser_args: argparse.Namespace,
+                         app_name: str,
                          app_config_types: Iterable[Type['BaseAppConfig']]) -> 'TrinityConfig':
         """
         Helper function for initializing from the namespace object produced by

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -15,6 +15,8 @@ from eth_keys import (
 
 from p2p.kademlia import Address, Node
 
+APP_NAME_ETH1 = 'trinity'
+APP_NAME_BEACON = 'trinity-beacon'
 
 # The file path to the non-python assets
 ASSETS_DIR = Path(__file__).parent / "assets"

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -23,6 +23,9 @@ from trinity.bootstrap import (
     run_database_process,
     setup_plugins,
 )
+from trinity.constants import (
+    APP_NAME_ETH1,
+)
 from trinity.config import (
     TrinityConfig,
     Eth1AppConfig,
@@ -66,7 +69,7 @@ def get_all_plugins() -> Iterable[BasePlugin]:
 
 
 def main() -> None:
-    main_entry(trinity_boot, get_all_plugins(), (Eth1AppConfig,))
+    main_entry(trinity_boot, get_all_plugins(), APP_NAME_ETH1, (Eth1AppConfig,))
 
 
 def trinity_boot(args: Namespace,

--- a/trinity/main_beacon.py
+++ b/trinity/main_beacon.py
@@ -23,6 +23,9 @@ from trinity.config import (
     TrinityConfig,
     BeaconAppConfig
 )
+from trinity.constants import (
+    APP_NAME_BEACON,
+)
 from trinity.events import (
     ShutdownRequest
 )
@@ -42,7 +45,7 @@ from trinity.utils.mp import (
 
 
 def main_beacon() -> None:
-    main_entry(trinity_boot, BASE_PLUGINS, (BeaconAppConfig,))
+    main_entry(trinity_boot, BASE_PLUGINS, APP_NAME_BEACON, (BeaconAppConfig,))
 
 
 def trinity_boot(args: Namespace,

--- a/trinity/utils/xdg.py
+++ b/trinity/utils/xdg.py
@@ -35,11 +35,12 @@ def get_xdg_data_home() -> Path:
         return get_home() / '.local' / 'share'
 
 
-def get_xdg_trinity_root() -> Path:
+def get_xdg_trinity_root(app_name: str) -> Path:
     """
     Returns the base directory under which trinity will store all data.
     """
+    xdg_lookup_key = f'XDG_{app_name.upper()}_ROOT'
     try:
-        return Path(os.environ['XDG_TRINITY_ROOT'])
+        return Path(os.environ[xdg_lookup_key])
     except KeyError:
-        return get_xdg_data_home() / 'trinity'
+        return get_xdg_data_home() / app_name


### PR DESCRIPTION
### What was wrong?

This is a spin off and a continuation of the discussion that started in https://github.com/ethereum/py-evm/pull/1566#discussion_r241366836

Now that we have support for the `trinity-beacon`  command, we still need to sort out how we would like to handle all the files that Trinity saves to discs. Today, that looks roughly like this:

```
/home/cburgdorf/.local/share/trinity
├── mainnet
│   ├── chain
│   │   ├── full
│   │   │   └── db files
│   │   └── light
│   │       └── db files
│   ├── logs
│   │   ├── trinity.log
│   │   ├── ...
│   │   └── trinity.log.7
│   └── nodekey
└── ropsten
    ├── chain
    │   ├── full
    │   │   └── db files
    │   └── light
    │       └── db files
    ├── logs
    │   └── trinity.log
    │   ├── ...
    │   └── trinity.log.7
    └── nodekey
```

For the beacon node, I guess we need a different `nodekey`, we want to keep logs separate and we need different directories for beacon and shard dbs.

My preferred solution, would be to treat the beacon node as an entirely different program and hence maintain an entirely separate root directory which would then roughly look like this.

```
/home/cburgdorf/.local/share/trinity-beacon   <-- notice the different root path
├── mainnet
│   ├── chain
│   │   ├── full
|   |   |     ├── beacon
│   │   │     |     └── db files
|   |   |     ├── shard-1
│   │   │     |     └── db files
|   |   |     └── shard-n
│   │   │           └── db files
│   │   ├── light
|   |   |     ├── beacon
│   │   │     |     └── db files
|   |   |     ├── shard-1
│   │   │     |     └── db files
|   |   |     └── shard-n
│   │   │           └── db files
│   ├── logs
│   │   ├── trinity.log
│   │   ├── ...
│   │   └── trinity.log.7
│   └── nodekey
└── some_future_testnet
     ├── chain
     │   ├── full
     |    |     ├── beacon
     │    │     |     └── db files
     |    |     ├── shard-1
     │    │     |     └── db files
     |    |     └── shard-n
     │    │           └── db files
     │    ├── light
     |    |     ├── beacon
     │    │     |     └── db files
     |    |     ├── shard-1
     │    │     |     └── db files
     |    |     └── shard-n
     │    │           └── db files
     ├── logs
     │   └── trinity.log
     │   ├── ...
     │   └── trinity.log.7
     └── nodekey
```

The alternative to that would be to figure out a new layout that places the beacon node files side by side inside the existing trinity root directory.

However, that would most likely also mean that existing data directories need to be migrated.

I personally think the cleanest thing to do is to treat the beacon node as an entirely different program which we already do by exposing it via a separate `trinity-beacon` command and providing a separate bootstrapping with different plugins etc.

### How was it fixed?

This implements the proposed solution by slightly changing our utils to allow setting using different root directories.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/64JKN7o9Wxo/maxresdefault.jpg)
