### PR TITLE
Fix #1564, rename hash_ to hash_eth2

### DIFF
--- a/eth/beacon/aggregation.py
+++ b/eth/beacon/aggregation.py
@@ -10,7 +10,6 @@ from eth.utils import bls
 from eth.utils.bitfield import (
     set_voted,
 )
-
 from eth.beacon.enums import SignatureDomain
 
 

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -21,7 +21,7 @@ from eth.utils.bitfield import (
     has_voted,
 )
 from eth.beacon.utils.hash import (
-    hash_,
+    hash_eth2,
 )
 from eth.utils.numeric import (
     clamp,
@@ -371,7 +371,7 @@ def get_new_validator_registry_delta_chain_tip(current_validator_registry_delta_
     """
     Compute the next hash in the validator registry delta hash chain.
     """
-    return hash_(
+    return hash_eth2(
         current_validator_registry_delta_chain_tip +
         flag.to_bytes(1, 'big') +
         index.to_bytes(3, 'big') +

--- a/eth/beacon/types/blocks.py
+++ b/eth/beacon/types/blocks.py
@@ -19,7 +19,7 @@ from eth.rlp.sedes import (
     uint64,
     uint256,
 )
-from eth.beacon.utils.hash import hash_
+from eth.beacon.utils.hash import hash_eth2
 
 from .attestations import Attestation
 from .proposer_slashings import ProposerSlashing
@@ -99,7 +99,7 @@ class BaseBeaconBlock(rlp.Serializable):
     @property
     def hash(self) -> Hash32:
         if self._hash is None:
-            self._hash = hash_(rlp.encode(self))
+            self._hash = hash_eth2(rlp.encode(self))
         return self._hash
 
     @property

--- a/eth/beacon/types/states.py
+++ b/eth/beacon/types/states.py
@@ -20,7 +20,7 @@ from eth.rlp.sedes import (
     hash32,
 )
 from eth.beacon.utils.hash import (
-    hash_,
+    hash_eth2,
 )
 
 from .pending_attestation_records import PendingAttestationRecord
@@ -141,7 +141,7 @@ class BeaconState(rlp.Serializable):
     @property
     def hash(self) -> Hash32:
         if self._hash is None:
-            self._hash = hash_(rlp.encode(self))
+            self._hash = hash_eth2(rlp.encode(self))
         return self._hash
 
     @property

--- a/eth/beacon/utils/hash.py
+++ b/eth/beacon/utils/hash.py
@@ -3,4 +3,9 @@ from eth_hash.auto import keccak
 
 
 def hash_eth2(data: bytes) -> Hash32:
+    """
+    Return Keccak-256 hashed result.
+    Note: it's a placeholder and we aim to migrate to a S[T/N]ARK-friendly hash function in
+    a future Ethereum 2.0 deployment phase.
+    """
     return Hash32(keccak(data))

--- a/eth/beacon/utils/hash.py
+++ b/eth/beacon/utils/hash.py
@@ -2,5 +2,5 @@ from eth_typing import Hash32
 from eth_hash.auto import keccak
 
 
-def hash_(data: bytes) -> Hash32:
+def hash_eth2(data: bytes) -> Hash32:
     return Hash32(keccak(data))

--- a/eth/beacon/utils/random.py
+++ b/eth/beacon/utils/random.py
@@ -15,7 +15,7 @@ from eth_utils import (
 )
 
 from eth.beacon.utils.hash import (
-    hash_,
+    hash_eth2,
 )
 from eth.beacon.constants import (
     RAND_BYTES,
@@ -50,7 +50,7 @@ def shuffle(values: Sequence[Any],
     index = 0
     while index < values_count - 1:
         # Re-hash the `source` to obtain a new pattern of bytes.
-        source = hash_(source)
+        source = hash_eth2(source)
 
         # Iterate through the `source` bytes in 3-byte chunks.
         for position in range(0, 32 - (32 % RAND_BYTES), RAND_BYTES):

--- a/eth/utils/bls.py
+++ b/eth/utils/bls.py
@@ -31,7 +31,7 @@ from py_ecc.optimized_bls12_381 import (  # NOQA
     curve_order,
     final_exponentiate
 )
-from eth.beacon.utils.hash import hash_
+from eth.beacon.utils.hash import hash_eth2
 
 
 G2_cofactor = 305502333931268344200999753193121504214466019254188142667664032982267604182971884026507427359259977847832272839041616661285803823378372096355777062779109  # noqa: E501
@@ -77,8 +77,8 @@ def hash_to_G2(message: bytes, domain: int) -> Tuple[FQ2, FQ2, FQ2]:
     domain_in_bytes = domain.to_bytes(8, 'big')
 
     # Initial candidate x coordinate
-    x_re = big_endian_to_int(hash_(domain_in_bytes + b'\x01' + message))
-    x_im = big_endian_to_int(hash_(domain_in_bytes + b'\x02' + message))
+    x_re = big_endian_to_int(hash_eth2(domain_in_bytes + b'\x01' + message))
+    x_im = big_endian_to_int(hash_eth2(domain_in_bytes + b'\x02' + message))
     x_coordinate = FQ2([x_re, x_im])  # x_re + x_im * i
 
     # Test candidate y coordinates until a one is found

--- a/tests/beacon/conftest.py
+++ b/tests/beacon/conftest.py
@@ -6,7 +6,7 @@ from eth.constants import (
     ZERO_HASH32,
 )
 import eth.utils.bls as bls
-from eth.beacon.utils.hash import hash_
+from eth.beacon.utils.hash import hash_eth2
 
 from eth.beacon.types.proposal_signed_data import (
     ProposalSignedData
@@ -46,7 +46,7 @@ DEFAULT_NUM_VALIDATORS = 40
 
 @pytest.fixture(scope="session")
 def privkeys():
-    return [int.from_bytes(hash_(str(i).encode('utf-8'))[:4], 'big') for i in range(1000)]
+    return [int.from_bytes(hash_eth2(str(i).encode('utf-8'))[:4], 'big') for i in range(1000)]
 
 
 @pytest.fixture(scope="session")

--- a/tests/beacon/db/test_chaindb.py
+++ b/tests/beacon/db/test_chaindb.py
@@ -15,7 +15,7 @@ from eth.exceptions import (
     ParentNotFound,
 )
 from eth.beacon.utils.hash import (
-    hash_,
+    hash_eth2,
 )
 from eth.utils.rlp import (
     validate_rlp_equal,
@@ -68,7 +68,7 @@ def test_chaindb_persist_block_and_slot_to_root(chaindb, block):
 
 @given(seed=st.binary(min_size=32, max_size=32))
 def test_chaindb_persist_block_and_unknown_parent(chaindb, block, seed):
-    n_block = block.copy(parent_root=hash_(seed))
+    n_block = block.copy(parent_root=hash_eth2(seed))
     with pytest.raises(ParentNotFound):
         chaindb.persist_block(n_block)
 

--- a/tests/beacon/types/test_states.py
+++ b/tests/beacon/types/test_states.py
@@ -12,7 +12,7 @@ from eth.beacon.types.crosslink_records import (
     CrosslinkRecord,
 )
 from eth.beacon.utils.hash import (
-    hash_,
+    hash_eth2,
 )
 
 from tests.beacon.helpers import (
@@ -98,4 +98,4 @@ def test_num_crosslink_records(expected,
 
 def test_hash(sample_beacon_state_params):
     state = BeaconState(**sample_beacon_state_params)
-    assert state.root == hash_(rlp.encode(state))
+    assert state.root == hash_eth2(rlp.encode(state))

--- a/tests/beacon/utils/test_hash.py
+++ b/tests/beacon/utils/test_hash.py
@@ -1,11 +1,11 @@
-from eth.beacon.utils.hash import hash_
+from eth.beacon.utils.hash import hash_eth2
 from eth_hash.auto import keccak
 
 
 def test_hash():
-    output = hash_(b'helloworld')
+    output = hash_eth2(b'helloworld')
     assert len(output) == 32
 
 
 def test_hash_is_keccak256():
-    assert hash_(b'foo') == keccak(b'foo')
+    assert hash_eth2(b'foo') == keccak(b'foo')


### PR DESCRIPTION
### What was wrong?

- `hash_` is unclear name for the specific hash that used everywhere in eth2.0

### How was it fixed?

- rename `hash_` to `hash_eth2`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/AnOP69h.jpg)
