### PR TITLE
Fix #1619, Rename DepositParameters to DepositInput

### DIFF
--- a/eth/beacon/types/deposit_data.py
+++ b/eth/beacon/types/deposit_data.py
@@ -1,7 +1,7 @@
 
 import rlp
 from eth.rlp.sedes import uint64
-from .deposit_parameters import DepositParameters
+from .deposit_input import DepositInput
 
 
 class DepositData(rlp.Serializable):
@@ -9,8 +9,7 @@ class DepositData(rlp.Serializable):
     Not in spec, this is for fields in Deposit
     """
     fields = [
-        # Deposit parameters
-        ('deposit_parameters', DepositParameters),
+        ('deposit_input', DepositInput),
         # Value in Gwei
         ('value', uint64),
         # Timestamp from deposit contract
@@ -18,12 +17,12 @@ class DepositData(rlp.Serializable):
     ]
 
     def __init__(self,
-                 deposit_parameters: DepositParameters,
+                 deposit_input: DepositInput,
                  value: int,
                  timestamp: int) -> None:
 
         super().__init__(
-            deposit_parameters,
+            deposit_input,
             value,
             timestamp,
         )

--- a/eth/beacon/types/deposit_input.py
+++ b/eth/beacon/types/deposit_input.py
@@ -16,7 +16,7 @@ from eth.rlp.sedes import (
 )
 
 
-class DepositParameters(rlp.Serializable):
+class DepositInput(rlp.Serializable):
     """
     Note: using RLP until we have standardized serialization format.
     """

--- a/tests/beacon/conftest.py
+++ b/tests/beacon/conftest.py
@@ -21,7 +21,7 @@ from eth.beacon.types.attestation_data import (
 )
 
 from eth.beacon.types.deposits import DepositData
-from eth.beacon.types.deposit_parameters import DepositParameters
+from eth.beacon.types.deposit_input import DepositInput
 
 from eth.beacon.types.blocks import (
     BeaconBlockBody,
@@ -169,29 +169,30 @@ def sample_crosslink_record_params():
 
 
 @pytest.fixture
-def sample_deposit_parameters_params():
+def sample_deposit_input_params():
     return {
-        # BLS pubkey
         'pubkey': 123,
-        # BLS proof of possession (a BLS signature)
         'proof_of_possession': (0, 0),
-        # Withdrawal credentials
         'withdrawal_credentials': b'\11' * 32,
-        # Initial RANDAO commitment
         'randao_commitment': b'\11' * 32,
     }
 
 
 @pytest.fixture
-def sample_deposit_params(sample_deposit_parameters_params):
+def sample_deposit_data_params(sample_deposit_input_params):
+    return {
+        'deposit_input': DepositInput(**sample_deposit_input_params),
+        'value': 56,
+        'timestamp': 1501851927,
+    }
+
+
+@pytest.fixture
+def sample_deposit_params(sample_deposit_data_params):
     return {
         'merkle_branch': (),
         'merkle_tree_index': 5,
-        'deposit_data': DepositData(
-            deposit_parameters=DepositParameters(**sample_deposit_parameters_params),
-            value=56,
-            timestamp=1501851927,
-        )
+        'deposit_data': DepositData(**sample_deposit_data_params)
     }
 
 

--- a/tests/beacon/types/test_deposit_data.py
+++ b/tests/beacon/types/test_deposit_data.py
@@ -1,0 +1,9 @@
+from eth.beacon.types.deposit_data import DepositData
+
+
+def test_defaults(sample_deposit_data_params):
+    deposit_data = DepositData(**sample_deposit_data_params)
+
+    assert deposit_data.deposit_input.pubkey == sample_deposit_data_params['deposit_input'].pubkey
+    assert deposit_data.value == sample_deposit_data_params['value']
+    assert deposit_data.timestamp == sample_deposit_data_params['timestamp']

--- a/tests/beacon/types/test_deposit_input.py
+++ b/tests/beacon/types/test_deposit_input.py
@@ -1,0 +1,7 @@
+from eth.beacon.types.deposit_input import DepositInput
+
+
+def test_defaults(sample_deposit_input_params):
+    deposit_input = DepositInput(**sample_deposit_input_params)
+
+    assert deposit_input.pubkey == sample_deposit_input_params['pubkey']

--- a/tests/beacon/types/test_deposit_parameters.py
+++ b/tests/beacon/types/test_deposit_parameters.py
@@ -1,7 +1,0 @@
-from eth.beacon.types.deposit_parameters import DepositParameters
-
-
-def test_defaults(sample_deposit_parameters_params):
-    deposit_parameters = DepositParameters(**sample_deposit_parameters_params)
-
-    assert deposit_parameters.pubkey == sample_deposit_parameters_params['pubkey']


### PR DESCRIPTION
### What was wrong?

Reflect https://github.com/ethereum/eth2.0-specs/pull/310/

### How was it fixed?

- Rename DepositParameters to DepositInput
- Add a test for DepositData

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/yZIGP0m.jpg)
