### PR TITLE
Implement get_transaction_receipt function as part of ChainDB

### DIFF
--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -398,8 +398,7 @@ class ChainDB(HeaderDB, BaseChainDB):
 
     def get_receipt_by_index(self,
                              block_number: BlockNumber,
-                             receipt_index: int,
-                             receipt_class: Type[Receipt]) -> Receipt:
+                             receipt_index: int) -> Receipt:
         """
         Returns the Receipt of the transaction at specified index
         for the block header obtained by the specified block number
@@ -413,7 +412,7 @@ class ChainDB(HeaderDB, BaseChainDB):
         receipt_key = rlp.encode(receipt_index)
         if receipt_key in receipt_db:
             receipt_data = receipt_db[receipt_key]
-            return rlp.decode(receipt_data, sedes=receipt_class)
+            return rlp.decode(receipt_data, sedes=Receipt)
         else:
             raise ReceiptNotFound(
                 "Receipt with index {} not found in block".format(receipt_index))

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -28,6 +28,7 @@ from eth.constants import (
 )
 from eth.exceptions import (
     HeaderNotFound,
+    ReceiptNotFound,
     TransactionNotFound,
 )
 from eth.db.header import BaseHeaderDB, HeaderDB
@@ -394,6 +395,28 @@ class ChainDB(HeaderDB, BaseChainDB):
 
         transaction_key = rlp.decode(encoded_key, sedes=TransactionKey)
         return (transaction_key.block_number, transaction_key.index)
+
+    def get_receipt_by_index(self,
+                             block_number: BlockNumber,
+                             receipt_index: int,
+                             receipt_class: Type[Receipt]) -> Receipt:
+        """
+        Returns the Receipt of the transaction at specified index
+        for the block header obtained by the specified block number
+        """
+        try:
+            block_header = self.get_canonical_block_header_by_number(block_number)
+        except HeaderNotFound:
+            raise ReceiptNotFound("Block {} is not in the canonical chain".format(block_number))
+
+        receipt_db = HexaryTrie(db=self.db, root_hash=block_header.receipt_root)
+        receipt_key = rlp.encode(receipt_index)
+        if receipt_key in receipt_db:
+            receipt_data = receipt_db[receipt_key]
+            return rlp.decode(receipt_data, sedes=receipt_class)
+        else:
+            raise ReceiptNotFound(
+                "Receipt with index {} not found in block".format(receipt_index))
 
     @staticmethod
     def _get_block_transaction_data(db: BaseDB, transaction_root: Hash32) -> Iterable[Hash32]:

--- a/eth/exceptions.py
+++ b/eth/exceptions.py
@@ -39,6 +39,13 @@ class TransactionNotFound(PyEVMError):
     pass
 
 
+class ReceiptNotFound(PyEVMError):
+    """
+    Raised when the Receipt with the given receipt index does not exist.
+    """
+    pass
+
+
 class ParentNotFound(HeaderNotFound):
     """
     Raised when the parent of a given block does not exist.


### PR DESCRIPTION
### What was wrong?
The ChainDB API could use the `get_transaction_receipt` method. This function is aimed to get the `Receipt` of the `Transaction` specified by the `Transaction Index` in the block of the provided `BlockHeader`. This function would also be useful to implement the `eth_getTransactionReceipt` JSON RPC function.


### How was it fixed?
The `Transaction Index` is RLP encoded and searched in the `receipt_db` whose root would be present in the `Header`.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://image.freepik.com/free-vector/cute-animal-doing-dabbing_23-2147847948.jpg)
