### PR TITLE
Cache transaction.get_sender()

### DIFF
--- a/eth/rlp/transactions.py
+++ b/eth/rlp/transactions.py
@@ -91,7 +91,7 @@ class BaseTransaction(BaseTransactionFields, BaseTransactionMethods):
     @cached_property
     def sender(self) -> Address:
         """
-        Convenience property for the return value of `get_sender`
+        Convenience and performance property for the return value of `get_sender`
         """
         return self.get_sender()
 
@@ -135,6 +135,8 @@ class BaseTransaction(BaseTransactionFields, BaseTransactionMethods):
     def get_sender(self) -> Address:
         """
         Get the 20-byte address which sent this transaction.
+
+        This can be a slow operation. ``transaction.sender`` is always preferred.
         """
         raise NotImplementedError("Must be implemented by subclasses")
 

--- a/eth/rlp/transactions.py
+++ b/eth/rlp/transactions.py
@@ -3,6 +3,7 @@ from abc import (
     abstractmethod
 )
 
+from cached_property import cached_property
 import rlp
 from rlp.sedes import (
     big_endian_int,
@@ -87,7 +88,7 @@ class BaseTransaction(BaseTransactionFields, BaseTransactionMethods):
     def from_base_transaction(cls, transaction: 'BaseTransaction') -> 'BaseTransaction':
         return rlp.decode(rlp.encode(transaction), sedes=cls)
 
-    @property
+    @cached_property
     def sender(self) -> Address:
         """
         Convenience property for the return value of `get_sender`

--- a/tests/json-fixtures/test_transactions.py
+++ b/tests/json-fixtures/test_transactions.py
@@ -139,4 +139,4 @@ def test_transaction_fixtures(fixture, fixture_transaction_class):
 
     if 'sender' in fixture:
         assert 'hash' in fixture, "Transaction was supposed to be invalid"
-        assert is_same_address(txn.get_sender(), fixture['sender'])
+        assert is_same_address(txn.sender, fixture['sender'])


### PR DESCRIPTION
A mainnet test previously showed this method took 3.8% of the total
import_block() time. After this change it was 0.5% of the total.

Tested against blocks: (7620447, 7620450, 7620453, 7620454)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/54/e7/ca/54e7ca485a55d6fba2749dddacbf0e94.jpg)
