### PR TITLE
Remove pandoc and setuptools markdown requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,11 @@ deps = {
         "bumpversion>=0.5.3,<1",
         "wheel",
         "setuptools>=36.2.0",
-        # Fixing this dependency due to: pytest 3.6.4 has requirement pluggy<0.8,>=0.5, but you'll have pluggy 0.8.0 which is incompatible.
+        # Fixing this dependency due to: pytest 3.6.4 has requirement
+        # pluggy<0.8,>=0.5, but you'll have pluggy 0.8.0 which is incompatible.
         "pluggy==0.7.1",
-        # Fixing this dependency due to: requests 2.20.1 has requirement idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
+        # Fixing this dependency due to: requests 2.20.1 has requirement
+        # idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
         "idna==2.7",
         # idna 2.7 is not supported by requests 2.18
         "requests>=2.20,<3",
@@ -82,12 +84,16 @@ deps['dev'] = (
 
 install_requires = deps['eth']
 
+with open('README.md') as readme_file:
+    long_description = readme_file.read()
+
 setup(
     name='py-evm',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version='0.2.0-alpha.40',
     description='Python implementation of the Ethereum Virtual Machine',
-    long_description_markdown_filename='README.md',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Ethereum Foundation',
     author_email='piper@pipermerriam.com',
     url='https://github.com/ethereum/py-evm',
@@ -95,7 +101,6 @@ setup(
     py_modules=['eth'],
     install_requires=install_requires,
     extras_require=deps,
-    setup_requires=['setuptools-markdown'],
     license='MIT',
     zip_safe=False,
     keywords='ethereum blockchain evm',


### PR DESCRIPTION
### What was wrong?

A while back we started using `setuptools-markdown` to correctly render markdown files in pypi.  

We just started getting CI failures that seem related to this requirement: https://circleci.com/gh/ethereum/py-evm/126552?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Also, the requirement requires the user to have a system requirement installed (`pandoc`)

Now pypi supports markdown directly so we can remove it 

### How was it fixed?

Emulated this project: https://pypi.org/project/markdown-description-example/

#### Cute Animal Picture

https://pypi.org/project/markdown-description-example/
