### PR TITLE
Remove wrongly placed event_bus.stop()

### DIFF
--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -315,7 +315,6 @@ class BaseIsolatedPlugin(BaseSyncStopPlugin):
         self.do_start()
 
     def do_stop(self) -> None:
-        self.context.event_bus.stop()
         kill_process_gracefully(self._process, self.logger)
 
 


### PR DESCRIPTION
### What was wrong?

While working on #1605 I noticed a wrongly placed `event_bus.stop()`. 

https://github.com/ethereum/py-evm/blob/977a446737569f66ab4c2fb931e3c8417fd16547/trinity/extensibility/plugin.py#L317-L319

The intend of this code is to stop the endpoint for an isolated process but the problem is,  this code runs in the process of the `PluginManager` which is the `main` process.

At best, this just doesn't do anything and at worst it causes weird things.

The real `endpoint.stop()` needs to happen inside the the process of the isolated plugin which in fact every isolated plugin takes care of itself.

E.g. this here

https://github.com/ethereum/py-evm/blob/977a446737569f66ab4c2fb931e3c8417fd16547/trinity/plugins/builtin/json_rpc/plugin.py#L70

boils down to

https://github.com/ethereum/py-evm/blob/977a446737569f66ab4c2fb931e3c8417fd16547/trinity/utils/shutdown.py#L19-L21

Which already does the call but in the correct process.

### How was it fixed?

Removed the wrong call.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/ezgN8PvlLsw/maxresdefault.jpg)
