### PR TITLE
Beacon chain Merkle tree APIs

### DIFF
--- a/eth/_utils/merkle.py
+++ b/eth/_utils/merkle.py
@@ -9,6 +9,7 @@ import math
 from typing import (
     cast,
     Hashable,
+    Iterable,
     NewType,
     Sequence,
 )
@@ -20,8 +21,8 @@ from cytoolz import (
     reduce,
     take,
 )
-from eth_hash.auto import (
-    keccak,
+from eth.beacon._utils.hash import (
+    hash_eth2,
 )
 from eth_typing import (
     Hash32,
@@ -36,17 +37,23 @@ MerkleProof = NewType("MerkleProof", Sequence[Hash32])
 
 
 def get_root(tree: MerkleTree) -> Hash32:
-    """Get the root hash of a Merkle tree."""
+    """
+    Get the root hash of a Merkle tree.
+    """
     return tree[0][0]
 
 
-def get_branch_indices(node_index: int, depth: int) -> Sequence[int]:
-    """Get the indices of all ancestors up until the root for a node with a given depth."""
+def get_branch_indices(node_index: int, depth: int) -> Iterable[int]:
+    """
+    Get the indices of all ancestors up until the root for a node with a given depth.
+    """
     return tuple(take(depth, iterate(lambda index: index // 2, node_index)))
 
 
-def get_merkle_proof(tree: MerkleTree, item_index: int) -> Sequence[Hash32]:
-    """Read off the Merkle proof for an item from a Merkle tree."""
+def get_merkle_proof(tree: MerkleTree, item_index: int) -> Iterable[Hash32]:
+    """
+    Read off the Merkle proof for an item from a Merkle tree.
+    """
     if item_index < 0 or item_index >= len(tree[-1]):
         raise ValidationError("Item index out of range")
 
@@ -64,16 +71,20 @@ def get_merkle_proof(tree: MerkleTree, item_index: int) -> Sequence[Hash32]:
 
 
 def _calc_parent_hash(left_node: Hash32, right_node: Hash32) -> Hash32:
-    """Calculate the parent hash of a node and its sibling."""
-    return keccak(left_node + right_node)
+    """
+    Calculate the parent hash of a node and its sibling.
+    """
+    return hash_eth2(left_node + right_node)
 
 
 def verify_merkle_proof(root: Hash32,
                         item: Hashable,
                         item_index: int,
                         proof: MerkleProof) -> bool:
-    """Verify a Merkle proof against a root hash."""
-    leaf = keccak(item)
+    """
+    Verify a Merkle proof against a root hash.
+    """
+    leaf = hash_eth2(item)
     branch_indices = get_branch_indices(item_index, len(proof))
     node_orderers = [
         identity if branch_index % 2 == 0 else reversed
@@ -87,28 +98,83 @@ def verify_merkle_proof(root: Hash32,
     return proof_root == root
 
 
-def _hash_layer(layer: Sequence[Hash32]) -> Sequence[Hash32]:
-    """Calculate the layer on top of another one."""
-    return tuple(_calc_parent_hash(left, right) for left, right in partition(2, layer))
+def _hash_layer(layer: Sequence[Hash32]) -> Iterable[Hash32]:
+    """
+    Calculate the layer on top of another one.
+    """
+    return tuple(
+        _calc_parent_hash(left, right)
+        for left, right in partition(2, layer)
+    )
 
 
 def calc_merkle_tree(items: Sequence[Hashable]) -> MerkleTree:
-    """Calculate the Merkle tree corresponding to a list of items."""
-    if len(items) == 0:
+    """
+    Calculate the Merkle tree corresponding to a list of items.
+    """
+    leaves = tuple(hash_eth2(item) for item in items)
+    return calc_merkle_tree_from_leaves(leaves)
+
+
+def calc_merkle_root(items: Sequence[Hashable]) -> Hash32:
+    """
+    Calculate the Merkle root corresponding to a list of items.
+    """
+    return get_root(calc_merkle_tree(items))
+
+
+def calc_merkle_tree_from_leaves(leaves: Sequence[Hash32]) -> MerkleTree:
+    if len(leaves) == 0:
         raise ValidationError("No items given")
-    n_layers = math.log2(len(items)) + 1
+    n_layers = math.log2(len(leaves)) + 1
     if not n_layers.is_integer():
         raise ValidationError("Item number is not a power of two")
     n_layers = int(n_layers)
-
-    leaves = tuple(keccak(item) for item in items)
-    tree = cast(MerkleTree, tuple(take(n_layers, iterate(_hash_layer, leaves)))[::-1])
+    tree = cast(
+        MerkleTree,
+        tuple(
+            take(
+                n_layers,
+                iterate(_hash_layer, leaves),
+            )
+        )[::-1]
+    )
     if len(tree[0]) != 1:
         raise Exception("Invariant: There must only be one root")
 
     return tree
 
 
-def calc_merkle_root(items: Sequence[Hashable]) -> Hash32:
-    """Calculate the Merkle root corresponding to a list of items."""
-    return get_root(calc_merkle_tree(items))
+def get_merkle_root(leaves: Sequence[Hash32]) -> Hash32:
+    """
+    Return the Merkle root of the given 32-byte hashes.
+    Note: it has to be a full tree, i.e., `len(values)` is an exact power of 2.
+    """
+    return get_root(calc_merkle_tree_from_leaves(leaves))
+
+
+def get_updated_merkle_accumulator(accumulator: Sequence[Hash32],
+                                   position: int,
+                                   value: Hash32) -> Iterable[Hash32]:
+    """
+    Return updated Merkle accumulator.
+
+    In the above case but where `len(leaves)` is not an exact power of 2,
+    any value in `leaves` will be a leaf of at least one Merkle tree whose root is
+    in `accumulator`.
+
+    For example, if `len(leaves) = 329` (note: 333 = 256 + 64 + 8 + 1),
+    then:
+        `accumulator[8] == merkle_root(leaves[0:256])`
+        `accumulator[6] == merkle_root(leaves[256:320])`
+        `accumulator[3] == merkle_root(leaves[320:328])`
+        `accumulator[0] == merkle_root(leaves[328:329])`
+    """
+    accumulator = tuple(accumulator)
+    new_hash = value
+    layer = 0
+    while (position + 1) % 2**(layer + 1) == 0:
+        new_hash = hash_eth2(accumulator[layer] + new_hash)
+        layer += 1
+
+    return accumulator[:layer] + (new_hash, ) + accumulator[layer + 1:]

--- a/eth/_utils/merkle.py
+++ b/eth/_utils/merkle.py
@@ -125,10 +125,10 @@ def calc_merkle_root(items: Sequence[Hashable]) -> Hash32:
 
 def calc_merkle_tree_from_leaves(leaves: Sequence[Hash32]) -> MerkleTree:
     if len(leaves) == 0:
-        raise ValidationError("No items given")
+        raise ValueError("No leaves given")
     n_layers = math.log2(len(leaves)) + 1
     if not n_layers.is_integer():
-        raise ValidationError("Item number is not a power of two")
+        raise ValueError("Number of leaves is not a power of two")
     n_layers = int(n_layers)
     tree = cast(
         MerkleTree,

--- a/eth/beacon/_utils/hash.py
+++ b/eth/beacon/_utils/hash.py
@@ -1,8 +1,12 @@
+from typing import (
+    Hashable,
+)
+
 from eth_typing import Hash32
 from eth_hash.auto import keccak
 
 
-def hash_eth2(data: bytes) -> Hash32:
+def hash_eth2(data: Hashable) -> Hash32:
     """
     Return Keccak-256 hashed result.
     Note: it's a placeholder and we aim to migrate to a S[T/N]ARK-friendly hash function in

--- a/tests/core/merkle-utils/test_merkle_trees.py
+++ b/tests/core/merkle-utils/test_merkle_trees.py
@@ -4,8 +4,11 @@ from eth_utils import (
     ValidationError,
 )
 
-from eth_hash.auto import (
-    keccak,
+from eth.constants import (
+    ZERO_HASH32,
+)
+from eth.beacon._utils.hash import (
+    hash_eth2,
 )
 
 from eth._utils.merkle import (
@@ -13,6 +16,8 @@ from eth._utils.merkle import (
     calc_merkle_tree,
     get_root,
     get_merkle_proof,
+    get_merkle_root,
+    get_updated_merkle_accumulator,
     verify_merkle_proof,
 )
 
@@ -21,41 +26,41 @@ from eth._utils.merkle import (
     (
         (b"single leaf",),
         (
-            (keccak(b"single leaf"),),
+            (hash_eth2(b"single leaf"),),
         ),
     ),
     (
         (b"left", b"right"),
         (
-            (keccak(keccak(b"left") + keccak(b"right")),),
-            (keccak(b"left"), keccak(b"right")),
+            (hash_eth2(hash_eth2(b"left") + hash_eth2(b"right")),),
+            (hash_eth2(b"left"), hash_eth2(b"right")),
         ),
     ),
     (
         (b"1", b"2", b"3", b"4"),
         (
             (
-                keccak(
-                    keccak(
-                        keccak(b"1") + keccak(b"2")
-                    ) + keccak(
-                        keccak(b"3") + keccak(b"4")
+                hash_eth2(
+                    hash_eth2(
+                        hash_eth2(b"1") + hash_eth2(b"2")
+                    ) + hash_eth2(
+                        hash_eth2(b"3") + hash_eth2(b"4")
                     )
                 ),
             ),
             (
-                keccak(
-                    keccak(b"1") + keccak(b"2")
+                hash_eth2(
+                    hash_eth2(b"1") + hash_eth2(b"2")
                 ),
-                keccak(
-                    keccak(b"3") + keccak(b"4")
+                hash_eth2(
+                    hash_eth2(b"3") + hash_eth2(b"4")
                 ),
             ),
             (
-                keccak(b"1"),
-                keccak(b"2"),
-                keccak(b"3"),
-                keccak(b"4"),
+                hash_eth2(b"1"),
+                hash_eth2(b"2"),
+                hash_eth2(b"3"),
+                hash_eth2(b"4"),
             ),
         ),
     ),
@@ -77,32 +82,32 @@ def test_invalid_merkle_root_calculation(leave_number):
     (
         (b"1", b"2"),
         0,
-        (keccak(b"2"),),
+        (hash_eth2(b"2"),),
     ),
     (
         (b"1", b"2"),
         1,
-        (keccak(b"1"),),
+        (hash_eth2(b"1"),),
     ),
     (
         (b"1", b"2", b"3", b"4"),
         0,
-        (keccak(b"2"), keccak(keccak(b"3") + keccak(b"4"))),
+        (hash_eth2(b"2"), hash_eth2(hash_eth2(b"3") + hash_eth2(b"4"))),
     ),
     (
         (b"1", b"2", b"3", b"4"),
         1,
-        (keccak(b"1"), keccak(keccak(b"3") + keccak(b"4"))),
+        (hash_eth2(b"1"), hash_eth2(hash_eth2(b"3") + hash_eth2(b"4"))),
     ),
     (
         (b"1", b"2", b"3", b"4"),
         2,
-        (keccak(b"4"), keccak(keccak(b"1") + keccak(b"2"))),
+        (hash_eth2(b"4"), hash_eth2(hash_eth2(b"1") + hash_eth2(b"2"))),
     ),
     (
         (b"1", b"2", b"3", b"4"),
         3,
-        (keccak(b"3"), keccak(keccak(b"1") + keccak(b"2"))),
+        (hash_eth2(b"3"), hash_eth2(hash_eth2(b"1") + hash_eth2(b"2"))),
     ),
 ])
 def test_merkle_proofs(leaves, index, proof):
@@ -142,3 +147,82 @@ def test_proof_generation_index_validation(leaves):
     for invalid_index in [-1, len(leaves)]:
         with pytest.raises(ValidationError):
             get_merkle_proof(tree, invalid_index)
+
+
+def test_get_merkle_root():
+    hash_0 = b"0" * 32
+    leaves = (hash_0,)
+    root = get_merkle_root(leaves)
+    assert root == hash_0
+
+    hash_1 = b"1" * 32
+    leaves = (hash_0, hash_1)
+    root = get_merkle_root(leaves)
+    assert root == hash_eth2(hash_0 + hash_1)
+
+
+def test_get_updated_merkle_accumulator_three_elements():
+    # Initialize the accumulator
+    accumulator = tuple(
+        ZERO_HASH32
+        for _ in range(8)
+    )
+
+    # Add element 1
+    position = 0
+    value_1 = b"a" * 32
+    accumulator = get_updated_merkle_accumulator(
+        accumulator,
+        position,
+        value_1,
+    )
+    assert accumulator[0] == value_1
+
+    # Add element 2
+    position = 1
+    value_2 = b"b" * 32
+    accumulator = get_updated_merkle_accumulator(
+        accumulator,
+        position,
+        value_2,
+    )
+    assert accumulator[1] == hash_eth2(accumulator[0] + value_2)
+
+    # Add element 3
+    position = 2
+    value_3 = b"c" * 32
+    accumulator = get_updated_merkle_accumulator(
+        accumulator,
+        position,
+        value_3,
+    )
+    assert accumulator[0] == value_3
+
+    leaves = (value_1, value_2, value_3)
+    assert accumulator[1] == get_merkle_root(leaves[0:2])
+    assert accumulator[0] == get_merkle_root(leaves[2:3])
+
+
+def test_get_updated_merkle_accumulator_spec_example():
+    accumulator = tuple(
+        ZERO_HASH32
+        for _ in range(64)
+    )
+
+    leaves = tuple(
+        i.to_bytes(32, 'big')
+        for i in range(329)
+    )
+
+    for i in range(329):
+        accumulator = get_updated_merkle_accumulator(
+            accumulator,
+            position=i,
+            value=leaves[i],
+        )
+
+    # `len(leaves) = 329` (note: 333 = 256 + 64 + 8 + 1)
+    assert accumulator[8] == get_merkle_root(leaves[0:256])
+    assert accumulator[6] == get_merkle_root(leaves[256:320])
+    assert accumulator[3] == get_merkle_root(leaves[320:328])
+    assert accumulator[0] == get_merkle_root(leaves[328:329])

--- a/tests/core/merkle-utils/test_merkle_trees.py
+++ b/tests/core/merkle-utils/test_merkle_trees.py
@@ -74,7 +74,7 @@ def test_merkle_tree_calculation(leaves, tree):
 
 @pytest.mark.parametrize("leave_number", [0, 3, 5, 6, 7, 9])
 def test_invalid_merkle_root_calculation(leave_number):
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValueError):
         calc_merkle_root((b"",) * leave_number)
 
 


### PR DESCRIPTION
### What was wrong?
Fixes #1673

### How was it fixed?
1. Refactor `eth._utils.merkle` APIs
2. Add `get_merkle_root` and `get_updated_merkle_accumulator` (per https://github.com/ethereum/eth2.0-specs/pull/354)

TODO in other PRs:
Not a fan of the dependency of `eth._utils.merkle -> eth.beacon._utils.hash`. I'm thinking about moving them to `eth2._utils` or `eth2.common` if we do https://github.com/ethereum/py-evm/issues/1659 in other PRs.

#### Cute Animal Picture

![xmas_turtle](https://user-images.githubusercontent.com/9263930/50420733-83fa7000-0873-11e9-962d-c61e79f8c97f.jpg)
