### PR TITLE
remove superfluous raise Halt from selfdestruct

### DIFF
--- a/eth/vm/logic/system.py
+++ b/eth/vm/logic/system.py
@@ -48,7 +48,6 @@ def revert(computation: BaseComputation) -> None:
 def selfdestruct(computation: BaseComputation) -> None:
     beneficiary = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
     _selfdestruct(computation, beneficiary)
-    raise Halt('SELFDESTRUCT')
 
 
 def selfdestruct_eip150(computation: BaseComputation) -> None:


### PR DESCRIPTION
### What was wrong?

`selfdestruct` calls `_selfdestruct` which already does `raise Halt('SELFDESTRUCT')`.
The `raise Halt('SELFDESTRUCT')` in `selfdestruct` is unreachable as a result.

### How was it fixed?
Removed the superfluous `raise Halt` from `selfdestruct`.
`selfdestruct_eip150` and `selfdestruct_eip161` use `_selfdestruct`, hence removed the superfluos code from `selfdestruct` and not  from `_selfdestruct`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/2y83t44cpfk21.jpg?width=640&crop=smart&auto=webp&s=b24163b8ad9c3c5e635acc4e215b79e65e50905c)
