### PR TITLE
Get access to all the pending JournalDB changes

### DIFF
--- a/eth/db/backends/base.py
+++ b/eth/db/backends/base.py
@@ -8,7 +8,8 @@ from collections.abc import (
 
 from typing import (
     Any,
-    TYPE_CHECKING
+    Iterator,
+    TYPE_CHECKING,
 )
 
 if TYPE_CHECKING:
@@ -58,7 +59,7 @@ class BaseDB(MM, ABC):
         except KeyError:
             return None
 
-    def __iter__(self) -> None:
+    def __iter__(self) -> Iterator[bytes]:
         raise NotImplementedError("By default, DB classes cannot be iterated.")
 
     def __len__(self) -> int:

--- a/eth/db/backends/memory.py
+++ b/eth/db/backends/memory.py
@@ -34,3 +34,6 @@ class MemoryDB(BaseDB):
 
     def __len__(self) -> int:
         return len(self.kv_store)
+
+    def __repr__(self) -> str:
+        return "MemoryDB(%r)" % self.kv_store

--- a/eth/db/backends/memory.py
+++ b/eth/db/backends/memory.py
@@ -1,5 +1,6 @@
 from typing import (
-    Dict
+    Dict,
+    Iterator,
 )
 
 from .base import (
@@ -27,3 +28,9 @@ class MemoryDB(BaseDB):
 
     def __delitem__(self, key: bytes) -> None:
         del self.kv_store[key]
+
+    def __iter__(self) -> Iterator[bytes]:
+        return iter(self.kv_store)
+
+    def __len__(self) -> int:
+        return len(self.kv_store)

--- a/eth/db/diff.py
+++ b/eth/db/diff.py
@@ -9,6 +9,10 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from eth_utils import (
+    encode_hex,
+)
+
 from eth.db.backends.base import BaseDB
 
 if TYPE_CHECKING:
@@ -126,6 +130,25 @@ class DBDiff(ABC_Mapping):
         raise NotImplementedError(
             "Cannot iterate through changes, use apply_to(db) to update a database"
         )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DBDiff):
+            return False
+        else:
+            return self._changes == other._changes
+
+    def __repr__(self) -> str:
+        deleted = [
+            'key=%s' % encode_hex(key)
+            for key, val in self._changes.items()
+            if val is DELETED
+        ]
+        updated = [
+            "key=%s to val=%s" % (encode_hex(key), encode_hex(val))
+            for key, val in self._changes.items()
+            if val is not DELETED
+        ]
+        return "<DBDiff: deletions=%r, updates=%r>" % (deleted, updated)
 
     def __len__(self) -> int:
         return len(self._changes)

--- a/tests/database/test_db_diff.py
+++ b/tests/database/test_db_diff.py
@@ -76,6 +76,18 @@ def test_database_api_missing_key_for_deletion(db):
         assert False, "key should be missing, but was retrieved as {}".format(val)
 
 
+def test_db_diff_equality(db):
+    db[b'key-1'] = b'value-1'
+    del db[b'key-2']
+
+    diff1 = db.diff()
+    diff2 = db.diff()
+    assert diff1 == diff2
+
+    db[b'key-3'] = b'value-3'
+    assert diff1 != db.diff()
+
+
 def test_database_api_deleted_key_for_deletion(db):
     # create an item, then delete it
     db[b'used-to-exist'] = b'old-value'


### PR DESCRIPTION
### What was wrong?

Wanted an easy way to get access to all pending changes. (for #1735 )

### How was it fixed?

- Added a new `JournalDB.diff()` which reuses the `DBDiff` class used elsewhere to represent a single diff
- Added test that `JournalDB.diff().apply_to(db)` is equivalent to `JournalDB(db).persist()`
- Added a new `DBDiff` equality test to help test its use in the journal
- Added `__iter__` and `__len__` to MemoryDB to enable equality and length checking

Several of these changes seem only a bit related. The final goal was the journal db change, so all the other changes support building and testing that. Still, if you would like me to split it out, I can. It is already split into separate commits, so it will be easy.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://aqua.org/-/media/Images/blog/2016/Blue-View/shutterstock_332494922.ashx?la=en&hash=D00ED367D598BCACA26A94B53E6A02F044A5E6FA)
