### PR TITLE
Update StateMachine.__init__() and add `BeaconBlock`

### DIFF
--- a/eth/beacon/state_machines/forks/serenity/blocks.py
+++ b/eth/beacon/state_machines/forks/serenity/blocks.py
@@ -1,5 +1,12 @@
-from eth.beacon.types.blocks import BaseBeaconBlock
+from eth.beacon.types.blocks import (
+    BeaconBlock,
+    BeaconBlockBody,
+)
 
 
-class SerenityBeaconBlock(BaseBeaconBlock):
+class SerenityBeaconBlockBody(BeaconBlockBody):
+    pass
+
+
+class SerenityBeaconBlock(BeaconBlock):
     pass

--- a/tests/beacon/conftest.py
+++ b/tests/beacon/conftest.py
@@ -55,6 +55,7 @@ from eth.beacon.types.fork_data import (
     ForkData,
 )
 
+
 DEFAULT_SHUFFLING_SEED = b'\00' * 32
 DEFAULT_RANDAO = b'\45' * 32
 DEFAULT_NUM_VALIDATORS = 40
@@ -131,7 +132,7 @@ def sample_beacon_block_body_params():
 def sample_beacon_block_params(sample_beacon_block_body_params):
     return {
         'slot': 10,
-        'parent_root': b'\x56' * 32,
+        'parent_root': ZERO_HASH32,
         'state_root': b'\x55' * 32,
         'randao_reveal': b'\x55' * 32,
         'candidate_pow_receipt_root': b'\x55' * 32,

--- a/tests/beacon/db/test_beacon_chaindb.py
+++ b/tests/beacon/db/test_beacon_chaindb.py
@@ -25,18 +25,20 @@ from eth.beacon.db.chain import (
     BeaconChainDB,
 )
 from eth.beacon.db.schema import SchemaV1
-from eth.beacon.types.blocks import BaseBeaconBlock
+from eth.beacon.state_machines.forks.serenity.blocks import (
+    BeaconBlock,
+)
 from eth.beacon.types.states import BeaconState
 
 
 @pytest.fixture
 def chaindb(base_db):
-    return BeaconChainDB(base_db)
+    return BeaconChainDB(base_db, BeaconBlock)
 
 
 @pytest.fixture(params=[0, 10, 999])
 def block(request, sample_beacon_block_params):
-    return BaseBeaconBlock(**sample_beacon_block_params).copy(
+    return BeaconBlock(**sample_beacon_block_params).copy(
         parent_root=GENESIS_PARENT_HASH,
         slot=request.param,
     )
@@ -81,7 +83,7 @@ def test_chaindb_persist_block_and_block_to_root(chaindb, block):
 
 
 def test_chaindb_get_score(chaindb, sample_beacon_block_params):
-    genesis = BaseBeaconBlock(**sample_beacon_block_params).copy(
+    genesis = BeaconBlock(**sample_beacon_block_params).copy(
         parent_root=GENESIS_PARENT_HASH,
         slot=0,
     )
@@ -92,7 +94,7 @@ def test_chaindb_get_score(chaindb, sample_beacon_block_params):
     assert genesis_score == 0
     assert chaindb.get_score(genesis.root) == 0
 
-    block1 = BaseBeaconBlock(**sample_beacon_block_params).copy(
+    block1 = BeaconBlock(**sample_beacon_block_params).copy(
         parent_root=genesis.root,
         slot=1,
     )

--- a/tests/beacon/state_machines/forks/test_serenity_operations.py
+++ b/tests/beacon/state_machines/forks/test_serenity_operations.py
@@ -14,8 +14,10 @@ from eth.beacon.helpers import (
 )
 
 from eth.beacon.types.attestation_data import AttestationData
-from eth.beacon.types.blocks import BaseBeaconBlock
-from eth.beacon.types.blocks import BeaconBlockBody
+from eth.beacon.state_machines.forks.serenity.blocks import (
+    SerenityBeaconBlock,
+    SerenityBeaconBlockBody,
+)
 from eth.beacon.state_machines.forks.serenity.operations import (
     process_attestations,
 )
@@ -110,10 +112,10 @@ def test_process_attestations(genesis_state,
         )
         attestations = attestations[:-1] + (invalid_attestation,)
 
-    block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
+    block_body = SerenityBeaconBlockBody(**sample_beacon_block_body_params).copy(
         attestations=attestations,
     )
-    block = BaseBeaconBlock(**sample_beacon_block_params).copy(
+    block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
         slot=current_slot,
         body=block_body,
     )

--- a/tests/beacon/state_machines/test_proposer_signature_validation.py
+++ b/tests/beacon/state_machines/test_proposer_signature_validation.py
@@ -9,7 +9,7 @@ from eth._utils import bls
 from eth.beacon.enums import (
     SignatureDomain,
 )
-from eth.beacon.types.blocks import BaseBeaconBlock
+from eth.beacon.types.blocks import BeaconBlock
 from eth.beacon.types.proposal_signed_data import (
     ProposalSignedData,
 )
@@ -59,7 +59,7 @@ def test_validate_serenity_proposer_signature(
         ),
     )
 
-    default_block = BaseBeaconBlock(**sample_beacon_block_params)
+    default_block = BeaconBlock(**sample_beacon_block_params)
     empty_signature_block_root = default_block.block_without_signature_root
 
     proposal_root = ProposalSignedData(
@@ -68,7 +68,7 @@ def test_validate_serenity_proposer_signature(
         empty_signature_block_root,
     ).root
 
-    proposed_block = BaseBeaconBlock(**sample_beacon_block_params).copy(
+    proposed_block = BeaconBlock(**sample_beacon_block_params).copy(
         signature=bls.sign(
             message=proposal_root,
             privkey=proposer_privkey,

--- a/tests/beacon/test_helpers.py
+++ b/tests/beacon/test_helpers.py
@@ -22,10 +22,12 @@ from eth.beacon.enums import (
     ValidatorStatusCode,
     SignatureDomain,
 )
+from eth.beacon.state_machines.forks.serenity.blocks import (
+    SerenityBeaconBlock,
+)
 from eth.beacon.types.attestation_data import (
     AttestationData,
 )
-from eth.beacon.types.blocks import BaseBeaconBlock
 from eth.beacon.types.fork_data import ForkData
 from eth.beacon.types.shard_committees import ShardCommittee
 from eth.beacon.types.slashable_vote_data import SlashableVoteData
@@ -61,7 +63,7 @@ from tests.beacon.helpers import (
 
 @pytest.fixture()
 def sample_block(sample_beacon_block_params):
-    return BaseBeaconBlock(**sample_beacon_block_params)
+    return SerenityBeaconBlock(**sample_beacon_block_params)
 
 
 @pytest.fixture()

--- a/tests/beacon/types/test_block.py
+++ b/tests/beacon/types/test_block.py
@@ -1,5 +1,5 @@
-from eth.beacon.types.blocks import (
-    BaseBeaconBlock,
+from eth.beacon.state_machines.forks.serenity.blocks import (
+    SerenityBeaconBlock,
 )
 from eth.beacon.types.attestations import (
     Attestation,
@@ -7,12 +7,12 @@ from eth.beacon.types.attestations import (
 
 
 def test_defaults(sample_beacon_block_params):
-    block = BaseBeaconBlock(**sample_beacon_block_params)
+    block = SerenityBeaconBlock(**sample_beacon_block_params)
     assert block.slot == sample_beacon_block_params['slot']
 
 
 def test_update_attestations(sample_attestation_params, sample_beacon_block_params):
-    block = BaseBeaconBlock(**sample_beacon_block_params)
+    block = SerenityBeaconBlock(**sample_beacon_block_params)
     attestations = block.body.attestations
     attestations = list(attestations)
     attestations.append(Attestation(**sample_attestation_params))


### PR DESCRIPTION
### What was wrong?
Make `StateMachine` better.

### How was it fixed?
1. Add `BeaconBlock` layer between `BaseBeaconBlock` and
`SerenityBeaconBlock`.
    - IMO the rule is:
        - In `eth.beacon.state_machines.forks.serenity` - use `SerenityBeaconBlock`.
        - In type hinting - use `BaseBeaconBlock`.
        - In other cases - use `BeaconBlock`.
2. Update `StateMachine.__init__()`
3. Add `BeaconChainDB.block_class` and `BeaconChainDB.set_block_class(block_class)`: now it's forkable.
    - TBD: It's for `rlp.decode(block_rlp, sedes=sedes)` with different subclasses of `BaseBeaconBlock`. Now I use set_block_class per `StateMachine` initialization, but I do think it doesn't a beautiful thing to do.

#### Cute Animal Picture

![penguin2](https://user-images.githubusercontent.com/9263930/50482430-6ec34400-0a21-11e9-8059-8d6f72a33b64.jpeg)
