### PR TITLE
[WIP] Refactor Stack to eliminate mix types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-benchmark
+  py36-stack-benchmark:
+    <<: *common
+    docker:
+        - image: circleci/python:3.6
+          environment:
+            TOXENV: py36-stack-benchmark
   py36-native-blockchain-byzantium:
     <<: *common
     docker:
@@ -237,6 +243,7 @@ workflows:
       - py36-native-blockchain-transition
       - py36-vm
       - py36-benchmark
+      - py36-stack-benchmark
       - py36-core
       - py36-transactions
       - py36-database

--- a/eth/vm/stack.py
+++ b/eth/vm/stack.py
@@ -102,23 +102,101 @@ class Stack(object):
             raise InsufficientStack("No stack items")
 
     def pop_n(self, num_items: int) -> Tuple[int, ...]:
+        try:
+            return tuple(self._pop_n(num_items))
+        except IndexError:
+            raise InsufficientStack("No stack items")
+
+    def _pop_n(self, num_items: int) -> Tuple[int, ...]:
         for _ in range(num_items):
             try:
                 yield self.values.pop()
             except IndexError:
                 raise InsufficientStack("No stack items")
 
-    def pop2(self) -> Tuple[int, int]:
+    def swap(self, position: int) -> None:
+        """
+        Perform a SWAP operation on the stack.
+        """
+        idx = -1 * position - 1
         try:
-            return (self.values.pop(), self.values.pop())
+            self.values[-1], self.values[idx] = self.values[idx], self.values[-1]
+        except IndexError:
+            raise InsufficientStack("Insufficient stack items for SWAP{0}".format(position))
+
+    def dup(self, position: int) -> None:
+        """
+        Perform a DUP operation on the stack.
+        """
+        idx = -1 * position
+        try:
+            self.push(self.values[idx])
+        except IndexError:
+            raise InsufficientStack("Insufficient stack items for DUP{0}".format(position))
+
+
+class Stack_Old(object):
+    """
+    VM Stack
+    """
+    __slots__ = ['values']
+    logger = logging.getLogger('eth.vm.stack.Stack')
+
+    def __init__(self) -> None:
+        self.values = []  # type: List[Union[int, bytes]]
+
+    def __len__(self) -> int:
+        return len(self.values)
+
+    def push(self, value: Union[int, bytes]) -> None:
+        """
+        Push an item onto the stack.
+        """
+        if len(self.values) > 1023:
+            raise FullStack('Stack limit reached')
+
+        validate_stack_item(value)
+
+        self.values.append(value)
+
+    def pop(self,
+            num_items: int,
+            type_hint: str) -> Union[int, bytes, Tuple[Union[int, bytes], ...]]:
+        """
+        Pop an item off the stack.
+        Note: This function is optimized for speed over readability.
+        """
+        try:
+            if num_items == 1:
+                return next(self._pop(num_items, type_hint))
+            else:
+                return tuple(self._pop(num_items, type_hint))
         except IndexError:
             raise InsufficientStack("No stack items")
 
-    def pop3(self) -> Tuple[int, int, int]:
-        try:
-            return (self.values.pop(), self.values.pop(), self.values.pop())
-        except IndexError:
-            raise InsufficientStack("No stack items")
+    def _pop(self, num_items: int, type_hint: str) -> Generator[Union[int, bytes], None, None]:
+        for _ in range(num_items):
+            if type_hint == constants.UINT256:
+                value = self.values.pop()
+                if isinstance(value, int):
+                    yield value
+                else:
+                    yield big_endian_to_int(value)
+            elif type_hint == constants.BYTES:
+                value = self.values.pop()
+                if isinstance(value, bytes):
+                    yield value
+                else:
+                    yield int_to_big_endian(value)
+            elif type_hint == constants.ANY:
+                yield self.values.pop()
+            else:
+                raise TypeError(
+                    "Unknown type_hint: {0}.  Must be one of {1}".format(
+                        type_hint,
+                        ", ".join((constants.UINT256, constants.BYTES)),
+                    )
+                )
 
     def swap(self, position: int) -> None:
         """

--- a/scripts/stack_benchmark.py
+++ b/scripts/stack_benchmark.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import time
 
 from eth.vm.stack import (

--- a/scripts/stack_benchmark.py
+++ b/scripts/stack_benchmark.py
@@ -1,0 +1,95 @@
+import time
+
+from eth.vm.stack import (
+    Stack,
+    Stack_Old,
+)
+
+
+def push_benchmark():
+    stack = Stack()
+    uint_max = 2**32 - 1
+
+    start_time = time.perf_counter()
+    for _ in range(500):
+        stack.push(uint_max)
+        stack.push(b'\x00' * 32)
+    time_taken_refactored = time.perf_counter() - start_time
+
+    stack_old = Stack_Old()
+    start_time = time.perf_counter()
+    for _ in range(500):
+        stack_old.push(uint_max)
+        stack_old.push(b'\x00' * 32)
+    time_taken_old = time.perf_counter() - start_time
+
+    return time_taken_refactored, time_taken_old
+
+
+def pop_benchmark1():
+    # This is a case which favours the new built Stack
+    stack = Stack()
+    stack_old = Stack_Old()
+
+    for stack_obj in (stack, stack_old):
+        for _ in range(1000):
+            stack_obj.push(b'\x00' * 32)
+
+    start_time = time.perf_counter()
+    stack.pop_n(1000)
+    time_taken_refactored = time.perf_counter() - start_time
+
+    start_time = time.perf_counter()
+    stack_old.pop(1000, "uint256")
+    time_taken_old = time.perf_counter() - start_time
+
+    return time_taken_refactored, time_taken_old
+
+
+def pop_benchmark2():
+    # This is a case which favours the old Stack
+    stack = Stack()
+    stack_old = Stack_Old()
+
+    for stack_obj in (stack, stack_old):
+        for _ in range(1000):
+            stack_obj.push(b'\x00' * 32)
+
+    start_time = time.perf_counter()
+    stack.pop_n(1000)
+    time_taken_refactored = time.perf_counter() - start_time
+
+    start_time = time.perf_counter()
+    stack_old.pop(1000, "bytes")
+    time_taken_old = time.perf_counter() - start_time
+
+    return time_taken_refactored, time_taken_old
+
+
+#push_benchmark()
+#pop_benchmark1()
+#pop_benchmark2()
+
+def main():
+    print("Stack Push of 500 bytestrings and 500 integers")
+    print("----------------------------------------------")
+    refactored_time, old_time = push_benchmark()
+    print("Old Code\t\t|\t{}".format(old_time))
+    print("Refactored Code\t\t|\t{}".format(refactored_time))
+    print("\n\n")
+    
+    print("Stack Pop 1000 times (Pushed 1000 bytestrings)(For old one, expected popped output in int)")
+    print("----------------------------------------------")
+    refactored_time, old_time = pop_benchmark1()
+    print("Old Code\t\t|\t{}".format(old_time))
+    print("Refactored Code\t\t|\t{}".format(refactored_time))
+    print("\n\n")
+
+    print("Stack Pop 1000 times (Pushed 1000 bytestrings)(For old one, expected popped output in bytes)")
+    print("----------------------------------------------")
+    refactored_time, old_time = pop_benchmark2()
+    print("Old Code\t\t|\t{}".format(old_time))
+    print("Refactored Code\t\t|\t{}".format(refactored_time))
+
+
+main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     py{35,36}-{core,database,transactions,vm}
-    py{36}-{benchmark,beacon}
+    py{36}-{benchmark,beacon,stack-benchmark}
     py{35,36}-native-blockchain-{frontier,homestead,eip150,eip158,byzantium,constantinople,metropolis,transition}
     py37-{core,beacon}
     py{35,36}-lint
@@ -55,6 +55,12 @@ commands=
 deps = .[eth-extra,benchmark]
 commands=
     benchmark: {toxinidir}/scripts/benchmark/run.py
+
+
+[testenv:py36-stack-benchmark]
+deps = .[eth-extra,stack-benchmark]
+commands=
+    stack-benchmark: {toxinidir}/scripts/stack_benchmark.py
 
 
 [common-lint]


### PR DESCRIPTION
### What was wrong?
As part of Issue #1656 


### How was it fixed?
The `Stack` now stores only objects of type `int`. It previously also used to store `bytes`. Now the `bytes` are converted to `int` before storing on the stack, and any the `Stack` issues out the popped elements in the form of `int`. It is expected to convert the `integers` to `bytes` at the call site, wherever necessary.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://ichef.bbci.co.uk/images/ic/976x549/p04f5x5v.jpg)
