### PR TITLE
Add get_transaction_receipt method to Chain API

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -272,6 +272,10 @@ class BaseChain(Configurable, ABC):
     def get_canonical_transaction(self, transaction_hash: Hash32) -> BaseTransaction:
         raise NotImplementedError("Chain classes must implement this method")
 
+    @abstractmethod
+    def get_transaction_receipt(self, transaction_hash: Hash32) -> Receipt:
+        raise NotImplementedError("Chain classes must implement this method")
+
     #
     # Execution API
     #
@@ -652,6 +656,17 @@ class Chain(BaseChain):
             value=value,
             data=data,
         )
+
+    def get_transaction_receipt(self, transaction_hash: Hash32) -> Receipt:
+        transaction_block_number, transaction_index = self.chaindb.get_transaction_index(
+            transaction_hash,
+        )
+        receipt = self.chaindb.get_receipt_by_index(
+            block_number=transaction_block_number,
+            receipt_index=transaction_index,
+        )
+
+        return receipt
 
     #
     # Execution API

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -126,6 +126,12 @@ class BaseChainDB(BaseHeaderDB):
         raise NotImplementedError("ChainDB classes must implement this method")
 
     @abstractmethod
+    def get_receipt_by_index(self,
+                             block_number: BlockNumber,
+                             receipt_index: int) -> Receipt:
+        raise NotImplementedError("ChainDB classes must implement this method")
+
+    @abstractmethod
     def get_receipts(self,
                      header: BlockHeader,
                      receipt_class: Type[Receipt]) -> Iterable[Receipt]:


### PR DESCRIPTION
### What was wrong?
Currently, if we want to implement the `getTransactionReceipt` JSON RPC functionality, then we would have to go all the way to the `ChainDB` part of the `Chain API`. This PR aims to make this functionality available as part of the `Chain API`, so that the convention of JSON RPC implementations using only the Chain API and not the `chaindb` part of the `Chain`, is followed.


### How was it fixed?
The `get_receipt_by_index` of `chaindb` was used in the `Chain API`, so as to abstract the usage.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://cuethat.com/wp-content/uploads/2017/12/cute-animal-in-the-word.jpg)
