### PR TITLE
Commit batch to target db

### DIFF
--- a/eth/db/batch.py
+++ b/eth/db/batch.py
@@ -41,7 +41,11 @@ class BatchDB(BaseDB):
         self._track_diff = DBDiffTracker()
 
     def commit(self, apply_deletes: bool = True) -> None:
-        self.diff().apply_to(self.wrapped_db, apply_deletes)
+        self.commit_to(self.wrapped_db, apply_deletes)
+
+    def commit_to(self, target_db: BaseDB, apply_deletes: bool = True) -> None:
+        diff = self.diff()
+        diff.apply_to(target_db, apply_deletes)
         self.clear()
 
     def _exists(self, key: bytes) -> bool:


### PR DESCRIPTION
### What was wrong?

I want to commit queued changes to a target database (specifically, I want to commit changes to an atomic write batch)

### How was it fixed?

Added new `BatchDB.commit_to()` method and tests.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.scubadiving.com/sites/scubadiving.com/files/styles/1000_1x_/public/import/2014/files/_images/201406/nudi-7-9x6.jpg?itok=eXzMxsts)
