### PR TITLE
[WIP] Extend round trip API to GetReceipts LES protocol command

### DIFF
--- a/trinity/protocol/les/exchanges.py
+++ b/trinity/protocol/les/exchanges.py
@@ -11,23 +11,27 @@ from eth.rlp.headers import BlockHeader
 from trinity.protocol.common.exchanges import (
     BaseExchange,
 )
+from trinity.protocol.common.types import ReceiptsBundles
 from trinity.utils.les import (
     gen_request_id,
 )
 
 from .normalizers import (
     BlockHeadersNormalizer,
+    ReceiptsNormalizer,
 )
 from .requests import (
     GetBlockHeadersRequest,
+    GetReceiptsRequest,
 )
 from .trackers import (
     GetBlockHeadersTracker,
+    GetReceiptsTracker,
 )
 from .validators import (
     GetBlockHeadersValidator,
     match_payload_request_id,
-)
+    ReceiptsValidator)
 
 TResult = TypeVar('TResult')
 
@@ -53,6 +57,28 @@ class GetBlockHeadersExchange(LESExchange[Tuple[BlockHeader, ...]]):
 
         command_args = original_request_args + (gen_request_id(),)
         request = self.request_class(*command_args)  # type: ignore
+
+        return await self.get_result(
+            request,
+            self._normalizer,
+            validator,
+            match_payload_request_id,
+            timeout,
+        )
+
+
+class GetReceiptsExchange(LESExchange[Tuple[ReceiptsBundles]]):
+    _normalizer = ReceiptsNormalizer()
+    request_class = GetReceiptsRequest
+    tracker_class = GetReceiptsTracker
+
+    async def __call__(self,  # type: ignore
+                       headers: Tuple[BlockHeader, ...],
+                       timeout: float = None) -> ReceiptsBundles:
+        validator = ReceiptsValidator(headers)
+
+        block_hashes = tuple(header.hash for header in headers)
+        request = self.request_class(block_hashes, gen_request_id())
 
         return await self.get_result(
             request,

--- a/trinity/protocol/les/handlers.py
+++ b/trinity/protocol/les/handlers.py
@@ -2,10 +2,14 @@ from trinity.protocol.common.handlers import (
     BaseChainExchangeHandler,
 )
 
-from .exchanges import GetBlockHeadersExchange
+from .exchanges import GetBlockHeadersExchange, GetReceiptsExchange
 
 
 class LESExchangeHandler(BaseChainExchangeHandler):
     _exchange_config = {
         'get_block_headers': GetBlockHeadersExchange,
+        'get_receipts': GetReceiptsExchange,
     }
+
+    # These are needed only to please mypy.
+    get_receipts: GetReceiptsExchange

--- a/trinity/protocol/les/normalizers.py
+++ b/trinity/protocol/les/normalizers.py
@@ -18,3 +18,10 @@ class BlockHeadersNormalizer(LESNormalizer[Tuple[BlockHeader, ...]]):
     def normalize_result(message: Dict[str, Any]) -> Tuple[BlockHeader, ...]:
         result = message['headers']
         return result
+
+
+class ReceiptsNormalizer(LESNormalizer[ReceiptsBundles]):
+    @staticmethod
+    def normalize_result(message: Dict[str, Any]) -> ReceiptsBundles:
+        trie_roots_and_data = tuple(map(make_trie_root_and_nodes, message))
+        return tuple(zip(message, trie_roots_and_data))

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -1,9 +1,13 @@
 from typing import (
     Any,
     Dict,
+    Tuple,
 )
 
-from eth_typing import BlockIdentifier
+from eth_typing import (
+    BlockIdentifier,
+    Hash32,
+)
 
 from p2p.protocol import BaseRequest
 
@@ -16,6 +20,8 @@ from .commands import (
     BlockHeaders,
     GetBlockHeaders,
     GetBlockHeadersQuery,
+    GetReceipts,
+    Receipts,
 )
 
 
@@ -40,7 +46,10 @@ class HeaderRequest(BaseHeaderRequest):
         self.request_id = request_id
 
 
-class GetBlockHeadersRequest(BaseRequest[Dict[str, Any]]):
+LESRequest = BaseRequest[Dict[str, Any]]
+
+
+class GetBlockHeadersRequest(LESRequest):
     cmd_type = GetBlockHeaders
     response_type = BlockHeaders
 
@@ -58,4 +67,17 @@ class GetBlockHeadersRequest(BaseRequest[Dict[str, Any]]):
                 skip,
                 reverse,
             ),
+        }
+
+
+class GetReceiptsRequest(LESRequest):
+    cmd_type = GetReceipts
+    response_type = Receipts
+
+    def __init__(self,
+                 block_hashes: Tuple[Hash32, ...], # Should I take the first element of this tuple?
+                 request_id: int) -> None:
+        self.command_payload = {
+            'request_id': request_id,
+            'block_hashes': block_hashes,
         }

--- a/trinity/protocol/les/trackers.py
+++ b/trinity/protocol/les/trackers.py
@@ -6,11 +6,12 @@ from typing import (
 from eth.rlp.headers import BlockHeader
 
 from trinity.protocol.common.trackers import BasePerformanceTracker
+from trinity.protocol.common.types import ReceiptsBundles
 from trinity.utils.headers import sequence_builder
 
 from .requests import (
     GetBlockHeadersRequest,
-)
+    GetReceiptsRequest)
 
 
 BaseGetBlockHeadersTracker = BasePerformanceTracker[
@@ -36,4 +37,21 @@ class GetBlockHeadersTracker(BaseGetBlockHeadersTracker):
         return len(result)
 
     def _get_result_item_count(self, result: Tuple[BlockHeader, ...]) -> int:
+        return len(result)
+
+
+BaseGetReceiptsTracker = BasePerformanceTracker[
+    GetReceiptsRequest,
+    ReceiptsBundles,
+]
+
+
+class GetReceiptsTracker(BaseGetReceiptsTracker):
+    def _get_request_size(self, request: GetReceiptsRequest) -> Optional[int]:
+        return len(request.command_payload['block_hashes'])
+
+    def _get_result_size(self, result: ReceiptsBundles) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: ReceiptsBundles) -> int:
         return len(result)

--- a/trinity/protocol/les/validators.py
+++ b/trinity/protocol/les/validators.py
@@ -1,20 +1,44 @@
 from typing import (
     Any,
     Dict,
-)
+    Tuple)
 
 from eth_utils import (
     ValidationError,
 )
 
+from eth.rlp.headers import BlockHeader
+from trinity.protocol.common.types import ReceiptsBundles
 from trinity.protocol.common.validators import (
     BaseBlockHeadersValidator,
-)
+    BaseValidator)
 from . import constants
 
 
 class GetBlockHeadersValidator(BaseBlockHeadersValidator):
     protocol_max_request_size = constants.MAX_HEADERS_FETCH
+
+
+class ReceiptsValidator(BaseValidator[ReceiptsBundles]):
+    def __init__(self, headers: Tuple[BlockHeader, ...]) -> None:
+        self.headers = headers
+
+    def validate_result(self, result: ReceiptsBundles) -> None:
+        if not result:
+            # empty result is always valid.
+            return
+
+        expected_receipt_roots = set(header.receipt_root for header in self.headers)
+        actual_receipt_roots = set(
+            root_hash
+            for receipt, (root_hash, trie_data)
+            in result
+        )
+
+        unexpected_roots = actual_receipt_roots.difference(expected_receipt_roots)
+
+        if unexpected_roots:
+            raise ValidationError(f"Got {len(unexpected_roots)} unexpected receipt roots")
 
 
 def match_payload_request_id(request: Dict[str, Any], response: Dict[str, Any]) -> None:


### PR DESCRIPTION
### What was wrong?
The following LES command pair does not have a round trip API available to it.

 * [ ]  `GetReceipts -> Receipts`

### How was it fixed?

Use and/or extend the existing Handler/Manager pattern to implement round trip APIs for these command pairs. At minimum each of these should be tested at the Request level and the Peer level. Feel free to borrow patterns and test cases from the existing tests.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/a4/4d/17/a44d171f83642f12e7774970ebc104a5.jpg)
