### PR TITLE
Implement fast integer square root

### DIFF
--- a/eth/_utils/numeric.py
+++ b/eth/_utils/numeric.py
@@ -1,3 +1,4 @@
+import decimal
 import functools
 import itertools
 from typing import (
@@ -103,8 +104,7 @@ def clamp(inclusive_lower_bound: int,
 
 def integer_squareroot(value: int) -> int:
     """
-    Return the largest integer ``x`` such that ``x**2 <= value``.
-    Ref: https://en.wikipedia.org/wiki/Integer_square_root
+    Return the integer square root of ``value``.
     """
     if not isinstance(value, int) or isinstance(value, bool):
         raise ValueError(
@@ -119,9 +119,8 @@ def integer_squareroot(value: int) -> int:
             )
         )
 
-    x = value
-    y = (x + 1) // 2
-    while y < x:
-        x = y
-        y = (x + value // x) // 2
-    return x
+    with decimal.localcontext() as ctx:
+        # Set precision to 128, since the largest square root of a
+        # 256-bit integer is a 128-bit integer.
+        ctx.prec = 128
+        return int(decimal.Decimal(value).sqrt())

--- a/eth/_utils/numeric.py
+++ b/eth/_utils/numeric.py
@@ -105,6 +105,10 @@ def clamp(inclusive_lower_bound: int,
 def integer_squareroot(value: int) -> int:
     """
     Return the integer square root of ``value``.
+
+    Uses Python's decimal module to compute the square root of ``value`` with
+    a precision of 128-bits. The value 128 is chosen since the largest square
+    root of a 256-bit integer is a 128-bit integer.
     """
     if not isinstance(value, int) or isinstance(value, bool):
         raise ValueError(
@@ -120,7 +124,5 @@ def integer_squareroot(value: int) -> int:
         )
 
     with decimal.localcontext() as ctx:
-        # Set precision to 128, since the largest square root of a
-        # 256-bit integer is a 128-bit integer.
         ctx.prec = 128
         return int(decimal.Decimal(value).sqrt())


### PR DESCRIPTION
### What was wrong?

See #1550.

### How was it fixed?

Used `decimal` module of Python to calculate the square root, which is ~4 times faster than the implementation described in Ethereum 2.0 specs.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/564x/4a/96/9c/4a969cf816788f83fec3b18c5599abb3.jpg)
