### PR TITLE
Remove the cryptography library from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools import setup, find_packages
 deps = {
     'eth': [
         "cached-property>=1.5.1,<2",
-        "cryptography>=2.0.3,<3.0.0",
         "eth-bloom>=1.0.3,<2.0.0",
         "eth-keys>=0.2.1,<1.0.0",
         "eth-typing>=2.0.0,<3.0.0",


### PR DESCRIPTION
### What was wrong?

This library specifies a dependency on `cryptography` but it doesn't actually appear to be used.

### How was it fixed?

Removed it.

#### Cute Animal Picture

![zebra1](https://user-images.githubusercontent.com/824194/56371446-5fc3f580-61ba-11e9-82e1-bbad65301583.jpg)

