### PR TITLE
Fix #1635, update pubkey and signature length: `uint256` to `uint384`

### DIFF
--- a/eth/beacon/types/attestations.py
+++ b/eth/beacon/types/attestations.py
@@ -9,7 +9,7 @@ from rlp.sedes import (
 )
 
 from eth.rlp.sedes import (
-    uint256,
+    uint384,
 )
 
 
@@ -29,7 +29,7 @@ class Attestation(rlp.Serializable):
         # Proof of custody bitfield
         ('custody_bitfield', binary),
         # BLS aggregate signature
-        ('aggregate_sig', CountableList(uint256)),
+        ('aggregate_sig', CountableList(uint384)),
     ]
 
     def __init__(self,

--- a/eth/beacon/types/blocks.py
+++ b/eth/beacon/types/blocks.py
@@ -17,7 +17,7 @@ from rlp.sedes import (
 from eth.rlp.sedes import (
     hash32,
     uint64,
-    uint256,
+    uint384,
 )
 from eth.beacon.utils.hash import hash_eth2
 
@@ -62,7 +62,7 @@ class BaseBeaconBlock(rlp.Serializable):
         ('state_root', hash32),
         ('randao_reveal', hash32),
         ('candidate_pow_receipt_root', hash32),
-        ('signature', CountableList(uint256)),
+        ('signature', CountableList(uint384)),
 
         #
         # Body

--- a/eth/beacon/types/deposit_input.py
+++ b/eth/beacon/types/deposit_input.py
@@ -12,7 +12,7 @@ from rlp.sedes import (
 
 from eth.rlp.sedes import (
     hash32,
-    uint256,
+    uint384,
 )
 
 
@@ -22,9 +22,9 @@ class DepositInput(rlp.Serializable):
     """
     fields = [
         # BLS pubkey
-        ('pubkey', uint256),
+        ('pubkey', uint384),
         # BLS proof of possession (a BLS signature)
-        ('proof_of_possession', CountableList(uint256)),
+        ('proof_of_possession', CountableList(uint384)),
         # Withdrawal credentials
         ('withdrawal_credentials', hash32),
         # Initial RANDAO commitment

--- a/eth/beacon/types/exits.py
+++ b/eth/beacon/types/exits.py
@@ -6,7 +6,7 @@ from rlp.sedes import (
 from eth.rlp.sedes import (
     uint24,
     uint64,
-    uint256,
+    uint384,
 )
 
 
@@ -20,7 +20,7 @@ class Exit(rlp.Serializable):
         # Index of the exiting validator
         ('validator_index', uint24),
         # Validator signature
-        ('signature', CountableList(uint256)),
+        ('signature', CountableList(uint384)),
     ]
 
     def __init__(self,

--- a/eth/beacon/types/proposer_slashings.py
+++ b/eth/beacon/types/proposer_slashings.py
@@ -5,7 +5,7 @@ from rlp.sedes import (
 )
 from eth.rlp.sedes import (
     uint24,
-    uint256,
+    uint384,
 )
 from .proposal_signed_data import ProposalSignedData
 
@@ -17,11 +17,11 @@ class ProposerSlashing(rlp.Serializable):
         # First proposal data
         ('proposal_data_1', ProposalSignedData),
         # First proposal signature
-        ('proposal_signature_1', CountableList(uint256)),
+        ('proposal_signature_1', CountableList(uint384)),
         # Second proposal data
         ('proposal_data_2', ProposalSignedData),
         # Second proposal signature
-        ('proposal_signature_2', CountableList(uint256)),
+        ('proposal_signature_2', CountableList(uint384)),
     ]
 
     def __init__(self,

--- a/eth/beacon/types/slashable_vote_data.py
+++ b/eth/beacon/types/slashable_vote_data.py
@@ -7,7 +7,7 @@ from typing import (
 )
 from eth.rlp.sedes import (
     uint24,
-    uint256,
+    uint384,
 )
 from .attestation_data import AttestationData
 
@@ -24,7 +24,7 @@ class SlashableVoteData(rlp.Serializable):
         # Attestation data
         ('data', AttestationData),
         # Aggregate signature
-        ('aggregate_signature', CountableList(uint256)),
+        ('aggregate_signature', CountableList(uint384)),
     ]
 
     def __init__(self,

--- a/eth/beacon/types/validator_records.py
+++ b/eth/beacon/types/validator_records.py
@@ -8,7 +8,7 @@ from eth.beacon.enums import (
 )
 from eth.rlp.sedes import (
     uint64,
-    uint256,
+    uint384,
     hash32,
 )
 
@@ -25,7 +25,7 @@ class ValidatorRecord(rlp.Serializable):
     """
     fields = [
         # BLS public key
-        ('pubkey', uint256),
+        ('pubkey', uint384),
         # Withdrawal credentials
         ('withdrawal_credentials', hash32),
         # RANDAO commitment


### PR DESCRIPTION
### What was wrong?

#1635

### How was it fixed?

- Update whenever `uint384` is in the spec.
- `get_new_validator_registry_delta_chain_tip` untouched, since it will be replaced with tree hash soon.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/fYp1JWj.jpg)
