### PR TITLE
Package test: always delete temp dir

### DIFF
--- a/scripts/release/test_package.py
+++ b/scripts/release/test_package.py
@@ -39,14 +39,13 @@ def install_wheel(venv_path, wheel_path, extras=tuple()):
 
 
 def test_install_local_wheel():
-    temporary_dir = TemporaryDirectory()
-    venv_path = create_venv(Path(temporary_dir.name))
-    wheel_path = find_wheel(Path('.'))
-    install_wheel(venv_path, wheel_path, extras=['p2p', 'trinity'])
-    print("Installed", wheel_path.absolute(), "to", venv_path)
-    print(f"Activate with `source {venv_path}/bin/activate`")
-    input("Press enter when the test has completed. The directory will be deleted.")
-    temporary_dir.cleanup()
+    with TemporaryDirectory() as tmpdir:
+        venv_path = create_venv(Path(tmpdir))
+        wheel_path = find_wheel(Path('.'))
+        install_wheel(venv_path, wheel_path, extras=['p2p', 'trinity'])
+        print("Installed", wheel_path.absolute(), "to", venv_path)
+        print(f"Activate with `source {venv_path}/bin/activate`")
+        input("Press enter when the test has completed. The directory will be deleted.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What was wrong?

Some exceptions/scenarios would cause the temporary dir to not be deleted.

Found in post-merge #1630 review

### How was it fixed?

Used the `TemporaryDirectory()` context manager.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/76/28/e0/7628e08ccecb7cc767748d40a1f002ec.jpg)
