### PR TITLE
Correct module namespace in docs guide

### DIFF
--- a/docs/guides/trinity/writing_plugins.rst
+++ b/docs/guides/trinity/writing_plugins.rst
@@ -274,7 +274,7 @@ is started with the ``--report-peer-count`` flag.
    :language: python
    :pyobject: PeerCountReporterPlugin.on_ready
 
-In case of a :class:`~trinity.extensibility.plugin.BaseIsolatedProcessPlugin`, this will cause the
+In case of a :class:`~trinity.extensibility.plugin.BaseIsolatedPlugin`, this will cause the
 :meth:`~trinity.extensibility.plugin.BaseIsolatedPlugin.do_start` method to run on an entirely
 separated, new process. In other cases
 :meth:`~trinity.extensibility.plugin.BaseIsolatedPlugin.do_start` will simply run in the same


### PR DESCRIPTION
### What was wrong?

The "Writing Plugins" guide had a module namespace wrong

### How was it fixed?

Changed it from `BaseIsolatedProcessPlugin` to `BaseIsolatedPlugin` 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/0e/7f/7b/0e7f7b3f029a82e8e797ab6d3525ee5f.jpg)
