### PR TITLE
Ensure isolated plugins are stopped concurrently

### DIFF
--- a/docs/api/trinity/extensibility/api.extensibility.plugin.rst
+++ b/docs/api/trinity/extensibility/api.extensibility.plugin.rst
@@ -14,12 +14,6 @@ BasePlugin
 .. autoclass:: trinity.extensibility.plugin.BasePlugin
   :members:
 
-BaseSyncStopPlugin
-------------------
-
-.. autoclass:: trinity.extensibility.plugin.BaseSyncStopPlugin
-  :members:
-
 BaseAsyncStopPlugin
 -------------------
 

--- a/trinity/extensibility/__init__.py
+++ b/trinity/extensibility/__init__.py
@@ -6,7 +6,6 @@ from trinity.extensibility.plugin import (  # noqa: F401
     BaseMainProcessPlugin,
     BaseIsolatedPlugin,
     BasePlugin,
-    BaseSyncStopPlugin,
     DebugPlugin,
     PluginContext,
     TrinityBootInfo,


### PR DESCRIPTION
### What was wrong?

As described in #1605, in current `master` isolated processes are stopped sequentially with blocking calls. The more we are moving towards a multiprocess architecture, the more this is going to be a problem.

One thing to highlight here is that all our current isolated plugins have their own signal handling logic which means they essentially begin unwinding **before** the `PluginManager` tells them to `stop`. However, that's an implementation detail of these plugins.

Here's a comparison taking down trinity with 8 isolated dummy plugins that **do rely on the `PluginManager`** to tell them to stop.

Current Master:

```
^C    INFO  12-18 20:47:09               trinity  Shutting down Trinity (CTRL+C / Keyboard Interrupt)
    INFO  12-18 20:47:09         PluginManager  Shutting down PluginManager with scope <class 'trinity.extensibility.plugin_manager.MainAndIsolatedProcessScope'>
    INFO  12-18 20:47:09         PluginManager  Stopping plugin: Peer Discovery
    INFO  12-18 20:47:09  BasePlugin#Peer Discovery  Sent SIGINT to process 25742, waiting 10 seconds for it to terminate
    INFO  12-18 20:47:09     DiscoveryProtocol  Bootstrapping cancelled: Cancellation requested by DiscoveryBootstrapService token
    INFO  12-18 20:47:14  DiscoveryBootstrapService  Timed out waiting for <trinity.plugins.builtin.peer_discovery.plugin.DiscoveryBootstrapService object at 0x7fa5be16d710> to finish its cleanup, forcibly cancelling pending tasks and exiting anyway
    INFO  12-18 20:47:14              FullNode  Timed out waiting for <trinity.nodes.full.FullNode object at 0x7fc7aec1b748> to finish its cleanup, forcibly cancelling pending tasks and exiting anyway
    INFO  12-18 20:47:15         PluginManager  Shutting down PluginManager with scope <class 'trinity.extensibility.plugin_manager.SharedProcessScope'>
    INFO  12-18 20:47:15  BasePlugin#Peer Discovery  Process 25742 has already terminated
    INFO  12-18 20:47:15         PluginManager  Successfully stopped plugin: Peer Discovery
    INFO  12-18 20:47:15         PluginManager  Stopping plugin: 1
    INFO  12-18 20:47:15          BasePlugin#1  Sent SIGINT to process 25773, waiting 10 seconds for it to terminate
    INFO  12-18 20:47:25          BasePlugin#1  Sent SIGTERM to process 25773, waiting 5 seconds for it to terminate
    INFO  12-18 20:47:25          BasePlugin#1  Process 25773 has already terminated
    INFO  12-18 20:47:25         PluginManager  Successfully stopped plugin: 1
    INFO  12-18 20:47:25         PluginManager  Stopping plugin: 2
    INFO  12-18 20:47:25          BasePlugin#2  Sent SIGINT to process 25781, waiting 10 seconds for it to terminate
    INFO  12-18 20:47:35          BasePlugin#2  Sent SIGTERM to process 25781, waiting 5 seconds for it to terminate
    INFO  12-18 20:47:35          BasePlugin#2  Process 25781 has already terminated
    INFO  12-18 20:47:35         PluginManager  Successfully stopped plugin: 2
    INFO  12-18 20:47:35         PluginManager  Stopping plugin: 3
    INFO  12-18 20:47:35          BasePlugin#3  Sent SIGINT to process 25785, waiting 10 seconds for it to terminate
    INFO  12-18 20:47:45          BasePlugin#3  Sent SIGTERM to process 25785, waiting 5 seconds for it to terminate
    INFO  12-18 20:47:45          BasePlugin#3  Process 25785 has already terminated
    INFO  12-18 20:47:45         PluginManager  Successfully stopped plugin: 3
    INFO  12-18 20:47:45         PluginManager  Stopping plugin: 4
    INFO  12-18 20:47:45          BasePlugin#4  Sent SIGINT to process 25791, waiting 10 seconds for it to terminate
    INFO  12-18 20:47:55          BasePlugin#4  Sent SIGTERM to process 25791, waiting 5 seconds for it to terminate
    INFO  12-18 20:47:55          BasePlugin#4  Process 25791 has already terminated
    INFO  12-18 20:47:55         PluginManager  Successfully stopped plugin: 4
    INFO  12-18 20:47:55         PluginManager  Stopping plugin: 5
    INFO  12-18 20:47:55          BasePlugin#5  Sent SIGINT to process 25795, waiting 10 seconds for it to terminate
    INFO  12-18 20:48:05          BasePlugin#5  Sent SIGTERM to process 25795, waiting 5 seconds for it to terminate
    INFO  12-18 20:48:05          BasePlugin#5  Process 25795 has already terminated
    INFO  12-18 20:48:05         PluginManager  Successfully stopped plugin: 5
    INFO  12-18 20:48:05         PluginManager  Stopping plugin: 6
    INFO  12-18 20:48:05          BasePlugin#6  Sent SIGINT to process 25799, waiting 10 seconds for it to terminate
    INFO  12-18 20:48:15          BasePlugin#6  Sent SIGTERM to process 25799, waiting 5 seconds for it to terminate
    INFO  12-18 20:48:15          BasePlugin#6  Process 25799 has already terminated
    INFO  12-18 20:48:15         PluginManager  Successfully stopped plugin: 6
    INFO  12-18 20:48:15         PluginManager  Stopping plugin: 7
    INFO  12-18 20:48:15          BasePlugin#7  Sent SIGINT to process 25803, waiting 10 seconds for it to terminate
    INFO  12-18 20:48:25          BasePlugin#7  Sent SIGTERM to process 25803, waiting 5 seconds for it to terminate
    INFO  12-18 20:48:25          BasePlugin#7  Process 25803 has already terminated
    INFO  12-18 20:48:25         PluginManager  Successfully stopped plugin: 7
    INFO  12-18 20:48:25         PluginManager  Stopping plugin: 8
    INFO  12-18 20:48:25          BasePlugin#8  Sent SIGINT to process 25807, waiting 10 seconds for it to terminate
    INFO  12-18 20:48:35          BasePlugin#8  Sent SIGTERM to process 25807, waiting 5 seconds for it to terminate
    INFO  12-18 20:48:35          BasePlugin#8  Process 25807 has already terminated
    INFO  12-18 20:48:35         PluginManager  Successfully stopped plugin: 8
    INFO  12-18 20:48:35         PluginManager  Stopping plugin: JSON-RPC Server
    INFO  12-18 20:48:35  BasePlugin#JSON-RPC Server  Sent SIGINT to process 25811, waiting 10 seconds for it to terminate
    INFO  12-18 20:48:35  BasePlugin#JSON-RPC Server  Process 25811 has already terminated
    INFO  12-18 20:48:35         PluginManager  Successfully stopped plugin: JSON-RPC Server
    INFO  12-18 20:48:35               trinity  DB process (pid=25735) terminated
    INFO  12-18 20:48:35               trinity  networking process (pid=25739) terminated
``` 

Notice that it takes **1 minute and 26 seconds** to stop trinity.

Here is the same with the proposed change.

```
^C    INFO  12-18 20:44:56               trinity  Shutting down Trinity (CTRL+C / Keyboard Interrupt)
    INFO  12-18 20:44:56         PluginManager  Shutting down PluginManager with scope <class 'trinity.extensibility.plugin_manager.MainAndIsolatedProcessScope'>
    INFO  12-18 20:44:56            FullServer  Closing server...
    INFO  12-18 20:44:56         PluginManager  Stopping plugin: Peer Discovery
    INFO  12-18 20:44:56         PluginManager  Stopping plugin: 1
    INFO  12-18 20:44:56         PluginManager  Stopping plugin: 2
    INFO  12-18 20:44:56         PluginManager  Stopping plugin: 3
    INFO  12-18 20:44:56         PluginManager  Stopping plugin: 4
    INFO  12-18 20:44:56         PluginManager  Stopping plugin: 5
    INFO  12-18 20:44:56     DiscoveryProtocol  Bootstrapping cancelled: Cancellation requested by DiscoveryBootstrapService token
    INFO  12-18 20:44:56         PluginManager  Stopping plugin: 6
    INFO  12-18 20:44:56         PluginManager  Stopping plugin: 7
    INFO  12-18 20:44:56         PluginManager  Stopping plugin: 8
    INFO  12-18 20:44:56         PluginManager  Stopping plugin: JSON-RPC Server
    INFO  12-18 20:44:56         PluginManager  Sent SIGINT to process 23863, waiting 10 seconds for it to terminate
    INFO  12-18 20:44:56         PluginManager  Sent SIGINT to process 23894, waiting 10 seconds for it to terminate
    INFO  12-18 20:44:56         PluginManager  Sent SIGINT to process 23902, waiting 10 seconds for it to terminate
    INFO  12-18 20:44:56         PluginManager  Sent SIGINT to process 23906, waiting 10 seconds for it to terminate
    INFO  12-18 20:44:56         PluginManager  Sent SIGINT to process 23911, waiting 10 seconds for it to terminate
    INFO  12-18 20:44:56         PluginManager  Sent SIGINT to process 23915, waiting 10 seconds for it to terminate
    INFO  12-18 20:44:56         PluginManager  Sent SIGINT to process 23919, waiting 10 seconds for it to terminate
    INFO  12-18 20:44:56         PluginManager  Sent SIGINT to process 23923, waiting 10 seconds for it to terminate
    INFO  12-18 20:44:56         PluginManager  Sent SIGINT to process 23927, waiting 10 seconds for it to terminate
    INFO  12-18 20:44:56         PluginManager  Sent SIGINT to process 23932, waiting 10 seconds for it to terminate
    INFO  12-18 20:45:01  DiscoveryBootstrapService  Timed out waiting for <trinity.plugins.builtin.peer_discovery.plugin.DiscoveryBootstrapService object at 0x7f050f88b6a0> to finish its cleanup, forcibly cancelling pending tasks and exiting anyway
    INFO  12-18 20:45:01              FullNode  Timed out waiting for <trinity.nodes.full.FullNode object at 0x7f472bf67f60> to finish its cleanup, forcibly cancelling pending tasks and exiting anyway
    INFO  12-18 20:45:02         PluginManager  Shutting down PluginManager with scope <class 'trinity.extensibility.plugin_manager.SharedProcessScope'>
    INFO  12-18 20:45:12         PluginManager  Process 23863 has already terminated
    INFO  12-18 20:45:12         PluginManager  Sent SIGTERM to process 23894, waiting 5 seconds for it to terminate
    INFO  12-18 20:45:12         PluginManager  Sent SIGTERM to process 23902, waiting 5 seconds for it to terminate
    INFO  12-18 20:45:12         PluginManager  Sent SIGTERM to process 23906, waiting 5 seconds for it to terminate
    INFO  12-18 20:45:12         PluginManager  Sent SIGTERM to process 23911, waiting 5 seconds for it to terminate
    INFO  12-18 20:45:12         PluginManager  Sent SIGTERM to process 23915, waiting 5 seconds for it to terminate
    INFO  12-18 20:45:12         PluginManager  Sent SIGTERM to process 23919, waiting 5 seconds for it to terminate
    INFO  12-18 20:45:12         PluginManager  Sent SIGTERM to process 23923, waiting 5 seconds for it to terminate
    INFO  12-18 20:45:12         PluginManager  Sent SIGTERM to process 23927, waiting 5 seconds for it to terminate
    INFO  12-18 20:45:12         PluginManager  Sent SIGTERM to process 23932, waiting 5 seconds for it to terminate
    INFO  12-18 20:45:12         PluginManager  Process 23863 has already terminated
    INFO  12-18 20:45:12         PluginManager  Process 23894 has already terminated
    INFO  12-18 20:45:12         PluginManager  Process 23902 has already terminated
    INFO  12-18 20:45:12         PluginManager  Process 23906 has already terminated
    INFO  12-18 20:45:12         PluginManager  Process 23911 has already terminated
    INFO  12-18 20:45:12         PluginManager  Process 23915 has already terminated
    INFO  12-18 20:45:12         PluginManager  Process 23919 has already terminated
    INFO  12-18 20:45:12         PluginManager  Process 23923 has already terminated
    INFO  12-18 20:45:12         PluginManager  Process 23927 has already terminated
    INFO  12-18 20:45:12         PluginManager  Process 23932 has already terminated
    INFO  12-18 20:45:12         PluginManager  Successfully stopped plugin: Peer Discovery
    INFO  12-18 20:45:12         PluginManager  Successfully stopped plugin: 1
    INFO  12-18 20:45:12         PluginManager  Successfully stopped plugin: 2
    INFO  12-18 20:45:12         PluginManager  Successfully stopped plugin: 3
    INFO  12-18 20:45:12         PluginManager  Successfully stopped plugin: 4
    INFO  12-18 20:45:12         PluginManager  Successfully stopped plugin: 5
    INFO  12-18 20:45:12         PluginManager  Successfully stopped plugin: 6
    INFO  12-18 20:45:12         PluginManager  Successfully stopped plugin: 7
    INFO  12-18 20:45:12         PluginManager  Successfully stopped plugin: 8
    INFO  12-18 20:45:12         PluginManager  Successfully stopped plugin: JSON-RPC Server
    INFO  12-18 20:45:12               trinity  DB process (pid=23856) terminated
    INFO  12-18 20:45:12               trinity  networking process (pid=23860) terminated
Trinity shutdown complete (CTRL+C / Keyboard Interrupt)
``` 

Notice that this takes only **16 seconds** to stop trinity.

### How was it fixed?

Ideally, I would love to have the `stop` method for all plugins to be `async`. However, so far, isolated plugins aren't taken down asynchronously and the reason for that is, that the code that unwinds trinity and all its plugins runs under the assumption that the event loop may or may not be closed already.

To get around this assumption, we would probably need to create a dedicated event loop in another thread and then do something like `dedicated_loop.run_until_complete(async_plugin_takedown())`.

I'm tempted to try this but this PR proposes a different path forward.

Instead, what this PR does is it gives us another helper 

```python
def kill_processes_gracefully(
        processes: Iterable[Process],
        logger: Logger,
        SIGINT_timeout: int=DEFAULT_SIGINT_TIMEOUT,
        SIGTERM_timeout: int=DEFAULT_SIGTERM_TIMEOUT) -> None:
...
``` 

This helper takes an `Iterable[Process]` and then kills them concurrently while maintaining a synchronous API.

The downside of this is, that the `PluginManager` needs to special case this because it needs to collect the different processes from all the isolated plugins.

That said, I don't consider that a big deal. In fact, killing the `BaseSyncStop` abstraction feels like a good thing to me because the `BaseIsolatedPlugin` really was the only one using it so it doesn't feel like a big deal to me.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.monstersandcritics.com/lists/wp-content/uploads/2015/03/cheetahs-running-1024x682.jpg)
