### PR TITLE
JournalDB.squash() and custom checkpoint ID

### DIFF
--- a/eth/db/journal.py
+++ b/eth/db/journal.py
@@ -46,7 +46,7 @@ class Journal(BaseDB):
         return first(self.journal_data.keys())
 
     @property
-    def is_squashed(self) -> bool:
+    def is_flattened(self) -> bool:
         """
         Returns the id of the root changeset
         """
@@ -136,8 +136,8 @@ class Journal(BaseDB):
             )
         return changeset_data
 
-    def squash(self) -> None:
-        if self.is_squashed:
+    def flatten(self) -> None:
+        if self.is_flattened:
             return
 
         changeset_id_after_root = nth(1, self.journal_data.keys())
@@ -284,11 +284,11 @@ class JournalDB(BaseDB):
         """
         self.commit(self.journal.root_changeset_id)
 
-    def squash(self) -> None:
+    def flatten(self) -> None:
         """
         Commit everything possible without persisting
         """
-        self.journal.squash()
+        self.journal.flatten()
 
     def reset(self) -> None:
         """

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -201,11 +201,11 @@ def test_committing_middle_changeset_merges_in_subsequent_changesets(journal_db)
     assert journal_db.journal.has_changeset(changeset_c) is False
 
 
-def test_squash_does_not_persist_0_checkpoints(journal_db, memory_db):
+def test_flatten_does_not_persist_0_checkpoints(journal_db, memory_db):
     journal_db.set(b'1', b'test-a')
 
     # should have no effect
-    journal_db.squash()
+    journal_db.flatten()
 
     assert b'1' not in memory_db
     assert b'1' in journal_db
@@ -215,7 +215,7 @@ def test_squash_does_not_persist_0_checkpoints(journal_db, memory_db):
     assert b'1' in memory_db
 
 
-def test_squash_does_not_persist_1_checkpoint(journal_db, memory_db):
+def test_flatten_does_not_persist_1_checkpoint(journal_db, memory_db):
     journal_db.set(b'1', b'test-a')
 
     checkpoint = journal_db.record()
@@ -224,7 +224,7 @@ def test_squash_does_not_persist_1_checkpoint(journal_db, memory_db):
 
     # should only remove this checkpoint, but b'2' still be available
     assert journal_db.has_changeset(checkpoint)
-    journal_db.squash()
+    journal_db.flatten()
     assert not journal_db.has_changeset(checkpoint)
 
     assert b'1' in journal_db
@@ -240,7 +240,7 @@ def test_squash_does_not_persist_1_checkpoint(journal_db, memory_db):
     assert b'2' in memory_db
 
 
-def test_squash_does_not_persist_2_checkpoint(journal_db, memory_db):
+def test_flatten_does_not_persist_2_checkpoint(journal_db, memory_db):
     journal_db.set(b'1', b'test-a')
 
     checkpoint1 = journal_db.record()
@@ -254,7 +254,7 @@ def test_squash_does_not_persist_2_checkpoint(journal_db, memory_db):
     # should only remove these checkpoints, but 2 and 3 still be available
     assert journal_db.has_changeset(checkpoint1)
     assert journal_db.has_changeset(checkpoint2)
-    journal_db.squash()
+    journal_db.flatten()
     assert not journal_db.has_changeset(checkpoint1)
     assert not journal_db.has_changeset(checkpoint2)
 

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -202,75 +202,75 @@ def test_committing_middle_changeset_merges_in_subsequent_changesets(journal_db)
 
 
 def test_flatten_does_not_persist_0_checkpoints(journal_db, memory_db):
-    journal_db.set(b'1', b'test-a')
+    journal_db.set(b'before-record', b'test-a')
 
     # should have no effect
     journal_db.flatten()
 
-    assert b'1' not in memory_db
-    assert b'1' in journal_db
+    assert b'before-record' not in memory_db
+    assert b'before-record' in journal_db
 
     journal_db.persist()
 
-    assert b'1' in memory_db
+    assert b'before-record' in memory_db
 
 
 def test_flatten_does_not_persist_1_checkpoint(journal_db, memory_db):
-    journal_db.set(b'1', b'test-a')
+    journal_db.set(b'before-record', b'test-a')
 
     checkpoint = journal_db.record()
 
-    journal_db.set(b'2', b'test-b')
+    journal_db.set(b'after-one-record', b'test-b')
 
-    # should only remove this checkpoint, but b'2' still be available
+    # should only remove this checkpoint, but after-one-record is still available
     assert journal_db.has_changeset(checkpoint)
     journal_db.flatten()
     assert not journal_db.has_changeset(checkpoint)
 
-    assert b'1' in journal_db
-    assert b'2' in journal_db
+    assert b'before-record' in journal_db
+    assert b'after-one-record' in journal_db
 
     # changes should not be persisted yet
-    assert b'1' not in memory_db
-    assert b'2' not in memory_db
+    assert b'before-record' not in memory_db
+    assert b'after-one-record' not in memory_db
 
     journal_db.persist()
 
-    assert b'1' in memory_db
-    assert b'2' in memory_db
+    assert b'before-record' in memory_db
+    assert b'after-one-record' in memory_db
 
 
 def test_flatten_does_not_persist_2_checkpoint(journal_db, memory_db):
-    journal_db.set(b'1', b'test-a')
+    journal_db.set(b'before-record', b'test-a')
 
     checkpoint1 = journal_db.record()
 
-    journal_db.set(b'2', b'test-b')
+    journal_db.set(b'after-one-record', b'test-b')
 
     checkpoint2 = journal_db.record()
 
-    journal_db.set(b'3', b'3')
+    journal_db.set(b'after-two-records', b'3')
 
-    # should only remove these checkpoints, but 2 and 3 still be available
+    # should remove these checkpoints, but after-one-record & after-two-records are still available
     assert journal_db.has_changeset(checkpoint1)
     assert journal_db.has_changeset(checkpoint2)
     journal_db.flatten()
     assert not journal_db.has_changeset(checkpoint1)
     assert not journal_db.has_changeset(checkpoint2)
 
-    assert b'1' in journal_db
-    assert b'2' in journal_db
-    assert b'3' in journal_db
+    assert b'before-record' in journal_db
+    assert b'after-one-record' in journal_db
+    assert b'after-two-records' in journal_db
 
-    assert b'1' not in memory_db
-    assert b'2' not in memory_db
-    assert b'3' not in memory_db
+    assert b'before-record' not in memory_db
+    assert b'after-one-record' not in memory_db
+    assert b'after-two-records' not in memory_db
 
     journal_db.persist()
 
-    assert b'1' in memory_db
-    assert b'2' in memory_db
-    assert b'3' in memory_db
+    assert b'before-record' in memory_db
+    assert b'after-one-record' in memory_db
+    assert b'after-two-records' in memory_db
 
 
 def test_persist_writes_to_underlying_db(journal_db, memory_db):


### PR DESCRIPTION
### What was wrong?

We will maintain a list of JournalDB's (one for each active storage slot). 

#### Squashing
When we create a JournalDB in the middle of a block, it may not have been keeping up will all previous checkpoints. If an earlier checkpoint is discarded, we can simply reset the entire JournalDB. If an earlier checkpoint is committed, then we want to commit everything but we don't want to persist it.

We could track the first checkpoint seen and commit back to that, but this public API on JournalDB seemed cleaner: Hence the new `squash()`.

#### Custom checkpoint IDs
It is ideal for a number of reasons to reuse the same checkpoint id for each of the different journals. This makes for a short and sweet checkpoint ID for the whole set of journals.

### How was it fixed?

Added implementations and tests for `JournalDB.squash` and `.record(custom_checkpoint_id)`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTxy0Cp4o0RfqsFkHKXiSGnoGf_mvog-Mp-F20ALB3u7nn237mR)