### PR TITLE
Add new beacon helpers and implement tests

### DIFF
--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -27,9 +27,8 @@ from eth.utils.numeric import (
     clamp,
 )
 
-from eth.beacon.block_committees_info import BlockCommitteesInfo
-from eth.beacon.enums import (
-    ValidatorStatusCode,
+from eth.beacon.block_committees_info import (
+    BlockCommitteesInfo,
 )
 from eth.beacon.types.shard_committees import (
     ShardCommittee,
@@ -156,7 +155,7 @@ def get_active_validator_indices(validators: Sequence['ValidatorRecord']) -> Tup
     """
     return tuple(
         i for i, v in enumerate(validators)
-        if v.status in [ValidatorStatusCode.ACTIVE, ValidatorStatusCode.ACTIVE_PENDING_EXIT]
+        if v.is_active
     )
 
 

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -430,3 +430,21 @@ def is_double_vote(attestation_data_1: 'AttestationData',
     due to a 'double vote'.
     """
     return attestation_data_1.slot == attestation_data_2.slot
+
+
+def is_surround_vote(attestation_data_1: 'AttestationData',
+                     attestation_data_2: 'AttestationData') -> bool:
+    """
+    Assumes ``attestation_data_1`` is distinct from ``attestation_data_2``.
+
+    Returns True if the provided ``AttestationData`` are slashable
+    due to a 'surround vote'.
+
+    Note: parameter order matters as this function only checks
+    that ``attestation_data_1`` surrounds ``attestation_data_2``.
+    """
+    return (
+        (attestation_data_1.justified_slot < attestation_data_2.justified_slot) and
+        (attestation_data_2.justified_slot + 1 == attestation_data_2.slot) and
+        (attestation_data_2.slot < attestation_data_1.slot)
+    )

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -41,7 +41,6 @@ from eth.beacon.utils.random import (
 
 if TYPE_CHECKING:
     from eth.beacon.enums import SignatureDomain  # noqa: F401
-    from eth.beacon.types.attestation_records import AttestationRecord  # noqa: F401
     from eth.beacon.types.attestation_data import AttestationData  # noqa: F401
     from eth.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
     from eth.beacon.types.states import BeaconState  # noqa: F401

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -42,6 +42,7 @@ from eth.beacon.utils.random import (
 if TYPE_CHECKING:
     from eth.beacon.enums import SignatureDomain  # noqa: F401
     from eth.beacon.types.attestation_records import AttestationRecord  # noqa: F401
+    from eth.beacon.types.attestation_data import AttestationData  # noqa: F401
     from eth.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
     from eth.beacon.types.states import BeaconState  # noqa: F401
     from eth.beacon.types.fork_data import ForkData  # noqa: F401
@@ -418,3 +419,14 @@ def get_domain(fork_data: 'ForkData',
         fork_data,
         slot,
     ) * 4294967296 + domain_type
+
+
+def is_double_vote(attestation_data_1: 'AttestationData',
+                   attestation_data_2: 'AttestationData') -> bool:
+    """
+    Assumes ``attestation_data_1`` is distinct from ``attestation_data_2``.
+
+    Returns True if the provided ``AttestationData`` are slashable
+    due to a 'double vote'.
+    """
+    return attestation_data_1.slot == attestation_data_2.slot

--- a/eth/beacon/types/validator_records.py
+++ b/eth/beacon/types/validator_records.py
@@ -3,6 +3,9 @@ from eth_typing import (
 )
 import rlp
 
+from eth.beacon.enums import (
+    ValidatorStatusCode,
+)
 from eth.rlp.sedes import (
     uint64,
     uint256,
@@ -52,3 +55,13 @@ class ValidatorRecord(rlp.Serializable):
             latest_status_change_slot=latest_status_change_slot,
             exit_count=exit_count,
         )
+
+    @property
+    def is_active(self) -> bool:
+        """
+        Returns ``True`` if the validator is active.
+        """
+        return self.status in [
+            ValidatorStatusCode.ACTIVE,
+            ValidatorStatusCode.ACTIVE_PENDING_EXIT
+        ]

--- a/eth/beacon/types/validator_records.py
+++ b/eth/beacon/types/validator_records.py
@@ -13,6 +13,12 @@ from eth.rlp.sedes import (
 )
 
 
+VALIDATOR_RECORD_ACTIVE_STATUSES = {
+    ValidatorStatusCode.ACTIVE,
+    ValidatorStatusCode.ACTIVE_PENDING_EXIT,
+}
+
+
 class ValidatorRecord(rlp.Serializable):
     """
     Note: using RLP until we have standardized serialization format.
@@ -61,7 +67,4 @@ class ValidatorRecord(rlp.Serializable):
         """
         Returns ``True`` if the validator is active.
         """
-        return self.status in [
-            ValidatorStatusCode.ACTIVE,
-            ValidatorStatusCode.ACTIVE_PENDING_EXIT
-        ]
+        return self.status in VALIDATOR_RECORD_ACTIVE_STATUSES

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -13,6 +13,9 @@ from eth.constants import (
 from eth.beacon.enums import (
     ValidatorStatusCode,
 )
+from eth.beacon.types.attestation_data import (
+    AttestationData,
+)
 from eth.beacon.types.blocks import BaseBeaconBlock
 from eth.beacon.types.fork_data import ForkData
 from eth.beacon.types.shard_committees import ShardCommittee
@@ -32,6 +35,7 @@ from eth.beacon.helpers import (
     get_new_validator_registry_delta_chain_tip,
     _get_shard_committees_at_slot,
     get_block_committees_info,
+    is_double_vote,
 )
 
 
@@ -729,3 +733,27 @@ def test_get_domain(pre_fork_version,
         slot=current_slot,
         domain_type=domain_type,
     )
+
+
+def test_is_double_vote(sample_attestation_data_params):
+    attestation_data_1_params = {
+        **sample_attestation_data_params,
+        'slot': 12345,
+    }
+    attestation_data_1 = AttestationData(**attestation_data_1_params)
+
+    attestation_data_2_params = {
+        **sample_attestation_data_params,
+        'slot': 12345,
+    }
+    attestation_data_2 = AttestationData(**attestation_data_2_params)
+
+    assert is_double_vote(attestation_data_1, attestation_data_2)
+
+    attestation_data_3_params = {
+        **sample_attestation_data_params,
+        'slot': 54321,
+    }
+    attestation_data_3 = AttestationData(**attestation_data_3_params)
+
+    assert not is_double_vote(attestation_data_1, attestation_data_3)

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -760,20 +760,40 @@ def test_is_double_vote(sample_attestation_data_params):
     assert not is_double_vote(attestation_data_1, attestation_data_3)
 
 
-def test_is_surround_vote(sample_attestation_data_params):
+@pytest.mark.parametrize(
+    (
+        'attestation_1_slot,'
+        'attestation_1_justified_slot,'
+        'attestation_2_slot,'
+        'attestation_2_justified_slot,'
+        'expected'
+    ),
+    [
+        (0, 0, 0, 0, False),
+        (4, 3, 3, 2, False),  # not (attestation_1_justified_slot < attestation_2_justified_slot
+        (4, 0, 3, 1, False),  # not (attestation_2_justified_slot + 1 == attestation_2_slot)
+        (4, 0, 4, 3, False),  # not (attestation_2_slot < attestation_1_slot)
+        (4, 0, 3, 2, True),
+    ],
+)
+def test_is_surround_vote(sample_attestation_data_params,
+                          attestation_1_slot,
+                          attestation_1_justified_slot,
+                          attestation_2_slot,
+                          attestation_2_justified_slot,
+                          expected):
     attestation_data_1_params = {
         **sample_attestation_data_params,
-        'slot': 4,
-        'justified_slot': 0,
-
+        'slot': attestation_1_slot,
+        'justified_slot': attestation_1_justified_slot,
     }
     attestation_data_1 = AttestationData(**attestation_data_1_params)
 
     attestation_data_2_params = {
         **sample_attestation_data_params,
-        'slot': 3,
-        'justified_slot': 2,
+        'slot': attestation_2_slot,
+        'justified_slot': attestation_2_justified_slot,
     }
     attestation_data_2 = AttestationData(**attestation_data_2_params)
 
-    assert is_surround_vote(attestation_data_1, attestation_data_2)
+    assert is_surround_vote(attestation_data_1, attestation_data_2) == expected

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -36,6 +36,7 @@ from eth.beacon.helpers import (
     _get_shard_committees_at_slot,
     get_block_committees_info,
     is_double_vote,
+    is_surround_vote,
 )
 
 
@@ -757,3 +758,22 @@ def test_is_double_vote(sample_attestation_data_params):
     attestation_data_3 = AttestationData(**attestation_data_3_params)
 
     assert not is_double_vote(attestation_data_1, attestation_data_3)
+
+
+def test_is_surround_vote(sample_attestation_data_params):
+    attestation_data_1_params = {
+        **sample_attestation_data_params,
+        'slot': 4,
+        'justified_slot': 0,
+
+    }
+    attestation_data_1 = AttestationData(**attestation_data_1_params)
+
+    attestation_data_2_params = {
+        **sample_attestation_data_params,
+        'slot': 3,
+        'justified_slot': 2,
+    }
+    attestation_data_2 = AttestationData(**attestation_data_2_params)
+
+    assert is_surround_vote(attestation_data_1, attestation_data_2)

--- a/tests/beacon/types/test_validator_record.py
+++ b/tests/beacon/types/test_validator_record.py
@@ -27,7 +27,6 @@ def test_is_active(sample_validator_record_params):
     validator = ValidatorRecord(**validator_record_params)
     assert validator.is_active
 
-
     validator_record_params = {
         **sample_validator_record_params,
         'status': ValidatorStatusCode.EXITED_WITHOUT_PENALTY

--- a/tests/beacon/types/test_validator_record.py
+++ b/tests/beacon/types/test_validator_record.py
@@ -1,3 +1,5 @@
+import pytest
+
 from eth.beacon.enums import (
     ValidatorStatusCode,
 )
@@ -12,24 +14,22 @@ def test_defaults(sample_validator_record_params):
     assert validator.withdrawal_credentials == sample_validator_record_params['withdrawal_credentials']  # noqa: E501
 
 
-def test_is_active(sample_validator_record_params):
+@pytest.mark.parametrize(
+    'status,expected',
+    [
+        (ValidatorStatusCode.PENDING_ACTIVATION, False),
+        (ValidatorStatusCode.ACTIVE, True),
+        (ValidatorStatusCode.ACTIVE_PENDING_EXIT, True),
+        (ValidatorStatusCode.EXITED_WITHOUT_PENALTY, False),
+        (ValidatorStatusCode.EXITED_WITH_PENALTY, False),
+    ],
+)
+def test_is_active(sample_validator_record_params,
+                   status,
+                   expected):
     validator_record_params = {
         **sample_validator_record_params,
-        'status': ValidatorStatusCode.ACTIVE
+        'status': status
     }
     validator = ValidatorRecord(**validator_record_params)
-    assert validator.is_active
-
-    validator_record_params = {
-        **sample_validator_record_params,
-        'status': ValidatorStatusCode.ACTIVE_PENDING_EXIT
-    }
-    validator = ValidatorRecord(**validator_record_params)
-    assert validator.is_active
-
-    validator_record_params = {
-        **sample_validator_record_params,
-        'status': ValidatorStatusCode.EXITED_WITHOUT_PENALTY
-    }
-    validator = ValidatorRecord(**validator_record_params)
-    assert not validator.is_active
+    assert validator.is_active == expected

--- a/tests/beacon/types/test_validator_record.py
+++ b/tests/beacon/types/test_validator_record.py
@@ -1,3 +1,6 @@
+from eth.beacon.enums import (
+    ValidatorStatusCode,
+)
 from eth.beacon.types.validator_records import (
     ValidatorRecord,
 )
@@ -7,3 +10,27 @@ def test_defaults(sample_validator_record_params):
     validator = ValidatorRecord(**sample_validator_record_params)
     assert validator.pubkey == sample_validator_record_params['pubkey']
     assert validator.withdrawal_credentials == sample_validator_record_params['withdrawal_credentials']  # noqa: E501
+
+
+def test_is_active(sample_validator_record_params):
+    validator_record_params = {
+        **sample_validator_record_params,
+        'status': ValidatorStatusCode.ACTIVE
+    }
+    validator = ValidatorRecord(**validator_record_params)
+    assert validator.is_active
+
+    validator_record_params = {
+        **sample_validator_record_params,
+        'status': ValidatorStatusCode.ACTIVE_PENDING_EXIT
+    }
+    validator = ValidatorRecord(**validator_record_params)
+    assert validator.is_active
+
+
+    validator_record_params = {
+        **sample_validator_record_params,
+        'status': ValidatorStatusCode.EXITED_WITHOUT_PENALTY
+    }
+    validator = ValidatorRecord(**validator_record_params)
+    assert not validator.is_active


### PR DESCRIPTION
### What was wrong?

See #1609 

### How was it fixed?

- [x] Add `is_active` property to `ValidatorRecord`.
- [x] Refactor `eth.beacon.helpers.get_active_validator_indices`.
- [x] Add relevant tests in `eth/beacon/types/validator_records.py`.
- [x] Implement `eth.beacon.helpers.is_double_vote`.
- [x] Implement tests for `eth.beacon.helpers.is_double_vote`.
- [x] Implement `eth.beacon.helpers.is_surround_vote`.
- [x] Implement tests for `eth.beacon.helpers.is_surround_vote`.


#### Cute Animal Picture

![](https://i.pinimg.com/564x/e5/36/d9/e536d9e09d694cb566817407a254739a.jpg)
