### PR TITLE
CI: rename EIP15{0,8} tox jobs to their long-form fork names.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,18 +84,18 @@ jobs:
       - image: circleci/python:3.5
         environment:
           TOXENV: py35-native-blockchain-homestead
-  py35-native-blockchain-eip150:
+  py35-native-blockchain-tangerine_whistle:
     <<: *common
     docker:
       - image: circleci/python:3.5
         environment:
-          TOXENV: py35-native-blockchain-eip150
-  py35-native-blockchain-eip158:
+          TOXENV: py35-native-blockchain-tangerine_whistle
+  py35-native-blockchain-spurious_dragon:
     <<: *common
     docker:
       - image: circleci/python:3.5
         environment:
-          TOXENV: py35-native-blockchain-eip158
+          TOXENV: py35-native-blockchain-spurious_dragon
   py35-native-blockchain-transition:
     <<: *common
     docker:
@@ -157,18 +157,18 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-native-blockchain-homestead
-  py36-native-blockchain-eip150:
+  py36-native-blockchain-tangerine_whistle:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-native-blockchain-eip150
-  py36-native-blockchain-eip158:
+          TOXENV: py36-native-blockchain-tangerine_whistle
+  py36-native-blockchain-spurious_dragon:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-native-blockchain-eip158
+          TOXENV: py36-native-blockchain-spurious_dragon
   py36-native-blockchain-transition:
     <<: *common
     docker:
@@ -232,8 +232,8 @@ workflows:
       - py36-native-blockchain-constantinople
       - py36-native-blockchain-frontier
       - py36-native-blockchain-homestead
-      - py36-native-blockchain-eip150
-      - py36-native-blockchain-eip158
+      - py36-native-blockchain-tangerine_whistle
+      - py36-native-blockchain-spurious_dragon
       - py36-native-blockchain-transition
       - py36-vm
       - py36-benchmark
@@ -246,8 +246,8 @@ workflows:
       - py35-native-blockchain-constantinople
       - py35-native-blockchain-frontier
       - py35-native-blockchain-homestead
-      - py35-native-blockchain-eip150
-      - py35-native-blockchain-eip158
+      - py35-native-blockchain-tangerine_whistle
+      - py35-native-blockchain-spurious_dragon
       - py35-native-blockchain-transition
       - py35-vm
       - py35-core

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     py{35,36}-{core,database,transactions,vm}
     py{36}-{benchmark,beacon}
-    py{35,36}-native-blockchain-{frontier,homestead,eip150,eip158,byzantium,constantinople,metropolis,transition}
+    py{35,36}-native-blockchain-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,metropolis,transition}
     py37-{core,beacon}
     py{35,36}-lint
     py36-docs
@@ -25,8 +25,8 @@ commands=
     vm: pytest {posargs:tests/json-fixtures/test_virtual_machine.py}
     native-blockchain-frontier: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Frontier}
     native-blockchain-homestead: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Homestead}
-    native-blockchain-eip150: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork EIP150}
-    native-blockchain-eip158: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork EIP158}
+    native-blockchain-tangerine_whistle: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork EIP150}
+    native-blockchain-spurious_dragon: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork EIP158}
     native-blockchain-byzantium: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Byzantium}
     native-blockchain-constantinople: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Constantinople}
     native-blockchain-metropolis: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Metropolis}


### PR DESCRIPTION
### What was wrong?

Fallout from PR https://github.com/ethereum/py-evm/pull/1577#discussion_r241148668.

CI jobs have `eip150`, `eip158` in their names.

One has to know the numbers refer to hard-forks to understand jobs don't check for kitty support, or the like.

### How was it fixed?

Renamed CI job name (label only).

(Or was the original request to rename it throughout the codebase?..)

### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://muc1.framepool.com/shotimg/856590910-pribilof-islands-eared-seal-eyes-closed-curiosity.jpg)

Source: thumbnail of a [video on framepool](http://muc1.framepool.com/en/shot/856590910-pribilof-islands-eared-seal-eyes-closed-curiosity)