### PR TITLE
Add default returns for eth_coinbase, eth_hashrate, eth_gasPrice json rpc calls

### DIFF
--- a/tests/trinity/core/json-rpc/test_ipc.py
+++ b/tests/trinity/core/json-rpc/test_ipc.py
@@ -176,6 +176,14 @@ def mock_network_id(network_id):
             {'result': False, 'id': 3, 'jsonrpc': '2.0'},
         ),
         (
+            build_request('eth_coinbase'),
+            {'result': '0x0000000000000000000000000000000000000000', 'id': 3, 'jsonrpc': '2.0'},
+        ),
+        (
+            build_request('eth_hashrate'),
+            {'result': '0x0', 'id': 3, 'jsonrpc': '2.0'},
+        ),
+        (
             build_request('web3_clientVersion'),
             {'result': construct_trinity_client_identifier(), 'id': 3, 'jsonrpc': '2.0'},
         ),

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -156,8 +156,10 @@ class Eth(RPCModule):
         result = self._chain.get_transaction_result(transaction, header)
         return encode_hex(result)
 
-    async def coinbase(self) -> Hash32:
-        raise NotImplementedError()
+    async def coinbase(self) -> str:
+        # Trinity doesn't support mining yet and hence coinbase_address is default (ZERO_ADDRESS)
+        coinbase_address = ZERO_ADDRESS
+        return encode_hex(coinbase_address)
 
     @format_params(identity, to_int_if_hex)
     async def estimateGas(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
@@ -263,7 +265,9 @@ class Eth(RPCModule):
         return header_to_dict(uncle)
 
     async def hashrate(self) -> str:
-        raise NotImplementedError()
+        # Trinity doesn't support mining yet and hence hashrate is default (0)
+        hashrate = 0
+        return hex(hashrate)
 
     async def mining(self) -> bool:
         return False

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -169,8 +169,17 @@ class Eth(RPCModule):
         gas = self._chain.estimate_gas(transaction, header)
         return hex(gas)
 
-    async def gasPrice(self) -> int:
-        raise NotImplementedError()
+    async def gasPrice(self) -> str:
+        canonical_header = self._chain.get_canonical_head()
+        canonical_block = self._chain.get_block_by_header(canonical_header)
+
+        # Sum of all the gas_price in transactions of the block
+        block_overall_gas_price = 0
+        for transaction in canonical_block.transactions:
+            block_overall_gas_price += transaction.gas_price
+        block_average_gas_price = block_overall_gas_price // len(canonical_block.transactions)
+
+        return hex(block_average_gas_price)
 
     @format_params(decode_hex, to_int_if_hex)
     async def getBalance(self, address: Address, at_block: Union[str, int]) -> str:


### PR DESCRIPTION
### What was wrong?
As part of Issue #835.
Implements `eth_coinbase` and `eth_hashrate` functions. The return values are the default values as `mining` isn't supported by `trinity` as of now.
`eth_gasPrice` currently returns the average of the `gasprices` of all the `transactions` in a `block`.


### How was it fixed?
The functions were `modified/added` to `trinity/rpc/eth.py`


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cosmos-images2.imgix.net/file/spina/photo/14772/GettyImages-691120979.jpg?ixlib=rails-2.1.4&auto=format&ch=Width%2CDPR&fit=max&w=835)
