### PR TITLE
Change inheritance order for chain_class_without_seal_validation

### DIFF
--- a/tests/core/builder-tools/test_chain_builder.py
+++ b/tests/core/builder-tools/test_chain_builder.py
@@ -2,6 +2,11 @@ import pytest
 
 from eth_utils import ValidationError
 
+from eth.chains import (
+    MainnetChain,
+    MainnetTesterChain,
+    RopstenChain,
+)
 from eth.chains.base import (
     Chain,
     MiningChain,
@@ -18,6 +23,9 @@ from eth.tools.builder.chain import (
     import_blocks,
     mine_block,
     mine_blocks,
+)
+from eth.tools.builder.chain.builders import (
+    NoChainSealValidationMixin,
 )
 
 
@@ -229,3 +237,18 @@ def test_chain_builder_chain_split(mining_chain):
 
     head_b = chain_b.get_canonical_head()
     assert head_b.block_number == 3
+
+
+@pytest.mark.parametrize(
+    "chain",
+    (
+        MainnetChain,
+        MainnetTesterChain,
+        RopstenChain,
+    )
+)
+def test_disabling_pow_for_already_pow_disabled_chain(chain):
+    pow_disabled_chain = disable_pow_check(chain)
+    assert issubclass(pow_disabled_chain, NoChainSealValidationMixin)
+    again_pow_disabled_chain = disable_pow_check(pow_disabled_chain)
+    assert issubclass(again_pow_disabled_chain, NoChainSealValidationMixin)


### PR DESCRIPTION
### What was wrong?
Previously the order in which `chain_class_without_seal_validation` would cause `MRO` errors when called on an instance of `NoChainSealValidationMixin` class. (Because `chain_class` is superset of `NoChainSealValidationMixin` class)


### How was it fixed?
The order was changed so that the superset class is added in the front. This prevents the `MRO` errors.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.totopets.com/img/cutest-animals/The-Cutest-Rabbit-Ever.jpg)
