### PR TITLE
Move storage lookups into new StorageDB

### DIFF
--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -390,19 +390,19 @@ class AccountDB(BaseAccountDB):
     #
     # Record and discard API
     #
-    def record(self) -> Tuple[UUID, UUID]:
-        return (self._journaldb.record(), self._journaltrie.record())
+    def record(self) -> UUID:
+        changeset_id = self._journaldb.record()
+        self._journaltrie.record(changeset_id)
+        return changeset_id
 
-    def discard(self, changeset: Tuple[UUID, UUID]) -> None:
-        db_changeset, trie_changeset = changeset
-        self._journaldb.discard(db_changeset)
-        self._journaltrie.discard(trie_changeset)
+    def discard(self, changeset: UUID) -> None:
+        self._journaldb.discard(changeset)
+        self._journaltrie.discard(changeset)
         self._account_cache.clear()
 
-    def commit(self, changeset: Tuple[UUID, UUID]) -> None:
-        db_changeset, trie_changeset = changeset
-        self._journaldb.commit(db_changeset)
-        self._journaltrie.commit(trie_changeset)
+    def commit(self, changeset: UUID) -> None:
+        self._journaldb.commit(changeset)
+        self._journaltrie.commit(changeset)
 
     def make_state_root(self) -> Hash32:
         self.logger.debug2("Generating AccountDB trie")

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -5,23 +5,27 @@ from abc import (
 from uuid import UUID
 import logging
 from lru import LRU
-from typing import cast, Set, Tuple  # noqa: F401
+from typing import (  # noqa: F401
+    cast,
+    Dict,
+    Iterable,
+    Set,
+    Tuple,
+)
 
+from eth_hash.auto import keccak
 from eth_typing import (
     Address,
     Hash32
 )
-
-import rlp
-
-from trie import (
-    HexaryTrie,
-)
-
-from eth_hash.auto import keccak
 from eth_utils import (
     encode_hex,
-    int_to_big_endian,
+    to_tuple,
+    ValidationError,
+)
+import rlp
+from trie import (
+    HexaryTrie,
 )
 
 from eth.constants import (
@@ -30,7 +34,6 @@ from eth.constants import (
 )
 from eth.db.backends.base import (
     BaseAtomicDB,
-    BaseDB,
 )
 from eth.db.batch import (
     BatchDB,
@@ -40,6 +43,9 @@ from eth.db.cache import (
 )
 from eth.db.journal import (
     JournalDB,
+)
+from eth.db.storage import (
+    AccountStorageDB,
 )
 from eth.rlp.accounts import (
     Account,
@@ -51,9 +57,6 @@ from eth.validation import (
 )
 from eth.tools.logging import (
     ExtendedDebugLogger
-)
-from eth._utils.padding import (
-    pad32,
 )
 
 from .hash_trie import HashTrie
@@ -80,11 +83,22 @@ class BaseAccountDB(ABC):
     # Storage
     #
     @abstractmethod
-    def get_storage(self, address: Address, slot: int) -> int:
+    def get_storage(self, address: Address, slot: int, from_journal: bool=True) -> int:
         raise NotImplementedError("Must be implemented by subclasses")
 
     @abstractmethod
     def set_storage(self, address: Address, slot: int, value: int) -> None:
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    @abstractmethod
+    def delete_storage(self, address: Address) -> None:
+        """
+        Delete *all* storage values in this account. This action is journaled, like set() actions.
+
+        Unlike set(), deleting storage will not cause :meth:`make_storage_roots` to emit a new
+        storage root (and therefore will not persist deletes to the base database).
+        The account's storage root must be explicitly set to the empty root.
+        """
         raise NotImplementedError("Must be implemented by subclasses")
 
     #
@@ -139,21 +153,29 @@ class BaseAccountDB(ABC):
     # Record and discard API
     #
     @abstractmethod
-    def record(self) -> Tuple[UUID, UUID]:
+    def record(self) -> UUID:
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def discard(self, changeset: Tuple[UUID, UUID]) -> None:
+    def discard(self, changeset: UUID) -> None:
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def commit(self, changeset: Tuple[UUID, UUID]) -> None:
+    def commit(self, changeset: UUID) -> None:
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
     def make_state_root(self) -> Hash32:
         """
         Generate the state root with all the current changes in AccountDB
+
+        Current changes include every pending change to storage, as well as all account changes.
+        After generating all the required tries, the final account state root is returned.
+
+        This is an expensive operation, so should be called as little as possible. For example,
+        pre-Byzantium, this is called after every transaction, because we need the state root
+        in each receipt. Byzantium+, we only need state roots at the end of the block,
+        so we *only* call it right before persistance.
 
         :return: the new state root
         """
@@ -164,6 +186,9 @@ class BaseAccountDB(ABC):
         """
         Send changes to underlying database, including the trie state
         so that it will forever be possible to read the trie from this checkpoint.
+
+        :meth:`make_state_root` must be explicitly called before this method.
+        Otherwise persist will raise a ValidationError.
         """
         raise NotImplementedError("Must be implemented by subclass")
 
@@ -179,8 +204,6 @@ class AccountDB(BaseAccountDB):
 
         .. code::
 
-                                                                    -> hash-trie -> storage lookups
-                                                                  /
             db > _batchdb ---------------------------> _journaldb ----------------> code lookups
              \
               -> _batchtrie -> _trie -> _trie_cache -> _journaltrie --------------> account lookups
@@ -207,7 +230,7 @@ class AccountDB(BaseAccountDB):
         rather than the nodes stored by the trie). This enables
         a squashing of all account changes before pushing them into the trie.
 
-        .. NOTE:: There is an opportunity to do something similar for storage
+        .. NOTE:: StorageDB works similarly
 
         AccountDB synchronizes the snapshot/revert/persist of both of the
         journals.
@@ -220,6 +243,8 @@ class AccountDB(BaseAccountDB):
         self._trie_cache = CacheDB(self._trie)
         self._journaltrie = JournalDB(self._trie_cache)
         self._account_cache = LRU(2048)
+        self._account_stores = {}  # type: Dict[Address, AccountStorageDB]
+        self._dirty_accounts = set()  # type: Set[Address]
 
     @property
     def state_root(self) -> Hash32:
@@ -227,8 +252,9 @@ class AccountDB(BaseAccountDB):
 
     @state_root.setter
     def state_root(self, value: Hash32) -> None:
-        self._trie_cache.reset_cache()
-        self._trie.root_hash = value
+        if self._trie.root_hash != value:
+            self._trie_cache.reset_cache()
+            self._trie.root_hash = value
 
     def has_root(self, state_root: bytes) -> bool:
         return state_root in self._batchtrie
@@ -240,40 +266,74 @@ class AccountDB(BaseAccountDB):
         validate_canonical_address(address, title="Storage Address")
         validate_uint256(slot, title="Storage Slot")
 
-        account = self._get_account(address, from_journal)
-        storage = HashTrie(HexaryTrie(self._journaldb, account.storage_root))
-
-        slot_as_key = pad32(int_to_big_endian(slot))
-
-        if slot_as_key in storage:
-            encoded_value = storage[slot_as_key]
-            return rlp.decode(encoded_value, sedes=rlp.sedes.big_endian_int)
-        else:
-            return 0
+        account_store = self._get_address_store(address)
+        return account_store.get(slot, from_journal)
 
     def set_storage(self, address: Address, slot: int, value: int) -> None:
         validate_uint256(value, title="Storage Value")
         validate_uint256(slot, title="Storage Slot")
         validate_canonical_address(address, title="Storage Address")
 
-        account = self._get_account(address)
-        storage = HashTrie(HexaryTrie(self._journaldb, account.storage_root))
-
-        slot_as_key = pad32(int_to_big_endian(slot))
-
-        if value:
-            encoded_value = rlp.encode(value)
-            storage[slot_as_key] = encoded_value
-        else:
-            del storage[slot_as_key]
-
-        self._set_account(address, account.copy(storage_root=storage.root_hash))
+        account_store = self._get_address_store(address)
+        self._dirty_accounts.add(address)
+        account_store.set(slot, value)
 
     def delete_storage(self, address: Address) -> None:
         validate_canonical_address(address, title="Storage Address")
 
+        self._set_storage_root(address, BLANK_ROOT_HASH)
+        self._wipe_storage(address)
+
+    def _wipe_storage(self, address: Address) -> None:
+        """
+        Wipe out the storage, without explicitly handling the storage root update
+        """
+        account_store = self._get_address_store(address)
+        self._dirty_accounts.add(address)
+        account_store.delete()
+
+    def _get_address_store(self, address: Address) -> AccountStorageDB:
+        if address in self._account_stores:
+            store = self._account_stores[address]
+        else:
+            storage_root = self._get_storage_root(address)
+            store = AccountStorageDB(self._raw_store_db, storage_root, address)
+            self._account_stores[address] = store
+        return store
+
+    def _dirty_account_stores(self) -> Iterable[Tuple[Address, AccountStorageDB]]:
+        for address in self._dirty_accounts:
+            store = self._account_stores[address]
+            yield address, store
+
+    @to_tuple
+    def _get_changed_roots(self) -> Iterable[Tuple[Address, Hash32]]:
+        # list all the accounts that were changed, and their new storage roots
+        for address, store in self._dirty_account_stores():
+            if store.has_changed_root:
+                yield address, store.get_changed_root()
+
+    def _get_storage_root(self, address: Address) -> Hash32:
         account = self._get_account(address)
-        self._set_account(address, account.copy(storage_root=BLANK_ROOT_HASH))
+        return account.storage_root
+
+    def _set_storage_root(self, address: Address, new_storage_root: Hash32) -> None:
+        account = self._get_account(address)
+        self._set_account(address, account.copy(storage_root=new_storage_root))
+
+    def _validate_flushed_storage(self, address: Address, store: AccountStorageDB) -> None:
+        if store.has_changed_root:
+            actual_storage_root = self._get_storage_root(address)
+            expected_storage_root = store.get_changed_root()
+            if expected_storage_root != actual_storage_root:
+                raise ValidationError(
+                    "Storage root was not saved to account before trying to persist roots. "
+                    "Account %r had storage %r, but should be %r." % (
+                        address,
+                        actual_storage_root,
+                        expected_storage_root,
+                    )
+                )
 
     #
     # Balance
@@ -352,9 +412,12 @@ class AccountDB(BaseAccountDB):
 
     def delete_account(self, address: Address) -> None:
         validate_canonical_address(address, title="Storage Address")
+
         if address in self._account_cache:
             del self._account_cache[address]
         del self._journaltrie[address]
+
+        self._wipe_storage(address)
 
     def account_exists(self, address: Address) -> bool:
         validate_canonical_address(address, title="Storage Address")
@@ -395,28 +458,80 @@ class AccountDB(BaseAccountDB):
     def record(self) -> UUID:
         changeset_id = self._journaldb.record()
         self._journaltrie.record(changeset_id)
+
+        for _, store in self._dirty_account_stores():
+            store.record(changeset_id)
         return changeset_id
 
     def discard(self, changeset: UUID) -> None:
         self._journaldb.discard(changeset)
         self._journaltrie.discard(changeset)
         self._account_cache.clear()
+        for _, store in self._dirty_account_stores():
+            store.discard(changeset)
 
     def commit(self, changeset: UUID) -> None:
         self._journaldb.commit(changeset)
         self._journaltrie.commit(changeset)
+        for _, store in self._dirty_account_stores():
+            store.commit(changeset)
 
     def make_state_root(self) -> Hash32:
-        self.logger.debug2("Generating AccountDB trie")
+        for _, store in self._dirty_account_stores():
+            store.make_storage_root()
+
+        for address, storage_root in self._get_changed_roots():
+            self.logger.debug2(
+                "Updating account 0x%s to storage root 0x%s",
+                address.hex(),
+                storage_root.hex(),
+            )
+            self._set_storage_root(address, storage_root)
+
         self._journaldb.persist()
         self._journaltrie.persist()
         return self.state_root
 
     def persist(self) -> None:
         self.make_state_root()
+
+        # persist storage
+        with self._raw_store_db.atomic_batch() as write_batch:
+            for address, store in self._dirty_account_stores():
+                self._validate_flushed_storage(address, store)
+                store.persist(write_batch)
+
+        for address, new_root in self._get_changed_roots():
+            if new_root not in self._raw_store_db and new_root != BLANK_ROOT_HASH:
+                raise ValidationError(
+                    "After persisting storage trie, a root node was not found. "
+                    "State root for account 0x%s is missing for hash 0x%s." % (
+                        address.hex(),
+                        new_root.hex(),
+                    )
+                )
+
+        # reset local storage trackers
+        self._account_stores = {}
+        self._dirty_accounts = set()
+
+        # persist accounts
+        self._validate_generated_root()
         with self._raw_store_db.atomic_batch() as write_batch:
             self._batchtrie.commit_to(write_batch, apply_deletes=False)
             self._batchdb.commit_to(write_batch, apply_deletes=False)
+
+    def _validate_generated_root(self) -> None:
+        db_diff = self._journaldb.diff()
+        if len(db_diff):
+            raise ValidationError(
+                "AccountDB had a dirty db when it needed to be clean: %r" % db_diff
+            )
+        trie_diff = self._journaltrie.diff()
+        if len(trie_diff):
+            raise ValidationError(
+                "AccountDB had a dirty trie when it needed to be clean: %r" % trie_diff
+            )
 
     def _log_pending_accounts(self) -> None:
         accounts_displayed = set()  # type: Set[bytes]

--- a/eth/db/journal.py
+++ b/eth/db/journal.py
@@ -384,6 +384,8 @@ class JournalDB(BaseDB):
 
         If this is the base changeset then all changes will be written to
         the underlying database and the Journal starts a new recording.
+        Typically, callers won't have access to the base changeset, because
+        it is dropped during .reset() which is called in JournalDB().
         """
         self._validate_changeset(changeset_id)
         journal_data = self.journal.commit_changeset(changeset_id)

--- a/eth/db/storage.py
+++ b/eth/db/storage.py
@@ -1,0 +1,264 @@
+import logging
+from typing import (  # noqa: F401
+    cast,
+    Dict,
+    Iterable,
+    Set,
+    Tuple,
+)
+from uuid import UUID
+
+from eth_hash.auto import keccak
+from eth_typing import (
+    Address,
+    Hash32
+)
+from eth_utils import (
+    ValidationError,
+    int_to_big_endian,
+)
+import rlp
+from trie import (
+    HexaryTrie,
+    exceptions as trie_exceptions,
+)
+
+from eth._utils.padding import (
+    pad32,
+)
+from eth.db.backends.base import (
+    BaseAtomicDB,
+    BaseDB,
+)
+from eth.db.batch import (
+    BatchDB,
+)
+from eth.db.cache import (
+    CacheDB,
+)
+from eth.db.journal import (
+    JournalDB,
+)
+from eth.tools.logging import (
+    ExtendedDebugLogger
+)
+
+
+class StorageLookup(BaseDB):
+    """
+    This lookup converts lookups of storage slot integers into the appropriate trie lookup.
+    Similarly, it persists changes to the appropriate trie at write time.
+
+    StorageLookup also tracks the state roots changed since the last persist.
+    """
+    logger = cast(ExtendedDebugLogger, logging.getLogger("eth.db.storage.StorageLookup"))
+
+    def __init__(self, db: BaseDB, storage_root: Hash32, address: Address) -> None:
+        self._db = db
+        self._starting_root_hash = storage_root
+        self._address = address
+        self._write_trie = None
+        self._trie_nodes_batch = None  # type: BatchDB
+
+    def _get_write_trie(self) -> HexaryTrie:
+        if self._trie_nodes_batch is None:
+            self._trie_nodes_batch = BatchDB(self._db, read_through_deletes=True)
+
+        if self._write_trie is None:
+            batch_db = self._trie_nodes_batch
+            self._write_trie = HexaryTrie(batch_db, root_hash=self._starting_root_hash, prune=True)
+
+        return self._write_trie
+
+    def _get_read_trie(self) -> HexaryTrie:
+        if self._write_trie is not None:
+            return self._write_trie
+        else:
+            # Creating "HexaryTrie" is a pretty light operation, so not a huge cost
+            # to create a new one at every read, but we could
+            # cache the read trie, if this becomes a bottleneck.
+            return HexaryTrie(self._db, root_hash=self._starting_root_hash)
+
+    def _decode_key(self, key: bytes) -> bytes:
+        padded_slot = pad32(key)
+        return keccak(padded_slot)
+
+    def __getitem__(self, key: bytes) -> bytes:
+        hashed_slot = self._decode_key(key)
+        read_trie = self._get_read_trie()
+        try:
+            return read_trie[hashed_slot]
+        except trie_exceptions.MissingTrieNode as exc:
+            self.logger.warning(exc)
+            self.logger.debug("expected to get slot, but:", exc_info=True)
+            raise exc
+
+    def __setitem__(self, key: bytes, value: bytes) -> None:
+        hashed_slot = self._decode_key(key)
+        write_trie = self._get_write_trie()
+        write_trie[hashed_slot] = value
+
+    def _exists(self, key: bytes) -> bool:
+        # used by BaseDB for __contains__ checks
+        hashed_slot = self._decode_key(key)
+        read_trie = self._get_read_trie()
+        return hashed_slot in read_trie
+
+    def __delitem__(self, key: bytes) -> None:
+        hashed_slot = self._decode_key(key)
+        write_trie = self._get_write_trie()
+        try:
+            del write_trie[hashed_slot]
+        except trie_exceptions.MissingTrieNode as exc:
+            self.logger.warning(exc)
+            self.logger.debug("expected to be able to delete slot, but:", exc_info=True)
+
+    @property
+    def has_changed_root(self) -> bool:
+        return self._write_trie and self._write_trie.root_hash != self._starting_root_hash
+
+    def get_changed_root(self) -> Hash32:
+        if self._write_trie is not None:
+            return self._write_trie.root_hash
+        else:
+            raise ValidationError("Asked for changed root when no writes have been made")
+
+    def _clear_changed_root(self) -> None:
+        self._write_trie = None
+        self._trie_nodes_batch = None
+        self._starting_root_hash = None
+
+    def commit_to(self, db: BaseDB) -> None:
+        """
+        Trying to commit changes when nothing has been written will raise a
+        ValidationError
+        """
+        self.logger.debug2('persist storage root to data store')
+        if self._trie_nodes_batch is None:
+            raise ValidationError(
+                "It is invalid to commit an account's storage if it has no pending changes. "
+                "Always check storage_lookup.has_changed_root before attempting to commit."
+            )
+        self._trie_nodes_batch.commit_to(db, apply_deletes=False)
+        self._clear_changed_root()
+
+
+class AccountStorageDB:
+    """
+    Storage cache and write batch for a single account. Changes are not
+    merklized until :meth:`make_storage_root` is called.
+    """
+    logger = cast(ExtendedDebugLogger, logging.getLogger("eth.db.storage.AccountStorageDB"))
+
+    def __init__(self, db: BaseAtomicDB, storage_root: Hash32, address: Address) -> None:
+        """
+        Database entries go through several pipes, like so...
+
+        .. code::
+
+            db -> _storage_lookup -> _storage_cache -> _journal_storage
+
+        db is the raw database, we can assume it hits disk when written to.
+        Keys are stored as node hashes and rlp-encoded node values.
+
+        _storage_lookup is itself a pair of databases: (BatchDB -> HexaryTrie),
+        writes to storage lookup *are* immeditaely applied to a trie, generating
+        the appropriate trie nodes and and root hash (via the HexaryTrie). The
+        writes are *not* persisted to db, until _storage_lookup is explicitly instructed to,
+        via :meth:`StorageLookup.commit_to`
+
+        _storage_cache is a cache tied to the state root of the trie. It
+        is important that this cache is checked *after* looking for
+        the key in _journal_storage, because the cache is only invalidated
+        after a state root change. Otherwise, you will see data since the last
+        storage root was calculated.
+
+        Journaling batches writes at the _journal_storage layer, until persist is called.
+        It manages all the checkpointing and rollbacks that happen during EVM execution.
+
+        In both _storage_cache and _journal_storage, Keys are set/retrieved as the
+        big_endian encoding of the slot integer, and the rlp-encoded value.
+        """
+        self._address = address
+        self._storage_lookup = StorageLookup(db, storage_root, address)
+        self._storage_cache = CacheDB(self._storage_lookup)
+        self._journal_storage = JournalDB(self._storage_cache)
+
+    def get(self, slot: int, from_journal: bool=True) -> int:
+        key = int_to_big_endian(slot)
+        lookup_db = self._journal_storage if from_journal else self._storage_cache
+        try:
+            encoded_value = lookup_db[key]
+        except KeyError:
+            return 0
+
+        if encoded_value == b'':
+            return 0
+        else:
+            return rlp.decode(encoded_value, sedes=rlp.sedes.big_endian_int)
+
+    def set(self, slot: int, value: int) -> None:
+        key = int_to_big_endian(slot)
+        if value:
+            self._journal_storage[key] = rlp.encode(value)
+        else:
+            del self._journal_storage[key]
+
+    def delete(self) -> None:
+        self.logger.debug2(
+            "Deleting all storage in account 0x%s, hashed 0x%s",
+            self._address.hex(),
+            keccak(self._address).hex(),
+        )
+        self._journal_storage.clear()
+        self._storage_cache.reset_cache()
+
+    def record(self, changeset: UUID) -> None:
+        self._journal_storage.record(changeset)
+
+    def discard(self, changeset: UUID) -> None:
+        self.logger.debug2('discard checkpoint %r', changeset)
+        if self._journal_storage.has_changeset(changeset):
+            self._journal_storage.discard(changeset)
+        else:
+            # if the changeset comes before this account started tracking,
+            #    then simply reset to the beginning
+            self._journal_storage.reset()
+        self._storage_cache.reset_cache()
+
+    def commit(self, changeset: UUID) -> None:
+        self.logger.debug2('commit checkpoint %r', changeset)
+        if self._journal_storage.has_changeset(changeset):
+            self._journal_storage.commit(changeset)
+        else:
+            # if the changeset comes before this account started tracking,
+            #    then flatten all changes, without persisting
+            self._journal_storage.flatten()
+
+    def make_storage_root(self) -> None:
+        """
+        Force calculation of the storage root for this account
+        """
+        self._journal_storage.persist()
+
+    def _validate_flushed(self) -> None:
+        """
+        Will raise an exception if there are some changes made since the last persist.
+        """
+        journal_diff = self._journal_storage.diff()
+        if len(journal_diff) > 0:
+            raise ValidationError(
+                "StorageDB had a dirty journal when it needed to be clean: %r" % journal_diff
+            )
+
+    @property
+    def has_changed_root(self) -> bool:
+        return self._storage_lookup.has_changed_root
+
+    def get_changed_root(self) -> Hash32:
+        return self._storage_lookup.get_changed_root()
+
+    def persist(self, db: BaseDB) -> None:
+        self._validate_flushed()
+        if self._storage_lookup.has_changed_root:
+            self._storage_lookup.commit_to(db)

--- a/eth/rlp/accounts.py
+++ b/eth/rlp/accounts.py
@@ -35,7 +35,7 @@ class Account(rlp.Serializable):
                  **kwargs: Any) -> None:
         super().__init__(nonce, balance, storage_root, code_hash, **kwargs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Account(nonce=%d, balance=%d, storage_root=0x%s, code_hash=0x%s)" % (
             self.nonce,
             self.balance,

--- a/eth/rlp/accounts.py
+++ b/eth/rlp/accounts.py
@@ -34,3 +34,11 @@ class Account(rlp.Serializable):
                  code_hash: bytes=EMPTY_SHA3,
                  **kwargs: Any) -> None:
         super().__init__(nonce, balance, storage_root, code_hash, **kwargs)
+
+    def __repr__(self):
+        return "Account(nonce=%d, balance=%d, storage_root=0x%s, code_hash=0x%s)" % (
+            self.nonce,
+            self.balance,
+            self.storage_root.hex(),
+            self.code_hash.hex(),
+        )

--- a/eth/tools/fixtures/fillers/_utils.py
+++ b/eth/tools/fixtures/fillers/_utils.py
@@ -23,7 +23,7 @@ from eth._utils.padding import (
     pad32,
 )
 from eth.constants import BLANK_ROOT_HASH
-from eth.db.backends.memory import MemoryDB
+from eth.db.atomic import AtomicDB
 from eth.typing import (
     AccountState,
     TransactionDict,
@@ -63,7 +63,7 @@ def add_transaction_to_group(group: Dict[str, Any],
 
 
 def calc_state_root(state_dict: AccountState, state_class: Type[BaseState]) -> bytes:
-    state = state_class(MemoryDB(), None, BLANK_ROOT_HASH)
+    state = state_class(AtomicDB(), None, BLANK_ROOT_HASH)
     apply_state_dict(state, state_dict)
     return state.state_root
 

--- a/tests/database/test_account_db.py
+++ b/tests/database/test_account_db.py
@@ -6,6 +6,7 @@ from eth_utils import (
     ValidationError,
 )
 
+from eth.db.atomic import AtomicDB
 from eth.db.backends.memory import MemoryDB
 from eth.db.account import (
     AccountDB,
@@ -19,6 +20,16 @@ from eth.constants import (
 ADDRESS = b'\xaa' * 20
 OTHER_ADDRESS = b'\xbb' * 20
 INVALID_ADDRESS = b'aa' * 20
+
+
+@pytest.fixture
+def base_db():
+    return AtomicDB()
+
+
+@pytest.fixture
+def account_db(base_db):
+    return AccountDB(base_db)
 
 
 @pytest.mark.parametrize("state", [
@@ -110,3 +121,85 @@ def test_accounts(state):
         state.delete_account(INVALID_ADDRESS)
     with pytest.raises(ValidationError):
         state.account_has_code_or_nonce(INVALID_ADDRESS)
+
+
+def test_storage(account_db):
+    assert account_db.get_storage(ADDRESS, 0) == 0
+
+    account_db.set_storage(ADDRESS, 0, 123)
+    assert account_db.get_storage(ADDRESS, 0) == 123
+    assert account_db.get_storage(ADDRESS, 1) == 0
+    assert account_db.get_storage(OTHER_ADDRESS, 0) == 0
+
+
+def test_storage_deletion(account_db):
+    account_db.set_storage(ADDRESS, 0, 123)
+    account_db.set_storage(OTHER_ADDRESS, 1, 321)
+    account_db.delete_storage(ADDRESS)
+    assert account_db.get_storage(ADDRESS, 0) == 0
+    assert account_db.get_storage(OTHER_ADDRESS, 1) == 321
+
+
+def test_account_db_storage_root(account_db):
+    """
+    Make sure that pruning doesn't screw up addresses that temporarily share storage roots
+    """
+    account_db.set_storage(ADDRESS, 1, 2)
+    account_db.set_storage(OTHER_ADDRESS, 1, 2)
+
+    # both addresses will share the same root
+    account_db.make_state_root()
+
+    account_db.set_storage(ADDRESS, 3, 4)
+    account_db.set_storage(OTHER_ADDRESS, 3, 5)
+
+    # addresses will have different roots
+    account_db.make_state_root()
+
+    assert account_db.get_storage(ADDRESS, 1) == 2
+    assert account_db.get_storage(OTHER_ADDRESS, 1) == 2
+    assert account_db.get_storage(ADDRESS, 3) == 4
+    assert account_db.get_storage(OTHER_ADDRESS, 3) == 5
+
+    account_db.persist()
+
+    assert account_db.get_storage(ADDRESS, 1) == 2
+    assert account_db.get_storage(OTHER_ADDRESS, 1) == 2
+    assert account_db.get_storage(ADDRESS, 3) == 4
+    assert account_db.get_storage(OTHER_ADDRESS, 3) == 5
+
+
+def test_account_db_update_then_make_root_then_read(account_db):
+    assert account_db.get_storage(ADDRESS, 1) == 0
+    account_db.set_storage(ADDRESS, 1, 2)
+    assert account_db.get_storage(ADDRESS, 1) == 2
+
+    account_db.make_state_root()
+
+    assert account_db.get_storage(ADDRESS, 1) == 2
+
+    account_db.persist()
+    assert account_db.get_storage(ADDRESS, 1) == 2
+
+
+def test_account_db_read_then_update_then_make_root_then_read(account_db):
+    account_db.set_storage(ADDRESS, 1, 2)
+
+    # must always explicitly make the root before persisting
+    account_db.make_state_root()
+    account_db.persist()
+
+    # read out of a non-empty account, to build a read-cache trie
+    assert account_db.get_storage(ADDRESS, 1) == 2
+
+    account_db.set_storage(ADDRESS, 1, 3)
+
+    assert account_db.get_storage(ADDRESS, 1) == 3
+
+    account_db.make_state_root()
+
+    assert account_db.get_storage(ADDRESS, 1) == 3
+
+    account_db.persist()
+    # if you start caching read tries, then you might get this answer wrong:
+    assert account_db.get_storage(ADDRESS, 1) == 3

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -190,12 +190,14 @@ INCORRECT_UPSTREAM_TESTS = {
     ('GeneralStateTests/stCreate2/RevertInCreateInInitCreate2_d0g0v0.json', 'RevertInCreateInInitCreate2_d0g0v0_Constantinople'),  # noqa: E501
     ('GeneralStateTests/stCreate2/RevertInCreateInInitCreate2_d0g0v0.json', 'RevertInCreateInInitCreate2_d0g0v0_ConstantinopleFix'),  # noqa: E501
 
-    # All four variants have been specifically added to test a collision type
+    # Four variants have been specifically added to test a collision type
     # like the above; therefore, they fail in the same manner.
     # * https://github.com/ethereum/py-evm/pull/1579#issuecomment-446591118
+    # Interestingly, d2 passes in Constantinople after a refactor of storage handling,
+    # the same test was already passing in ConstantinopleFix. Since the situation is synthetic,
+    # not much research went into why, yet.
     ('GeneralStateTests/stSStoreTest/InitCollision_d0g0v0.json', 'InitCollision_d0g0v0_Constantinople'),  # noqa: E501
     ('GeneralStateTests/stSStoreTest/InitCollision_d1g0v0.json', 'InitCollision_d1g0v0_Constantinople'),  # noqa: E501
-    ('GeneralStateTests/stSStoreTest/InitCollision_d2g0v0.json', 'InitCollision_d2g0v0_Constantinople'),  # noqa: E501
     ('GeneralStateTests/stSStoreTest/InitCollision_d3g0v0.json', 'InitCollision_d3g0v0_Constantinople'),  # noqa: E501
     ('GeneralStateTests/stSStoreTest/InitCollision_d0g0v0.json', 'InitCollision_d0g0v0_ConstantinopleFix'),  # noqa: E501
     ('GeneralStateTests/stSStoreTest/InitCollision_d1g0v0.json', 'InitCollision_d1g0v0_ConstantinopleFix'),  # noqa: E501


### PR DESCRIPTION
### What was wrong?

We are currently calculating storage roots at every storage change.

We need to request state from other nodes at the previous block boundary, even when running the query from in the middle of block execution.

It's also a waste of disk space, and a waste of cycles on `keccak` hashing for the trie reorgs.

### How was it fixed?

- Moved the storage logic out of `AccountDB` into new `StorageDB`
- Set up a similar pipeline, with a special database adapter that looks up storage roots on demand
- The storage db now keeps a journal of changes in their decoded state (slot number and int value) rather than keeping a journal of trie changes.
- Moved the storage API used by VM execution out to `state.set_storage(...)` instead of `state.account_db.set_storage(...)`, which seems like an improvement. Going forward, it lets us tweak the Storage DB API while keeping the `VMState` API the same.

TODO:
- [x] docstrings
- [x] squash commits
- [x] split out any prerequisite changes and rebase on top after merge, like
  - [x] #1716 - made some updates, to avoid persisting state before the miner reward
  - [x] #1737 
  - [x] #1738
  - [x] #1739
  - [x] #1740
  - [x] #1741
  - [x] #1745
  - [x] #1746
  - [x] #1749
  - [x] #1755
  - [x] #1756
  - on request: `Account.__repr__` 8918923990b61c70edcf2b740b757557e3cb4aca
  - [x] ~~probably more to go~~
- [x] pass all state tests
- [x] type annotations
- [x] lint
- [x] also batch writes in accountdb ~~(probably separate PR)~~ (but it's in a separate commit if reviewers want to split it)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.nhm.ac.uk/content/dam/nhmwww/discover/nudibranchs-psychedelic-thieves/nudibranch-variable-neon-slug-two-column.jpg)
