### PR TITLE
update Quickstart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ full or light node directly.
 
 ## Quickstart
 
-[Get started in 5 minutes](https://py-evm.readthedocs.io/en/latest/quickstart.html)
+[Get started in 5 minutes](https://py-evm.readthedocs.io/en/latest/guides/quickstart.html)
 
 ## Documentation
 


### PR DESCRIPTION
Change from: 

https://py-evm.readthedocs.io/en/latest/quickstart.html

Change to:

https://py-evm.readthedocs.io/en/latest/guides/quickstart.html

### What was wrong?

Link was wrong

### How was it fixed?

Changed link 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/xJEtzLj.png)

