### PR TITLE
Add proof of custody placeholders

### DIFF
--- a/eth/beacon/deposit_helpers.py
+++ b/eth/beacon/deposit_helpers.py
@@ -54,11 +54,13 @@ def validate_proof_of_possession(state: BeaconState,
                                  pubkey: BLSPubkey,
                                  proof_of_possession: BLSSignature,
                                  withdrawal_credentials: Hash32,
-                                 randao_commitment: Hash32) -> None:
+                                 randao_commitment: Hash32,
+                                 custody_commitment: Hash32) -> None:
     deposit_input = DepositInput(
         pubkey=pubkey,
         withdrawal_credentials=withdrawal_credentials,
         randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
         proof_of_possession=EMPTY_SIGNATURE,
     )
 
@@ -119,6 +121,7 @@ def process_deposit(*,
                     proof_of_possession: BLSSignature,
                     withdrawal_credentials: Hash32,
                     randao_commitment: Hash32,
+                    custody_commitment: Hash32,
                     zero_balance_validator_ttl: int) -> Tuple[BeaconState, ValidatorIndex]:
     """
     Process a deposit from Ethereum 1.0.
@@ -129,6 +132,7 @@ def process_deposit(*,
         proof_of_possession,
         withdrawal_credentials,
         randao_commitment,
+        custody_commitment,
     )
 
     validator_pubkeys = tuple(v.pubkey for v in state.validator_registry)
@@ -138,6 +142,7 @@ def process_deposit(*,
             withdrawal_credentials=withdrawal_credentials,
             randao_commitment=randao_commitment,
             latest_status_change_slot=state.slot,
+            custody_commitment=custody_commitment,
         )
 
         state, index = add_pending_validator(

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -437,9 +437,9 @@ def generate_aggregate_pubkeys(validators: Sequence['ValidatorRecord'],
     Compute the aggregate pubkey we expect based on
     the proof-of-custody indices found in the ``vote_data``.
     """
-    proof_of_custody_0_indices = vote_data.aggregate_signature_poc_0_indices
-    proof_of_custody_1_indices = vote_data.aggregate_signature_poc_1_indices
-    all_indices = (proof_of_custody_0_indices, proof_of_custody_1_indices)
+    custody_bit_0_indices = vote_data.custody_bit_0_indices
+    custody_bit_1_indices = vote_data.custody_bit_1_indices
+    all_indices = (custody_bit_0_indices, custody_bit_1_indices)
     get_pubkeys = functools.partial(get_pubkey_for_indices, validators)
     return map(
         bls.aggregate_pubkeys,

--- a/eth/beacon/types/attestation_data_and_custody_bits.py
+++ b/eth/beacon/types/attestation_data_and_custody_bits.py
@@ -1,0 +1,50 @@
+import rlp
+from rlp.sedes import (
+    Boolean,
+)
+from eth_typing import (
+    Hash32,
+)
+
+from eth.beacon._utils.hash import (
+    hash_eth2,
+)
+
+from .attestation_data import (
+    AttestationData,
+)
+
+
+class AttestationDataAndCustodyBit(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Attestation data
+        ('data', AttestationData),
+        # Custody bit
+        ('custody_bit', Boolean),
+    ]
+
+    def __init__(self,
+                 data: AttestationData,
+                 custody_bit: bool)-> None:
+
+        super().__init__(
+            data=data,
+            custody_bit=custody_bit,
+        )
+
+    _hash = None
+
+    @property
+    def hash(self) -> Hash32:
+        if self._hash is None:
+            self._hash = hash_eth2(rlp.encode(self.data))
+        return self._hash
+
+    @property
+    def root(self) -> Hash32:
+        # Alias of `hash`.
+        # Using flat hash, will likely use SSZ tree hash.
+        return self.hash

--- a/eth/beacon/types/blocks.py
+++ b/eth/beacon/types/blocks.py
@@ -39,10 +39,13 @@ from eth.beacon.typing import (
 
 
 from .attestations import Attestation
-from .proposer_slashings import ProposerSlashing
+from .custody_challenges import CustodyChallenge
+from .custody_reseeds import CustodyReseed
+from .custody_responses import CustodyResponse
 from .casper_slashings import CasperSlashing
 from .deposits import Deposit
 from .exits import Exit
+from .proposer_slashings import ProposerSlashing
 
 if TYPE_CHECKING:
     from eth.beacon.db.chain import BaseBeaconChainDB  # noqa: F401
@@ -53,20 +56,29 @@ class BaseBeaconBlockBody(rlp.Serializable):
         ('proposer_slashings', CountableList(ProposerSlashing)),
         ('casper_slashings', CountableList(CasperSlashing)),
         ('attestations', CountableList(Attestation)),
+        ('custody_reseeds', CountableList(CustodyReseed)),
+        ('custody_challenges', CountableList(CustodyChallenge)),
+        ('custody_responses', CountableList(CustodyResponse)),
         ('deposits', CountableList(Deposit)),
         ('exits', CountableList(Exit)),
     ]
 
     def __init__(self,
-                 proposer_slashings: Sequence[int],
-                 casper_slashings: Sequence[int],
-                 attestations: Sequence[int],
-                 deposits: Sequence[int],
-                 exits: Sequence[int])-> None:
+                 proposer_slashings: Sequence[ProposerSlashing],
+                 casper_slashings: Sequence[CasperSlashing],
+                 attestations: Sequence[Attestation],
+                 custody_reseeds: Sequence[CustodyReseed],
+                 custody_challenges: Sequence[CustodyResponse],
+                 custody_responses: Sequence[CustodyResponse],
+                 deposits: Sequence[Deposit],
+                 exits: Sequence[Exit])-> None:
         super().__init__(
             proposer_slashings=proposer_slashings,
             casper_slashings=casper_slashings,
             attestations=attestations,
+            custody_reseeds=custody_reseeds,
+            custody_challenges=custody_challenges,
+            custody_responses=custody_responses,
             deposits=deposits,
             exits=exits,
         )
@@ -166,6 +178,9 @@ class BeaconBlock(BaseBeaconBlock):
             proposer_slashings=block.body.proposer_slashings,
             casper_slashings=block.body.casper_slashings,
             attestations=block.body.attestations,
+            custody_reseeds=block.body.custody_reseeds,
+            custody_challenges=block.body.custody_challenges,
+            custody_responses=block.body.custody_responses,
             deposits=block.body.deposits,
             exits=block.body.exits,
         )

--- a/eth/beacon/types/custody_challenges.py
+++ b/eth/beacon/types/custody_challenges.py
@@ -1,0 +1,5 @@
+import rlp
+
+
+class CustodyChallenge(rlp.Serializable):
+    pass

--- a/eth/beacon/types/custody_reseeds.py
+++ b/eth/beacon/types/custody_reseeds.py
@@ -1,0 +1,5 @@
+import rlp
+
+
+class CustodyReseed(rlp.Serializable):
+    pass

--- a/eth/beacon/types/custody_responses.py
+++ b/eth/beacon/types/custody_responses.py
@@ -1,0 +1,5 @@
+import rlp
+
+
+class CustodyResponse(rlp.Serializable):
+    pass

--- a/eth/beacon/types/deposit_input.py
+++ b/eth/beacon/types/deposit_input.py
@@ -29,6 +29,8 @@ class DepositInput(rlp.Serializable):
         ('withdrawal_credentials', hash32),
         # Initial RANDAO commitment
         ('randao_commitment', hash32),
+        # Initial proof of custody commitment
+        ('custody_commitment', hash32),
         # BLS proof of possession (a BLS signature)
         ('proof_of_possession', CountableList(uint384)),
     ]
@@ -37,11 +39,13 @@ class DepositInput(rlp.Serializable):
                  pubkey: BLSPubkey,
                  withdrawal_credentials: Hash32,
                  randao_commitment: Hash32,
+                 custody_commitment: Hash32,
                  proof_of_possession: BLSSignature=EMPTY_SIGNATURE) -> None:
         super().__init__(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
             randao_commitment=randao_commitment,
+            custody_commitment=custody_commitment,
             proof_of_possession=proof_of_possession,
         )
 

--- a/eth/beacon/types/pending_attestation_records.py
+++ b/eth/beacon/types/pending_attestation_records.py
@@ -25,9 +25,9 @@ class PendingAttestationRecord(rlp.Serializable):
         ('data', AttestationData),
         # Attester participation bitfield
         ('participation_bitfield', binary),
-        # Proof of custody bitfield
+        # Custody bitfield
         ('custody_bitfield', binary),
-        # Slot in which it was included
+        # Slot the attestation was included
         ('slot_included', uint64),
     ]
 

--- a/eth/beacon/types/states.py
+++ b/eth/beacon/types/states.py
@@ -65,8 +65,7 @@ class BeaconState(rlp.Serializable):
         ('persistent_committees', CountableList(CountableList(uint24))),
         ('persistent_committee_reassignments', CountableList(ShardReassignmentRecord)),
 
-
-        # Proof of custody
+        # Custody challenges
         ('custody_challenges', CountableList(CustodyChallenge)),
 
         # Finality

--- a/eth/beacon/types/states.py
+++ b/eth/beacon/types/states.py
@@ -33,6 +33,7 @@ from eth.beacon.typing import (
 
 from .pending_attestation_records import PendingAttestationRecord
 from .candidate_pow_receipt_root_records import CandidatePoWReceiptRootRecord
+from .custody_challenges import CustodyChallenge
 from .crosslink_records import CrosslinkRecord
 from .fork_data import ForkData
 from .shard_committees import ShardCommittee
@@ -63,6 +64,10 @@ class BeaconState(rlp.Serializable):
         ('shard_committees_at_slots', CountableList(CountableList((ShardCommittee)))),
         ('persistent_committees', CountableList(CountableList(uint24))),
         ('persistent_committee_reassignments', CountableList(ShardReassignmentRecord)),
+
+
+        # Proof of custody
+        ('custody_challenges', CountableList(CustodyChallenge)),
 
         # Finality
         ('previous_justified_slot', uint64),
@@ -103,6 +108,7 @@ class BeaconState(rlp.Serializable):
             shard_committees_at_slots: Sequence[Sequence[ShardCommittee]]=(),
             persistent_committees: Sequence[Sequence[ValidatorIndex]]=(),
             persistent_committee_reassignments: Sequence[ShardReassignmentRecord]=(),
+            custody_challenges: Sequence[CustodyChallenge]=(),
             latest_crosslinks: Sequence[CrosslinkRecord]=(),
             latest_block_roots: Sequence[Hash32]=(),
             latest_penalized_exit_balances: Sequence[Gwei]=(),
@@ -127,6 +133,8 @@ class BeaconState(rlp.Serializable):
             shard_committees_at_slots=shard_committees_at_slots,
             persistent_committees=persistent_committees,
             persistent_committee_reassignments=persistent_committee_reassignments,
+            # Proof of Custody
+            custody_challenges=custody_challenges,
             # Finality
             previous_justified_slot=previous_justified_slot,
             justified_slot=justified_slot,

--- a/eth/beacon/types/validator_records.py
+++ b/eth/beacon/types/validator_records.py
@@ -42,6 +42,11 @@ class ValidatorRecord(rlp.Serializable):
         ('latest_status_change_slot', uint64),
         # Sequence number when validator exited (or 0)
         ('exit_count', uint64),
+        # Proof of custody commitment
+        ('custody_commitment', hash32),
+        # Slot the proof of custody seed was last changed
+        ('latest_custody_reseed_slot', uint64),
+        ('penultimate_custody_reseed_slot', uint64),
     ]
 
     def __init__(self,
@@ -51,7 +56,10 @@ class ValidatorRecord(rlp.Serializable):
                  randao_layers: int,
                  status: ValidatorStatusCode,
                  latest_status_change_slot: SlotNumber,
-                 exit_count: int) -> None:
+                 exit_count: int,
+                 custody_commitment: Hash32,
+                 latest_custody_reseed_slot: SlotNumber,
+                 penultimate_custody_reseed_slot: SlotNumber) -> None:
         super().__init__(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
@@ -60,6 +68,9 @@ class ValidatorRecord(rlp.Serializable):
             status=status,
             latest_status_change_slot=latest_status_change_slot,
             exit_count=exit_count,
+            custody_commitment=custody_commitment,
+            latest_custody_reseed_slot=latest_custody_reseed_slot,
+            penultimate_custody_reseed_slot=penultimate_custody_reseed_slot,
         )
 
     @property
@@ -74,7 +85,8 @@ class ValidatorRecord(rlp.Serializable):
                               pubkey: BLSPubkey,
                               withdrawal_credentials: Hash32,
                               randao_commitment: Hash32,
-                              latest_status_change_slot: SlotNumber) -> 'ValidatorRecord':
+                              latest_status_change_slot: SlotNumber,
+                              custody_commitment: Hash32) -> 'ValidatorRecord':
         """
         Return a new pending ``ValidatorRecord`` with the given fields.
         """
@@ -86,4 +98,7 @@ class ValidatorRecord(rlp.Serializable):
             status=ValidatorStatusCode.PENDING_ACTIVATION,
             latest_status_change_slot=latest_status_change_slot,
             exit_count=0,
+            custody_commitment=custody_commitment,
+            latest_custody_reseed_slot=SlotNumber(0),
+            penultimate_custody_reseed_slot=SlotNumber(0),
         )

--- a/tests/beacon/conftest.py
+++ b/tests/beacon/conftest.py
@@ -123,6 +123,9 @@ def sample_beacon_block_body_params():
         'proposer_slashings': (),
         'casper_slashings': (),
         'attestations': (),
+        'custody_reseeds': (),
+        'custody_challenges': (),
+        'custody_responses': (),
         'deposits': (),
         'exits': (),
     }
@@ -157,6 +160,7 @@ def sample_beacon_state_params(sample_fork_data_params):
         'shard_committees_at_slots': (),
         'persistent_committees': (),
         'persistent_committee_reassignments': (),
+        'custody_challenges': (),
         'previous_justified_slot': 0,
         'justified_slot': 0,
         'justification_bitfield': b'\x00',
@@ -191,9 +195,10 @@ def sample_crosslink_record_params():
 def sample_deposit_input_params():
     return {
         'pubkey': 123,
-        'proof_of_possession': (0, 0),
         'withdrawal_credentials': b'\11' * 32,
         'randao_commitment': b'\11' * 32,
+        'custody_commitment': ZERO_HASH32,
+        'proof_of_possession': (0, 0),
     }
 
 
@@ -307,7 +312,10 @@ def sample_validator_record_params():
         'randao_layers': 1,
         'status': 1,
         'latest_status_change_slot': 0,
-        'exit_count': 0
+        'exit_count': 0,
+        'custody_commitment': ZERO_HASH32,
+        'latest_custody_reseed_slot': 0,
+        'penultimate_custody_reseed_slot': 0,
     }
 
 
@@ -549,6 +557,9 @@ def genesis_validators(init_validator_keys,
             status=ValidatorStatusCode.ACTIVE,
             latest_status_change_slot=0,
             exit_count=0,
+            custody_commitment=ZERO_HASH32,
+            latest_custody_reseed_slot=0,
+            penultimate_custody_reseed_slot=0,
         ) for pub in init_validator_keys
     )
 

--- a/tests/beacon/conftest.py
+++ b/tests/beacon/conftest.py
@@ -118,6 +118,14 @@ def sample_attestation_data_params():
 
 
 @pytest.fixture
+def sample_attestation_data_and_custody_bit_params(sample_attestation_data_params):
+    return {
+        'data': AttestationData(**sample_attestation_data_params),
+        'custody_bit': False,
+    }
+
+
+@pytest.fixture
 def sample_beacon_block_body_params():
     return {
         'proposer_slashings': (),
@@ -287,8 +295,8 @@ def sample_shard_reassignment_record():
 @pytest.fixture
 def sample_slashable_vote_data_params(sample_attestation_data_params):
     return {
-        'aggregate_signature_poc_0_indices': (10, 11, 12, 15, 28),
-        'aggregate_signature_poc_1_indices': (7, 8, 100, 131, 249),
+        'custody_bit_0_indices': (10, 11, 12, 15, 28),
+        'custody_bit_1_indices': (7, 8, 100, 131, 249),
         'data': AttestationData(**sample_attestation_data_params),
         'aggregate_signature': (1, 2, 3, 4, 5),
     }

--- a/tests/beacon/helpers.py
+++ b/tests/beacon/helpers.py
@@ -17,6 +17,9 @@ def mock_validator_record(pubkey):
         status=ValidatorStatusCode.ACTIVE,
         latest_status_change_slot=0,
         exit_count=0,
+        custody_commitment=b'\x55' * 32,
+        latest_custody_reseed_slot=0,
+        penultimate_custody_reseed_slot=0,
     )
 
 

--- a/tests/beacon/test_deposit_helpers.py
+++ b/tests/beacon/test_deposit_helpers.py
@@ -34,11 +34,12 @@ def sign_proof_of_possession(deposit_input, privkey, domain):
     return bls.sign(deposit_input.root, privkey, domain)
 
 
-def make_deposit_input(pubkey, withdrawal_credentials, randao_commitment):
+def make_deposit_input(pubkey, withdrawal_credentials, randao_commitment, custody_commitment):
     return DepositInput(
         pubkey=pubkey,
         withdrawal_credentials=withdrawal_credentials,
         randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
         proof_of_possession=EMPTY_SIGNATURE,
     )
 
@@ -158,6 +159,7 @@ def test_validate_proof_of_possession(sample_beacon_state_params, pubkeys, privk
     privkey = privkeys[0]
     pubkey = pubkeys[0]
     withdrawal_credentials = b'\x34' * 32
+    custody_commitment = b'\x12' * 32
     randao_commitment = b'\x56' * 32
     domain = get_domain(
         state.fork_data,
@@ -169,6 +171,7 @@ def test_validate_proof_of_possession(sample_beacon_state_params, pubkeys, privk
         pubkey=pubkey,
         withdrawal_credentials=withdrawal_credentials,
         randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
     )
     if expected is True:
         proof_of_possession = sign_proof_of_possession(deposit_input, privkey, domain)
@@ -179,6 +182,7 @@ def test_validate_proof_of_possession(sample_beacon_state_params, pubkeys, privk
             proof_of_possession=proof_of_possession,
             withdrawal_credentials=withdrawal_credentials,
             randao_commitment=randao_commitment,
+            custody_commitment=custody_commitment,
         )
     else:
         proof_of_possession = b'\x11' * 32
@@ -189,6 +193,7 @@ def test_validate_proof_of_possession(sample_beacon_state_params, pubkeys, privk
                 proof_of_possession=proof_of_possession,
                 withdrawal_credentials=withdrawal_credentials,
                 randao_commitment=randao_commitment,
+                custody_commitment=custody_commitment,
             )
 
 
@@ -205,6 +210,7 @@ def test_process_deposit(sample_beacon_state_params,
     pubkey_1 = pubkeys[0]
     deposit = 32 * denoms.gwei
     withdrawal_credentials = b'\x34' * 32
+    custody_commitment = b'\x11' * 32
     randao_commitment = b'\x56' * 32
     domain = get_domain(
         state.fork_data,
@@ -216,6 +222,7 @@ def test_process_deposit(sample_beacon_state_params,
         pubkey=pubkey_1,
         withdrawal_credentials=withdrawal_credentials,
         randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
     )
     proof_of_possession = sign_proof_of_possession(deposit_input, privkey_1, domain)
     # Add the first validator
@@ -226,6 +233,7 @@ def test_process_deposit(sample_beacon_state_params,
         proof_of_possession=proof_of_possession,
         withdrawal_credentials=withdrawal_credentials,
         randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
         zero_balance_validator_ttl=zero_balance_validator_ttl,
     )
 
@@ -245,6 +253,7 @@ def test_process_deposit(sample_beacon_state_params,
         pubkey=pubkey_2,
         withdrawal_credentials=withdrawal_credentials,
         randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
     )
     proof_of_possession = sign_proof_of_possession(deposit_input, privkey_2, domain)
     result_state, index = process_deposit(
@@ -254,6 +263,7 @@ def test_process_deposit(sample_beacon_state_params,
         proof_of_possession=proof_of_possession,
         withdrawal_credentials=withdrawal_credentials,
         randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
         zero_balance_validator_ttl=zero_balance_validator_ttl,
     )
     assert len(result_state.validator_registry) == 2
@@ -278,6 +288,7 @@ def test_process_deposit(sample_beacon_state_params,
         pubkey=pubkey_3,
         withdrawal_credentials=withdrawal_credentials,
         randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
     )
     proof_of_possession = sign_proof_of_possession(deposit_input, privkey_3, domain)
     result_state, index = process_deposit(
@@ -287,6 +298,7 @@ def test_process_deposit(sample_beacon_state_params,
         proof_of_possession=proof_of_possession,
         withdrawal_credentials=withdrawal_credentials,
         randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
         zero_balance_validator_ttl=zero_balance_validator_ttl,
     )
     # Overwrite the second validator.

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -766,13 +766,13 @@ def test_generate_aggregate_pubkeys(genesis_validators, sample_slashable_vote_da
             max_value=max_value_for_list,
         )
     )
-    proof_of_custody_0_indices = indices[:some_index]
-    proof_of_custody_1_indices = indices[some_index:]
+    custody_bit_0_indices = indices[:some_index]
+    custody_bit_1_indices = indices[some_index:]
 
-    key = "aggregate_signature_poc_0_indices"
-    sample_slashable_vote_data_params[key] = proof_of_custody_0_indices
-    key = "aggregate_signature_poc_1_indices"
-    sample_slashable_vote_data_params[key] = proof_of_custody_1_indices
+    key = "custody_bit_0_indices"
+    sample_slashable_vote_data_params[key] = custody_bit_0_indices
+    key = "custody_bit_1_indices"
+    sample_slashable_vote_data_params[key] = custody_bit_1_indices
 
     votes = SlashableVoteData(**sample_slashable_vote_data_params)
 
@@ -781,8 +781,8 @@ def test_generate_aggregate_pubkeys(genesis_validators, sample_slashable_vote_da
 
     (poc_0_key, poc_1_key) = keys
 
-    poc_0_keys = get_pubkey_for_indices(genesis_validators, proof_of_custody_0_indices)
-    poc_1_keys = get_pubkey_for_indices(genesis_validators, proof_of_custody_1_indices)
+    poc_0_keys = get_pubkey_for_indices(genesis_validators, custody_bit_0_indices)
+    poc_1_keys = get_pubkey_for_indices(genesis_validators, custody_bit_1_indices)
 
     assert bls.aggregate_pubkeys(poc_0_keys) == poc_0_key
     assert bls.aggregate_pubkeys(poc_1_keys) == poc_1_key
@@ -791,13 +791,13 @@ def test_generate_aggregate_pubkeys(genesis_validators, sample_slashable_vote_da
 @given(st.data())
 def test_verify_vote_count(max_casper_votes, sample_slashable_vote_data_params, data):
     (indices, some_index) = _list_and_index(data, max_size=max_casper_votes)
-    proof_of_custody_0_indices = indices[:some_index]
-    proof_of_custody_1_indices = indices[some_index:]
+    custody_bit_0_indices = indices[:some_index]
+    custody_bit_1_indices = indices[some_index:]
 
-    key = "aggregate_signature_poc_0_indices"
-    sample_slashable_vote_data_params[key] = proof_of_custody_0_indices
-    key = "aggregate_signature_poc_1_indices"
-    sample_slashable_vote_data_params[key] = proof_of_custody_1_indices
+    key = "custody_bit_0_indices"
+    sample_slashable_vote_data_params[key] = custody_bit_0_indices
+    key = "custody_bit_1_indices"
+    sample_slashable_vote_data_params[key] = custody_bit_1_indices
 
     votes = SlashableVoteData(**sample_slashable_vote_data_params)
 
@@ -821,7 +821,7 @@ def _correct_slashable_vote_data_params(params, validators, messages, privkeys):
 
     num_validators = len(validators)
 
-    key = "aggregate_signature_poc_0_indices"
+    key = "custody_bit_0_indices"
     (poc_0_indices, poc_0_signatures) = _get_indices_and_signatures(
         num_validators,
         messages[0],
@@ -829,7 +829,7 @@ def _correct_slashable_vote_data_params(params, validators, messages, privkeys):
     )
     valid_params[key] = poc_0_indices
 
-    key = "aggregate_signature_poc_1_indices"
+    key = "custody_bit_1_indices"
     # NOTE: does not guarantee non-empty intersection
     (poc_1_indices, poc_1_signatures) = _get_indices_and_signatures(
         num_validators,
@@ -857,7 +857,7 @@ def _corrupt_signature(params):
 
 def _corrupt_vote_count(params):
     params = copy.deepcopy(params)
-    key = "aggregate_signature_poc_0_indices"
+    key = "custody_bit_0_indices"
     for i in itertools.count():
         if i not in params[key]:
             params[key].append(i)

--- a/tests/beacon/types/test_attestation_data_and_custody_bit.py
+++ b/tests/beacon/types/test_attestation_data_and_custody_bit.py
@@ -1,0 +1,11 @@
+from eth.beacon.types.attestation_data_and_custody_bits import (
+    AttestationDataAndCustodyBit,
+)
+
+
+def test_defaults(sample_attestation_data_and_custody_bit_params):
+    params = sample_attestation_data_and_custody_bit_params
+    attestation_data_and_custody_bit = AttestationDataAndCustodyBit(**params)
+
+    assert attestation_data_and_custody_bit.data == params['data']
+    assert attestation_data_and_custody_bit.custody_bit == params['custody_bit']

--- a/tests/beacon/types/test_block.py
+++ b/tests/beacon/types/test_block.py
@@ -9,6 +9,7 @@ from eth.beacon.types.attestations import (
 def test_defaults(sample_beacon_block_params):
     block = SerenityBeaconBlock(**sample_beacon_block_params)
     assert block.slot == sample_beacon_block_params['slot']
+    assert len(block.body.custody_challenges) == 0
 
 
 def test_update_attestations(sample_attestation_params, sample_beacon_block_params):

--- a/tests/beacon/types/test_casper_slashings.py
+++ b/tests/beacon/types/test_casper_slashings.py
@@ -5,12 +5,12 @@ def test_defaults(sample_casper_slashing_params):
     slashing = CasperSlashing(**sample_casper_slashing_params)
 
     assert (slashing.slashable_vote_data_1
-            .aggregate_signature_poc_0_indices ==
+            .custody_bit_0_indices ==
             sample_casper_slashing_params['slashable_vote_data_1']
-            .aggregate_signature_poc_0_indices
+            .custody_bit_0_indices
             )
     assert (slashing.slashable_vote_data_2
-            .aggregate_signature_poc_1_indices ==
+            .custody_bit_1_indices ==
             sample_casper_slashing_params['slashable_vote_data_2']
-            .aggregate_signature_poc_1_indices
+            .custody_bit_1_indices
             )

--- a/tests/beacon/types/test_slashable_vote_data.py
+++ b/tests/beacon/types/test_slashable_vote_data.py
@@ -1,21 +1,24 @@
+from eth.beacon.types.attestation_data_and_custody_bits import (
+    AttestationDataAndCustodyBit,
+)
 from eth.beacon.types.slashable_vote_data import (
     SlashableVoteData,
 )
 
 
 def test_defaults(sample_slashable_vote_data_params):
-    votes = SlashableVoteData(**sample_slashable_vote_data_params)
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
 
-    assert (votes.aggregate_signature_poc_0_indices ==
-            sample_slashable_vote_data_params['aggregate_signature_poc_0_indices'])
-    assert (votes.aggregate_signature_poc_1_indices ==
-            sample_slashable_vote_data_params['aggregate_signature_poc_1_indices'])
-    assert votes.data == sample_slashable_vote_data_params['data']
-    assert votes.aggregate_signature == sample_slashable_vote_data_params['aggregate_signature']
+    assert (vote_data.custody_bit_0_indices ==
+            sample_slashable_vote_data_params['custody_bit_0_indices'])
+    assert (vote_data.custody_bit_1_indices ==
+            sample_slashable_vote_data_params['custody_bit_1_indices'])
+    assert vote_data.data == sample_slashable_vote_data_params['data']
+    assert vote_data.aggregate_signature == sample_slashable_vote_data_params['aggregate_signature']
 
 
 def test_hash(sample_slashable_vote_data_params):
-    votes = SlashableVoteData(**sample_slashable_vote_data_params)
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
 
     # NOTE: this hash was simply copied from the existing implementation
     # which should be the keccak-256 of the rlp serialization of `votes`.
@@ -24,36 +27,33 @@ def test_hash(sample_slashable_vote_data_params):
     # if we expect the hash computation is not working correctly
     hash_hex = "7e4b4cf3ac47988865d693a29b6aa5a825f27e065cf21a80af5e077ea102e297"
 
-    assert votes.hash == bytes.fromhex(hash_hex)
+    assert vote_data.hash == bytes.fromhex(hash_hex)
 
 
 def test_root(sample_slashable_vote_data_params):
-    votes = SlashableVoteData(**sample_slashable_vote_data_params)
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
 
     # NOTE: see note in `test_hash`, this test will need to be updated
     # once ssz tree hash lands...
 
-    assert votes.root == votes.hash
+    assert vote_data.root == vote_data.hash
 
 
 def test_vote_count(sample_slashable_vote_data_params):
-    votes = SlashableVoteData(**sample_slashable_vote_data_params)
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
 
-    key = "aggregate_signature_poc_0_indices"
-    proof_of_custody_0_indices = sample_slashable_vote_data_params[key]
-    key = "aggregate_signature_poc_1_indices"
-    proof_of_custody_1_indices = sample_slashable_vote_data_params[key]
+    key = "custody_bit_0_indices"
+    custody_bit_0_indices = sample_slashable_vote_data_params[key]
+    key = "custody_bit_1_indices"
+    custody_bit_1_indices = sample_slashable_vote_data_params[key]
 
-    assert votes.vote_count == len(proof_of_custody_0_indices) + len(proof_of_custody_1_indices)
+    assert vote_data.vote_count == len(custody_bit_0_indices) + len(custody_bit_1_indices)
 
 
 def test_messages(sample_slashable_vote_data_params):
-    votes = SlashableVoteData(**sample_slashable_vote_data_params)
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
 
-    zero_discriminator = (0).to_bytes(1, 'big')
-    one_discriminator = (1).to_bytes(1, 'big')
-
-    assert votes.messages == (
-        votes.root + zero_discriminator,
-        votes.root + one_discriminator,
+    assert vote_data.messages == (
+        AttestationDataAndCustodyBit(vote_data.data, False).root,
+        AttestationDataAndCustodyBit(vote_data.data, True).root,
     )

--- a/tests/beacon/types/test_validator_record.py
+++ b/tests/beacon/types/test_validator_record.py
@@ -40,12 +40,14 @@ def test_get_pending_validator():
     withdrawal_credentials = b'\x11' * 32
     randao_commitment = b'\x22' * 32
     latest_status_change_slot = 10
+    custody_commitment = b'\x33' * 32
 
     validator = ValidatorRecord.get_pending_validator(
         pubkey=pubkey,
         withdrawal_credentials=withdrawal_credentials,
         randao_commitment=randao_commitment,
         latest_status_change_slot=latest_status_change_slot,
+        custody_commitment=custody_commitment,
     )
 
     assert validator.pubkey == pubkey


### PR DESCRIPTION
### What was wrong?

#1671 part 1: proof of custody placeholders

### How was it fixed?
1. Apply #1671: add proof of custody placeholders 
2. Renamings of https://github.com/ethereum/eth2.0-specs/issues/358 ideas: `poc_` to `custody_`
    - `poc_seed_changes` => `custody_reseeds`
    - `poc_challenges` => `custody_challenges`
    - `poc_responses` => `custody_responses`
    - `ProofOfCustodyChallenge` => `CustodyChallenge`
    - `poc_commitment` => `custody_commitment`
    - `last_poc_change_slot`=> `latest_custody_reseed_slot`
    - `second_last_poc_change_slot` => `penultimate_custody_reseed_slot`
    -  `aggregate_signature_poc_0_indices` => `custody_bit_0_indices`
    - `aggregate_signature_poc_1_indices` => `custody_bit_1_indices`
3. Add `AttestationDataAndCustodyBit` data structure
4. Update `SlashableVoteData.messages`: use `AttestationDataAndCustodyBit`

#### Cute Animal Picture

![xmas_snake_2](https://user-images.githubusercontent.com/9263930/50421659-e99f2a00-087c-11e9-85bc-ee0109f4bfb3.jpg)
