### PR TITLE
Separate JournalDB's commit() and persist()

### DIFF
--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -557,3 +557,12 @@ def test_journal_db_diff_respects_clear():
 
     pending = journal_db.diff().pending_items()
     assert len(pending) == 0
+
+
+def test_journal_db_rejects_committing_root():
+    memory_db = MemoryDB({})
+    journal_db = JournalDB(memory_db)
+
+    root = journal_db.journal.root_changeset_id
+    with pytest.raises(ValidationError):
+        journal_db.commit(root)


### PR DESCRIPTION
A tiny refactor to JournalDB. The active part of `commit()` was only ever called by `persist()`, so that logic now lives in `persist()` where it will cause less confusion.

Closes #1762 

This leaves one hole open: If you call `commit()` with the root changeset you'll end up in a bad state. All your data is now lost and calling methods will probably give you exceptions until you call `JournalDB.reset()`. There are a few things we could do here:
1. Ignore the problem. Users shouldn't have access to `root_changeset_id` and in fact trinity never uses it.
2. Change `Journal.commit()` such that this is okay. If you're `Journal.commit()`ing the root changeset then squash changes like before but put them back into the Journal under a new root changeset.
3. Throw a `ValidationError` when the user calls `JournalDB.commit()` with the root changeset.

I'm kind of leaning toward 2 but which would you prefer?

#### Cute Animal Picture

![tiny-turtle](https://user-images.githubusercontent.com/466333/56944512-877b5d80-6ad8-11e9-8d27-5ba4211a5973.gif)

