### PR TITLE
fix ecpairing for py_ecc upgrade

### DIFF
--- a/eth/_utils/bn128.py
+++ b/eth/_utils/bn128.py
@@ -5,6 +5,9 @@ from py_ecc.optimized_bn128 import (
     FQP,
     FQ2,
 )
+from py_ecc.fields import (
+    optimized_bn128_FQ,
+)
 
 from eth_utils import (
     ValidationError,
@@ -14,7 +17,7 @@ from typing import Tuple
 
 
 def validate_point(x: int, y: int) -> Tuple[bn128.FQ, bn128.FQ, bn128.FQ]:
-    FQ = bn128.FQ
+    FQ = optimized_bn128_FQ
 
     if x >= bn128.field_modulus:
         raise ValidationError("Point x value is greater than field modulus")
@@ -29,14 +32,3 @@ def validate_point(x: int, y: int) -> Tuple[bn128.FQ, bn128.FQ, bn128.FQ]:
         p1 = (FQ(1), FQ(1), FQ(0))
 
     return p1
-
-
-def FQP_point_to_FQ2_point(pt: Tuple[FQP, FQP, FQP]) -> Tuple[FQ2, FQ2, FQ2]:
-    """
-    Transform FQP to FQ2 for type hinting.
-    """
-    return (
-        FQ2(pt[0].coeffs),
-        FQ2(pt[1].coeffs),
-        FQ2(pt[2].coeffs),
-    )


### PR DESCRIPTION
### What was wrong?

Fix py-evm to adapt for upgrades in py_ecc 

### How was it fixed?

import all field elements from `py_ecc.fields`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
