### PR TITLE
Bring in HasExtendedDebugLogger into this codebase

### DIFF
--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -3,7 +3,6 @@ from abc import (
     abstractmethod
 )
 from uuid import UUID
-import logging
 from lru import LRU
 from typing import cast, Set, Tuple  # noqa: F401
 
@@ -49,7 +48,7 @@ from eth.validation import (
     validate_canonical_address,
 )
 from eth.tools.logging import (
-    ExtendedDebugLogger
+    HasExtendedDebugLogger,
 )
 from eth._utils.padding import (
     pad32,
@@ -58,7 +57,7 @@ from eth._utils.padding import (
 from .hash_trie import HashTrie
 
 
-class BaseAccountDB(ABC):
+class BaseAccountDB(HasExtendedDebugLogger, ABC):
 
     @abstractmethod
     def __init__(self) -> None:
@@ -171,9 +170,6 @@ class BaseAccountDB(ABC):
 
 
 class AccountDB(BaseAccountDB):
-
-    logger = cast(ExtendedDebugLogger, logging.getLogger('eth.db.account.AccountDB'))
-
     def __init__(self, db: BaseDB, state_root: Hash32=BLANK_ROOT_HASH) -> None:
         r"""
         Internal implementation details (subject to rapid change):

--- a/eth/tools/logging.py
+++ b/eth/tools/logging.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, cast
 
 DEBUG2_LEVEL_NUM = 8
 
@@ -14,3 +14,16 @@ def setup_extended_logging() -> None:
     logging.setLoggerClass(ExtendedDebugLogger)
     logging.addLevelName(DEBUG2_LEVEL_NUM, 'DEBUG2')
     setattr(logging, 'DEBUG2', DEBUG2_LEVEL_NUM)  # typing: ignore
+
+
+class HasExtendedDebugLogger:
+    _logger = None  # typing: ExtendedDebugLogger
+
+    @property
+    def logger(self) -> ExtendedDebugLogger:
+        if self._logger is None:
+            self._logger = cast(
+                ExtendedDebugLogger,
+                logging.getLogger(self.__module__ + '.' + self.__class__.__name__)
+            )
+        return self._logger

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -3,7 +3,6 @@ from abc import (
     abstractmethod
 )
 import itertools
-import logging
 from typing import (  # noqa: F401
     Any,
     Callable,
@@ -33,7 +32,7 @@ from eth.typing import (
     BytesOrView,
 )
 from eth.tools.logging import (
-    ExtendedDebugLogger,
+    HasExtendedDebugLogger,
 )
 from eth._utils.datatypes import (
     Configurable,
@@ -84,7 +83,7 @@ def memory_gas_cost(size_in_bytes: int) -> int:
     return total_cost
 
 
-class BaseComputation(Configurable, ABC):
+class BaseComputation(Configurable, HasExtendedDebugLogger, ABC):
     """
     The base class for all execution computations.
 
@@ -119,8 +118,6 @@ class BaseComputation(Configurable, ABC):
     # VM configuration
     opcodes = None  # type: Dict[int, Any]
     _precompiles = None  # type: Dict[Address, Callable[['BaseComputation'], 'BaseComputation']]
-
-    logger = cast(ExtendedDebugLogger, logging.getLogger('eth.vm.computation.Computation'))
 
     def __init__(self,
                  state: BaseState,

--- a/eth/vm/gas_meter.py
+++ b/eth/vm/gas_meter.py
@@ -1,7 +1,5 @@
-import logging
 from typing import (
     Callable,
-    cast,
 )
 from eth_utils import (
     ValidationError,
@@ -13,7 +11,7 @@ from eth.validation import (
     validate_uint256,
 )
 from eth.tools.logging import (
-    ExtendedDebugLogger
+    HasExtendedDebugLogger,
 )
 
 
@@ -31,14 +29,12 @@ def allow_negative_refund_strategy(gas_refunded_total: int, amount: int) -> int:
 RefundStrategy = Callable[[int, int], int]
 
 
-class GasMeter(object):
+class GasMeter(HasExtendedDebugLogger):
 
     start_gas = None  # type: int
 
     gas_refunded = None  # type: int
     gas_remaining = None  # type: int
-
-    logger = cast(ExtendedDebugLogger, logging.getLogger('eth.gas.GasMeter'))
 
     def __init__(self,
                  start_gas: int,

--- a/eth/vm/opcode.py
+++ b/eth/vm/opcode.py
@@ -1,5 +1,4 @@
 import functools
-import logging
 
 from abc import (
     ABC,
@@ -9,13 +8,12 @@ from abc import (
 from typing import (
     Any,
     Callable,
-    cast,
     Type,
     TypeVar,
     TYPE_CHECKING,
 )
 
-from eth.tools.logging import ExtendedDebugLogger
+from eth.tools.logging import HasExtendedDebugLogger
 
 from eth._utils.datatypes import Configurable
 
@@ -26,7 +24,7 @@ if TYPE_CHECKING:
 T = TypeVar('T')
 
 
-class Opcode(Configurable, ABC):
+class Opcode(Configurable, HasExtendedDebugLogger, ABC):
     mnemonic = None  # type: str
     gas_cost = None  # type: int
 
@@ -42,11 +40,6 @@ class Opcode(Configurable, ABC):
         Hook for performing the actual VM execution.
         """
         raise NotImplementedError("Must be implemented by subclasses")
-
-    @property
-    def logger(self) -> ExtendedDebugLogger:
-        logger_obj = logging.getLogger('eth.vm.logic.{0}'.format(self.mnemonic))
-        return cast(ExtendedDebugLogger, logger_obj)
 
     @classmethod
     def as_opcode(cls: Type[T],

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -3,7 +3,6 @@ from abc import (
     abstractmethod
 )
 import contextlib
-import logging
 from typing import (  # noqa: F401
     cast,
     Callable,
@@ -34,7 +33,7 @@ from eth.db.backends.base import (
 )
 from eth.exceptions import StateRootNotFound
 from eth.tools.logging import (
-    ExtendedDebugLogger,
+    HasExtendedDebugLogger,
 )
 from eth.typing import (
     BaseOrSpoofTransaction,
@@ -60,7 +59,7 @@ if TYPE_CHECKING:
     )
 
 
-class BaseState(Configurable, ABC):
+class BaseState(Configurable, HasExtendedDebugLogger, ABC):
     """
     The base class that encapsulates all of the various moving parts related to
     the state of the VM during execution.
@@ -90,14 +89,6 @@ class BaseState(Configurable, ABC):
         self._db = db
         self.execution_context = execution_context
         self.account_db = self.get_account_db_class()(self._db, state_root)
-
-    #
-    # Logging
-    #
-    @property
-    def logger(self) -> ExtendedDebugLogger:
-        normal_logger = logging.getLogger('eth.vm.state.{0}'.format(self.__class__.__name__))
-        return cast(ExtendedDebugLogger, normal_logger)
 
     #
     # Block Object Properties (in opcodes)


### PR DESCRIPTION
### What was wrong?

The `HasExtendedDebugLogger` from the `trinity` codebase is useful beyond that codebase.

https://github.com/ethereum/trinity/blob/3b52bdeef6e145f9d079de1dfdf0e246bcf62b54/p2p/persistence.py#L9

### How was it fixed?

Added it to `eth.tools.logging` and used it in places where it made sense.

#### Cute Animal Picture

![68312a6e5df3945fc22ac808fb0a7b55](https://user-images.githubusercontent.com/824194/55995933-2566cf80-5c73-11e9-8057-2643cb1cd8f9.jpg)

