### PR TITLE
Flake8 bugbear

### DIFF
--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -422,7 +422,7 @@ class AccountDB(BaseAccountDB):
         accounts_displayed = set()  # type: Set[bytes]
         queued_changes = self._journaltrie.journal.journal_data.items()
         # mypy bug for ordered dict reversibility: https://github.com/python/typeshed/issues/2078
-        for checkpoint, accounts in reversed(queued_changes):
+        for _, accounts in reversed(queued_changes):
             for address in accounts:
                 if address in accounts_displayed:
                     continue

--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -38,12 +38,12 @@ class CodeStream(object):
         return self
 
     def __next__(self) -> int:
-        return self.next()
+        return self._next()
 
     def __getitem__(self, i: int) -> int:
         return self._raw_code_bytes[i]
 
-    def next(self) -> int:
+    def _next(self) -> int:
         next_opcode_as_byte = self.read(1)
 
         if next_opcode_as_byte:

--- a/eth/vm/forks/frontier/state.py
+++ b/eth/vm/forks/frontier/state.py
@@ -174,7 +174,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
         self.vm_state.account_db.delta_balance(self.vm_state.coinbase, transaction_fee)
 
         # Process Self Destructs
-        for account, beneficiary in computation.get_accounts_for_deletion():
+        for account, _ in computation.get_accounts_for_deletion():
             # TODO: need to figure out how we prevent multiple selfdestructs from
             # the same account and if this is the right place to put this.
             self.vm_state.logger.debug2('DELETING ACCOUNT: %s', encode_hex(account))

--- a/scripts/benchmark/checks/deploy_dos.py
+++ b/scripts/benchmark/checks/deploy_dos.py
@@ -122,7 +122,7 @@ class BaseDOSContractBenchmark(BaseBenchmark):
                    block_number: int,
                    num_tx: int) -> BaseBlock:
 
-        for i in range(1, num_tx + 1):
+        for _ in range(1, num_tx + 1):
             self._apply_transaction(chain)
 
         return chain.mine_block()

--- a/scripts/benchmark/checks/erc20_interact.py
+++ b/scripts/benchmark/checks/erc20_interact.py
@@ -122,7 +122,7 @@ class BaseERC20Benchmark(BaseBenchmark):
                    chain: MiningChain,
                    block_number: int,
                    num_tx: int) -> BaseBlock:
-        for i in range(1, num_tx + 1):
+        for _ in range(1, num_tx + 1):
             self._apply_transaction(chain)
         return chain.mine_block()
 

--- a/scripts/benchmark/checks/simple_value_transfers.py
+++ b/scripts/benchmark/checks/simple_value_transfers.py
@@ -107,7 +107,7 @@ class SimpleValueTransferBenchmark(BaseBenchmark):
         return total_gas_used, total_num_tx
 
     def mine_block(self, chain: MiningChain, block_number: int, num_tx: int) -> BaseBlock:
-        for i in range(1, num_tx + 1):
+        for _ in range(1, num_tx + 1):
             self.apply_transaction(chain)
 
         return chain.mine_block()

--- a/scripts/release/test_package.py
+++ b/scripts/release/test_package.py
@@ -22,7 +22,7 @@ def find_wheel(project_path):
     return wheels[0]
 
 
-def install_wheel(venv_path, wheel_path, extras=tuple()):
+def install_wheel(venv_path, wheel_path, extras=()):
     if extras:
         extra_suffix = f"[{','.join(extras)}]"
     else:

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ deps = {
     ],
     'lint': [
         "flake8==3.5.0",
+        "flake8-bugbear==18.8.0",
         "mypy==0.641",
     ],
     'benchmark': [

--- a/tests/core/code-stream/test_code_stream.py
+++ b/tests/core/code-stream/test_code_stream.py
@@ -23,9 +23,9 @@ def test_code_stream_rejects_invalid_code_byte_values(code_bytes):
 
 def test_next_returns_the_correct_next_opcode():
     code_stream = CodeStream(b'\x01\x02\x30')
-    assert code_stream.next() == opcode_values.ADD
+    assert next(code_stream) == opcode_values.ADD
     assert next(code_stream) == opcode_values.MUL
-    assert code_stream.next() == opcode_values.ADDRESS
+    assert next(code_stream) == opcode_values.ADDRESS
 
 
 def test_peek_returns_next_opcode_without_changing_code_stream_location():
@@ -33,7 +33,7 @@ def test_peek_returns_next_opcode_without_changing_code_stream_location():
     assert code_stream.pc == 0
     assert code_stream.peek() == opcode_values.ADD
     assert code_stream.pc == 0
-    assert code_stream.next() == opcode_values.ADD
+    assert next(code_stream) == opcode_values.ADD
     assert code_stream.pc == 1
     assert code_stream.peek() == opcode_values.MUL
     assert code_stream.pc == 1
@@ -41,9 +41,9 @@ def test_peek_returns_next_opcode_without_changing_code_stream_location():
 
 def test_STOP_opcode_is_returned_when_bytecode_end_is_reached():
     code_stream = CodeStream(b'\x01\x02')
-    code_stream.next()
-    code_stream.next()
-    assert code_stream.next() == opcode_values.STOP
+    next(code_stream)
+    next(code_stream)
+    assert next(code_stream) == opcode_values.STOP
 
 
 def test_seek_reverts_to_original_stream_position_when_context_exits():
@@ -51,7 +51,7 @@ def test_seek_reverts_to_original_stream_position_when_context_exits():
     assert code_stream.pc == 0
     with code_stream.seek(1):
         assert code_stream.pc == 1
-        assert code_stream.next() == opcode_values.MUL
+        assert next(code_stream) == opcode_values.MUL
     assert code_stream.pc == 0
     assert code_stream.peek() == opcode_values.ADD
 

--- a/tests/core/stack/test_stack.py
+++ b/tests/core/stack/test_stack.py
@@ -55,7 +55,7 @@ def test_push_does_not_allow_stack_to_exceed_1024_items(stack):
 
 def test_dup_does_not_allow_stack_to_exceed_1024_items(stack):
     stack.push(1)
-    for num in range(1023):
+    for _ in range(1023):
         stack.dup(1)
     assert len(stack.values) == 1024
     with pytest.raises(FullStack):

--- a/tests/json-fixtures/test_transactions.py
+++ b/tests/json-fixtures/test_transactions.py
@@ -59,7 +59,7 @@ def expand_fixtures_forks(all_fixtures):
     """
     for fixture_path, fixture_key in all_fixtures:
         fixture = load_fixture(fixture_path, fixture_key)
-        for fixture_fork, fork_states in fixture.items():
+        for fixture_fork, _ in fixture.items():
             if fixture_fork not in FIXTURE_FORK_SKIPS:
                 yield fixture_path, fixture_key, fixture_fork
 


### PR DESCRIPTION
### What was wrong?

There are some linting checks that we want like:

- no mutable values for default arguments
- `getattr(x, 'value)` since we can use `x.value` since the attribute string is a constant value
- see more at https://github.com/PyCQA/flake8-bugbear

### How was it fixed?

Added `flake8-bugbear` to the `[lint]` installs.

#### Cute Animal Picture

![71da8415374d3a4c766e32e40a7b1f33](https://user-images.githubusercontent.com/824194/53350304-0e933600-38dc-11e9-8f9c-d41603eae61c.jpg)

