### PR TITLE
Add `make package` target to test packaged release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ docs: build-docs
 linux-docs: build-docs
 	readlink -f docs/_build/html/index.html
 
+package: clean
+	python setup.py sdist bdist_wheel
+	python scripts/release/test_package.py
+
 release: clean
 	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
 	git config commit.gpgSign true

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -91,6 +91,9 @@ GitHub interface and make sure all tests are passing. In general pull requests t
 Releasing
 ~~~~~~~~~
 
+One time setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Pandoc is required for transforming the markdown README to the proper
 format to render correctly on pypi.
 
@@ -106,30 +109,54 @@ Or on OSX:
 
     brew install pandoc
 
-To release a new version:
+Final test before each release
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Before releasing a new version, build and test the package that will be released:
 
 .. code:: sh
 
-    bumpversion $$VERSION_PART_TO_BUMP$$
-    git push && git push --tags
-    make release
+    git checkout master && git pull
 
-How to bumpversion
-^^^^^^^^^^^^^^^^^^
+    make package
+
+    # in another shell, navigate to the virtualenv mentioned in output of ^
+
+    # load the virtualenv with the packaged trinity release
+    source package-smoke-test/bin/activate
+
+    # smoke test the release
+    trinity --ropsten
+
+Push the release to github & pypi
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After confirming that the release package looks okay, release a new version:
+
+.. code:: sh
+
+    make release bump=$$VERSION_PART_TO_BUMP$$
+
+    # While trinity and py-evm are colocated,
+    # manually change trinity & py-evm version in setup_trinity.py
+    make release-trinity
+
+Which version part to bump
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The version format for this repo is ``{major}.{minor}.{patch}`` for
 stable, and ``{major}.{minor}.{patch}-{stage}.{devnum}`` for unstable
 (``stage`` can be alpha or beta).
 
-To issue the next version in line, use bumpversion and specify which
-part to bump, like ``bumpversion minor`` or ``bumpversion devnum``.
+During a release, specify which part to bump, like
+``make release bump=minor`` or ``make release bump=devnum``.
 
-If you are in a beta version, ``bumpversion stage`` will switch to a
+If you are in a beta version, ``make release bump=stage`` will switch to a
 stable.
 
 To issue an unstable version when the current version is stable, specify
 the new version explicitly, like
-``bumpversion --new-version 4.0.0-alpha.1 devnum``
+``make release bump="--new-version 4.0.0-alpha.1 devnum"``
 
 
 How to release docker images

--- a/scripts/release/test_package.py
+++ b/scripts/release/test_package.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+import venv
+
+
+def create_venv(parent_path):
+    venv_path = parent_path / 'package-smoke-test'
+    venv.create(venv_path, with_pip=True)
+    subprocess.run([venv_path / 'bin' / 'pip', 'install', '-U', 'pip', 'setuptools'], check=True)
+    return venv_path
+
+
+def find_wheel(project_path):
+    wheels = list(project_path.glob('dist/*.whl'))
+
+    if len(wheels) != 1:
+        raise Exception(
+            f"Expected one wheel. Instead found: {wheels} in project {project_path.absolute()}"
+        )
+
+    return wheels[0]
+
+
+def install_wheel(venv_path, wheel_path, extras=tuple()):
+    if extras:
+        extra_suffix = f"[{','.join(extras)}]"
+    else:
+        extra_suffix = ""
+
+    subprocess.run(
+        [
+            venv_path / 'bin' / 'pip',
+            'install',
+            f"{wheel_path}{extra_suffix}"
+        ],
+        check=True,
+    )
+
+
+def test_install_local_wheel():
+    temporary_dir = TemporaryDirectory()
+    venv_path = create_venv(Path(temporary_dir.name))
+    wheel_path = find_wheel(Path('.'))
+    install_wheel(venv_path, wheel_path, extras=['p2p', 'trinity'])
+    print("Installed", wheel_path.absolute(), "to", venv_path)
+    print(f"Activate with `source {venv_path}/bin/activate`")
+    input("Press enter when the test has completed. The directory will be deleted.")
+    temporary_dir.cleanup()
+
+
+if __name__ == '__main__':
+    test_install_local_wheel()


### PR DESCRIPTION
### What was wrong?

#1608 release issues - hard/slow/error-prone to test a local package of a release

### How was it fixed?

Add a new script and `Makefile` target.

Works locally, in fact I think I found a bug that would affect the next release. PR for that will show up tomorrow.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/01/16/2e/01162e1f4b46b9fd35673ef7fdcb4089.jpg)
