### PR TITLE
Migrate to mypy.ini file

### DIFF
--- a/eth/tools/_utils/normalization.py
+++ b/eth/tools/_utils/normalization.py
@@ -252,7 +252,7 @@ normalize_state = compose(
 )
 
 
-normalize_main_transaction = cast(Normalizer, dict_normalizer({
+normalize_main_transaction = dict_normalizer({
     "data": normalize_bytes,
     "gasLimit": normalize_int,
     "gasPrice": normalize_int,
@@ -260,7 +260,7 @@ normalize_main_transaction = cast(Normalizer, dict_normalizer({
     "secretKey": normalize_bytes,
     "to": normalize_to_address,
     "value": normalize_int,
-}))
+})
 
 
 normalize_transaction = cast(TransactionNormalizer, dict_options_normalizer([
@@ -268,7 +268,7 @@ normalize_transaction = cast(TransactionNormalizer, dict_options_normalizer([
 ]))
 
 
-normalize_main_transaction_group = cast(Normalizer, dict_normalizer({
+normalize_main_transaction_group = dict_normalizer({
     "data": eth_utils.curried.apply_formatter_to_array(normalize_bytes),
     "gasLimit": eth_utils.curried.apply_formatter_to_array(normalize_int),
     "gasPrice": normalize_int,
@@ -276,7 +276,7 @@ normalize_main_transaction_group = cast(Normalizer, dict_normalizer({
     "secretKey": normalize_bytes,
     "to": normalize_to_address,
     "value": eth_utils.curried.apply_formatter_to_array(normalize_int),
-}))
+})
 
 
 normalize_transaction_group = cast(TransactionNormalizer, dict_options_normalizer([

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,11 +1,13 @@
 [mypy]
 
 warn_unused_ignores = True
+warn_unused_configs = True
 warn_redundant_casts = True
 ignore_missing_imports = True
 strict_optional = False
 check_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
+disallow_untyped_calls = True
 disallow_any_generics = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 
-follow_imports = silent
 warn_unused_ignores = True
+warn_redundant_casts = True
 ignore_missing_imports = True
 strict_optional = False
 check_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+
+follow_imports = silent
+warn_unused_ignores = True
+ignore_missing_imports = True
+strict_optional = False
+check_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+disallow_any_generics = True
+

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands=
     flake8 {toxinidir}/eth
     flake8 {toxinidir}/tests
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
-    mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p eth
+    mypy -p eth --config-file {toxinidir}/mypy.ini
 
 [testenv:py35-lint]
 deps = {[common-lint]deps}


### PR DESCRIPTION
### What was wrong?

Our `mypy` invocation was getting rather lengthy and hence discouraged adding further checks which is bad as we all love to be punished and bow to our `mypy` master as often as we can.


### How was it fixed?

- migrated to `mypy.ini` file
- added more checks and fixed some issues in the process

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://i.imgur.com/YcoTtX7.jpg)
