### PR TITLE
Move SpoofTransaction out of private namespace

### DIFF
--- a/eth/_utils/spoof.py
+++ b/eth/_utils/spoof.py
@@ -59,8 +59,3 @@ class SpoofAttributes:
         new_target = self.spoof_target.copy(**kwargs)
         new_overrides = merge(self.overrides, kwargs)
         return type(self)(new_target, **new_overrides)
-
-
-class SpoofTransaction(SpoofAttributes):
-    def __init__(self, transaction: BaseTransaction, **overrides: Any) -> None:
-        super().__init__(transaction, **overrides)

--- a/eth/estimators/gas.py
+++ b/eth/estimators/gas.py
@@ -5,7 +5,7 @@ from eth_utils.toolz import curry
 from eth.exceptions import VMError
 
 from eth.rlp.transactions import BaseTransaction
-from eth.spoof import SpoofTransaction
+from eth.vm.spoof import SpoofTransaction
 from eth.vm.state import BaseState
 
 

--- a/eth/estimators/gas.py
+++ b/eth/estimators/gas.py
@@ -1,26 +1,12 @@
-from typing import (
-    Optional,
-)
+from typing import Optional
 
-from cytoolz import (
-    curry,
-)
+from eth_utils.toolz import curry
 
-from eth.exceptions import (
-    VMError,
-)
+from eth.exceptions import VMError
 
-from eth.rlp.transactions import (
-    BaseTransaction,
-)
-
-from eth._utils.spoof import (
-    SpoofTransaction,
-)
-
-from eth.vm.state import (
-    BaseState,
-)
+from eth.rlp.transactions import BaseTransaction
+from eth.spoof import SpoofTransaction
+from eth.vm.state import BaseState
 
 
 def _get_computation_error(state: BaseState, transaction: SpoofTransaction) -> Optional[VMError]:

--- a/eth/typing.py
+++ b/eth/typing.py
@@ -25,15 +25,9 @@ from mypy_extensions import (
 )
 
 if TYPE_CHECKING:
-    from eth.rlp.transactions import (  # noqa: F401
-        BaseTransaction
-    )
-    from eth.spoof import (  # noqa: F401
-        SpoofTransaction
-    )
-    from eth.vm.base import (  # noqa: F401
-        BaseVM
-    )
+    from eth.rlp.transactions import BaseTransaction  # noqa: F401
+    from eth.vm.spoof import SpoofTransaction  # noqa: F401
+    from eth.vm.base import BaseVM  # noqa: F401
 
 
 # TODO: Move into eth_typing

--- a/eth/typing.py
+++ b/eth/typing.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from eth.rlp.transactions import (  # noqa: F401
         BaseTransaction
     )
-    from eth._utils.spoof import (  # noqa: F401
+    from eth.spoof import (  # noqa: F401
         SpoofTransaction
     )
     from eth.vm.base import (  # noqa: F401

--- a/eth/vm/spoof.py
+++ b/eth/vm/spoof.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from eth.rlp.transactions import BaseTransaction
+from eth._utils.spoof import SpoofAttributes
+
+
+class SpoofTransaction(SpoofAttributes):
+    def __init__(self, transaction: BaseTransaction, **overrides: Any) -> None:
+        super().__init__(transaction, **overrides)

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -11,7 +11,7 @@ from eth_utils import (
 
 from eth.chains.base import MiningChain
 
-from eth._utils.spoof import (
+from eth.vm.spoof import (
     SpoofTransaction,
 )
 

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -33,7 +33,7 @@ from eth.rlp.blocks import (
 from eth.rlp.headers import (
     BlockHeader
 )
-from eth._utils.spoof import (
+from eth.vm.spoof import (
     SpoofTransaction,
 )
 from eth.vm.state import (


### PR DESCRIPTION
### What was wrong?

The `SpoofTransaction` data type was located in a private namespace.

### How was it fixed?

Move it to a public namespace so that it can be used by 3rd party libraries.

#### Cute Animal Picture

![cat-in-a-bread-basket](https://user-images.githubusercontent.com/824194/50309864-96347280-045d-11e9-911e-43979314a3b2.jpg)

