### PR TITLE
Fix broken imports

### DIFF
--- a/eth/beacon/state_machines/base.py
+++ b/eth/beacon/state_machines/base.py
@@ -7,7 +7,7 @@ from typing import (
     Type,
 )
 
-from eth.utils.datatypes import (
+from eth._utils.datatypes import (
     Configurable,
 )
 

--- a/eth/beacon/state_machines/state_transitions.py
+++ b/eth/beacon/state_machines/state_transitions.py
@@ -3,7 +3,7 @@ from abc import (
     abstractmethod,
 )
 
-from eth.utils.datatypes import (
+from eth._utils.datatypes import (
     Configurable,
 )
 


### PR DESCRIPTION
### What was wrong?

After https://github.com/ethereum/py-evm/pull/1633 was merged, some imports are broken. This is because all `utils` directories where renamed to `_utils` and #1633 did not rebase on top when it landed. Since it provided **new code** that imported from `utils` git could not identify this possible breakage upfront.

### How was it fixed?

Renamed imports to `_utils`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/1f/28/93/1f2893b55738d7049c57fec1d8887dad.jpg)
