### PR TITLE
[WIP] Refactor DB persistence logic to work with iterators

### DIFF
--- a/eth/db/header.py
+++ b/eth/db/header.py
@@ -5,6 +5,7 @@ from typing import Iterable, Tuple
 import rlp
 
 from cytoolz import (
+    concat,
     first,
     sliding_window,
 )
@@ -205,61 +206,77 @@ class HeaderDB(BaseHeaderDB):
             return self._persist_header_chain(db, headers)
 
     @classmethod
+    def _set_hash_scores_to_db(
+            cls,
+            db: BaseDB,
+            header: BlockHeader,
+            score
+    ):
+        db.set(
+            header.hash,
+            rlp.encode(header),
+        )
+
+        new_score = score + header.difficulty
+
+        db.set(
+            SchemaV1.make_block_hash_to_score_lookup_key(header.hash),
+            rlp.encode(new_score, sedes=rlp.sedes.big_endian_int),
+        )
+
+        return new_score
+
+    @classmethod
     def _persist_header_chain(
             cls,
             db: BaseDB,
             headers: Iterable[BlockHeader]
     ) -> Tuple[Tuple[BlockHeader, ...], Tuple[BlockHeader, ...]]:
+        headers_iterator = iter(headers)
+
         try:
-            first_header = first(headers)
+            first_header = first(headers_iterator)
         except StopIteration:
             return tuple(), tuple()
+
+        is_genesis = first_header.parent_hash == GENESIS_PARENT_HASH
+        if not is_genesis and not cls._header_exists(db, first_header.parent_hash):
+            raise ParentNotFound(
+                "Cannot persist block header ({}) with unknown parent ({})".format(
+                    encode_hex(first_header.hash), encode_hex(first_header.parent_hash)))
+
+        if is_genesis:
+            score = 0
         else:
+            score = cls._get_score(db, first_header.parent_hash)
 
-            for parent, child in sliding_window(2, headers):
-                if parent.hash != child.parent_hash:
-                    raise ValidationError(
-                        "Non-contiguous chain. Expected {} to have {} as parent but was {}".format(
-                            encode_hex(child.hash),
-                            encode_hex(parent.hash),
-                            encode_hex(child.parent_hash),
-                        )
+        curr_chain_head = first_header
+        score = cls._set_hash_scores_to_db(db, curr_chain_head, score)
+
+        orig_headers_seq = concat([(first_header,), headers_iterator])
+        for parent, child in sliding_window(2, orig_headers_seq):
+            if parent.hash != child.parent_hash:
+                raise ValidationError(
+                    "Non-contiguous chain. Expected {} to have {} as parent but was {}".format(
+                        encode_hex(child.hash),
+                        encode_hex(parent.hash),
+                        encode_hex(child.parent_hash),
                     )
+                )
 
-            is_genesis = first_header.parent_hash == GENESIS_PARENT_HASH
-            if not is_genesis and not cls._header_exists(db, first_header.parent_hash):
-                raise ParentNotFound(
-                    "Cannot persist block header ({}) with unknown parent ({})".format(
-                        encode_hex(first_header.hash), encode_hex(first_header.parent_hash)))
-
-            if is_genesis:
-                score = 0
-            else:
-                score = cls._get_score(db, first_header.parent_hash)
-
-        for header in headers:
-            db.set(
-                header.hash,
-                rlp.encode(header),
-            )
-
-            score += header.difficulty
-
-            db.set(
-                SchemaV1.make_block_hash_to_score_lookup_key(header.hash),
-                rlp.encode(score, sedes=rlp.sedes.big_endian_int),
-            )
+            curr_chain_head = child
+            score = cls._set_hash_scores_to_db(db, curr_chain_head, score)
 
         try:
             previous_canonical_head = cls._get_canonical_head(db).hash
             head_score = cls._get_score(db, previous_canonical_head)
         except CanonicalHeadNotFound:
-            return cls._set_as_canonical_chain_head(db, header.hash)
+            return cls._set_as_canonical_chain_head(db, curr_chain_head.hash)
 
         if score > head_score:
-            return cls._set_as_canonical_chain_head(db, header.hash)
-        else:
-            return tuple(), tuple()
+            return cls._set_as_canonical_chain_head(db, curr_chain_head.hash)
+
+        return tuple(), tuple()
 
     @classmethod
     def _set_as_canonical_chain_head(cls, db: BaseDB, block_hash: Hash32


### PR DESCRIPTION
### What was wrong?

See #1648 for details.

1. `HeaderDB.persist_header_chain` was failing when passed an iterator of `BlockHeader` objects.
2. We were looping over the headers multiple timesm which had a performance cost. This was actually also the cause for the above failure.

### How was it fixed?

I eliminated the need to loop on the sequence of headers twice. Essentially, I'm handling chain validation and setting of scores inside a single loop. I did some small refactoring as well to make the function more flat and readable.

**TODO**

- [ ] Fix a similar bug in the `eth.beacon.db.chain._persist_block_chain` module.
- [ ] Implement unit tests

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/564x/26/20/ba/2620ba65e93ed0f31e26b6201381d8d3.jpg)
