### PR TITLE
Move several methods from AccountDB to VMState

### DIFF
--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -103,8 +103,8 @@ Considering our previous example, we can get the balance of our pre-funded accou
 .. doctest::
 
   >>> current_vm = chain.get_vm()
-  >>> account_db = current_vm.state.account_db
-  >>> account_db.get_balance(SOME_ADDRESS)
+  >>> state = current_vm.state
+  >>> state.get_balance(SOME_ADDRESS)
   10000000000000000000000
 
 .. _evm_cookbook_recipe_building_blocks_incrementally:

--- a/docs/guides/building_an_app_that_uses_pyevm.rst
+++ b/docs/guides/building_an_app_that_uses_pyevm.rst
@@ -106,7 +106,7 @@ Next, we'll create a new directory ``app`` and create a file ``main.py`` inside.
 
   >>> chain = MainnetChain.from_genesis(AtomicDB(), GENESIS_PARAMS, GENESIS_STATE)
 
-  >>> mock_address_balance = chain.get_vm().state.account_db.get_balance(MOCK_ADDRESS)
+  >>> mock_address_balance = chain.get_vm().state.get_balance(MOCK_ADDRESS)
 
   >>> print("The balance of address {} is {} wei".format(
   ...     encode_hex(MOCK_ADDRESS),

--- a/docs/guides/understanding_the_mining_process.rst
+++ b/docs/guides/understanding_the_mining_process.rst
@@ -269,7 +269,7 @@ With sender and receiver prepared, let's create the actual transaction.
 ::
 
     vm = chain.get_vm()
-    nonce = vm.state.account_db.get_nonce(SENDER)
+    nonce = vm.state.get_nonce(SENDER)
 
     tx = vm.create_unsigned_transaction(
         nonce=nonce,
@@ -283,7 +283,7 @@ With sender and receiver prepared, let's create the actual transaction.
 Every transaction needs a ``nonce`` not to be confused with the ``nonce`` that we previously
 mined as part of the PoW algorithm. The *transaction nonce* serves as a counter to ensure
 all transactions from one address are processed in order. We retrieve the current ``nonce``
-by calling :func:`~eth.vm.base.VM.state.account_db.get_nonce(sender)`.
+by calling :func:`~eth.vm.base.VM.state.get_nonce(sender)`.
 
 Once we have the ``nonce`` we can call :func:`~eth.vm.base.VM.create_unsigned_transaction` and
 pass the ``nonce`` among the rest of the transaction attributes as key-value pairs.
@@ -356,7 +356,7 @@ zero value transfer transaction.
   >>> chain = klass.from_genesis(AtomicDB(), GENESIS_PARAMS)
   >>> vm = chain.get_vm()
 
-  >>> nonce = vm.state.account_db.get_nonce(SENDER)
+  >>> nonce = vm.state.get_nonce(SENDER)
 
   >>> tx = vm.create_unsigned_transaction(
   ...     nonce=nonce,

--- a/eth/_utils/address.py
+++ b/eth/_utils/address.py
@@ -14,7 +14,7 @@ def force_bytes_to_address(value: bytes) -> Address:
     return Address(padded_value)
 
 
-def generate_contract_address(address: Address, nonce: bytes) -> Address:
+def generate_contract_address(address: Address, nonce: int) -> Address:
     return force_bytes_to_address(keccak(rlp.encode([address, nonce])))
 
 

--- a/eth/_utils/db.py
+++ b/eth/_utils/db.py
@@ -6,15 +6,14 @@ from eth_typing import (
     Hash32,
 )
 
-from eth.db.account import (
-    BaseAccountDB,
-)
-
 from eth.rlp.headers import (
     BlockHeader,
 )
 from eth.typing import (
     AccountState,
+)
+from eth.vm.state import (
+    BaseState,
 )
 
 if TYPE_CHECKING:
@@ -35,7 +34,8 @@ def get_block_header_by_hash(block_hash: Hash32, db: 'BaseChainDB') -> BlockHead
     return db.get_block_header_by_hash(block_hash)
 
 
-def apply_state_dict(account_db: BaseAccountDB, state_dict: AccountState) -> BaseAccountDB:
+def apply_state_dict(state: BaseState, state_dict: AccountState) -> None:
+    account_db = state.account_db
 
     for account, account_data in state_dict.items():
         account_db.set_balance(account, account_data["balance"])
@@ -43,6 +43,4 @@ def apply_state_dict(account_db: BaseAccountDB, state_dict: AccountState) -> Bas
         account_db.set_code(account, account_data["code"])
 
         for slot, value in account_data["storage"].items():
-            account_db.set_storage(account, slot, value)
-
-    return account_db
+            state.set_storage(account, slot, value)

--- a/eth/_utils/db.py
+++ b/eth/_utils/db.py
@@ -35,12 +35,10 @@ def get_block_header_by_hash(block_hash: Hash32, db: 'BaseChainDB') -> BlockHead
 
 
 def apply_state_dict(state: BaseState, state_dict: AccountState) -> None:
-    account_db = state.account_db
-
     for account, account_data in state_dict.items():
-        account_db.set_balance(account, account_data["balance"])
-        account_db.set_nonce(account, account_data["nonce"])
-        account_db.set_code(account, account_data["code"])
+        state.set_balance(account, account_data["balance"])
+        state.set_nonce(account, account_data["nonce"])
+        state.set_code(account, account_data["code"])
 
         for slot, value in account_data["storage"].items():
             state.set_storage(account, slot, value)

--- a/eth/_utils/state.py
+++ b/eth/_utils/state.py
@@ -2,24 +2,24 @@ from eth_utils import (
     to_tuple,
 )
 
-from eth.db.account import (
-    BaseAccountDB,
-)
 from eth.typing import (
     AccountDiff,
     AccountState,
 )
+from eth.vm.state import BaseState
 
 
 @to_tuple
-def diff_account_db(expected_state: AccountState,
-                    account_db: BaseAccountDB) -> AccountDiff:
+def diff_state(
+        expected_state: AccountState,
+        state: BaseState) -> AccountDiff:
 
     for account, account_data in sorted(expected_state.items()):
         expected_balance = account_data['balance']
         expected_nonce = account_data['nonce']
         expected_code = account_data['code']
 
+        account_db = state.account_db
         actual_nonce = account_db.get_nonce(account)
         actual_code = account_db.get_code(account)
         actual_balance = account_db.get_balance(account)
@@ -32,7 +32,7 @@ def diff_account_db(expected_state: AccountState,
             yield (account, 'balance', actual_balance, expected_balance)
 
         for slot, expected_storage_value in sorted(account_data['storage'].items()):
-            actual_storage_value = account_db.get_storage(account, slot)
+            actual_storage_value = state.get_storage(account, slot)
             if actual_storage_value != expected_storage_value:
                 yield (
                     account,

--- a/eth/_utils/state.py
+++ b/eth/_utils/state.py
@@ -19,10 +19,9 @@ def diff_state(
         expected_nonce = account_data['nonce']
         expected_code = account_data['code']
 
-        account_db = state.account_db
-        actual_nonce = account_db.get_nonce(account)
-        actual_code = account_db.get_code(account)
-        actual_balance = account_db.get_balance(account)
+        actual_nonce = state.get_nonce(account)
+        actual_code = state.get_code(account)
+        actual_balance = state.get_balance(account)
 
         if actual_nonce != expected_nonce:
             yield (account, 'nonce', actual_nonce, expected_nonce)

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -413,7 +413,6 @@ class Chain(BaseChain):
 
         pre_genesis_header = BlockHeader(difficulty=0, block_number=-1, gas_limit=0)
         state = genesis_vm_class.build_state(base_db, pre_genesis_header)
-        account_db = state.account_db
 
         if genesis_state is None:
             genesis_state = {}
@@ -425,14 +424,14 @@ class Chain(BaseChain):
         if 'state_root' not in genesis_params:
             # If the genesis state_root was not specified, use the value
             # computed from the initialized state database.
-            genesis_params = assoc(genesis_params, 'state_root', account_db.state_root)
-        elif genesis_params['state_root'] != account_db.state_root:
+            genesis_params = assoc(genesis_params, 'state_root', state.state_root)
+        elif genesis_params['state_root'] != state.state_root:
             # If the genesis state_root was specified, validate that it matches
             # the computed state from the initialized state database.
             raise ValidationError(
                 "The provided genesis state root does not match the computed "
                 "genesis state root.  Got {0}.  Expected {1}".format(
-                    account_db.state_root,
+                    state.state_root,
                     genesis_params['state_root'],
                 )
             )

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -40,7 +40,6 @@ from eth_utils.toolz import (
 )
 
 from eth.constants import (
-    BLANK_ROOT_HASH,
     EMPTY_UNCLE_HASH,
     MAX_UNCLE_DEPTH,
 )
@@ -412,17 +411,16 @@ class Chain(BaseChain):
         """
         genesis_vm_class = cls.get_vm_class_for_block_number(BlockNumber(0))
 
-        account_db = genesis_vm_class.get_state_class().get_account_db_class()(
-            base_db,
-            BLANK_ROOT_HASH,
-        )
+        pre_genesis_header = BlockHeader(difficulty=0, block_number=-1, gas_limit=0)
+        state = genesis_vm_class.build_state(base_db, pre_genesis_header)
+        account_db = state.account_db
 
         if genesis_state is None:
             genesis_state = {}
 
         # mutation
-        apply_state_dict(account_db, genesis_state)
-        account_db.persist()
+        apply_state_dict(state, genesis_state)
+        state.persist()
 
         if 'state_root' not in genesis_params:
             # If the genesis state_root was not specified, use the value
@@ -903,7 +901,7 @@ class MiningChain(Chain):
         header_with_receipt = vm.add_receipt_to_header(base_block.header, receipt)
 
         # since we are building the block locally, we have to persist all the incremental state
-        vm.state.account_db.persist()
+        vm.state.persist()
         new_header = header_with_receipt.copy(state_root=vm.state.state_root)
 
         transactions = base_block.transactions + (transaction, )

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -108,9 +108,6 @@ class BaseAccountDB(ABC):
     def set_balance(self, address: Address, balance: int) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
 
-    def delta_balance(self, address: Address, delta: int) -> None:
-        self.set_balance(address, self.get_balance(address) + delta)
-
     #
     # Code
     #

--- a/eth/tools/fixtures/__init__.py
+++ b/eth/tools/fixtures/__init__.py
@@ -10,9 +10,9 @@ from .helpers import (  # noqa: F401
     new_chain_from_fixture,
     genesis_params_from_fixture,
     apply_fixture_block_to_chain,
-    setup_account_db,
+    setup_state,
     should_run_slow_tests,
-    verify_account_db,
+    verify_state,
 )
 from eth.tools._utils.normalization import (  # noqa: F401
     normalize_block,

--- a/eth/tools/fixtures/fillers/_utils.py
+++ b/eth/tools/fixtures/fillers/_utils.py
@@ -1,6 +1,5 @@
 import copy
 import random
-
 from typing import (
     Any,
     Dict,
@@ -9,20 +8,12 @@ from typing import (
     Type,
 )
 
+from eth_keys import keys
 from eth_typing import (
     Address,
 )
-
 from eth_utils import (
     int_to_big_endian,
-)
-
-from eth.db.backends.memory import MemoryDB
-from eth.db.account import BaseAccountDB
-
-from eth.typing import (
-    AccountState,
-    TransactionDict,
 )
 
 from eth._utils.db import (
@@ -31,8 +22,15 @@ from eth._utils.db import (
 from eth._utils.padding import (
     pad32,
 )
-
-from eth_keys import keys
+from eth.constants import BLANK_ROOT_HASH
+from eth.db.backends.memory import MemoryDB
+from eth.typing import (
+    AccountState,
+    TransactionDict,
+)
+from eth.vm.state import (
+    BaseState,
+)
 
 
 def wrap_in_list(item: Any) -> List[Any]:
@@ -64,10 +62,10 @@ def add_transaction_to_group(group: Dict[str, Any],
     return new_group, indexes
 
 
-def calc_state_root(state: AccountState, account_db_class: Type[BaseAccountDB]) -> bytes:
-    account_db = account_db_class(MemoryDB())
-    apply_state_dict(account_db, state)
-    return account_db.state_root
+def calc_state_root(state_dict: AccountState, state_class: Type[BaseState]) -> bytes:
+    state = state_class(MemoryDB(), None, BLANK_ROOT_HASH)
+    apply_state_dict(state, state_dict)
+    return state.state_root
 
 
 def generate_random_keypair() -> Tuple[bytes, Address]:

--- a/eth/tools/fixtures/fillers/state.py
+++ b/eth/tools/fixtures/fillers/state.py
@@ -8,9 +8,6 @@ from typing import (  # noqa: F401
 
 from eth_utils import encode_hex
 
-from eth.db.account import (
-    AccountDB,
-)
 from eth.tools.fixtures.helpers import (
     get_test_name,
 )
@@ -21,6 +18,14 @@ from eth.tools._utils.normalization import (
     normalize_transaction_group,
 )
 from eth.tools._utils.mappings import deep_merge
+from eth.vm.forks.byzantium.state import ByzantiumState
+from eth.vm.forks.constantinople.state import ConstantinopleState
+from eth.vm.forks.frontier.state import FrontierState
+from eth.vm.forks.homestead.state import HomesteadState
+from eth.vm.forks.istanbul.state import IstanbulState
+from eth.vm.forks.petersburg.state import PetersburgState
+from eth.vm.forks.spurious_dragon.state import SpuriousDragonState
+from eth.vm.forks.tangerine_whistle.state import TangerineWhistleState
 
 from ._utils import (
     calc_state_root,
@@ -34,17 +39,23 @@ ALL_NETWORKS = [
     "EIP158",
     "Byzantium",
     "Constantinople",
+    "Petersburg",
+    "Istanbul",
 ]
 
-ACCOUNT_STATE_DB_CLASSES = {
-    "Frontier": AccountDB,
-    "Homestead": AccountDB,
-    "EIP150": AccountDB,
-    "EIP158": AccountDB,
-    "Byzantium": AccountDB,
-    "Constantinople": AccountDB,
+STATE_CLASSES = {
+    "Frontier": FrontierState,
+    "Homestead": HomesteadState,
+    "EIP150": TangerineWhistleState,
+    "EIP158": SpuriousDragonState,
+    "Byzantium": ByzantiumState,
+    "Constantinople": ConstantinopleState,
+    "Petersburg": PetersburgState,
+    "Istanbul": IstanbulState,
 }
-assert all(network in ACCOUNT_STATE_DB_CLASSES for network in ALL_NETWORKS)
+
+_missing_state_classes = set(ALL_NETWORKS) - set(STATE_CLASSES)
+assert not any(_missing_state_classes)
 
 
 def fill_state_test(filler: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
@@ -65,8 +76,8 @@ def fill_state_test(filler: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
         result = normalize_state(expect["result"])
         post_state = deep_merge(pre_state, result)
         for network in networks:
-            account_db_class = ACCOUNT_STATE_DB_CLASSES[network]
-            post_state_root = calc_state_root(post_state, account_db_class)
+            state_class = STATE_CLASSES[network]
+            post_state_root = calc_state_root(post_state, state_class)
             post[network].append({
                 "hash": encode_hex(post_state_root),
                 "indexes": indexes,

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -65,10 +65,9 @@ def setup_state(desired_state: AccountState, state: BaseState) -> None:
         code = account_data['code']
         balance = account_data['balance']
 
-        account_db = state.account_db
-        account_db.set_nonce(account, nonce)
-        account_db.set_code(account, code)
-        account_db.set_balance(account, balance)
+        state.set_nonce(account, nonce)
+        state.set_code(account, code)
+        state.set_balance(account, balance)
     state.persist()
 
 

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -27,9 +27,6 @@ from eth.chains.base import (
 from eth.chains.mainnet import (
     MainnetDAOValidatorVM,
 )
-from eth.db.account import (
-    BaseAccountDB,
-)
 from eth.tools.builder.chain import (
     disable_pow_check,
 )
@@ -37,7 +34,7 @@ from eth.typing import (
     AccountState,
 )
 from eth._utils.state import (
-    diff_account_db,
+    diff_state,
 )
 from eth.vm.base import (
     BaseVM,
@@ -51,28 +48,32 @@ from eth.vm.forks import (
     HomesteadVM as BaseHomesteadVM,
     SpuriousDragonVM,
 )
+from eth.vm.state import (
+    BaseState,
+)
 
 
 #
 # State Setup
 #
-def setup_account_db(desired_state: AccountState, account_db: BaseAccountDB) -> None:
+def setup_state(desired_state: AccountState, state: BaseState) -> None:
     for account, account_data in desired_state.items():
         for slot, value in account_data['storage'].items():
-            account_db.set_storage(account, slot, value)
+            state.set_storage(account, slot, value)
 
         nonce = account_data['nonce']
         code = account_data['code']
         balance = account_data['balance']
 
+        account_db = state.account_db
         account_db.set_nonce(account, nonce)
         account_db.set_code(account, code)
         account_db.set_balance(account, balance)
-    account_db.persist()
+    state.persist()
 
 
-def verify_account_db(expected_state: AccountState, account_db: BaseAccountDB) -> None:
-    diff = diff_account_db(expected_state, account_db)
+def verify_state(expected_state: AccountState, state: BaseState) -> None:
+    diff = diff_state(expected_state, state)
     if diff:
         error_messages = []
         for account, field, actual_value, expected_value in diff:

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -84,13 +84,22 @@ class BaseVM(Configurable, ABC):
     chaindb = None  # type: BaseChainDB
     _state_class = None  # type: Type[BaseState]
 
+    @abstractmethod
+    def __init__(self, header: BlockHeader, chaindb: BaseChainDB) -> None:
+        pass
+
     @property
     @abstractmethod
     def state(self) -> BaseState:
         pass
 
+    @classmethod
     @abstractmethod
-    def __init__(self, header: BlockHeader, chaindb: BaseChainDB) -> None:
+    def build_state(
+            cls,
+            db: BaseAtomicDB,
+            header: BlockHeader,
+            previous_hashes: Iterable[Hash32] = ()) -> BaseState:
         pass
 
     @property
@@ -651,7 +660,7 @@ class VM(BaseVM):
 
         # We need to call `persist` here since the state db batches
         # all writes until we tell it to write to the underlying db
-        self.state.account_db.persist()
+        self.state.persist()
 
         return block.copy(header=block.header.copy(state_root=self.state.state_root))
 

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -634,7 +634,7 @@ class VM(BaseVM):
             len(block.uncles) * self.get_nephew_reward()
         )
 
-        self.state.account_db.delta_balance(block.header.coinbase, block_reward)
+        self.state.delta_balance(block.header.coinbase, block_reward)
         self.logger.debug(
             "BLOCK REWARD: %s -> %s",
             block_reward,
@@ -643,7 +643,7 @@ class VM(BaseVM):
 
         for uncle in block.uncles:
             uncle_reward = self.get_uncle_reward(block.number, uncle)
-            self.state.account_db.delta_balance(uncle.coinbase, uncle_reward)
+            self.state.delta_balance(uncle.coinbase, uncle_reward)
             self.logger.debug(
                 "UNCLE REWARD REWARD: %s -> %s",
                 uncle_reward,

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -113,8 +113,8 @@ class BaseComputation(Configurable, ABC):
     return_data = b''
     _error = None  # type: VMError
 
-    _log_entries = None  # type: List[Tuple[int, bytes, List[int], bytes]]
-    accounts_to_delete = None  # type: Dict[bytes, bytes]
+    _log_entries = None  # type: List[Tuple[int, Address, List[int], bytes]]
+    accounts_to_delete = None  # type: Dict[Address, Address]
 
     # VM configuration
     opcodes = None  # type: Dict[int, Any]
@@ -439,7 +439,7 @@ class BaseComputation(Configurable, ABC):
             )
         self.accounts_to_delete[self.msg.storage_address] = beneficiary
 
-    def get_accounts_for_deletion(self) -> Tuple[Tuple[bytes, bytes], ...]:
+    def get_accounts_for_deletion(self) -> Tuple[Tuple[Address, Address], ...]:
         if self.is_error:
             return tuple()
         else:

--- a/eth/vm/forks/constantinople/storage.py
+++ b/eth/vm/forks/constantinople/storage.py
@@ -15,12 +15,12 @@ from eth.vm.forks.constantinople import (
 def sstore_eip1283(computation: BaseComputation) -> None:
     slot, value = computation.stack_pop(num_items=2, type_hint=UINT256)
 
-    current_value = computation.state.account_db.get_storage(
+    current_value = computation.state.get_storage(
         address=computation.msg.storage_address,
         slot=slot,
     )
 
-    original_value = computation.state.account_db.get_storage(
+    original_value = computation.state.get_storage(
         address=computation.msg.storage_address,
         slot=slot,
         from_journal=False
@@ -68,7 +68,7 @@ def sstore_eip1283(computation: BaseComputation) -> None:
     if gas_refund:
         computation.refund_gas(gas_refund)
 
-    computation.state.account_db.set_storage(
+    computation.state.set_storage(
         address=computation.msg.storage_address,
         slot=slot,
         value=value,

--- a/eth/vm/forks/frontier/__init__.py
+++ b/eth/vm/forks/frontier/__init__.py
@@ -94,7 +94,7 @@ class FrontierVM(VM):
         return old_header.copy(
             bloom=int(BloomFilter(old_header.bloom) | receipt.bloom),
             gas_used=receipt.gas_used,
-            state_root=self.state.account_db.make_state_root(),
+            state_root=self.state.make_state_root(),
         )
 
     @staticmethod
@@ -107,5 +107,5 @@ class FrontierVM(VM):
         receipt_without_state_root = make_frontier_receipt(base_header, transaction, computation)
 
         return receipt_without_state_root.copy(
-            state_root=state.account_db.make_state_root()
+            state_root=state.make_state_root()
         )

--- a/eth/vm/forks/frontier/computation.py
+++ b/eth/vm/forks/frontier/computation.py
@@ -51,15 +51,15 @@ class FrontierComputation(BaseComputation):
             raise StackDepthLimit("Stack depth limit reached")
 
         if self.msg.should_transfer_value and self.msg.value:
-            sender_balance = self.state.account_db.get_balance(self.msg.sender)
+            sender_balance = self.state.get_balance(self.msg.sender)
 
             if sender_balance < self.msg.value:
                 raise InsufficientFunds(
                     "Insufficient funds: {0} < {1}".format(sender_balance, self.msg.value)
                 )
 
-            self.state.account_db.delta_balance(self.msg.sender, -1 * self.msg.value)
-            self.state.account_db.delta_balance(self.msg.storage_address, self.msg.value)
+            self.state.delta_balance(self.msg.sender, -1 * self.msg.value)
+            self.state.delta_balance(self.msg.storage_address, self.msg.value)
 
             self.logger.debug2(
                 "TRANSFERRED: %s from %s -> %s",
@@ -68,7 +68,7 @@ class FrontierComputation(BaseComputation):
                 encode_hex(self.msg.storage_address),
             )
 
-        self.state.account_db.touch_account(self.msg.storage_address)
+        self.state.touch_account(self.msg.storage_address)
 
         computation = self.apply_computation(
             self.state,
@@ -107,5 +107,5 @@ class FrontierComputation(BaseComputation):
                         len(contract_code),
                         encode_hex(keccak(contract_code))
                     )
-                    self.state.account_db.set_code(self.msg.storage_address, contract_code)
+                    self.state.set_code(self.msg.storage_address, contract_code)
             return computation

--- a/eth/vm/forks/frontier/state.py
+++ b/eth/vm/forks/frontier/state.py
@@ -182,7 +182,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
             # TODO: this balance setting is likely superflous and can be
             # removed since `delete_account` does this.
             self.vm_state.account_db.set_balance(account, 0)
-            self.vm_state.account_db.delete_account(account)
+            self.vm_state.delete_account(account)
 
         return computation
 

--- a/eth/vm/forks/frontier/validation.py
+++ b/eth/vm/forks/frontier/validation.py
@@ -2,23 +2,19 @@ from eth_utils import (
     ValidationError,
 )
 
-from eth.db.account import BaseAccountDB
-
 from eth.rlp.headers import BlockHeader
-
 from eth.rlp.transactions import BaseTransaction
-
 from eth.typing import (
     BaseOrSpoofTransaction
 )
-
 from eth.vm.base import BaseVM
+from eth.vm.state import BaseState
 
 
-def validate_frontier_transaction(account_db: BaseAccountDB,
+def validate_frontier_transaction(state: BaseState,
                                   transaction: BaseOrSpoofTransaction) -> None:
     gas_cost = transaction.gas * transaction.gas_price
-    sender_balance = account_db.get_balance(transaction.sender)
+    sender_balance = state.get_balance(transaction.sender)
 
     if sender_balance < gas_cost:
         raise ValidationError(
@@ -30,7 +26,7 @@ def validate_frontier_transaction(account_db: BaseAccountDB,
     if sender_balance < total_cost:
         raise ValidationError("Sender account balance cannot afford txn")
 
-    if account_db.get_nonce(transaction.sender) != transaction.nonce:
+    if state.get_nonce(transaction.sender) != transaction.nonce:
         raise ValidationError("Invalid transaction nonce")
 
 

--- a/eth/vm/forks/homestead/computation.py
+++ b/eth/vm/forks/homestead/computation.py
@@ -55,7 +55,7 @@ class HomesteadComputation(FrontierComputation):
                             encode_hex(keccak(contract_code))
                         )
 
-                    self.state.account_db.set_code(self.msg.storage_address, contract_code)
+                    self.state.set_code(self.msg.storage_address, contract_code)
                     self.state.commit(snapshot)
             else:
                 self.state.commit(snapshot)

--- a/eth/vm/forks/homestead/headers.py
+++ b/eth/vm/forks/homestead/headers.py
@@ -3,6 +3,9 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from eth_typing import (
+    Address,
+)
 from eth_utils import (
     decode_hex,
 )
@@ -88,10 +91,10 @@ def configure_homestead_header(vm: "HomesteadVM", **header_params: Any) -> Block
             state = vm.state
 
             for account in dao_drain_list:
-                account = decode_hex(account)
-                balance = state.account_db.get_balance(account)
-                state.account_db.delta_balance(dao_refund_contract, balance)
-                state.account_db.set_balance(account, 0)
+                address = Address(decode_hex(account))
+                balance = state.get_balance(address)
+                state.delta_balance(dao_refund_contract, balance)
+                state.set_balance(address, 0)
 
             # Persist the changes to the database
             state.persist()
@@ -103,7 +106,7 @@ def configure_homestead_header(vm: "HomesteadVM", **header_params: Any) -> Block
     return header
 
 
-dao_refund_contract = decode_hex('0xbf4ed7b27f1d666546e30d74d50d173d20bca754')
+dao_refund_contract = Address(decode_hex('0xbf4ed7b27f1d666546e30d74d50d173d20bca754'))
 dao_drain_list = [
     "0xd4fe7bc31cedb7bfb8a345f31e668033056b2728",
     "0xb3fb0e5aba0e20e5c49d252dfd30e102b171a425",

--- a/eth/vm/forks/homestead/headers.py
+++ b/eth/vm/forks/homestead/headers.py
@@ -94,7 +94,7 @@ def configure_homestead_header(vm: "HomesteadVM", **header_params: Any) -> Block
                 state.account_db.set_balance(account, 0)
 
             # Persist the changes to the database
-            state.account_db.persist()
+            state.persist()
 
             # Update state_root manually
             changeset.state_root = state.state_root

--- a/eth/vm/forks/homestead/state.py
+++ b/eth/vm/forks/homestead/state.py
@@ -1,7 +1,3 @@
-from eth.typing import (
-    BaseOrSpoofTransaction,
-)
-
 from eth.vm.forks.frontier.state import (
     FrontierState,
     FrontierTransactionExecutor,
@@ -14,8 +10,7 @@ from .validation import validate_homestead_transaction
 class HomesteadState(FrontierState):
     computation_class = HomesteadComputation
 
-    def validate_transaction(self, transaction: BaseOrSpoofTransaction) -> None:
-        validate_homestead_transaction(self.account_db, transaction)
+    validate_transaction = validate_homestead_transaction
 
 
 class HomesteadTransactionExecutor(FrontierTransactionExecutor):

--- a/eth/vm/forks/homestead/validation.py
+++ b/eth/vm/forks/homestead/validation.py
@@ -6,18 +6,16 @@ from eth.constants import (
     SECPK1_N,
 )
 
-from eth.db.account import BaseAccountDB
-
 from eth.typing import BaseOrSpoofTransaction
-
 from eth.vm.forks.frontier.validation import (
     validate_frontier_transaction,
 )
+from eth.vm.state import BaseState
 
 
-def validate_homestead_transaction(account_db: BaseAccountDB,
+def validate_homestead_transaction(state: BaseState,
                                    transaction: BaseOrSpoofTransaction) -> None:
     if transaction.s > SECPK1_N // 2 or transaction.s == 0:
         raise ValidationError("Invalid signature S value")
 
-    validate_frontier_transaction(account_db, transaction)
+    validate_frontier_transaction(state, transaction)

--- a/eth/vm/forks/spurious_dragon/computation.py
+++ b/eth/vm/forks/spurious_dragon/computation.py
@@ -28,7 +28,7 @@ class SpuriousDragonComputation(HomesteadComputation):
         snapshot = self.state.snapshot()
 
         # EIP161 nonce incrementation
-        self.state.account_db.increment_nonce(self.msg.storage_address)
+        self.state.increment_nonce(self.msg.storage_address)
 
         computation = self.apply_message()
 
@@ -68,7 +68,7 @@ class SpuriousDragonComputation(HomesteadComputation):
                             encode_hex(keccak(contract_code))
                         )
 
-                    self.state.account_db.set_code(self.msg.storage_address, contract_code)
+                    self.state.set_code(self.msg.storage_address, contract_code)
                     self.state.commit(snapshot)
             else:
                 self.state.commit(snapshot)

--- a/eth/vm/forks/spurious_dragon/state.py
+++ b/eth/vm/forks/spurious_dragon/state.py
@@ -30,8 +30,8 @@ class SpuriousDragonTransactionExecutor(HomesteadTransactionExecutor):
 
         for account in touched_accounts:
             should_delete = (
-                self.vm_state.account_db.account_exists(account) and
-                self.vm_state.account_db.account_is_empty(account)
+                self.vm_state.account_exists(account) and
+                self.vm_state.account_is_empty(account)
             )
             if should_delete:
                 self.vm_state.logger.debug2(

--- a/eth/vm/forks/spurious_dragon/state.py
+++ b/eth/vm/forks/spurious_dragon/state.py
@@ -38,7 +38,7 @@ class SpuriousDragonTransactionExecutor(HomesteadTransactionExecutor):
                     "CLEARING EMPTY ACCOUNT: %s",
                     encode_hex(account),
                 )
-                self.vm_state.account_db.delete_account(account)
+                self.vm_state.delete_account(account)
 
         return computation
 

--- a/eth/vm/logic/context.py
+++ b/eth/vm/logic/context.py
@@ -16,7 +16,7 @@ from eth.vm.computation import BaseComputation
 
 def balance(computation: BaseComputation) -> None:
     addr = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
-    balance = computation.state.account_db.get_balance(addr)
+    balance = computation.state.get_balance(addr)
     computation.stack_push(balance)
 
 
@@ -112,7 +112,7 @@ def gasprice(computation: BaseComputation) -> None:
 
 def extcodesize(computation: BaseComputation) -> None:
     account = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
-    code_size = len(computation.state.account_db.get_code(account))
+    code_size = len(computation.state.get_code(account))
 
     computation.stack_push(code_size)
 
@@ -135,7 +135,7 @@ def extcodecopy(computation: BaseComputation) -> None:
         reason='EXTCODECOPY: word gas cost',
     )
 
-    code = computation.state.account_db.get_code(account)
+    code = computation.state.get_code(account)
 
     code_bytes = code[code_start_position:code_start_position + size]
     padded_code_bytes = code_bytes.ljust(size, b'\x00')
@@ -149,12 +149,12 @@ def extcodehash(computation: BaseComputation) -> None:
     EIP: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1052.md
     """
     account = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
-    account_db = computation.state.account_db
+    state = computation.state
 
-    if account_db.account_is_empty(account):
+    if state.account_is_empty(account):
         computation.stack_push(constants.NULL_BYTE)
     else:
-        computation.stack_push(account_db.get_code_hash(account))
+        computation.stack_push(state.get_code_hash(account))
 
 
 def returndatasize(computation: BaseComputation) -> None:

--- a/eth/vm/logic/storage.py
+++ b/eth/vm/logic/storage.py
@@ -9,7 +9,7 @@ from eth.vm.computation import BaseComputation
 def sstore(computation: BaseComputation) -> None:
     slot, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
 
-    current_value = computation.state.account_db.get_storage(
+    current_value = computation.state.get_storage(
         address=computation.msg.storage_address,
         slot=slot,
     )
@@ -43,7 +43,7 @@ def sstore(computation: BaseComputation) -> None:
     if gas_refund:
         computation.refund_gas(gas_refund)
 
-    computation.state.account_db.set_storage(
+    computation.state.set_storage(
         address=computation.msg.storage_address,
         slot=slot,
         value=value,
@@ -53,7 +53,7 @@ def sstore(computation: BaseComputation) -> None:
 def sload(computation: BaseComputation) -> None:
     slot = computation.stack_pop(type_hint=constants.UINT256)
 
-    value = computation.state.account_db.get_storage(
+    value = computation.state.get_storage(
         address=computation.msg.storage_address,
         slot=slot,
     )

--- a/eth/vm/logic/system.py
+++ b/eth/vm/logic/system.py
@@ -246,7 +246,7 @@ class Create2(CreateByzantium):
         # to its original state root.
         snapshot = computation.state.snapshot()
 
-        computation.state.account_db.delete_storage(child_msg.storage_address)
+        computation.state.delete_storage(child_msg.storage_address)
 
         child_computation = computation.apply_child_computation(child_msg)
 

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -79,7 +79,7 @@ class BaseState(Configurable, ABC):
     #
     # Set from __init__
     #
-    __slots__ = ['_db', 'execution_context', 'account_db']
+    __slots__ = ['_db', 'execution_context', '_account_db']
 
     computation_class = None  # type: Type[BaseComputation]
     transaction_context_class = None  # type: Type[BaseTransactionContext]
@@ -89,7 +89,7 @@ class BaseState(Configurable, ABC):
     def __init__(self, db: BaseDB, execution_context: ExecutionContext, state_root: bytes) -> None:
         self._db = db
         self.execution_context = execution_context
-        self.account_db = self.get_account_db_class()(self._db, state_root)
+        self._account_db = self.get_account_db_class()(self._db, state_root)
 
     #
     # Logging
@@ -156,22 +156,64 @@ class BaseState(Configurable, ABC):
         """
         Return the current ``state_root`` from the underlying database
         """
-        return self.account_db.state_root
+        return self._account_db.state_root
 
     def make_state_root(self) -> Hash32:
-        return self.account_db.make_state_root()
+        return self._account_db.make_state_root()
 
     def get_storage(self, address: Address, slot: int, from_journal: bool=True) -> int:
-        return self.account_db.get_storage(address, slot, from_journal)
+        return self._account_db.get_storage(address, slot, from_journal)
 
     def set_storage(self, address: Address, slot: int, value: int) -> None:
-        self.account_db.set_storage(address, slot, value)
+        self._account_db.set_storage(address, slot, value)
 
     def delete_storage(self, address: Address) -> None:
-        self.account_db.delete_storage(address)
+        self._account_db.delete_storage(address)
 
     def delete_account(self, address: Address) -> None:
-        self.account_db.delete_account(address)
+        self._account_db.delete_account(address)
+
+    def get_balance(self, address: Address) -> int:
+        return self._account_db.get_balance(address)
+
+    def set_balance(self, address: Address, balance: int) -> None:
+        self._account_db.set_balance(address, balance)
+
+    def delta_balance(self, address: Address, delta: int) -> None:
+        self.set_balance(address, self.get_balance(address) + delta)
+
+    def get_nonce(self, address: Address) -> int:
+        return self._account_db.get_nonce(address)
+
+    def set_nonce(self, address: Address, nonce: int) -> None:
+        self._account_db.set_nonce(address, nonce)
+
+    def increment_nonce(self, address: Address) -> None:
+        self._account_db.increment_nonce(address)
+
+    def get_code(self, address: Address) -> bytes:
+        return self._account_db.get_code(address)
+
+    def set_code(self, address: Address, code: bytes) -> None:
+        self._account_db.set_code(address, code)
+
+    def get_code_hash(self, address: Address) -> Hash32:
+        return self._account_db.get_code_hash(address)
+
+    def delete_code(self, address: Address) -> None:
+        self._account_db.delete_code(address)
+
+    def has_code_or_nonce(self, address: Address) -> bool:
+        return self._account_db.account_has_code_or_nonce(address)
+
+    def account_exists(self, address: Address) -> bool:
+        return self._account_db.account_exists(address)
+
+    def touch_account(self, address: Address) -> None:
+        self._account_db.touch_account(address)
+
+    def account_is_empty(self, address: Address) -> bool:
+        return self._account_db.account_is_empty(address)
 
     #
     # Access self._chaindb
@@ -183,7 +225,7 @@ class BaseState(Configurable, ABC):
         Snapshots are a combination of the :attr:`~state_root` at the time of the
         snapshot and the id of the changeset from the journaled DB.
         """
-        return (self.state_root, self.account_db.record())
+        return (self.state_root, self._account_db.record())
 
     def revert(self, snapshot: Tuple[bytes, Tuple[UUID, UUID]]) -> None:
         """
@@ -192,9 +234,9 @@ class BaseState(Configurable, ABC):
         state_root, changeset_id = snapshot
 
         # first revert the database state root.
-        self.account_db.state_root = state_root
+        self._account_db.state_root = state_root
         # now roll the underlying database back
-        self.account_db.discard(changeset_id)
+        self._account_db.discard(changeset_id)
 
     def commit(self, snapshot: Tuple[bytes, Tuple[UUID, UUID]]) -> None:
         """
@@ -202,10 +244,10 @@ class BaseState(Configurable, ABC):
         will merge in any changesets that were recorded *after* the snapshot changeset.
         """
         _, checkpoint_id = snapshot
-        self.account_db.commit(checkpoint_id)
+        self._account_db.commit(checkpoint_id)
 
     def persist(self) -> None:
-        self.account_db.persist()
+        self._account_db.persist()
 
     #
     # Access self.prev_hashes (Read-only)
@@ -271,7 +313,7 @@ class BaseState(Configurable, ABC):
         :param transaction: the transaction to apply
         :return: the computation
         """
-        if self.state_root != BLANK_ROOT_HASH and not self.account_db.has_root(self.state_root):
+        if self.state_root != BLANK_ROOT_HASH and not self._account_db.has_root(self.state_root):
             raise StateRootNotFound(self.state_root)
         else:
             return self.execute_transaction(transaction)

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -152,11 +152,26 @@ class BaseState(Configurable, ABC):
         return cls.account_db_class
 
     @property
-    def state_root(self) -> bytes:
+    def state_root(self) -> Hash32:
         """
         Return the current ``state_root`` from the underlying database
         """
         return self.account_db.state_root
+
+    def make_state_root(self) -> Hash32:
+        return self.account_db.make_state_root()
+
+    def get_storage(self, address: Address, slot: int, from_journal: bool=True) -> int:
+        return self.account_db.get_storage(address, slot, from_journal)
+
+    def set_storage(self, address: Address, slot: int, value: int) -> None:
+        self.account_db.set_storage(address, slot, value)
+
+    def delete_storage(self, address: Address) -> None:
+        self.account_db.delete_storage(address)
+
+    def delete_account(self, address: Address) -> None:
+        self.account_db.delete_account(address)
 
     #
     # Access self._chaindb
@@ -188,6 +203,9 @@ class BaseState(Configurable, ABC):
         """
         _, checkpoint_id = snapshot
         self.account_db.commit(checkpoint_id)
+
+    def persist(self) -> None:
+        self.account_db.persist()
 
     #
     # Access self.prev_hashes (Read-only)

--- a/scripts/benchmark/_utils/tx.py
+++ b/scripts/benchmark/_utils/tx.py
@@ -28,7 +28,7 @@ def new_transaction(
 
     The transaction will be signed with the given private key.
     """
-    nonce = vm.state.account_db.get_nonce(from_)
+    nonce = vm.state.get_nonce(from_)
     tx = vm.create_unsigned_transaction(
         nonce=nonce,
         gas_price=gas_price,

--- a/tests/core/builder-tools/test_chain_initializer.py
+++ b/tests/core/builder-tools/test_chain_initializer.py
@@ -62,8 +62,8 @@ def test_chain_builder_initialize_chain_with_state_simple(chain_class):
 
     assert header.state_root != constants.BLANK_ROOT_HASH
 
-    account_db = chain.get_vm().state.account_db
-    assert account_db.get_balance(ADDRESS_A) == 1
+    state = chain.get_vm().state
+    assert state.get_balance(ADDRESS_A) == 1
 
 
 def test_chain_builder_initialize_chain_with_state_multiple(chain_class):
@@ -79,9 +79,9 @@ def test_chain_builder_initialize_chain_with_state_multiple(chain_class):
 
     assert header.state_root != constants.BLANK_ROOT_HASH
 
-    account_db = chain.get_vm().state.account_db
-    assert account_db.get_balance(ADDRESS_A) == 1
-    assert account_db.get_balance(ADDRESS_B) == 2
+    state = chain.get_vm().state
+    assert state.get_balance(ADDRESS_A) == 1
+    assert state.get_balance(ADDRESS_B) == 2
 
 
 def test_chain_builder_initialize_chain_with_params(chain_class):
@@ -114,5 +114,5 @@ def test_chain_builder_initialize_chain_with_params_and_state(chain_class):
 
     assert header.state_root != constants.BLANK_ROOT_HASH
 
-    account_db = chain.get_vm().state.account_db
-    assert account_db.get_balance(ADDRESS_A) == 1
+    state = chain.get_vm().state
+    assert state.get_balance(ADDRESS_A) == 1

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -47,11 +47,11 @@ def test_import_block_validation(valid_chain, funded_address, funded_address_ini
     tx = imported_block.transactions[0]
     assert tx.value == 10
     vm = valid_chain.get_vm()
-    account_db = vm.state.account_db
-    assert account_db.get_balance(
+    state = vm.state
+    assert state.get_balance(
         decode_hex("095e7baea6a6c7c4c2dfeb977efac326af552d87")) == tx.value
     tx_gas = tx.gas_price * constants.GAS_TX
-    assert account_db.get_balance(funded_address) == (
+    assert state.get_balance(funded_address) == (
         funded_address_initial_balance - tx.value - tx_gas)
 
 

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -38,7 +38,7 @@ def new_transaction(
 
     The transaction will be signed with the given private key.
     """
-    nonce = vm.state.account_db.get_nonce(from_)
+    nonce = vm.state.get_nonce(from_)
     tx = vm.create_unsigned_transaction(
         nonce=nonce,
         gas_price=gas_price,

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -618,8 +618,8 @@ def test_sstore(vm_class, code, gas_used, refund, original):
     computation = setup_computation(vm_class, CANONICAL_ADDRESS_B, decode_hex(code))
 
     computation.state.account_db.set_balance(CANONICAL_ADDRESS_B, 100000000000)
-    computation.state.account_db.set_storage(CANONICAL_ADDRESS_B, 0, original)
-    computation.state.account_db.persist()
+    computation.state.set_storage(CANONICAL_ADDRESS_B, 0, original)
+    computation.state.persist()
 
     comp = computation.apply_message()
     assert comp.get_gas_refund() == refund

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -84,10 +84,10 @@ def prepare_general_computation(vm_class, create_address=None, code=b''):
 
     computation = setup_computation(vm_class, create_address, code)
 
-    computation.state.account_db.touch_account(decode_hex(EMPTY_ADDRESS_IN_STATE))
-    computation.state.account_db.set_code(decode_hex(ADDRESS_WITH_CODE[0]), ADDRESS_WITH_CODE[1])
+    computation.state.touch_account(decode_hex(EMPTY_ADDRESS_IN_STATE))
+    computation.state.set_code(decode_hex(ADDRESS_WITH_CODE[0]), ADDRESS_WITH_CODE[1])
 
-    computation.state.account_db.set_balance(decode_hex(ADDRESS_WITH_JUST_BALANCE), 1)
+    computation.state.set_balance(decode_hex(ADDRESS_WITH_JUST_BALANCE), 1)
 
     return computation
 
@@ -617,7 +617,7 @@ def test_sstore(vm_class, code, gas_used, refund, original):
 
     computation = setup_computation(vm_class, CANONICAL_ADDRESS_B, decode_hex(code))
 
-    computation.state.account_db.set_balance(CANONICAL_ADDRESS_B, 100000000000)
+    computation.state.set_balance(CANONICAL_ADDRESS_B, 100000000000)
     computation.state.set_storage(CANONICAL_ADDRESS_B, 0, original)
     computation.state.persist()
 

--- a/tests/core/vm/test_frontier_computation.py
+++ b/tests/core/vm/test_frontier_computation.py
@@ -24,7 +24,7 @@ CANONICAL_ADDRESS_B = to_canonical_address("0xcd1722f3947def4cf144679da39c4c32bd
 @pytest.fixture
 def state(chain_without_block_validation):
     state = chain_without_block_validation.get_vm().state
-    state.account_db.set_balance(CANONICAL_ADDRESS_A, 1000)
+    state.set_balance(CANONICAL_ADDRESS_A, 1000)
     return state
 
 

--- a/tests/core/vm/test_rewards.py
+++ b/tests/core/vm/test_rewards.py
@@ -71,8 +71,8 @@ def test_rewards(vm_fn, miner_1_balance, miner_2_balance):
     assert block.uncles[0] == uncle
 
     vm = chain.get_vm()
-    coinbase_balance = vm.state.account_db.get_balance(block.header.coinbase)
-    other_miner_balance = vm.state.account_db.get_balance(uncle.coinbase)
+    coinbase_balance = vm.state.get_balance(block.header.coinbase)
+    other_miner_balance = vm.state.get_balance(uncle.coinbase)
 
     # We first test if the balance matches what we would determine
     # if we made all the API calls involved ourselves.
@@ -167,8 +167,8 @@ def test_rewards_uncle_created_at_different_generations(
     block = chain.get_block_by_hash(header.hash)
 
     vm = chain.get_vm()
-    coinbase_balance = vm.state.account_db.get_balance(block.header.coinbase)
-    other_miner_balance = vm.state.account_db.get_balance(uncle.coinbase)
+    coinbase_balance = vm.state.get_balance(block.header.coinbase)
+    other_miner_balance = vm.state.get_balance(uncle.coinbase)
 
     # We first test if the balance matches what we would determine
     # if we made all the API calls involved ourselves.
@@ -278,8 +278,8 @@ def test_rewards_nephew_uncle_different_vm(
     assert block.uncles[0] == uncle
 
     vm = chain.get_vm()
-    coinbase_balance = vm.state.account_db.get_balance(block.header.coinbase)
-    other_miner_balance = vm.state.account_db.get_balance(uncle.coinbase)
+    coinbase_balance = vm.state.get_balance(block.header.coinbase)
+    other_miner_balance = vm.state.get_balance(uncle.coinbase)
 
     uncle_vm = chain.get_vm_class_for_block_number(0)
     nephew_vm = chain.get_vm_class_for_block_number(VM_CHANGE_BLOCK_NUMBER)

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -32,10 +32,10 @@ def test_apply_transaction(
 
     assert not computation.is_error
     tx_gas = tx.gas_price * constants.GAS_TX
-    account_db = vm.state.account_db
-    assert account_db.get_balance(from_) == (
+    state = vm.state
+    assert state.get_balance(from_) == (
         funded_address_initial_balance - amount - tx_gas)
-    assert account_db.get_balance(recipient) == amount
+    assert state.get_balance(recipient) == amount
 
     assert new_header.gas_used == constants.GAS_TX
 
@@ -47,7 +47,7 @@ def test_mine_block_issues_block_reward(chain):
 
     block = chain.mine_block()
     vm = chain.get_vm()
-    coinbase_balance = vm.state.account_db.get_balance(block.header.coinbase)
+    coinbase_balance = vm.state.get_balance(block.header.coinbase)
     assert coinbase_balance == vm.get_block_reward()
 
 

--- a/tests/database/test_account_db.py
+++ b/tests/database/test_account_db.py
@@ -31,20 +31,12 @@ def test_balance(state):
     assert state.get_balance(ADDRESS) == 1
     assert state.get_balance(OTHER_ADDRESS) == 0
 
-    state.delta_balance(ADDRESS, 2)
-    assert state.get_balance(ADDRESS) == 3
-    assert state.get_balance(OTHER_ADDRESS) == 0
-
     with pytest.raises(ValidationError):
         state.get_balance(INVALID_ADDRESS)
     with pytest.raises(ValidationError):
         state.set_balance(INVALID_ADDRESS, 1)
     with pytest.raises(ValidationError):
-        state.delta_balance(INVALID_ADDRESS, 1)
-    with pytest.raises(ValidationError):
         state.set_balance(ADDRESS, 1.0)
-    with pytest.raises(ValidationError):
-        state.delta_balance(ADDRESS, 1.0)
 
 
 @pytest.mark.parametrize("state", [

--- a/tests/database/test_account_db.py
+++ b/tests/database/test_account_db.py
@@ -94,43 +94,6 @@ def test_code(state):
 @pytest.mark.parametrize("state", [
     AccountDB(MemoryDB()),
 ])
-def test_storage(state):
-    assert state.get_storage(ADDRESS, 0) == 0
-
-    state.set_storage(ADDRESS, 0, 123)
-    assert state.get_storage(ADDRESS, 0) == 123
-    assert state.get_storage(ADDRESS, 1) == 0
-    assert state.get_storage(OTHER_ADDRESS, 0) == 0
-
-    with pytest.raises(ValidationError):
-        state.get_storage(INVALID_ADDRESS, 0)
-    with pytest.raises(ValidationError):
-        state.set_storage(INVALID_ADDRESS, 0, 0)
-    with pytest.raises(ValidationError):
-        state.get_storage(ADDRESS, b'\x00')
-    with pytest.raises(ValidationError):
-        state.set_storage(ADDRESS, b'\x00', 0)
-    with pytest.raises(ValidationError):
-        state.set_storage(ADDRESS, 0, b'asdf')
-
-
-@pytest.mark.parametrize("state", [
-    AccountDB(MemoryDB()),
-])
-def test_storage_deletion(state):
-    state.set_storage(ADDRESS, 0, 123)
-    state.set_storage(OTHER_ADDRESS, 1, 321)
-    state.delete_storage(ADDRESS)
-    assert state.get_storage(ADDRESS, 0) == 0
-    assert state.get_storage(OTHER_ADDRESS, 1) == 321
-
-    with pytest.raises(ValidationError):
-        state.delete_storage(INVALID_ADDRESS)
-
-
-@pytest.mark.parametrize("state", [
-    AccountDB(MemoryDB()),
-])
 def test_accounts(state):
     assert not state.account_exists(ADDRESS)
     assert not state.account_has_code_or_nonce(ADDRESS)

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -26,7 +26,7 @@ from eth.tools.fixtures import (
     load_fixture,
     new_chain_from_fixture,
     should_run_slow_tests,
-    verify_account_db,
+    verify_state,
 )
 
 
@@ -318,4 +318,4 @@ def test_blockchain_fixtures(fixture_data, fixture):
 
     latest_block_hash = chain.get_canonical_block_by_number(chain.get_block().number - 1).hash
     if latest_block_hash != fixture['lastblockhash']:
-        verify_account_db(fixture['postState'], chain.get_vm().state.account_db)
+        verify_state(fixture['postState'], chain.get_vm().state)

--- a/tests/json-fixtures/test_virtual_machine.py
+++ b/tests/json-fixtures/test_virtual_machine.py
@@ -192,7 +192,7 @@ def test_vm_fixtures(fixture, vm_class, computation_getter):
     vm = vm_class(header=header, chaindb=chaindb)
     state = vm.state
     setup_state(fixture['pre'], state)
-    code = state.account_db.get_code(fixture['exec']['address'])
+    code = state.get_code(fixture['exec']['address'])
     # Update state_root manually
     vm.block = vm.block.copy(header=vm.header.copy(state_root=state.state_root))
 

--- a/tests/json-fixtures/test_virtual_machine.py
+++ b/tests/json-fixtures/test_virtual_machine.py
@@ -23,8 +23,8 @@ from eth.tools.fixtures import (
     filter_fixtures,
     generate_fixture_tests,
     load_fixture,
-    setup_account_db,
-    verify_account_db,
+    setup_state,
+    verify_state,
 )
 from eth.tools._utils.normalization import (
     normalize_vmtest_fixture,
@@ -191,7 +191,7 @@ def test_vm_fixtures(fixture, vm_class, computation_getter):
     )
     vm = vm_class(header=header, chaindb=chaindb)
     state = vm.state
-    setup_account_db(fixture['pre'], state.account_db)
+    setup_state(fixture['pre'], state)
     code = state.account_db.get_code(fixture['exec']['address'])
     # Update state_root manually
     vm.block = vm.block.copy(header=vm.header.copy(state_root=state.state_root))
@@ -265,4 +265,4 @@ def test_vm_fixtures(fixture, vm_class, computation_getter):
         assert isinstance(computation._error, VMError)
         expected_account_db = fixture['pre']
 
-    verify_account_db(expected_account_db, vm.state.account_db)
+    verify_state(expected_account_db, vm.state)


### PR DESCRIPTION
- set_storage
- get_storage
- delete_storage
- delete_account
- make_state_root
- persist

### What was wrong?

#1735 will cause some churn in the `AccountDB` API, which would cause effects all over the code. It makes sense for external callers to just call `VMState` and ask the state class to figure out the right way to delegate the responsibility (like how to get storage values).

### How was it fixed?

Moved all the listed methods from `AccountDB` to `VMState` (they just pass through the implementations, until #1735)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRWjHxEMzOQxfbX-XXQECU-RBxndC3e4VJQ0Mt-1qCKySFx6h2d)
