### PR TITLE
Remove last occurrences of apostrophe docstrings

### DIFF
--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -221,11 +221,11 @@ class ChainDB(HeaderDB, BaseChainDB):
     def persist_block(self,
                       block: 'BaseBlock'
                       ) -> Tuple[Tuple[Hash32, ...], Tuple[Hash32, ...]]:
-        '''
+        """
         Persist the given block's header and uncles.
 
         Assumes all block transactions have been persisted already.
-        '''
+        """
         with self.db.atomic_batch() as db:
             return self._persist_block(db, block)
 
@@ -397,9 +397,9 @@ class ChainDB(HeaderDB, BaseChainDB):
 
     @staticmethod
     def _get_block_transaction_data(db: BaseDB, transaction_root: Hash32) -> Iterable[Hash32]:
-        '''
+        """
         Returns iterable of the encoded transactions for the given block header
-        '''
+        """
         transaction_db = HexaryTrie(db, root_hash=transaction_root)
         for transaction_idx in itertools.count():
             transaction_key = rlp.encode(transaction_idx)

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -210,9 +210,9 @@ def apply_fixture_block_to_chain(
         block_fixture: Dict[str, Any],
         chain: BaseChain,
         perform_validation: bool=True) -> Tuple[BaseBlock, BaseBlock, BaseBlock]:
-    '''
+    """
     :return: (premined_block, mined_block, rlp_encoded_mined_block)
-    '''
+    """
     # The block to import may be in a different block-class-range than the
     # chain's current one, so we use the block number specified in the
     # fixture to look up the correct block class.


### PR DESCRIPTION
### What was wrong?

There were a few instances of docstrings with inconsistent style.

### How was it fixed?

Fixed them.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i0.wp.com/frametoframe.ca/wp-content/uploads/2014/11/red-fox-in-algonquin-park-november-2014-pic-3.jpg)
