### PR TITLE
Lazy VM.block generation

### DIFF
--- a/eth/vm/forks/byzantium/headers.py
+++ b/eth/vm/forks/byzantium/headers.py
@@ -94,7 +94,7 @@ def configure_header(difficulty_fn: Callable[[BlockHeader, int], int],
                      **header_params: Any) -> BlockHeader:
     validate_header_params_for_configuration(header_params)
 
-    with vm.block.header.build_changeset(**header_params) as changeset:
+    with vm.header.build_changeset(**header_params) as changeset:
         if 'timestamp' in header_params and changeset.block_number > 0:
             parent_header = get_parent_header(changeset.build_rlp(), vm.chaindb)
             changeset.difficulty = difficulty_fn(

--- a/eth/vm/forks/frontier/headers.py
+++ b/eth/vm/forks/frontier/headers.py
@@ -97,8 +97,8 @@ def create_frontier_header_from_parent(parent_header: BlockHeader,
 def configure_frontier_header(vm: "FrontierVM", **header_params: Any) -> BlockHeader:
     validate_header_params_for_configuration(header_params)
 
-    with vm.block.header.build_changeset(**header_params) as changeset:
-        if 'timestamp' in header_params and vm.block.header.block_number > 0:
+    with vm.header.build_changeset(**header_params) as changeset:
+        if 'timestamp' in header_params and vm.header.block_number > 0:
             parent_header = get_parent_header(changeset.build_rlp(), vm.chaindb)
             changeset.difficulty = compute_frontier_difficulty(
                 parent_header,

--- a/eth/vm/forks/homestead/headers.py
+++ b/eth/vm/forks/homestead/headers.py
@@ -71,7 +71,7 @@ def create_homestead_header_from_parent(parent_header: BlockHeader,
 def configure_homestead_header(vm: "HomesteadVM", **header_params: Any) -> BlockHeader:
     validate_header_params_for_configuration(header_params)
 
-    with vm.block.header.build_changeset(**header_params) as changeset:
+    with vm.header.build_changeset(**header_params) as changeset:
         if 'timestamp' in header_params and changeset.block_number > 0:
             parent_header = get_parent_header(changeset.build_rlp(), vm.chaindb)
             changeset.difficulty = compute_homestead_difficulty(

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -65,7 +65,7 @@ def fill_block(chain, from_, key, gas, data):
     amount = 100
 
     vm = chain.get_vm()
-    assert vm.block.header.gas_used == 0
+    assert vm.header.gas_used == 0
 
     while True:
         tx = new_transaction(chain.get_vm(), from_, recipient, amount, key, gas=gas, data=data)

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -27,8 +27,8 @@ def test_apply_transaction(
     amount = 100
     from_ = funded_address
     tx = new_transaction(vm, from_, recipient, amount, funded_address_private_key)
-    receipt, computation = vm.apply_transaction(vm.block.header, tx)
-    new_header = vm.add_receipt_to_header(vm.block.header, receipt)
+    receipt, computation = vm.apply_transaction(vm.header, tx)
+    new_header = vm.add_receipt_to_header(vm.header, receipt)
 
     assert not computation.is_error
     tx_gas = tx.gas_price * constants.GAS_TX

--- a/tests/json-fixtures/test_virtual_machine.py
+++ b/tests/json-fixtures/test_virtual_machine.py
@@ -194,7 +194,7 @@ def test_vm_fixtures(fixture, vm_class, computation_getter):
     setup_account_db(fixture['pre'], state.account_db)
     code = state.account_db.get_code(fixture['exec']['address'])
     # Update state_root manually
-    vm.block = vm.block.copy(header=vm.block.header.copy(state_root=state.state_root))
+    vm.block = vm.block.copy(header=vm.header.copy(state_root=state.state_root))
 
     message = Message(
         to=fixture['exec']['address'],
@@ -215,7 +215,7 @@ def test_vm_fixtures(fixture, vm_class, computation_getter):
     )
     # Update state_root manually
     vm.block = vm.block.copy(
-        header=vm.block.header.copy(state_root=computation.state.state_root),
+        header=vm.header.copy(state_root=computation.state.state_root),
     )
 
     if 'post' in fixture:


### PR DESCRIPTION
This makes it easier to inspect data, even if the block transactions are
missing (for example, during light sync or parts of beam sync)

### What was wrong?

Loading the VM immediately tries to look up the block in the database, but we don't always have the block ready. (Also, it's slower, for cases when we don't need the block)

### How was it fixed?

Lazily generate `vm.block` when it's needed. Often all we need is the header, so make that directly accessible on the VM, and prefer its usage `vm.header` over `vm.block.header`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.kym-cdn.com/photos/images/original/001/360/712/e8b)
