### PR TITLE
Update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 deps = {
     'eth': [
         "cryptography>=2.0.3,<3.0.0",
-        "eth-bloom>=1.0.2,<2.0.0",
+        "eth-bloom>=1.0.3,<2.0.0",
         "eth-keys>=0.2.1,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.3.0,<2.0.0",


### PR DESCRIPTION
### What was wrong?

Multiple dependencies have newer releases that expose various fixes, primarily exposing type hints in a first class way.

### How was it fixed?

Updated the dependencies.  Also removed the explicit `cytoolz` dependency in favor of relying on `eth-utils`.  New issue being opened to convert all imports to be from `eth_utils.toolz`

#### Cute Animal Picture

![23-hilarious-photos-of-surprised-animals](https://user-images.githubusercontent.com/824194/50926411-2be67080-1412-11e9-885d-e883b86b2ab5.jpg)

