### PR TITLE
CodeStream.is_valid_opcode() speedup

### DIFF
--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -93,9 +93,9 @@ class CodeStream(object):
     def is_valid_opcode(self, position: int) -> bool:
         if position >= self._length_cache:
             return False
-        if position in self.invalid_positions:
+        elif position in self.invalid_positions:
             return False
-        if position in self.valid_positions:
+        elif position in self.valid_positions:
             return True
         else:
             # An opcode is not valid, iff it is the "data" following a PUSH_


### PR DESCRIPTION
A mainnet test previously showed this method took 7.1% of the total
import_block() time. After this change it was 0.9% of the total.

Tested against blocks: (7620447, 7620450, 7620453, 7620454)

### What was wrong?

Importing blocks is too slow.

### How was it fixed?

Started going after some low-hanging fruit. The other things are simple enough to slam together in a single PR, but this optimization is involved enough to isolate for review.

A decent chunk of the time was actually set manipulation (about 20% of that 7.1%). The rest was just the time it took to iterate over all the code and check for validity.

The primary win is probabalistic: often we can tell that an opcode is valid without having to backtrack through all the code, even if we have to make a few hops back to find out for sure. It still takes O(n) to calculate in the worst case. But probabilistically, the complexity is something like: `1 + p(PREV_PUSH) + p(PREV_PUSH)^2 + ... + p(PREV_PUSH)^n`. Of course, `p(PREV_PUSH) is something that the code author can control, but it's not a big enough difference to knock us off the network AFAICT. So I don't think there's any incentive to do it, even for trolls. Worst case, it's roughly as expensive as before the optimization.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://blogs.discovermagazine.com/d-brief/files/2015/06/octopus.jpg)