### PR TITLE
JournalDB updates: stop swallowing KeyError & keep diff if persist() errors

### DIFF
--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -546,3 +546,14 @@ def test_journal_persist_set_KeyError_then_persist():
     assert b'data-to-delete' not in memory_db
     # This key is set on the second attempt
     assert b'failing-to-set-key' in memory_db
+
+
+def test_journal_db_diff_respects_clear():
+    memory_db = MemoryDB({})
+    journal_db = JournalDB(memory_db)
+
+    journal_db[b'first'] = b'val'
+    journal_db.clear()
+
+    pending = journal_db.diff().pending_items()
+    assert len(pending) == 0


### PR DESCRIPTION
### What was wrong?

- `KeyError` was being swallowed during `persist()`, which caused some painful debugging
- On any kind of error during `persist()`, `JournalDB` was dropping all its changes on the floor (those that haven't yet been persisted, anyway)

(Pulled from #1735)

### How was it fixed?

- Track whether the wrapped DB has the key, and don't attempt delete if it was already missing (slight performance benefit, too)
- Catch exceptions and rebuild the pending diff of changes so that `persist()` can be reattempted after catching an exception

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.grindtv.com/uploads/2017/06/eagle2.jpg)
