### PR TITLE
Apply computation speedup

### DIFF
--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -19,6 +19,7 @@ from eth_typing import (
 )
 from eth_utils import (
     encode_hex,
+    ValidationError,
 )
 
 from eth.constants import (
@@ -74,7 +75,13 @@ from eth.vm.transaction_context import (
     BaseTransactionContext
 )
 
-NO_RESULT = object()
+
+def NO_RESULT(computation: 'BaseComputation') -> None:
+    """
+    This is a special method intended for usage as the "no precompile found" result.
+    The type signature is designed to match the other precompiles.
+    """
+    raise ValidationError("This method is never intended to be executed")
 
 
 def memory_gas_cost(size_in_bytes: int) -> int:

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -74,6 +74,8 @@ from eth.vm.transaction_context import (
     BaseTransactionContext
 )
 
+NO_RESULT = object()
+
 
 def memory_gas_cost(size_in_bytes: int) -> int:
     size_in_words = ceil32(size_in_bytes) // 32
@@ -568,14 +570,19 @@ class BaseComputation(Configurable, ABC):
         """
         with cls(state, message, transaction_context) as computation:
             # Early exit on pre-compiles
-            if message.code_address in computation.precompiles:
-                computation.precompiles[message.code_address](computation)
+            precompile = computation.precompiles.get(message.code_address, NO_RESULT)
+            if precompile is not NO_RESULT:
+                precompile(computation)
                 return computation
 
             show_debug2 = computation.logger.show_debug2
 
+            opcode_lookup = computation.opcodes
             for opcode in computation.code:
-                opcode_fn = computation.get_opcode_fn(opcode)
+                try:
+                    opcode_fn = opcode_lookup[opcode]
+                except KeyError:
+                    opcode_fn = InvalidOpcode(opcode)
 
                 if show_debug2:
                     computation.logger.debug2(

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -19,7 +19,6 @@ from eth_typing import (
 )
 from eth_utils import (
     encode_hex,
-    ValidationError,
 )
 
 from eth.constants import (
@@ -81,7 +80,7 @@ def NO_RESULT(computation: 'BaseComputation') -> None:
     This is a special method intended for usage as the "no precompile found" result.
     The type signature is designed to match the other precompiles.
     """
-    raise ValidationError("This method is never intended to be executed")
+    raise Exception("This method is never intended to be executed")
 
 
 def memory_gas_cost(size_in_bytes: int) -> int:


### PR DESCRIPTION
Shaved off 1.5% of total import_block() time.

Tested against blocks: (7620447, 7620450, 7620453, 7620454)

### How was it fixed?

- inline some hot code
- avoid some attribute lookups
- appease mypy without an ignore or cast

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://i.imgur.com/rtXwnpD.jpg)
