### PR TITLE
Optimize code stream iteration

### DIFF
--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -39,11 +39,17 @@ class CodeStream(object):
     def __len__(self) -> int:
         return self._length_cache
 
-    def __iter__(self) -> 'CodeStream':
-        return self
-
     def __getitem__(self, i: int) -> int:
         return self._raw_code_bytes[i]
+
+    def __iter__(self) -> Iterator[int]:
+        # a very performance-sensitive method
+        read = self.read
+        try:
+            while True:
+                yield ord(read(1))
+        except TypeError:
+            yield STOP
 
     def __next__(self) -> int:
         # a very performance-sensitive method


### PR DESCRIPTION
### What was wrong?

`CodeStream.__next__()` is called a lot, and is slow

A mainnet test previously showed this method took 5.0% of the total
import_block() time. After this change it was 2.6% of the total.

Tested against blocks: (7620447, 7620450, 7620453, 7620454)

### How was it fixed?

Removed a couple attribute lookups

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/02/81/9c/02819c18e96b26e2a6e2b82c30000a46.jpg)
