### PR TITLE
JournalDB.latest_id speedup

### DIFF
--- a/eth/db/journal.py
+++ b/eth/db/journal.py
@@ -4,7 +4,6 @@ import uuid
 
 from eth_utils.toolz import (
     first,
-    last,
     merge,
     nth,
 )
@@ -68,7 +67,8 @@ class Journal(BaseDB):
         """
         Returns the id of the latest changeset
         """
-        return last(self.journal_data.keys())
+        # last() was iterating through all values, so first(reversed()) gives a 12.5x speedup
+        return first(reversed(self.journal_data.keys()))
 
     @property
     def latest(self) -> Dict[bytes, Union[bytes, DeletedEntry]]:


### PR DESCRIPTION
A mainnet test previously showed this method took 7.0% of the total
import_block() time. After this change it was 0.6% of the total.

Tested against blocks: (7620447, 7620450, 7620453, 7620454)

### How was it fixed?

OrderedDict docs say that `__reversed__` is natively supported, so I took a shot at `first(reversed(...keys()))` and that gave a significant speedup.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/gUlB3Hhh.jpg)
