### PR TITLE
[WIP] Extend round trip API to GetNodeData LES protocol command

### DIFF
--- a/trinity/protocol/les/exchanges.py
+++ b/trinity/protocol/les/exchanges.py
@@ -5,29 +5,30 @@ from typing import (
     TypeVar,
 )
 
-from eth_typing import BlockIdentifier
+from eth_typing import BlockIdentifier, Hash32
 from eth.rlp.headers import BlockHeader
 
 from trinity.protocol.common.exchanges import (
     BaseExchange,
 )
+from trinity.protocol.common.types import NodeDataBundles
 from trinity.utils.les import (
     gen_request_id,
 )
 
 from .normalizers import (
     BlockHeadersNormalizer,
-)
+    GetNodeDataNormalizer)
 from .requests import (
     GetBlockHeadersRequest,
-)
+    GetNodeDataRequest)
 from .trackers import (
     GetBlockHeadersTracker,
-)
+    GetNodeDataTracker)
 from .validators import (
     GetBlockHeadersValidator,
     match_payload_request_id,
-)
+    GetNodeDataValidator)
 
 TResult = TypeVar('TResult')
 
@@ -54,6 +55,25 @@ class GetBlockHeadersExchange(LESExchange[Tuple[BlockHeader, ...]]):
         command_args = original_request_args + (gen_request_id(),)
         request = self.request_class(*command_args)  # type: ignore
 
+        return await self.get_result(
+            request,
+            self._normalizer,
+            validator,
+            match_payload_request_id,
+            timeout,
+        )
+
+
+class GetNodeDataExchange(LESExchange[Tuple[NodeDataBundles]]):
+    _normalizer = GetNodeDataNormalizer()
+    request_class = GetNodeDataRequest
+    tracker_class = GetNodeDataTracker
+
+    async def __call__(self,  # type: ignore
+                       node_hashes: Tuple[Hash32, ...],
+                       timeout: float = None) -> NodeDataBundles:
+        validator = GetNodeDataValidator(node_hashes)
+        request = self.request_class(node_hashes, gen_request_id())
         return await self.get_result(
             request,
             self._normalizer,

--- a/trinity/protocol/les/handlers.py
+++ b/trinity/protocol/les/handlers.py
@@ -2,10 +2,14 @@ from trinity.protocol.common.handlers import (
     BaseChainExchangeHandler,
 )
 
-from .exchanges import GetBlockHeadersExchange
+from .exchanges import GetBlockHeadersExchange, GetNodeDataExchange
 
 
 class LESExchangeHandler(BaseChainExchangeHandler):
     _exchange_config = {
         'get_block_headers': GetBlockHeadersExchange,
+        'get_node_data': GetNodeDataExchange,
     }
+
+    # These are needed only to please mypy.
+    get_node_data: GetNodeDataExchange

--- a/trinity/protocol/les/normalizers.py
+++ b/trinity/protocol/les/normalizers.py
@@ -5,9 +5,12 @@ from typing import (
     TypeVar,
 )
 
+from eth_utils import keccak
+
 from eth.rlp.headers import BlockHeader
 
 from trinity.protocol.common.normalizers import BaseNormalizer
+from trinity.protocol.common.types import NodeDataBundles
 
 TResult = TypeVar('TResult')
 LESNormalizer = BaseNormalizer[Dict[str, Any], TResult]
@@ -17,4 +20,15 @@ class BlockHeadersNormalizer(LESNormalizer[Tuple[BlockHeader, ...]]):
     @staticmethod
     def normalize_result(message: Dict[str, Any]) -> Tuple[BlockHeader, ...]:
         result = message['headers']
+        return result
+
+
+
+class GetNodeDataNormalizer(LESNormalizer[NodeDataBundles]):
+    is_normalization_slow = True
+
+    @staticmethod
+    def normalize_result(msg: Dict[str, Any]) -> NodeDataBundles:
+        node_keys = tuple(map(keccak, msg))
+        result = tuple(zip(node_keys, msg))
         return result

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -1,15 +1,16 @@
 from typing import (
     Any,
     Dict,
-)
+    Tuple)
 
-from eth_typing import BlockIdentifier
+from eth_typing import BlockIdentifier, Hash32
 
 from p2p.protocol import BaseRequest
 
 from trinity.protocol.common.requests import (
     BaseHeaderRequest,
 )
+from trinity.protocol.eth.commands import GetNodeData, NodeData
 
 from trinity.protocol.les.constants import MAX_HEADERS_FETCH
 from .commands import (
@@ -40,7 +41,10 @@ class HeaderRequest(BaseHeaderRequest):
         self.request_id = request_id
 
 
-class GetBlockHeadersRequest(BaseRequest[Dict[str, Any]]):
+LESRequest = BaseRequest[Dict[str, Any]]
+
+
+class GetBlockHeadersRequest(LESRequest):
     cmd_type = GetBlockHeaders
     response_type = BlockHeaders
 
@@ -58,4 +62,17 @@ class GetBlockHeadersRequest(BaseRequest[Dict[str, Any]]):
                 skip,
                 reverse,
             ),
+        }
+
+
+class GetNodeDataRequest(LESRequest):
+    cmd_type = GetNodeData
+    response_type = NodeData
+
+    def __init__(self,
+                 block_hashes: Tuple[Hash32, ...], # Should I take the first element of this tuple?
+                 request_id: int) -> None:
+        self.command_payload = {
+            'request_id': request_id,
+            'block_hashes': block_hashes,
         }

--- a/trinity/protocol/les/trackers.py
+++ b/trinity/protocol/les/trackers.py
@@ -6,11 +6,12 @@ from typing import (
 from eth.rlp.headers import BlockHeader
 
 from trinity.protocol.common.trackers import BasePerformanceTracker
+from trinity.protocol.common.types import NodeDataBundles
 from trinity.utils.headers import sequence_builder
 
 from .requests import (
     GetBlockHeadersRequest,
-)
+    GetNodeDataRequest)
 
 
 BaseGetBlockHeadersTracker = BasePerformanceTracker[
@@ -36,4 +37,22 @@ class GetBlockHeadersTracker(BaseGetBlockHeadersTracker):
         return len(result)
 
     def _get_result_item_count(self, result: Tuple[BlockHeader, ...]) -> int:
+        return len(result)
+
+
+
+BaseNodeDataTracker = BasePerformanceTracker[
+    GetNodeDataRequest,
+    NodeDataBundles,
+]
+
+
+class GetNodeDataTracker(BaseNodeDataTracker):
+    def _get_request_size(self, request: GetNodeDataRequest) -> Optional[int]:
+        return len(request.command_payload['block_hashes'])
+
+    def _get_result_size(self, result: NodeDataBundles) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: NodeDataBundles) -> int:
         return len(result)

--- a/trinity/protocol/les/validators.py
+++ b/trinity/protocol/les/validators.py
@@ -1,20 +1,43 @@
 from typing import (
     Any,
     Dict,
-)
+    Tuple)
 
+from eth_typing import Hash32
 from eth_utils import (
     ValidationError,
 )
 
+from trinity.protocol.common.types import NodeDataBundles
 from trinity.protocol.common.validators import (
     BaseBlockHeadersValidator,
-)
+    BaseValidator)
 from . import constants
 
 
 class GetBlockHeadersValidator(BaseBlockHeadersValidator):
     protocol_max_request_size = constants.MAX_HEADERS_FETCH
+
+
+class GetNodeDataValidator(BaseValidator[NodeDataBundles]):
+    def __init__(self, node_hashes: Tuple[Hash32, ...]) -> None:
+        self.node_hashes = node_hashes
+
+    def validate_result(self, response: NodeDataBundles) -> None:
+        if not response:
+            # an empty response is always valid
+            return
+
+        node_keys = tuple(node_key for node_key, node in response)
+        node_key_set = set(node_keys)
+
+        if len(node_keys) != len(node_key_set):
+            raise ValidationError("Response may not contain duplicate nodes")
+
+        unexpected_keys = node_key_set.difference(self.node_hashes)
+
+        if unexpected_keys:
+            raise ValidationError(f"Response contains {len(unexpected_keys)} unexpected nodes")
 
 
 def match_payload_request_id(request: Dict[str, Any], response: Dict[str, Any]) -> None:


### PR DESCRIPTION
### What was wrong?
The following LES command pair does not have a round trip API available to it.

 * [ ]  `GetNodeData -> NodeData`

### How was it fixed?

Use and/or extend the existing Handler/Manager pattern to implement round trip APIs for these command pairs. At minimum each of these should be tested at the Request level and the Peer level. Feel free to borrow patterns and test cases from the existing tests.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.thatcutesite.com/uploads/2010/01/animals_working_14.jpg)
