### PR TITLE
Batch db optional read through delete

### DIFF
--- a/eth/db/batch.py
+++ b/eth/db/batch.py
@@ -1,5 +1,9 @@
 import logging
 
+from eth_utils import (
+    ValidationError,
+)
+
 from eth.db.diff import (
     DBDiff,
     DBDiffTracker,
@@ -45,6 +49,8 @@ class BatchDB(BaseDB):
         self.commit_to(self.wrapped_db, apply_deletes)
 
     def commit_to(self, target_db: BaseDB, apply_deletes: bool = True) -> None:
+        if apply_deletes and self._read_through_deletes:
+            raise ValidationError("BatchDB should never apply deletes when reading through deletes")
         diff = self.diff()
         diff.apply_to(target_db, apply_deletes)
         self.clear()


### PR DESCRIPTION
### What was wrong?

I have a scenario where I want to delete all intermediate data, but leave the underlying data immutable. (Specifically: adding several items to a trie, which generates a bunch of nodes we don't need)

Unfortunately, that means that in memory, the trie tries to "delete" the old root hash (and other old nodes). We don't have to worry about this getting propagated to the DB, because we use `BatchDB.commit(apply_deletes=False)`. But, sometimes we need to read out of those nodes that we deleted during the process, while we are in the process of reading.

### How was it fixed?

Added a new init flag to `BatchDB` that allows you to read through deletes. If a delete happens in batch, you fall back to getting whatever the wrapped database tells you the value is.

`read_through_deletes` and `apply_deletes` seem heavily linked. It *might* make sense do do something like `NonDeletingBatchDB` (ugh, that name) and a regular `BatchDB`. Open to thoughts.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.artfido.com/2018/09/cute-bunny-rabbits-002.jpg)
