### PR TITLE
Add beacon chain related new type

### DIFF
--- a/eth/_utils/bls.py
+++ b/eth/_utils/bls.py
@@ -35,7 +35,6 @@ from eth.beacon._utils.hash import hash_eth2
 
 from eth.beacon.typing import (
     BLSPubkey,
-    BLSPubkeyAggregated,
     BLSSignature,
     BLSSignatureAggregated,
 )
@@ -202,11 +201,11 @@ def aggregate_signatures(signatures: Sequence[BLSSignature]) -> BLSSignatureAggr
     return BLSSignatureAggregated(compress_G2(o))
 
 
-def aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkeyAggregated:
+def aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
     o = Z1
     for p in pubkeys:
         o = add(o, decompress_G1(p))
-    return BLSPubkeyAggregated(compress_G1(o))
+    return BLSPubkey(compress_G1(o))
 
 
 def verify_multiple(pubkeys: Sequence[BLSPubkey],

--- a/eth/_utils/bls.py
+++ b/eth/_utils/bls.py
@@ -35,8 +35,8 @@ from eth.beacon._utils.hash import hash_eth2
 
 from eth.beacon.typing import (
     BLSPubkey,
-    BLSSignature,
-    BLSSignatureAggregated,
+    BLSSignatureBytes,
+    BLSSignatureIntegers,
 )
 
 G2_cofactor = 305502333931268344200999753193121504214466019254188142667664032982267604182971884026507427359259977847832272839041616661285803823378372096355777062779109  # noqa: E501
@@ -161,8 +161,8 @@ def decompress_G2(p: bytes) -> Tuple[FQP, FQP, FQP]:
 #
 def sign(message: bytes,
          privkey: int,
-         domain: int) -> BLSSignatureAggregated:
-    return BLSSignatureAggregated(
+         domain: int) -> BLSSignatureIntegers:
+    return BLSSignatureIntegers(
         compress_G2(
             multiply(
                 hash_to_G2(message, domain),
@@ -175,7 +175,7 @@ def privtopub(k: int) -> BLSPubkey:
     return BLSPubkey(compress_G1(multiply(G1, k)))
 
 
-def verify(message: bytes, pubkey: BLSPubkey, signature: BLSSignature, domain: int) -> bool:
+def verify(message: bytes, pubkey: BLSPubkey, signature: BLSSignatureBytes, domain: int) -> bool:
     try:
         final_exponentiation = final_exponentiate(
             pairing(
@@ -194,11 +194,11 @@ def verify(message: bytes, pubkey: BLSPubkey, signature: BLSSignature, domain: i
         return False
 
 
-def aggregate_signatures(signatures: Sequence[BLSSignature]) -> BLSSignatureAggregated:
+def aggregate_signatures(signatures: Sequence[BLSSignatureBytes]) -> BLSSignatureIntegers:
     o = Z2
     for s in signatures:
         o = FQP_point_to_FQ2_point(add(o, decompress_G2(s)))
-    return BLSSignatureAggregated(compress_G2(o))
+    return BLSSignatureIntegers(compress_G2(o))
 
 
 def aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
@@ -210,7 +210,7 @@ def aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
 
 def verify_multiple(pubkeys: Sequence[BLSPubkey],
                     messages: Sequence[bytes],
-                    signature: BLSSignature,
+                    signature: BLSSignatureBytes,
                     domain: int) -> bool:
     len_msgs = len(messages)
 

--- a/eth/beacon/aggregation.py
+++ b/eth/beacon/aggregation.py
@@ -13,16 +13,18 @@ from eth._utils.bitfield import (
 from eth.beacon.enums import SignatureDomain
 from eth.beacon.typing import (
     BLSPubkey,
-    BLSSignature,
-    BLSSignatureAggregated,
+    BLSSignatureBytes,
+    BLSSignatureIntegers,
     Bitfield,
+    CommitteeIndex,
 )
 
 
 def verify_votes(
-        message: bytes,
-        votes: Iterable[Tuple[int, BLSSignature, BLSPubkey]],
-        domain: SignatureDomain) -> Tuple[Tuple[bytes, ...], Tuple[int, ...]]:
+    message: bytes,
+    votes: Iterable[Tuple[CommitteeIndex, BLSSignatureBytes, BLSPubkey]],
+    domain: SignatureDomain
+) -> Tuple[Tuple[BLSSignatureBytes, ...], Tuple[CommitteeIndex, ...]]:
     """
     Verify the given votes.
 
@@ -44,10 +46,11 @@ def verify_votes(
 
 
 def aggregate_votes(
-        bitfield: Bitfield,
-        sigs: Iterable[BLSSignature],
-        voting_sigs: Iterable[BLSSignature],
-        voting_committee_indices: Iterable[int]) -> Tuple[Bitfield, BLSSignatureAggregated]:
+    bitfield: Bitfield,
+    sigs: Iterable[BLSSignatureBytes],
+    voting_sigs: Iterable[BLSSignatureBytes],
+    voting_committee_indices: Iterable[CommitteeIndex]
+) -> Tuple[Bitfield, BLSSignatureIntegers]:
     """
     Aggregate the votes.
     """

--- a/eth/beacon/aggregation.py
+++ b/eth/beacon/aggregation.py
@@ -11,11 +11,17 @@ from eth._utils.bitfield import (
     set_voted,
 )
 from eth.beacon.enums import SignatureDomain
+from eth.beacon.typing import (
+    BLSPubkey,
+    BLSSignature,
+    BLSSignatureAggregated,
+    Bitfield,
+)
 
 
 def verify_votes(
         message: bytes,
-        votes: Iterable[Tuple[int, bytes, int]],
+        votes: Iterable[Tuple[int, BLSSignature, BLSPubkey]],
         domain: SignatureDomain) -> Tuple[Tuple[bytes, ...], Tuple[int, ...]]:
     """
     Verify the given votes.
@@ -37,10 +43,10 @@ def verify_votes(
     return sigs, committee_indices
 
 
-def aggregate_votes(bitfield: bytes,
-                    sigs: Iterable[bytes],
-                    voting_sigs: Iterable[bytes],
-                    voting_committee_indices: Iterable[int]) -> Tuple[bytes, Tuple[int, int]]:
+def aggregate_votes(bitfield: Bitfield,
+                    sigs: Iterable[BLSSignature],
+                    voting_sigs: Iterable[BLSSignature],
+                    voting_committee_indices: Iterable[int]) -> Tuple[Bitfield, BLSSignatureAggregated]:
     """
     Aggregate the votes.
     """

--- a/eth/beacon/aggregation.py
+++ b/eth/beacon/aggregation.py
@@ -43,10 +43,11 @@ def verify_votes(
     return sigs, committee_indices
 
 
-def aggregate_votes(bitfield: Bitfield,
-                    sigs: Iterable[BLSSignature],
-                    voting_sigs: Iterable[BLSSignature],
-                    voting_committee_indices: Iterable[int]) -> Tuple[Bitfield, BLSSignatureAggregated]:
+def aggregate_votes(
+        bitfield: Bitfield,
+        sigs: Iterable[BLSSignature],
+        voting_sigs: Iterable[BLSSignature],
+        voting_committee_indices: Iterable[int]) -> Tuple[Bitfield, BLSSignatureAggregated]:
     """
     Aggregate the votes.
     """

--- a/eth/beacon/aggregation.py
+++ b/eth/beacon/aggregation.py
@@ -13,8 +13,7 @@ from eth._utils.bitfield import (
 from eth.beacon.enums import SignatureDomain
 from eth.beacon.typing import (
     BLSPubkey,
-    BLSSignatureBytes,
-    BLSSignatureIntegers,
+    BLSSignature,
     Bitfield,
     CommitteeIndex,
 )
@@ -22,9 +21,9 @@ from eth.beacon.typing import (
 
 def verify_votes(
     message: bytes,
-    votes: Iterable[Tuple[CommitteeIndex, BLSSignatureBytes, BLSPubkey]],
+    votes: Iterable[Tuple[CommitteeIndex, BLSSignature, BLSPubkey]],
     domain: SignatureDomain
-) -> Tuple[Tuple[BLSSignatureBytes, ...], Tuple[CommitteeIndex, ...]]:
+) -> Tuple[Tuple[BLSSignature, ...], Tuple[CommitteeIndex, ...]]:
     """
     Verify the given votes.
 
@@ -47,10 +46,10 @@ def verify_votes(
 
 def aggregate_votes(
     bitfield: Bitfield,
-    sigs: Iterable[BLSSignatureBytes],
-    voting_sigs: Iterable[BLSSignatureBytes],
+    sigs: Iterable[BLSSignature],
+    voting_sigs: Iterable[BLSSignature],
     voting_committee_indices: Iterable[CommitteeIndex]
-) -> Tuple[Bitfield, BLSSignatureIntegers]:
+) -> Tuple[Bitfield, BLSSignature]:
     """
     Aggregate the votes.
     """

--- a/eth/beacon/constants.py
+++ b/eth/beacon/constants.py
@@ -1,4 +1,4 @@
-from eth.beacon.typing import BLSSignatureAggregated
+from eth.beacon.typing import BLSSignatureIntegers
 
 #
 # shuffle function
@@ -13,4 +13,4 @@ RAND_BYTES = 3
 # The highest possible result of the RNG.
 RAND_MAX = 2 ** (RAND_BYTES * 8) - 1
 
-EMPTY_SIGNATURE = BLSSignatureAggregated((0, 0))
+EMPTY_SIGNATURE = BLSSignatureIntegers((0, 0))

--- a/eth/beacon/constants.py
+++ b/eth/beacon/constants.py
@@ -1,3 +1,5 @@
+from eth.beacon.typing import BLSSignatureAggregated
+
 #
 # shuffle function
 #
@@ -11,4 +13,4 @@ RAND_BYTES = 3
 # The highest possible result of the RNG.
 RAND_MAX = 2 ** (RAND_BYTES * 8) - 1
 
-EMPTY_SIGNATURE = (0, 0)
+EMPTY_SIGNATURE = BLSSignatureAggregated((0, 0))

--- a/eth/beacon/constants.py
+++ b/eth/beacon/constants.py
@@ -1,4 +1,4 @@
-from eth.beacon.typing import BLSSignatureIntegers
+from eth.beacon.typing import BLSSignature
 
 #
 # shuffle function
@@ -13,4 +13,4 @@ RAND_BYTES = 3
 # The highest possible result of the RNG.
 RAND_MAX = 2 ** (RAND_BYTES * 8) - 1
 
-EMPTY_SIGNATURE = BLSSignatureIntegers((0, 0))
+EMPTY_SIGNATURE = BLSSignature((0, 0))

--- a/eth/beacon/deposit_helpers.py
+++ b/eth/beacon/deposit_helpers.py
@@ -29,7 +29,7 @@ from eth.beacon.helpers import (
 )
 from eth.beacon.typing import (
     BLSPubkey,
-    BLSSignature,
+    BLSSignatureBytes,
     Gwei,
 )
 
@@ -50,7 +50,7 @@ def get_min_empty_validator_index(validators: Sequence[ValidatorRecord],
 
 def validate_proof_of_possession(state: BeaconState,
                                  pubkey: BLSPubkey,
-                                 proof_of_possession: BLSSignature,
+                                 proof_of_possession: BLSSignatureBytes,
                                  withdrawal_credentials: Hash32,
                                  randao_commitment: Hash32) -> None:
     deposit_input = DepositInput(
@@ -115,7 +115,7 @@ def process_deposit(*,
                     state: BeaconState,
                     pubkey: BLSPubkey,
                     deposit: Gwei,
-                    proof_of_possession: BLSSignature,
+                    proof_of_possession: BLSSignatureBytes,
                     withdrawal_credentials: Hash32,
                     randao_commitment: Hash32,
                     zero_balance_validator_ttl: int) -> Tuple[BeaconState, int]:

--- a/eth/beacon/deposit_helpers.py
+++ b/eth/beacon/deposit_helpers.py
@@ -27,6 +27,11 @@ from eth.beacon.types.validator_records import ValidatorRecord
 from eth.beacon.helpers import (
     get_domain,
 )
+from eth.beacon.typing import (
+    BLSPubkey,
+    BLSSignature,
+    Gwei,
+)
 
 
 def get_min_empty_validator_index(validators: Sequence[ValidatorRecord],
@@ -44,8 +49,8 @@ def get_min_empty_validator_index(validators: Sequence[ValidatorRecord],
 
 
 def validate_proof_of_possession(state: BeaconState,
-                                 pubkey: int,
-                                 proof_of_possession: bytes,
+                                 pubkey: BLSPubkey,
+                                 proof_of_possession: BLSSignature,
                                  withdrawal_credentials: Hash32,
                                  randao_commitment: Hash32) -> None:
     deposit_input = DepositInput(
@@ -75,7 +80,7 @@ def validate_proof_of_possession(state: BeaconState,
 
 def add_pending_validator(state: BeaconState,
                           validator: ValidatorRecord,
-                          deposit: int,
+                          deposit: Gwei,
                           zero_balance_validator_ttl: int) -> Tuple[BeaconState, int]:
     """
     Add a validator to the existing minimum empty validator index or
@@ -108,9 +113,9 @@ def add_pending_validator(state: BeaconState,
 
 def process_deposit(*,
                     state: BeaconState,
-                    pubkey: int,
-                    deposit: int,
-                    proof_of_possession: bytes,
+                    pubkey: BLSPubkey,
+                    deposit: Gwei,
+                    proof_of_possession: BLSSignature,
                     withdrawal_credentials: Hash32,
                     randao_commitment: Hash32,
                     zero_balance_validator_ttl: int) -> Tuple[BeaconState, int]:

--- a/eth/beacon/deposit_helpers.py
+++ b/eth/beacon/deposit_helpers.py
@@ -30,7 +30,7 @@ from eth.beacon.helpers import (
 from eth.beacon.typing import (
     SlotNumber,
     BLSPubkey,
-    BLSSignatureBytes,
+    BLSSignature,
     ValidatorIndex,
     Gwei,
 )
@@ -52,7 +52,7 @@ def get_min_empty_validator_index(validators: Sequence[ValidatorRecord],
 
 def validate_proof_of_possession(state: BeaconState,
                                  pubkey: BLSPubkey,
-                                 proof_of_possession: BLSSignatureBytes,
+                                 proof_of_possession: BLSSignature,
                                  withdrawal_credentials: Hash32,
                                  randao_commitment: Hash32) -> None:
     deposit_input = DepositInput(
@@ -116,7 +116,7 @@ def process_deposit(*,
                     state: BeaconState,
                     pubkey: BLSPubkey,
                     deposit: Gwei,
-                    proof_of_possession: BLSSignatureBytes,
+                    proof_of_possession: BLSSignature,
                     withdrawal_credentials: Hash32,
                     randao_commitment: Hash32,
                     zero_balance_validator_ttl: int) -> Tuple[BeaconState, ValidatorIndex]:

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -33,6 +33,7 @@ from eth.beacon.block_committees_info import (
 )
 from eth.beacon.enums import (
     SignatureDomain,
+    ValidatorRegistryDeltaFlag,
 )
 from eth.beacon.types.shard_committees import (
     ShardCommittee,
@@ -44,13 +45,13 @@ from eth.beacon._utils.random import (
 import functools
 
 from eth.beacon.typing import (
-    ShardNumber,
+    Bitfield,
     BLSPubkey,
+    Ether,
+    Gwei,
+    ShardNumber,
     SlotNumber,
     ValidatorIndex,
-    Bitfield,
-    Gwei,
-    Ether,
 )
 
 if TYPE_CHECKING:
@@ -162,7 +163,7 @@ def get_active_validator_indices(
 #
 @to_tuple
 def _get_shards_committees_for_shard_indices(
-        shard_indices: Sequence[Sequence[ShardNumber]],
+        shard_indices: Sequence[Sequence[ValidatorIndex]],
         start_shard: ShardNumber,
         total_validator_count: int,
         shard_count: int) -> Iterable[ShardCommittee]:

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -385,7 +385,7 @@ def get_effective_balance(
 def get_new_validator_registry_delta_chain_tip(current_validator_registry_delta_chain_tip: Hash32,
                                                validator_index: ValidatorIndex,
                                                pubkey: BLSPubkey,
-                                               flag: int) -> Hash32:
+                                               flag: ValidatorRegistryDeltaFlag) -> Hash32:
     """
     Compute the next hash in the validator registry delta hash chain.
     """

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -43,6 +43,10 @@ from eth.beacon._utils.random import (
 )
 import functools
 
+from eth.beacon.typing import (
+    ShardNumber,
+    BLSPubkey,
+)
 
 if TYPE_CHECKING:
     from eth.beacon.types.attestation_data import AttestationData  # noqa: F401
@@ -51,10 +55,6 @@ if TYPE_CHECKING:
     from eth.beacon.types.fork_data import ForkData  # noqa: F401
     from eth.beacon.types.slashable_vote_data import SlashableVoteData  # noqa: F401
     from eth.beacon.types.validator_records import ValidatorRecord  # noqa: F401
-    from eth.beacon.typing import (
-        ShardNumber,
-        BLSPubkey,
-    )
 
 
 def _get_element_from_recent_list(

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -296,7 +296,7 @@ def get_block_committees_info(parent_block: 'BaseBeaconBlock',
 
 def get_beacon_proposer_index(state: 'BeaconState',
                               slot: SlotNumber,
-                              epoch_length: int) -> int:
+                              epoch_length: int) -> ValidatorIndex:
     """
     Return the beacon proposer index for the ``slot``.
     """

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
         BLSPubkey,
     )
 
+
 def _get_element_from_recent_list(
         target_list: Sequence[Any],
         target_slot: int,

--- a/eth/beacon/helpers.py
+++ b/eth/beacon/helpers.py
@@ -51,7 +51,10 @@ if TYPE_CHECKING:
     from eth.beacon.types.fork_data import ForkData  # noqa: F401
     from eth.beacon.types.slashable_vote_data import SlashableVoteData  # noqa: F401
     from eth.beacon.types.validator_records import ValidatorRecord  # noqa: F401
-
+    from eth.beacon.typing import (
+        ShardNumber,
+        BLSPubkey,
+    )
 
 def _get_element_from_recent_list(
         target_list: Sequence[Any],
@@ -161,7 +164,7 @@ def _get_shards_committees_for_shard_indices(
     """
     for index, indices in enumerate(shard_indices):
         yield ShardCommittee(
-            shard=(start_shard + index) % shard_count,
+            shard=ShardNumber((start_shard + index) % shard_count),
             committee=indices,
             total_validator_count=total_validator_count,
         )
@@ -371,7 +374,7 @@ def get_effective_balance(validator_balances: Sequence[int], index: int, max_dep
 
 def get_new_validator_registry_delta_chain_tip(current_validator_registry_delta_chain_tip: Hash32,
                                                validator_index: int,
-                                               pubkey: int,
+                                               pubkey: BLSPubkey,
                                                flag: int) -> Hash32:
     """
     Compute the next hash in the validator registry delta hash chain.

--- a/eth/beacon/state_machines/configs.py
+++ b/eth/beacon/state_machines/configs.py
@@ -9,7 +9,7 @@ from eth.beacon.typing import (
     SlotNumber,
     ShardNumber,
     Ether,
-    Seconds,
+    Second,
 )
 
 
@@ -37,7 +37,7 @@ BeaconConfig = NamedTuple(
         ('INITIAL_FORK_VERSION', int),
         ('INITIAL_SLOT_NUMBER', SlotNumber),
         # Time parameters
-        ('SLOT_DURATION', Seconds),
+        ('SLOT_DURATION', Second),
         ('MIN_ATTESTATION_INCLUSION_DELAY', int),
         ('EPOCH_LENGTH', int),
         ('POW_RECEIPT_ROOT_VOTING_PERIOD', int),

--- a/eth/beacon/state_machines/configs.py
+++ b/eth/beacon/state_machines/configs.py
@@ -5,6 +5,12 @@ from typing import (
 from eth.typing import (
     Address,
 )
+from eth.beacon.typing import (
+    SlotNumber,
+    ShardNumber,
+    Ether,
+    Seconds,
+)
 
 
 BeaconConfig = NamedTuple(
@@ -13,9 +19,9 @@ BeaconConfig = NamedTuple(
         # Misc
         ('SHARD_COUNT', int),
         ('TARGET_COMMITTEE_SIZE', int),
-        ('EJECTION_BALANCE', int),
+        ('EJECTION_BALANCE', Ether),
         ('MAX_BALANCE_CHURN_QUOTIENT', int),
-        ('BEACON_CHAIN_SHARD_NUMBER', int),
+        ('BEACON_CHAIN_SHARD_NUMBER', ShardNumber),
         ('BLS_WITHDRAWAL_PREFIX_BYTE', bytes),
         ('MAX_CASPER_VOTES', int),
         ('LATEST_BLOCK_ROOTS_LENGTH', int),
@@ -24,14 +30,14 @@ BeaconConfig = NamedTuple(
         # Deposit contract
         ('DEPOSIT_CONTRACT_ADDRESS', Address),
         ('DEPOSIT_CONTRACT_TREE_DEPTH', int),
-        ('MIN_DEPOSIT', int),
-        ('MAX_DEPOSIT', int),
+        ('MIN_DEPOSIT', Ether),
+        ('MAX_DEPOSIT', Ether),
         # ZERO_HASH (ZERO_HASH32) is defined in constants.py
         # Initial values
         ('INITIAL_FORK_VERSION', int),
-        ('INITIAL_SLOT_NUMBER', int),
+        ('INITIAL_SLOT_NUMBER', SlotNumber),
         # Time parameters
-        ('SLOT_DURATION', int),
+        ('SLOT_DURATION', Seconds),
         ('MIN_ATTESTATION_INCLUSION_DELAY', int),
         ('EPOCH_LENGTH', int),
         ('POW_RECEIPT_ROOT_VOTING_PERIOD', int),

--- a/eth/beacon/state_machines/forks/serenity/configs.py
+++ b/eth/beacon/state_machines/forks/serenity/configs.py
@@ -6,7 +6,7 @@ from eth.beacon.typing import (
     SlotNumber,
     ShardNumber,
     Ether,
-    Seconds,
+    Second,
 )
 
 
@@ -30,7 +30,7 @@ SERENITY_CONFIG = BeaconConfig(
     INITIAL_FORK_VERSION=0,
     INITIAL_SLOT_NUMBER=SlotNumber(0),
     # Time parameters
-    SLOT_DURATION=Seconds(6),  # seconds
+    SLOT_DURATION=Second(6),  # seconds
     MIN_ATTESTATION_INCLUSION_DELAY=2**2,  # (= 4) slots
     EPOCH_LENGTH=2**6,  # (= 64) slots
     POW_RECEIPT_ROOT_VOTING_PERIOD=2**10,  # (= 1,024) slots

--- a/eth/beacon/state_machines/forks/serenity/configs.py
+++ b/eth/beacon/state_machines/forks/serenity/configs.py
@@ -2,15 +2,21 @@ from eth.constants import (
     ZERO_ADDRESS,
 )
 from eth.beacon.state_machines.configs import BeaconConfig
+from eth.beacon.typing import (
+    SlotNumber,
+    ShardNumber,
+    Ether,
+    Seconds,
+)
 
 
 SERENITY_CONFIG = BeaconConfig(
     # Misc
     SHARD_COUNT=2**10,  # (= 1,024) shards
     TARGET_COMMITTEE_SIZE=2**7,  # (= 128) validators
-    EJECTION_BALANCE=2**4,  # (= 16) ETH
+    EJECTION_BALANCE=Ether(2**4),  # (= 16) ETH
     MAX_BALANCE_CHURN_QUOTIENT=2**5,  # (= 32)
-    BEACON_CHAIN_SHARD_NUMBER=2**64 - 1,
+    BEACON_CHAIN_SHARD_NUMBER=ShardNumber(2**64 - 1),
     BLS_WITHDRAWAL_PREFIX_BYTE=b'\x00',
     MAX_CASPER_VOTES=2**10,  # (= 1,024) votes
     LATEST_BLOCK_ROOTS_LENGTH=2**13,  # (= 8,192) block roots
@@ -18,13 +24,13 @@ SERENITY_CONFIG = BeaconConfig(
     # Deposit contract
     DEPOSIT_CONTRACT_ADDRESS=ZERO_ADDRESS,  # TBD
     DEPOSIT_CONTRACT_TREE_DEPTH=2**5,  # (= 32)
-    MIN_DEPOSIT=2**0,  # (= 1) ETH
-    MAX_DEPOSIT=2**5,  # (= 32) ETH
+    MIN_DEPOSIT=Ether(2**0),  # (= 1) ETH
+    MAX_DEPOSIT=Ether(2**5),  # (= 32) ETH
     # Initial values
     INITIAL_FORK_VERSION=0,
-    INITIAL_SLOT_NUMBER=0,
+    INITIAL_SLOT_NUMBER=SlotNumber(0),
     # Time parameters
-    SLOT_DURATION=6,  # seconds
+    SLOT_DURATION=Seconds(6),  # seconds
     MIN_ATTESTATION_INCLUSION_DELAY=2**2,  # (= 4) slots
     EPOCH_LENGTH=2**6,  # (= 64) slots
     POW_RECEIPT_ROOT_VOTING_PERIOD=2**10,  # (= 1,024) slots

--- a/eth/beacon/state_machines/validation.py
+++ b/eth/beacon/state_machines/validation.py
@@ -23,10 +23,14 @@ from eth._utils.bls import (
     verify,
 )
 
+from eth.beacon.typing import (
+    ShardNumber,
+)
+
 
 def validate_proposer_signature(state: BeaconState,
                                 block: BaseBeaconBlock,
-                                beacon_chain_shard_number: int,
+                                beacon_chain_shard_number: ShardNumber,
                                 epoch_length: int) -> None:
     block_without_signature_root = block.block_without_signature_root
 

--- a/eth/beacon/types/attestation_data.py
+++ b/eth/beacon/types/attestation_data.py
@@ -8,6 +8,11 @@ from eth.rlp.sedes import (
     hash32,
 )
 
+from eth.beacon.typing import (
+    SlotNumber,
+    ShardNumber,
+)
+
 
 class AttestationData(rlp.Serializable):
     """
@@ -33,13 +38,13 @@ class AttestationData(rlp.Serializable):
     ]
 
     def __init__(self,
-                 slot: int,
-                 shard: int,
+                 slot: SlotNumber,
+                 shard: ShardNumber,
                  beacon_block_root: Hash32,
                  epoch_boundary_root: Hash32,
                  shard_block_root: Hash32,
                  latest_crosslink_root: Hash32,
-                 justified_slot: int,
+                 justified_slot: SlotNumber,
                  justified_block_root: Hash32) -> None:
         super().__init__(
             slot,

--- a/eth/beacon/types/attestations.py
+++ b/eth/beacon/types/attestations.py
@@ -1,7 +1,3 @@
-from typing import (
-    Sequence,
-)
-
 import rlp
 from rlp.sedes import (
     binary,

--- a/eth/beacon/types/attestations.py
+++ b/eth/beacon/types/attestations.py
@@ -15,7 +15,7 @@ from .attestation_data import (
 
 from eth.beacon.typing import (
     Bitfield,
-    BLSSignatureIntegers,
+    BLSSignature,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 
@@ -38,7 +38,7 @@ class Attestation(rlp.Serializable):
                  data: AttestationData,
                  participation_bitfield: Bitfield,
                  custody_bitfield: Bitfield,
-                 aggregate_signature: BLSSignatureIntegers=EMPTY_SIGNATURE) -> None:
+                 aggregate_signature: BLSSignature=EMPTY_SIGNATURE) -> None:
         super().__init__(
             data,
             participation_bitfield,

--- a/eth/beacon/types/attestations.py
+++ b/eth/beacon/types/attestations.py
@@ -17,6 +17,12 @@ from .attestation_data import (
     AttestationData,
 )
 
+from eth.beacon.typing import (
+    Bitfield,
+    BLSSignatureAggregated,
+)
+from eth.beacon.constants import EMPTY_SIGNATURE
+
 
 class Attestation(rlp.Serializable):
     """
@@ -34,9 +40,9 @@ class Attestation(rlp.Serializable):
 
     def __init__(self,
                  data: AttestationData,
-                 participation_bitfield: bytes,
-                 custody_bitfield: bytes,
-                 aggregate_signature: Sequence[int]=(0, 0)) -> None:
+                 participation_bitfield: Bitfield,
+                 custody_bitfield: Bitfield,
+                 aggregate_signature: BLSSignatureAggregated=EMPTY_SIGNATURE) -> None:
         super().__init__(
             data,
             participation_bitfield,

--- a/eth/beacon/types/attestations.py
+++ b/eth/beacon/types/attestations.py
@@ -15,7 +15,7 @@ from .attestation_data import (
 
 from eth.beacon.typing import (
     Bitfield,
-    BLSSignatureAggregated,
+    BLSSignatureIntegers,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 
@@ -38,7 +38,7 @@ class Attestation(rlp.Serializable):
                  data: AttestationData,
                  participation_bitfield: Bitfield,
                  custody_bitfield: Bitfield,
-                 aggregate_signature: BLSSignatureAggregated=EMPTY_SIGNATURE) -> None:
+                 aggregate_signature: BLSSignatureIntegers=EMPTY_SIGNATURE) -> None:
         super().__init__(
             data,
             participation_bitfield,

--- a/eth/beacon/types/blocks.py
+++ b/eth/beacon/types/blocks.py
@@ -24,7 +24,7 @@ from eth.beacon.constants import EMPTY_SIGNATURE
 from eth.beacon._utils.hash import hash_eth2
 from eth.beacon.typing import (
     SlotNumber,
-    BLSSignatureIntegers,
+    BLSSignature,
 )
 
 
@@ -84,7 +84,7 @@ class BaseBeaconBlock(rlp.Serializable):
                  randao_reveal: Hash32,
                  candidate_pow_receipt_root: Hash32,
                  body: BeaconBlockBody,
-                 signature: BLSSignatureIntegers=EMPTY_SIGNATURE) -> None:
+                 signature: BLSSignature=EMPTY_SIGNATURE) -> None:
         super().__init__(
             slot,
             parent_root,

--- a/eth/beacon/types/blocks.py
+++ b/eth/beacon/types/blocks.py
@@ -24,7 +24,7 @@ from eth.beacon.constants import EMPTY_SIGNATURE
 from eth.beacon._utils.hash import hash_eth2
 from eth.beacon.typing import (
     SlotNumber,
-    BLSSignatureAggregated,
+    BLSSignatureIntegers,
 )
 
 
@@ -84,7 +84,7 @@ class BaseBeaconBlock(rlp.Serializable):
                  randao_reveal: Hash32,
                  candidate_pow_receipt_root: Hash32,
                  body: BeaconBlockBody,
-                 signature: BLSSignatureAggregated=EMPTY_SIGNATURE) -> None:
+                 signature: BLSSignatureIntegers=EMPTY_SIGNATURE) -> None:
         super().__init__(
             slot,
             parent_root,

--- a/eth/beacon/types/blocks.py
+++ b/eth/beacon/types/blocks.py
@@ -22,6 +22,11 @@ from eth.rlp.sedes import (
 
 from eth.beacon.constants import EMPTY_SIGNATURE
 from eth.beacon._utils.hash import hash_eth2
+from eth.beacon.typing import (
+    SlotNumber,
+    BLSSignatureAggregated,
+)
+
 
 from .attestations import Attestation
 from .proposer_slashings import ProposerSlashing
@@ -73,13 +78,13 @@ class BaseBeaconBlock(rlp.Serializable):
     ]
 
     def __init__(self,
-                 slot: int,
+                 slot: SlotNumber,
                  parent_root: Hash32,
                  state_root: Hash32,
                  randao_reveal: Hash32,
                  candidate_pow_receipt_root: Hash32,
                  body: BeaconBlockBody,
-                 signature: Sequence[int]=(0, 0)) -> None:
+                 signature: BLSSignatureAggregated=EMPTY_SIGNATURE) -> None:
         super().__init__(
             slot,
             parent_root,

--- a/eth/beacon/types/crosslink_records.py
+++ b/eth/beacon/types/crosslink_records.py
@@ -8,6 +8,8 @@ from eth.rlp.sedes import (
     hash32,
 )
 
+from eth.beacon.typing import SlotNumber
+
 
 class CrosslinkRecord(rlp.Serializable):
     """
@@ -21,7 +23,7 @@ class CrosslinkRecord(rlp.Serializable):
     ]
 
     def __init__(self,
-                 slot: int,
+                 slot: SlotNumber,
                  shard_block_root: Hash32) -> None:
 
         super().__init__(

--- a/eth/beacon/types/deposit_data.py
+++ b/eth/beacon/types/deposit_data.py
@@ -2,6 +2,10 @@
 import rlp
 from eth.rlp.sedes import uint64
 from .deposit_input import DepositInput
+from eth.beacon.typing import (
+    UnixTime,
+    Gwei,
+)
 
 
 class DepositData(rlp.Serializable):
@@ -18,8 +22,8 @@ class DepositData(rlp.Serializable):
 
     def __init__(self,
                  deposit_input: DepositInput,
-                 value: int,
-                 timestamp: int) -> None:
+                 value: Gwei,
+                 timestamp: UnixTime) -> None:
 
         super().__init__(
             deposit_input,

--- a/eth/beacon/types/deposit_data.py
+++ b/eth/beacon/types/deposit_data.py
@@ -3,7 +3,7 @@ import rlp
 from eth.rlp.sedes import uint64
 from .deposit_input import DepositInput
 from eth.beacon.typing import (
-    UnixTime,
+    Timestamp,
     Gwei,
 )
 
@@ -23,7 +23,7 @@ class DepositData(rlp.Serializable):
     def __init__(self,
                  deposit_input: DepositInput,
                  value: Gwei,
-                 timestamp: UnixTime) -> None:
+                 timestamp: Timestamp) -> None:
 
         super().__init__(
             deposit_input,

--- a/eth/beacon/types/deposit_input.py
+++ b/eth/beacon/types/deposit_input.py
@@ -15,7 +15,11 @@ from eth.rlp.sedes import (
     uint384,
 )
 from eth.beacon._utils.hash import hash_eth2
-
+from eth.beacon.typing import (
+    BLSPubkey,
+    BLSSignatureAggregated,
+)
+from eth.beacon.constants import EMPTY_SIGNATURE
 
 class DepositInput(rlp.Serializable):
     """
@@ -33,10 +37,10 @@ class DepositInput(rlp.Serializable):
     ]
 
     def __init__(self,
-                 pubkey: int,
+                 pubkey: BLSPubkey,
                  withdrawal_credentials: Hash32,
                  randao_commitment: Hash32,
-                 proof_of_possession: Sequence[int]=(0, 0)) -> None:
+                 proof_of_possession: BLSSignatureAggregated=EMPTY_SIGNATURE) -> None:
         super().__init__(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,

--- a/eth/beacon/types/deposit_input.py
+++ b/eth/beacon/types/deposit_input.py
@@ -13,7 +13,7 @@ from eth.rlp.sedes import (
 from eth.beacon._utils.hash import hash_eth2
 from eth.beacon.typing import (
     BLSPubkey,
-    BLSSignatureIntegers,
+    BLSSignature,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 
@@ -37,7 +37,7 @@ class DepositInput(rlp.Serializable):
                  pubkey: BLSPubkey,
                  withdrawal_credentials: Hash32,
                  randao_commitment: Hash32,
-                 proof_of_possession: BLSSignatureIntegers=EMPTY_SIGNATURE) -> None:
+                 proof_of_possession: BLSSignature=EMPTY_SIGNATURE) -> None:
         super().__init__(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,

--- a/eth/beacon/types/deposit_input.py
+++ b/eth/beacon/types/deposit_input.py
@@ -1,7 +1,3 @@
-from typing import (
-    Sequence,
-)
-
 from eth_typing import (
     Hash32,
 )
@@ -20,6 +16,7 @@ from eth.beacon.typing import (
     BLSSignatureAggregated,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
+
 
 class DepositInput(rlp.Serializable):
     """

--- a/eth/beacon/types/deposit_input.py
+++ b/eth/beacon/types/deposit_input.py
@@ -13,7 +13,7 @@ from eth.rlp.sedes import (
 from eth.beacon._utils.hash import hash_eth2
 from eth.beacon.typing import (
     BLSPubkey,
-    BLSSignatureAggregated,
+    BLSSignatureIntegers,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 
@@ -37,7 +37,7 @@ class DepositInput(rlp.Serializable):
                  pubkey: BLSPubkey,
                  withdrawal_credentials: Hash32,
                  randao_commitment: Hash32,
-                 proof_of_possession: BLSSignatureAggregated=EMPTY_SIGNATURE) -> None:
+                 proof_of_possession: BLSSignatureIntegers=EMPTY_SIGNATURE) -> None:
         super().__init__(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,

--- a/eth/beacon/types/exits.py
+++ b/eth/beacon/types/exits.py
@@ -9,7 +9,7 @@ from eth.rlp.sedes import (
 )
 from eth.beacon.typing import (
     SlotNumber,
-    BLSSignatureAggregated,
+    BLSSignatureIntegers,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 
@@ -30,7 +30,7 @@ class Exit(rlp.Serializable):
     def __init__(self,
                  slot: SlotNumber,
                  validator_index: int,
-                 signature: BLSSignatureAggregated=EMPTY_SIGNATURE) -> None:
+                 signature: BLSSignatureIntegers=EMPTY_SIGNATURE) -> None:
         super().__init__(
             slot,
             validator_index,

--- a/eth/beacon/types/exits.py
+++ b/eth/beacon/types/exits.py
@@ -8,7 +8,11 @@ from eth.rlp.sedes import (
     uint64,
     uint384,
 )
-
+from eth.beacon.typing import (
+    SlotNumber,
+    BLSSignatureAggregated,
+)
+from eth.beacon.constants import EMPTY_SIGNATURE
 
 class Exit(rlp.Serializable):
     """
@@ -24,9 +28,9 @@ class Exit(rlp.Serializable):
     ]
 
     def __init__(self,
-                 slot: int,
+                 slot: SlotNumber,
                  validator_index: int,
-                 signature: Sequence[int]) -> None:
+                 signature: BLSSignatureAggregated=EMPTY_SIGNATURE) -> None:
         super().__init__(
             slot,
             validator_index,

--- a/eth/beacon/types/exits.py
+++ b/eth/beacon/types/exits.py
@@ -29,7 +29,7 @@ class Exit(rlp.Serializable):
 
     def __init__(self,
                  slot: SlotNumber,
-                 validator_index: int,
+                 validator_index: ValidatorIndex,
                  signature: BLSSignatureIntegers=EMPTY_SIGNATURE) -> None:
         super().__init__(
             slot,

--- a/eth/beacon/types/exits.py
+++ b/eth/beacon/types/exits.py
@@ -1,4 +1,3 @@
-from typing import Sequence
 import rlp
 from rlp.sedes import (
     CountableList,
@@ -13,6 +12,7 @@ from eth.beacon.typing import (
     BLSSignatureAggregated,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
+
 
 class Exit(rlp.Serializable):
     """

--- a/eth/beacon/types/exits.py
+++ b/eth/beacon/types/exits.py
@@ -9,7 +9,7 @@ from eth.rlp.sedes import (
 )
 from eth.beacon.typing import (
     SlotNumber,
-    BLSSignatureIntegers,
+    BLSSignature,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 
@@ -30,7 +30,7 @@ class Exit(rlp.Serializable):
     def __init__(self,
                  slot: SlotNumber,
                  validator_index: ValidatorIndex,
-                 signature: BLSSignatureIntegers=EMPTY_SIGNATURE) -> None:
+                 signature: BLSSignature=EMPTY_SIGNATURE) -> None:
         super().__init__(
             slot,
             validator_index,

--- a/eth/beacon/types/exits.py
+++ b/eth/beacon/types/exits.py
@@ -8,8 +8,9 @@ from eth.rlp.sedes import (
     uint384,
 )
 from eth.beacon.typing import (
-    SlotNumber,
     BLSSignature,
+    SlotNumber,
+    ValidatorIndex,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 

--- a/eth/beacon/types/fork_data.py
+++ b/eth/beacon/types/fork_data.py
@@ -4,6 +4,9 @@ from eth.rlp.sedes import (
     uint64,
 )
 
+from eth.beacon.typing import (
+    SlotNumber,
+)
 
 class ForkData(rlp.Serializable):
     """
@@ -21,7 +24,7 @@ class ForkData(rlp.Serializable):
     def __init__(self,
                  pre_fork_version: int,
                  post_fork_version: int,
-                 fork_slot: int) -> None:
+                 fork_slot: SlotNumber) -> None:
         super().__init__(
             pre_fork_version=pre_fork_version,
             post_fork_version=post_fork_version,

--- a/eth/beacon/types/fork_data.py
+++ b/eth/beacon/types/fork_data.py
@@ -8,6 +8,7 @@ from eth.beacon.typing import (
     SlotNumber,
 )
 
+
 class ForkData(rlp.Serializable):
     """
     Note: using RLP until we have standardized serialization format.

--- a/eth/beacon/types/pending_attestation_records.py
+++ b/eth/beacon/types/pending_attestation_records.py
@@ -6,11 +6,16 @@ from rlp.sedes import (
 from eth.rlp.sedes import (
     uint64,
 )
-
+from eth.beacon.typing import (
+    SlotNumber,
+    Bitfield,
+)
 
 from .attestation_data import (
     AttestationData,
 )
+
+
 
 
 class PendingAttestationRecord(rlp.Serializable):
@@ -30,9 +35,9 @@ class PendingAttestationRecord(rlp.Serializable):
 
     def __init__(self,
                  data: AttestationData,
-                 participation_bitfield: bytes,
-                 custody_bitfield: bytes,
-                 slot_included: int) -> None:
+                 participation_bitfield: Bitfield,
+                 custody_bitfield: Bitfield,
+                 slot_included: SlotNumber) -> None:
         super().__init__(
             data=data,
             participation_bitfield=participation_bitfield,

--- a/eth/beacon/types/pending_attestation_records.py
+++ b/eth/beacon/types/pending_attestation_records.py
@@ -16,8 +16,6 @@ from .attestation_data import (
 )
 
 
-
-
 class PendingAttestationRecord(rlp.Serializable):
     """
     Note: using RLP until we have standardized serialization format.

--- a/eth/beacon/types/proposal_signed_data.py
+++ b/eth/beacon/types/proposal_signed_data.py
@@ -9,6 +9,10 @@ from eth.rlp.sedes import (
     uint64,
     hash32,
 )
+from eth.beacon.typing import (
+    SlotNumber,
+    ShardNumber,
+)
 
 
 class ProposalSignedData(rlp.Serializable):
@@ -25,8 +29,8 @@ class ProposalSignedData(rlp.Serializable):
     ]
 
     def __init__(self,
-                 slot: int,
-                 shard: int,
+                 slot: SlotNumber,
+                 shard: ShardNumber,
                  block_root: Hash32) -> None:
         super().__init__(
             slot,

--- a/eth/beacon/types/proposer_slashings.py
+++ b/eth/beacon/types/proposer_slashings.py
@@ -1,4 +1,3 @@
-from typing import Sequence
 import rlp
 from rlp.sedes import (
     CountableList,
@@ -12,6 +11,7 @@ from eth.beacon.typing import (
     BLSSignatureAggregated,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
+
 
 class ProposerSlashing(rlp.Serializable):
     fields = [

--- a/eth/beacon/types/proposer_slashings.py
+++ b/eth/beacon/types/proposer_slashings.py
@@ -8,7 +8,10 @@ from eth.rlp.sedes import (
     uint384,
 )
 from .proposal_signed_data import ProposalSignedData
-
+from eth.beacon.typing import (
+    BLSSignatureAggregated,
+)
+from eth.beacon.constants import EMPTY_SIGNATURE
 
 class ProposerSlashing(rlp.Serializable):
     fields = [
@@ -27,13 +30,14 @@ class ProposerSlashing(rlp.Serializable):
     def __init__(self,
                  proposer_index: int,
                  proposal_data_1: ProposalSignedData,
-                 proposal_signature_1: Sequence[int],
                  proposal_data_2: ProposalSignedData,
-                 proposal_signature_2: Sequence[int]) -> None:
+                 # default arguments follow non-default arguments
+                 proposal_signature_1: BLSSignatureAggregated = EMPTY_SIGNATURE,
+                 proposal_signature_2: BLSSignatureAggregated = EMPTY_SIGNATURE) -> None:
         super().__init__(
             proposer_index,
             proposal_data_1,
-            proposal_signature_1,
             proposal_data_2,
+            proposal_signature_1,
             proposal_signature_2,
         )

--- a/eth/beacon/types/proposer_slashings.py
+++ b/eth/beacon/types/proposer_slashings.py
@@ -9,6 +9,7 @@ from eth.rlp.sedes import (
 from .proposal_signed_data import ProposalSignedData
 from eth.beacon.typing import (
     BLSSignature,
+    ValidatorIndex,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 

--- a/eth/beacon/types/proposer_slashings.py
+++ b/eth/beacon/types/proposer_slashings.py
@@ -8,7 +8,7 @@ from eth.rlp.sedes import (
 )
 from .proposal_signed_data import ProposalSignedData
 from eth.beacon.typing import (
-    BLSSignatureAggregated,
+    BLSSignatureIntegers,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 
@@ -32,8 +32,8 @@ class ProposerSlashing(rlp.Serializable):
                  proposal_data_1: ProposalSignedData,
                  proposal_data_2: ProposalSignedData,
                  # default arguments follow non-default arguments
-                 proposal_signature_1: BLSSignatureAggregated = EMPTY_SIGNATURE,
-                 proposal_signature_2: BLSSignatureAggregated = EMPTY_SIGNATURE) -> None:
+                 proposal_signature_1: BLSSignatureIntegers = EMPTY_SIGNATURE,
+                 proposal_signature_2: BLSSignatureIntegers = EMPTY_SIGNATURE) -> None:
         super().__init__(
             proposer_index=proposer_index,
             proposal_data_1=proposal_data_1,

--- a/eth/beacon/types/proposer_slashings.py
+++ b/eth/beacon/types/proposer_slashings.py
@@ -8,7 +8,7 @@ from eth.rlp.sedes import (
 )
 from .proposal_signed_data import ProposalSignedData
 from eth.beacon.typing import (
-    BLSSignatureIntegers,
+    BLSSignature,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 
@@ -32,8 +32,8 @@ class ProposerSlashing(rlp.Serializable):
                  proposal_data_1: ProposalSignedData,
                  proposal_data_2: ProposalSignedData,
                  # default arguments follow non-default arguments
-                 proposal_signature_1: BLSSignatureIntegers = EMPTY_SIGNATURE,
-                 proposal_signature_2: BLSSignatureIntegers = EMPTY_SIGNATURE) -> None:
+                 proposal_signature_1: BLSSignature = EMPTY_SIGNATURE,
+                 proposal_signature_2: BLSSignature = EMPTY_SIGNATURE) -> None:
         super().__init__(
             proposer_index=proposer_index,
             proposal_data_1=proposal_data_1,

--- a/eth/beacon/types/proposer_slashings.py
+++ b/eth/beacon/types/proposer_slashings.py
@@ -28,7 +28,7 @@ class ProposerSlashing(rlp.Serializable):
     ]
 
     def __init__(self,
-                 proposer_index: int,
+                 proposer_index: ValidatorIndex,
                  proposal_data_1: ProposalSignedData,
                  proposal_data_2: ProposalSignedData,
                  # default arguments follow non-default arguments

--- a/eth/beacon/types/proposer_slashings.py
+++ b/eth/beacon/types/proposer_slashings.py
@@ -35,9 +35,9 @@ class ProposerSlashing(rlp.Serializable):
                  proposal_signature_1: BLSSignatureAggregated = EMPTY_SIGNATURE,
                  proposal_signature_2: BLSSignatureAggregated = EMPTY_SIGNATURE) -> None:
         super().__init__(
-            proposer_index,
-            proposal_data_1,
-            proposal_data_2,
-            proposal_signature_1,
-            proposal_signature_2,
+            proposer_index=proposer_index,
+            proposal_data_1=proposal_data_1,
+            proposal_data_2=proposal_data_2,
+            proposal_signature_1=proposal_signature_1,
+            proposal_signature_2=proposal_signature_2,
         )

--- a/eth/beacon/types/shard_committees.py
+++ b/eth/beacon/types/shard_committees.py
@@ -31,7 +31,7 @@ class ShardCommittee(rlp.Serializable):
 
     def __init__(self,
                  shard: ShardNumber,
-                 committee: Sequence[int],
+                 committee: Sequence[ValidatorIndex],
                  total_validator_count: int)-> None:
 
         super().__init__(

--- a/eth/beacon/types/shard_committees.py
+++ b/eth/beacon/types/shard_committees.py
@@ -13,6 +13,7 @@ from eth.rlp.sedes import (
 )
 from eth.beacon.typing import (
     ShardNumber,
+    ValidatorIndex,
 )
 
 

--- a/eth/beacon/types/shard_committees.py
+++ b/eth/beacon/types/shard_committees.py
@@ -11,6 +11,9 @@ from eth.rlp.sedes import (
     uint24,
     uint64,
 )
+from eth.beacon.typing import (
+    ShardNumber,
+)
 
 
 class ShardCommittee(rlp.Serializable):
@@ -27,7 +30,7 @@ class ShardCommittee(rlp.Serializable):
     ]
 
     def __init__(self,
-                 shard: int,
+                 shard: ShardNumber,
                  committee: Sequence[int],
                  total_validator_count: int)-> None:
 

--- a/eth/beacon/types/shard_reassignment_records.py
+++ b/eth/beacon/types/shard_reassignment_records.py
@@ -7,6 +7,7 @@ from eth.rlp.sedes import (
 from eth.beacon.typing import (
     SlotNumber,
     ShardNumber,
+    ValidatorIndex,
 )
 
 

--- a/eth/beacon/types/shard_reassignment_records.py
+++ b/eth/beacon/types/shard_reassignment_records.py
@@ -24,7 +24,7 @@ class ShardReassignmentRecord(rlp.Serializable):
     ]
 
     def __init__(self,
-                 validator_index: int,
+                 validator_index: ValidatorIndex,
                  shard: ShardNumber,
                  slot: SlotNumber)-> None:
         super().__init__(

--- a/eth/beacon/types/shard_reassignment_records.py
+++ b/eth/beacon/types/shard_reassignment_records.py
@@ -4,6 +4,10 @@ from eth.rlp.sedes import (
     uint24,
     uint64,
 )
+from eth.beacon.typing import (
+    SlotNumber,
+    ShardNumber,
+)
 
 
 class ShardReassignmentRecord(rlp.Serializable):
@@ -21,8 +25,8 @@ class ShardReassignmentRecord(rlp.Serializable):
 
     def __init__(self,
                  validator_index: int,
-                 shard: int,
-                 slot: int)-> None:
+                 shard: ShardNumber,
+                 slot: SlotNumber)-> None:
         super().__init__(
             validator_index=validator_index,
             shard=shard,

--- a/eth/beacon/types/slashable_vote_data.py
+++ b/eth/beacon/types/slashable_vote_data.py
@@ -14,6 +14,11 @@ from eth.rlp.sedes import (
     uint24,
     uint384,
 )
+from eth.beacon.typing import (
+    BLSSignatureAggregated,
+)
+from eth.beacon.constants import EMPTY_SIGNATURE
+
 from .attestation_data import AttestationData
 
 
@@ -36,7 +41,7 @@ class SlashableVoteData(rlp.Serializable):
                  aggregate_signature_poc_0_indices: Sequence[int],
                  aggregate_signature_poc_1_indices: Sequence[int],
                  data: AttestationData,
-                 aggregate_signature: Sequence[int]) -> None:
+                 aggregate_signature: BLSSignatureAggregated = EMPTY_SIGNATURE) -> None:
         super().__init__(
             aggregate_signature_poc_0_indices,
             aggregate_signature_poc_1_indices,

--- a/eth/beacon/types/slashable_vote_data.py
+++ b/eth/beacon/types/slashable_vote_data.py
@@ -15,7 +15,7 @@ from eth.rlp.sedes import (
     uint384,
 )
 from eth.beacon.typing import (
-    BLSSignatureIntegers,
+    BLSSignature,
     ValidatorIndex,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
@@ -42,7 +42,7 @@ class SlashableVoteData(rlp.Serializable):
                  aggregate_signature_poc_0_indices: Sequence[ValidatorIndex],
                  aggregate_signature_poc_1_indices: Sequence[ValidatorIndex],
                  data: AttestationData,
-                 aggregate_signature: BLSSignatureIntegers = EMPTY_SIGNATURE) -> None:
+                 aggregate_signature: BLSSignature = EMPTY_SIGNATURE) -> None:
         super().__init__(
             aggregate_signature_poc_0_indices,
             aggregate_signature_poc_1_indices,

--- a/eth/beacon/types/slashable_vote_data.py
+++ b/eth/beacon/types/slashable_vote_data.py
@@ -16,6 +16,7 @@ from eth.rlp.sedes import (
 )
 from eth.beacon.typing import (
     BLSSignatureIntegers,
+    ValidatorIndex,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 
@@ -38,8 +39,8 @@ class SlashableVoteData(rlp.Serializable):
     ]
 
     def __init__(self,
-                 aggregate_signature_poc_0_indices: Sequence[int],
-                 aggregate_signature_poc_1_indices: Sequence[int],
+                 aggregate_signature_poc_0_indices: Sequence[ValidatorIndex],
+                 aggregate_signature_poc_1_indices: Sequence[ValidatorIndex],
                  data: AttestationData,
                  aggregate_signature: BLSSignatureIntegers = EMPTY_SIGNATURE) -> None:
         super().__init__(

--- a/eth/beacon/types/slashable_vote_data.py
+++ b/eth/beacon/types/slashable_vote_data.py
@@ -15,7 +15,7 @@ from eth.rlp.sedes import (
     uint384,
 )
 from eth.beacon.typing import (
-    BLSSignatureAggregated,
+    BLSSignatureIntegers,
 )
 from eth.beacon.constants import EMPTY_SIGNATURE
 
@@ -41,7 +41,7 @@ class SlashableVoteData(rlp.Serializable):
                  aggregate_signature_poc_0_indices: Sequence[int],
                  aggregate_signature_poc_1_indices: Sequence[int],
                  data: AttestationData,
-                 aggregate_signature: BLSSignatureAggregated = EMPTY_SIGNATURE) -> None:
+                 aggregate_signature: BLSSignatureIntegers = EMPTY_SIGNATURE) -> None:
         super().__init__(
             aggregate_signature_poc_0_indices,
             aggregate_signature_poc_1_indices,

--- a/eth/beacon/types/states.py
+++ b/eth/beacon/types/states.py
@@ -22,6 +22,12 @@ from eth.rlp.sedes import (
 from eth.beacon._utils.hash import (
     hash_eth2,
 )
+from eth.beacon.typing import (
+    SlotNumber,
+    Bitfield,
+    UnixTime,
+    Gwei,
+)
 
 from .pending_attestation_records import PendingAttestationRecord
 from .candidate_pow_receipt_root_records import CandidatePoWReceiptRootRecord
@@ -76,19 +82,19 @@ class BeaconState(rlp.Serializable):
 
     def __init__(
             self,
-            slot: int,
-            genesis_time: int,
+            slot: SlotNumber,
+            genesis_time: UnixTime,
             fork_data: ForkData,
-            validator_registry_latest_change_slot: int,
+            validator_registry_latest_change_slot: SlotNumber,
             validator_registry_exit_count: int,
             validator_registry_delta_chain_tip: Hash32,
-            previous_justified_slot: int,
-            justified_slot: int,
-            justification_bitfield: int,
-            finalized_slot: int,
+            previous_justified_slot: SlotNumber,
+            justified_slot: SlotNumber,
+            justification_bitfield: Bitfield,
+            finalized_slot: SlotNumber,
             processed_pow_receipt_root: Hash32,
             validator_registry: Sequence[ValidatorRecord]=(),
-            validator_balances: Sequence[int]=(),
+            validator_balances: Sequence[Gwei]=(),
             latest_randao_mixes: Sequence[Hash32]=(),
             latest_vdf_outputs: Sequence[Hash32]=(),
             shard_committees_at_slots: Sequence[Sequence[ShardCommittee]]=(),
@@ -96,7 +102,7 @@ class BeaconState(rlp.Serializable):
             persistent_committee_reassignments: Sequence[ShardReassignmentRecord]=(),
             latest_crosslinks: Sequence[CrosslinkRecord]=(),
             latest_block_roots: Sequence[Hash32]=(),
-            latest_penalized_exit_balances: Sequence[int]=(),
+            latest_penalized_exit_balances: Sequence[Gwei]=(),
             batched_block_roots: Sequence[Hash32]=(),
             latest_attestations: Sequence[PendingAttestationRecord]=(),
             candidate_pow_receipt_roots: Sequence[CandidatePoWReceiptRootRecord]=()
@@ -164,7 +170,7 @@ class BeaconState(rlp.Serializable):
     def update_validator(self,
                          validator_index: int,
                          validator: ValidatorRecord,
-                         balance: int) -> 'BeaconState':
+                         balance: Gwei) -> 'BeaconState':
         validator_registry = list(self.validator_registry)
         validator_registry[validator_index] = validator
 

--- a/eth/beacon/types/states.py
+++ b/eth/beacon/types/states.py
@@ -11,6 +11,7 @@ from eth_utils import (
 
 import rlp
 from rlp.sedes import (
+    binary,
     CountableList,
 )
 
@@ -66,7 +67,8 @@ class BeaconState(rlp.Serializable):
         # Finality
         ('previous_justified_slot', uint64),
         ('justified_slot', uint64),
-        ('justification_bitfield', uint64),
+        # TODO: check if justification_bitfield is bytes or int
+        ('justification_bitfield', binary),
         ('finalized_slot', uint64),
 
         # Recent state

--- a/eth/beacon/types/states.py
+++ b/eth/beacon/types/states.py
@@ -27,6 +27,7 @@ from eth.beacon.typing import (
     Bitfield,
     Timestamp,
     Gwei,
+    ValidatorIndex,
 )
 
 from .pending_attestation_records import PendingAttestationRecord
@@ -168,7 +169,7 @@ class BeaconState(rlp.Serializable):
         return len(self.latest_crosslinks)
 
     def update_validator(self,
-                         validator_index: int,
+                         validator_index: ValidatorIndex,
                          validator: ValidatorRecord,
                          balance: Gwei) -> 'BeaconState':
         validator_registry = list(self.validator_registry)

--- a/eth/beacon/types/states.py
+++ b/eth/beacon/types/states.py
@@ -99,7 +99,7 @@ class BeaconState(rlp.Serializable):
             latest_randao_mixes: Sequence[Hash32]=(),
             latest_vdf_outputs: Sequence[Hash32]=(),
             shard_committees_at_slots: Sequence[Sequence[ShardCommittee]]=(),
-            persistent_committees: Sequence[Sequence[int]]=(),
+            persistent_committees: Sequence[Sequence[ValidatorIndex]]=(),
             persistent_committee_reassignments: Sequence[ShardReassignmentRecord]=(),
             latest_crosslinks: Sequence[CrosslinkRecord]=(),
             latest_block_roots: Sequence[Hash32]=(),

--- a/eth/beacon/types/states.py
+++ b/eth/beacon/types/states.py
@@ -25,7 +25,7 @@ from eth.beacon._utils.hash import (
 from eth.beacon.typing import (
     SlotNumber,
     Bitfield,
-    UnixTime,
+    Timestamp,
     Gwei,
 )
 
@@ -83,7 +83,7 @@ class BeaconState(rlp.Serializable):
     def __init__(
             self,
             slot: SlotNumber,
-            genesis_time: UnixTime,
+            genesis_time: Timestamp,
             fork_data: ForkData,
             validator_registry_latest_change_slot: SlotNumber,
             validator_registry_exit_count: int,

--- a/eth/beacon/types/validator_records.py
+++ b/eth/beacon/types/validator_records.py
@@ -17,7 +17,6 @@ from eth.beacon.typing import (
 )
 
 
-
 VALIDATOR_RECORD_ACTIVE_STATUSES = {
     ValidatorStatusCode.ACTIVE,
     ValidatorStatusCode.ACTIVE_PENDING_EXIT,

--- a/eth/beacon/types/validator_records.py
+++ b/eth/beacon/types/validator_records.py
@@ -11,6 +11,11 @@ from eth.rlp.sedes import (
     uint384,
     hash32,
 )
+from eth.beacon.typing import (
+    SlotNumber,
+    BLSPubkey,
+)
+
 
 
 VALIDATOR_RECORD_ACTIVE_STATUSES = {
@@ -41,12 +46,12 @@ class ValidatorRecord(rlp.Serializable):
     ]
 
     def __init__(self,
-                 pubkey: int,
+                 pubkey: BLSPubkey,
                  withdrawal_credentials: Hash32,
                  randao_commitment: Hash32,
-                 randao_layers: int,
-                 status: int,
-                 latest_status_change_slot: int,
+                 randao_layers: SlotNumber,
+                 status: ValidatorStatusCode,
+                 latest_status_change_slot: SlotNumber,
                  exit_count: int) -> None:
         super().__init__(
             pubkey=pubkey,
@@ -67,10 +72,10 @@ class ValidatorRecord(rlp.Serializable):
 
     @classmethod
     def get_pending_validator(cls,
-                              pubkey: int,
+                              pubkey: BLSPubkey,
                               withdrawal_credentials: Hash32,
                               randao_commitment: Hash32,
-                              latest_status_change_slot: int) -> 'ValidatorRecord':
+                              latest_status_change_slot: SlotNumber) -> 'ValidatorRecord':
         """
         Return a new pending ``ValidatorRecord`` with the given fields.
         """
@@ -78,7 +83,7 @@ class ValidatorRecord(rlp.Serializable):
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
             randao_commitment=randao_commitment,
-            randao_layers=0,
+            randao_layers=SlotNumber(0),
             status=ValidatorStatusCode.PENDING_ACTIVATION,
             latest_status_change_slot=latest_status_change_slot,
             exit_count=0,

--- a/eth/beacon/types/validator_records.py
+++ b/eth/beacon/types/validator_records.py
@@ -48,7 +48,7 @@ class ValidatorRecord(rlp.Serializable):
                  pubkey: BLSPubkey,
                  withdrawal_credentials: Hash32,
                  randao_commitment: Hash32,
-                 randao_layers: SlotNumber,
+                 randao_layers: int,
                  status: ValidatorStatusCode,
                  latest_status_change_slot: SlotNumber,
                  exit_count: int) -> None:
@@ -82,7 +82,7 @@ class ValidatorRecord(rlp.Serializable):
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
             randao_commitment=randao_commitment,
-            randao_layers=SlotNumber(0),
+            randao_layers=0,
             status=ValidatorStatusCode.PENDING_ACTIVATION,
             latest_status_change_slot=latest_status_change_slot,
             exit_count=0,

--- a/eth/beacon/types/validator_registry_delta_block.py
+++ b/eth/beacon/types/validator_registry_delta_block.py
@@ -33,7 +33,7 @@ class ValidatorRegistryDeltaBlock(rlp.Serializable):
                  latest_registry_delta_root: Hash32,
                  validator_index: ValidatorIndex,
                  pubkey: BLSPubkey,
-                 flag: int) -> None:
+                 flag: ValidatorRegistryDeltaFlag) -> None:
         super().__init__(
             latest_registry_delta_root=latest_registry_delta_root,
             validator_index=validator_index,

--- a/eth/beacon/types/validator_registry_delta_block.py
+++ b/eth/beacon/types/validator_registry_delta_block.py
@@ -6,6 +6,10 @@ import rlp
 from eth.beacon._utils.hash import (
     hash_eth2,
 )
+from eth.beacon.typing import (
+    BLSPubkey,
+)
+
 from eth.rlp.sedes import (
     hash32,
     uint24,
@@ -28,7 +32,7 @@ class ValidatorRegistryDeltaBlock(rlp.Serializable):
     def __init__(self,
                  latest_registry_delta_root: Hash32,
                  validator_index: int,
-                 pubkey: int,
+                 pubkey: BLSPubkey,
                  flag: int) -> None:
         super().__init__(
             latest_registry_delta_root=latest_registry_delta_root,

--- a/eth/beacon/types/validator_registry_delta_block.py
+++ b/eth/beacon/types/validator_registry_delta_block.py
@@ -31,7 +31,7 @@ class ValidatorRegistryDeltaBlock(rlp.Serializable):
 
     def __init__(self,
                  latest_registry_delta_root: Hash32,
-                 validator_index: int,
+                 validator_index: ValidatorIndex,
                  pubkey: BLSPubkey,
                  flag: int) -> None:
         super().__init__(

--- a/eth/beacon/types/validator_registry_delta_block.py
+++ b/eth/beacon/types/validator_registry_delta_block.py
@@ -8,6 +8,11 @@ from eth.beacon._utils.hash import (
 )
 from eth.beacon.typing import (
     BLSPubkey,
+    ValidatorIndex,
+)
+
+from eth.beacon.enums import (
+    ValidatorRegistryDeltaFlag,
 )
 
 from eth.rlp.sedes import (

--- a/eth/beacon/typing.py
+++ b/eth/beacon/typing.py
@@ -1,0 +1,18 @@
+from typing import NewType, Tuple
+
+SlotNumber = NewType('SlotNumber', int)  # uint64
+ShardNumber = NewType('ShardNumber', int)  # uint64
+BLSPubkey = NewType('BLSPubkey', int)  # uint384
+BLSPubkeyAggregated = NewType('BLSPubkeyAggregated', int)  # uint384
+BLSSignature = NewType('BLSSignature', bytes)  
+BLSSignatureAggregated = NewType('BLSSignatureAggregated', Tuple[int, int]) # Tuple[uint384, uint384]
+ValidatorIndex = NewType('ValidatorIndex', int)  # uint24
+Bitfield = NewType('Bitfield', bytes)  # uint64
+
+UnixTime = NewType('UnixTime', int)
+
+Ether = NewType('Ether', int)  # uint64
+Gwei = NewType('Gwei', int)  # uint64
+
+
+Seconds = NewType('Seconds', int)

--- a/eth/beacon/typing.py
+++ b/eth/beacon/typing.py
@@ -3,7 +3,6 @@ from typing import NewType, Tuple
 SlotNumber = NewType('SlotNumber', int)  # uint64
 ShardNumber = NewType('ShardNumber', int)  # uint64
 BLSPubkey = NewType('BLSPubkey', int)  # uint384
-BLSPubkeyAggregated = NewType('BLSPubkeyAggregated', int)  # uint384
 BLSSignature = NewType('BLSSignature', bytes)
 BLSSignatureAggregated = NewType(
     'BLSSignatureAggregated',

--- a/eth/beacon/typing.py
+++ b/eth/beacon/typing.py
@@ -4,8 +4,11 @@ SlotNumber = NewType('SlotNumber', int)  # uint64
 ShardNumber = NewType('ShardNumber', int)  # uint64
 BLSPubkey = NewType('BLSPubkey', int)  # uint384
 BLSPubkeyAggregated = NewType('BLSPubkeyAggregated', int)  # uint384
-BLSSignature = NewType('BLSSignature', bytes)  
-BLSSignatureAggregated = NewType('BLSSignatureAggregated', Tuple[int, int]) # Tuple[uint384, uint384]
+BLSSignature = NewType('BLSSignature', bytes)
+BLSSignatureAggregated = NewType(
+    'BLSSignatureAggregated',
+    Tuple[int, int]
+)  # Tuple[uint384, uint384]
 ValidatorIndex = NewType('ValidatorIndex', int)  # uint24
 Bitfield = NewType('Bitfield', bytes)  # uint64
 

--- a/eth/beacon/typing.py
+++ b/eth/beacon/typing.py
@@ -3,18 +3,18 @@ from typing import NewType, Tuple
 SlotNumber = NewType('SlotNumber', int)  # uint64
 ShardNumber = NewType('ShardNumber', int)  # uint64
 BLSPubkey = NewType('BLSPubkey', int)  # uint384
-BLSSignature = NewType('BLSSignature', bytes)
-BLSSignatureAggregated = NewType(
-    'BLSSignatureAggregated',
-    Tuple[int, int]
-)  # Tuple[uint384, uint384]
-ValidatorIndex = NewType('ValidatorIndex', int)  # uint24
+BLSSignatureBytes = NewType('BLSSignatureBytes', bytes)
+BLSSignatureIntegers = NewType('BLSSignatureIntegers', Tuple[int, int])  # Tuple[uint384, uint384]
+
 Bitfield = NewType('Bitfield', bytes)  # uint64
 
-UnixTime = NewType('UnixTime', int)
+
+ValidatorIndex = NewType('ValidatorIndex', int)  # uint24
+CommitteeIndex = NewType('CommitteeIndex', int)
+
 
 Ether = NewType('Ether', int)  # uint64
 Gwei = NewType('Gwei', int)  # uint64
 
-
-Seconds = NewType('Seconds', int)
+Timestamp = NewType('Timestamp', int)
+Second = NewType('Second', int)

--- a/eth/beacon/typing.py
+++ b/eth/beacon/typing.py
@@ -3,8 +3,7 @@ from typing import NewType, Tuple
 SlotNumber = NewType('SlotNumber', int)  # uint64
 ShardNumber = NewType('ShardNumber', int)  # uint64
 BLSPubkey = NewType('BLSPubkey', int)  # uint384
-BLSSignatureBytes = NewType('BLSSignatureBytes', bytes)
-BLSSignatureIntegers = NewType('BLSSignatureIntegers', Tuple[int, int])  # Tuple[uint384, uint384]
+BLSSignature = NewType('BLSSignature', Tuple[int, int])  # Tuple[uint384, uint384]
 
 Bitfield = NewType('Bitfield', bytes)  # uint64
 

--- a/tests/beacon/conftest.py
+++ b/tests/beacon/conftest.py
@@ -219,7 +219,7 @@ def sample_exit_params():
     return {
         'slot': 123,
         'validator_index': 15,
-        'signature': (b'\56' * 32),
+        'signature': (0, 0),
     }
 
 

--- a/tests/beacon/conftest.py
+++ b/tests/beacon/conftest.py
@@ -158,7 +158,7 @@ def sample_beacon_state_params(sample_fork_data_params):
         'persistent_committee_reassignments': (),
         'previous_justified_slot': 0,
         'justified_slot': 0,
-        'justification_bitfield': 0,
+        'justification_bitfield': b'\x00',
         'finalized_slot': 0,
         'latest_crosslinks': (),
         'latest_block_roots': (),


### PR DESCRIPTION
### What was wrong?

This is an attempt to fix #1383

### How was it fixed?

- Add `NewType`s in `eth/beacon/typing.py`

### Discussion

I added some additional new types:

1. Differentiate signatures in `bytes` and `Tuple[int, int]` form.
```python
BLSSignature = NewType('BLSSignature', bytes)  
BLSSignatureAggregated = NewType('BLSSignatureAggregated', Tuple[int, int]) # Tuple[uint384, uint384]
```
2. Add `Timestamp` and `Second` types.
3. Add a `ValidatorIndex` type.

#### Also, some issues need to resolve

- Are 5th slot and 5 slots considered same `SlotNumber` type?
- Do we need `uint64` and `uint384` types to differentiate different integers? The purpose is to check the intention of the variable rather than to check integer length or signed/unsigned.

#### Suggested types

- CommitteeIndex

### Cute Animal Picture

![image](https://i.imgur.com/51wbpU0.jpg)
