### PR TITLE
Add pysha as dependency for docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ deps = {
     ],
     'doc': [
         "py-evm>=0.2.0-alpha.14",
+        # We need to have pysha for autodoc to be able to extract API docs
+        "pysha3>=1.0.0,<2.0.0",
         "pytest~=3.2",
         # Sphinx pined to `<1.8.0`: https://github.com/sphinx-doc/sphinx/issues/3494
         "Sphinx>=1.5.5,<1.8.0",


### PR DESCRIPTION
### What was wrong?

Our live API docs are broken because `pysha` is needed for autodoc to be able to build and extract the docs.

### How was it fixed?

Added pysha as a `docs` dependency.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.kimballstock.com/pix/MAM/09/MAM_09_TL0029_01_P.JPG)
