### PR TITLE
Lazily evaluate vm.previous_hashes

### DIFF
--- a/eth/_utils/generator.py
+++ b/eth/_utils/generator.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import (
+from typing import (  # noqa: F401
     Generic,
     Iterable,
     Iterator,
@@ -12,14 +12,14 @@ TItem = TypeVar('TItem')
 
 
 class CachedIterable(Generic[TItem], Iterable[TItem]):
-    def __init__(self, iterator: Iterable[TItem]) -> None:
-        self._cached_results: List[TItem] = []
-        self._iterator = iterator
+    def __init__(self, iterable: Iterable[TItem]) -> None:
+        self._cached_results = []  # type: List[TItem]
+        self._iterator = iter(iterable)
 
     def __iter__(self) -> Iterator[TItem]:
         return itertools.chain(self._cached_results, self._cache_and_yield())
 
-    def _cache_and_yield(self) -> Iterable[TItem]:
+    def _cache_and_yield(self) -> Iterator[TItem]:
         for item in self._iterator:
             self._cached_results.append(item)
             yield item

--- a/eth/_utils/generator.py
+++ b/eth/_utils/generator.py
@@ -1,0 +1,25 @@
+import itertools
+from typing import (
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    TypeVar,
+)
+
+
+TItem = TypeVar('TItem')
+
+
+class CachedIterable(Generic[TItem], Iterable[TItem]):
+    def __init__(self, iterator: Iterable[TItem]) -> None:
+        self._cached_results: List[TItem] = []
+        self._iterator = iterator
+
+    def __iter__(self) -> Iterator[TItem]:
+        return itertools.chain(self._cached_results, self._cache_and_yield())
+
+    def _cache_and_yield(self) -> Iterable[TItem]:
+        for item in self._iterator:
+            self._cached_results.append(item)
+            yield item

--- a/eth/rlp/headers.py
+++ b/eth/rlp/headers.py
@@ -1,7 +1,7 @@
 import time
 from typing import (
+    Iterable,
     Optional,
-    Tuple,
     Union,
     overload,
 )
@@ -203,7 +203,7 @@ class BlockHeader(rlp.Serializable):
         return header
 
     def create_execution_context(
-            self, prev_hashes: Tuple[Hash32, ...]) -> ExecutionContext:
+            self, prev_hashes: Iterable[Hash32]) -> ExecutionContext:
 
         return ExecutionContext(
             coinbase=self.coinbase,

--- a/eth/vm/execution_context.py
+++ b/eth/vm/execution_context.py
@@ -1,4 +1,6 @@
-from typing import Tuple
+from typing import (
+    Iterable,
+)
 
 from eth_typing import (
     Address,
@@ -22,7 +24,7 @@ class ExecutionContext:
             block_number: int,
             difficulty: int,
             gas_limit: int,
-            prev_hashes: Tuple[Hash32, ...]) -> None:
+            prev_hashes: Iterable[Hash32]) -> None:
         self._coinbase = coinbase
         self._timestamp = timestamp
         self._block_number = block_number
@@ -51,5 +53,5 @@ class ExecutionContext:
         return self._gas_limit
 
     @property
-    def prev_hashes(self) -> Tuple[Hash32, ...]:
+    def prev_hashes(self) -> Iterable[Hash32]:
         return self._prev_hashes

--- a/eth/vm/execution_context.py
+++ b/eth/vm/execution_context.py
@@ -7,6 +7,8 @@ from eth_typing import (
     Hash32,
 )
 
+from eth._utils.generator import CachedIterable
+
 
 class ExecutionContext:
     _coinbase = None
@@ -30,7 +32,7 @@ class ExecutionContext:
         self._block_number = block_number
         self._difficulty = difficulty
         self._gas_limit = gas_limit
-        self._prev_hashes = prev_hashes
+        self._prev_hashes = CachedIterable(prev_hashes)
 
     @property
     def coinbase(self) -> Address:

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -3,7 +3,6 @@ from abc import (
     abstractmethod
 )
 import contextlib
-import itertools
 import logging
 from typing import (  # noqa: F401
     cast,
@@ -20,6 +19,7 @@ from eth_typing import (
     Address,
     Hash32,
 )
+from eth_utils.toolz import nth
 
 from eth.constants import (
     BLANK_ROOT_HASH,
@@ -85,14 +85,11 @@ class BaseState(Configurable, ABC):
     transaction_context_class = None  # type: Type[BaseTransactionContext]
     account_db_class = None  # type: Type[BaseAccountDB]
     transaction_executor = None  # type: Type[BaseTransactionExecutor]
-    prev_hashes_generator_backup = None
 
     def __init__(self, db: BaseDB, execution_context: ExecutionContext, state_root: bytes) -> None:
         self._db = db
         self.execution_context = execution_context
         self.account_db = self.get_account_db_class()(self._db, state_root)
-        if execution_context:
-            self.prev_hashes_generator_backup = execution_context.prev_hashes
 
     #
     # Logging
@@ -201,12 +198,6 @@ class BaseState(Configurable, ABC):
         Return the empty bytestring ``b''`` if the block number is outside of the
         range of available block numbers (typically the last 255 blocks).
         """
-        # Create a copy of the generator so that traversing it doesn't change the
-        # original generator
-        self.prev_hashes_generator_backup, temp_prev_hashes_generator = itertools.tee(
-            self.prev_hashes_generator_backup
-        )
-
         ancestor_depth = self.block_number - block_number - 1
         is_ancestor_depth_out_of_range = (
             ancestor_depth >= MAX_PREV_HEADER_DEPTH or
@@ -216,19 +207,11 @@ class BaseState(Configurable, ABC):
         if is_ancestor_depth_out_of_range:
             return Hash32(b'')
 
-        current_ancestor_depth = 0
-        current_ancestor_hash = None
-        while True:
-            try:
-                current_ancestor_hash = next(temp_prev_hashes_generator)
-            except StopIteration:
-                # Ancestor with specified depth not present
-                return Hash32(b'')
-            if current_ancestor_depth == ancestor_depth:
-                return current_ancestor_hash
-            current_ancestor_depth += 1
-
-        raise Exception("Invariant: unreachable code path")
+        try:
+            return nth(ancestor_depth, self.execution_context.prev_hashes)
+        except StopIteration:
+            # Ancestor with specified depth not present
+            return Hash32(b'')
 
     #
     # Computation

--- a/tests/core/generator-utils/test_cached_iterable.py
+++ b/tests/core/generator-utils/test_cached_iterable.py
@@ -23,3 +23,10 @@ def test_laziness():
     repeated_use = CachedIterable(crash_after_first_val())
     assert first(repeated_use) == 1
     assert first(repeated_use) == 1
+
+
+def test_cached_generator_iterable():
+    input_vals = [2]
+    repeated_use = CachedIterable(input_vals)
+    assert list(repeated_use) == input_vals
+    assert list(repeated_use) == input_vals

--- a/tests/core/generator-utils/test_cached_iteratable.py
+++ b/tests/core/generator-utils/test_cached_iteratable.py
@@ -1,0 +1,25 @@
+from eth._utils.generator import CachedIterable
+
+from eth_utils.toolz import (
+    first,
+    nth,
+)
+import itertools
+
+
+def test_cached_generator():
+    use_once = itertools.count()
+    repeated_use = CachedIterable(use_once)
+
+    for find_val in [1, 0, 10, 5]:
+        assert find_val == nth(find_val, repeated_use)
+
+
+def test_laziness():
+    def crash_after_first_val():
+        yield 1
+        raise Exception("oops, iterated past first value")
+
+    repeated_use = CachedIterable(crash_after_first_val())
+    assert first(repeated_use) == 1
+    assert first(repeated_use) == 1


### PR DESCRIPTION
### What was wrong?
Fixes #648 


### How was it fixed?
The `execution_context` variable and also the `ExecutionContext` class now stores the variable `prev_hashes` or `_prev_hases` as a `Generator` object. Even the function `get_prev_hashes` of `eth/vm/base.py` returns a `generator` object instead of `tuple`.

The `Generator` object is converted to tuple only if `get_ancestor_hash` function of `eth/vm/state.py` is called, which is in turn called only by the `BLOCKHASH` opcode functionality.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://r.ddmcdn.com/w_624/s_f/o_1/cx_0/cy_17/cw_624/ch_416/APL/uploads/2014/06/cute-animals-pictures12.jpg)
