### PR TITLE
EVM stack operation speedup, ~9% speedup

### DIFF
--- a/eth/rlp/logs.py
+++ b/eth/rlp/logs.py
@@ -5,7 +5,6 @@ from rlp.sedes import (
 )
 
 from typing import (
-    List,
     Tuple,
 )
 
@@ -22,7 +21,7 @@ class Log(rlp.Serializable):
         ('data', binary)
     ]
 
-    def __init__(self, address: bytes, topics: List[int], data: bytes) -> None:
+    def __init__(self, address: bytes, topics: Tuple[int, ...], data: bytes) -> None:
         super().__init__(address, topics, data)
 
     @property

--- a/eth/tools/_utils/hashing.py
+++ b/eth/tools/_utils/hashing.py
@@ -4,7 +4,6 @@ import rlp
 
 from typing import (
     Iterable,
-    List,
     Tuple,
 )
 
@@ -15,7 +14,7 @@ from eth_typing import (
 from eth.rlp.logs import Log
 
 
-def hash_log_entries(log_entries: Iterable[Tuple[bytes, List[int], bytes]]) -> Hash32:
+def hash_log_entries(log_entries: Iterable[Tuple[bytes, Tuple[int, ...], bytes]]) -> Hash32:
     """
     Helper function for computing the RLP hash of the logs from transaction
     execution.

--- a/eth/tools/fixtures/fillers/vm.py
+++ b/eth/tools/fixtures/fillers/vm.py
@@ -2,7 +2,6 @@ from typing import (
     Any,
     Dict,
     Iterable,
-    List,
     Tuple,
     Union,
 )
@@ -29,7 +28,7 @@ def fill_vm_test(
         call_creates: Any=None,
         gas_price: Union[int, str]=None,
         gas_remaining: Union[int, str]=0,
-        logs: Iterable[Tuple[bytes, List[int], bytes]]=None,
+        logs: Iterable[Tuple[bytes, Tuple[int, ...], bytes]]=None,
         output: bytes=b"") -> Dict[str, Dict[str, Any]]:
 
     test_name = get_test_name(filler)

--- a/eth/validation.py
+++ b/eth/validation.py
@@ -190,14 +190,21 @@ def validate_uint256(value: int, title: str="Value") -> None:
         )
 
 
-def validate_stack_item(value: Union[int, bytes]) -> None:
-    if isinstance(value, bytes) and len(value) <= 32:
-        return
-    elif isinstance(value, int) and 0 <= value <= UINT_256_MAX:
+def validate_stack_int(value: int) -> None:
+    if 0 <= value <= UINT_256_MAX:
         return
     raise ValidationError(
         "Invalid Stack Item: Must be either a length 32 byte "
-        "string or a 256 bit integer. Got {0}".format(value)
+        "string or a 256 bit integer. Got {!r}".format(value)
+    )
+
+
+def validate_stack_bytes(value: bytes) -> None:
+    if len(value) <= 32:
+        return
+    raise ValidationError(
+        "Invalid Stack Item: Must be either a length 32 byte "
+        "string or a 256 bit integer. Got {!r}".format(value)
     )
 
 

--- a/eth/vm/forks/constantinople/storage.py
+++ b/eth/vm/forks/constantinople/storage.py
@@ -2,10 +2,6 @@ from eth_utils import (
     encode_hex,
 )
 
-from eth.constants import (
-    UINT256
-)
-
 from eth.vm.computation import BaseComputation
 from eth.vm.forks.constantinople import (
     constants
@@ -13,7 +9,7 @@ from eth.vm.forks.constantinople import (
 
 
 def sstore_eip1283(computation: BaseComputation) -> None:
-    slot, value = computation.stack_pop(num_items=2, type_hint=UINT256)
+    slot, value = computation.stack_pop_ints(2)
 
     current_value = computation.state.get_storage(
         address=computation.msg.storage_address,

--- a/eth/vm/logic/arithmetic.py
+++ b/eth/vm/logic/arithmetic.py
@@ -17,50 +17,50 @@ def add(computation: BaseComputation) -> None:
     """
     Addition
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(2)
 
     result = (left + right) & constants.UINT_256_MAX
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def addmod(computation: BaseComputation) -> None:
     """
     Modulo Addition
     """
-    left, right, mod = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    left, right, mod = computation.stack_pop_ints(3)
 
     if mod == 0:
         result = 0
     else:
         result = (left + right) % mod
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def sub(computation: BaseComputation) -> None:
     """
     Subtraction
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(2)
 
     result = (left - right) & constants.UINT_256_MAX
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def mod(computation: BaseComputation) -> None:
     """
     Modulo
     """
-    value, mod = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    value, mod = computation.stack_pop_ints(2)
 
     if mod == 0:
         result = 0
     else:
         result = value % mod
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def smod(computation: BaseComputation) -> None:
@@ -69,7 +69,7 @@ def smod(computation: BaseComputation) -> None:
     """
     value, mod = map(
         unsigned_to_signed,
-        computation.stack_pop(num_items=2, type_hint=constants.UINT256),
+        computation.stack_pop_ints(2),
     )
 
     pos_or_neg = -1 if value < 0 else 1
@@ -79,45 +79,45 @@ def smod(computation: BaseComputation) -> None:
     else:
         result = (abs(value) % abs(mod) * pos_or_neg) & constants.UINT_256_MAX
 
-    computation.stack_push(signed_to_unsigned(result))
+    computation.stack_push_int(signed_to_unsigned(result))
 
 
 def mul(computation: BaseComputation) -> None:
     """
     Multiplication
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(2)
 
     result = (left * right) & constants.UINT_256_MAX
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def mulmod(computation: BaseComputation) -> None:
     """
     Modulo Multiplication
     """
-    left, right, mod = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    left, right, mod = computation.stack_pop_ints(3)
 
     if mod == 0:
         result = 0
     else:
         result = (left * right) % mod
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def div(computation: BaseComputation) -> None:
     """
     Division
     """
-    numerator, denominator = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    numerator, denominator = computation.stack_pop_ints(2)
 
     if denominator == 0:
         result = 0
     else:
         result = (numerator // denominator) & constants.UINT_256_MAX
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def sdiv(computation: BaseComputation) -> None:
@@ -126,7 +126,7 @@ def sdiv(computation: BaseComputation) -> None:
     """
     numerator, denominator = map(
         unsigned_to_signed,
-        computation.stack_pop(num_items=2, type_hint=constants.UINT256),
+        computation.stack_pop_ints(2),
     )
 
     pos_or_neg = -1 if numerator * denominator < 0 else 1
@@ -136,7 +136,7 @@ def sdiv(computation: BaseComputation) -> None:
     else:
         result = (pos_or_neg * (abs(numerator) // abs(denominator)))
 
-    computation.stack_push(signed_to_unsigned(result))
+    computation.stack_push_int(signed_to_unsigned(result))
 
 
 @curry
@@ -144,7 +144,7 @@ def exp(computation: BaseComputation, gas_per_byte: int) -> None:
     """
     Exponentiation
     """
-    base, exponent = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    base, exponent = computation.stack_pop_ints(2)
 
     bit_size = exponent.bit_length()
     byte_size = ceil8(bit_size) // 8
@@ -161,14 +161,14 @@ def exp(computation: BaseComputation, gas_per_byte: int) -> None:
         reason="EXP: exponent bytes",
     )
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def signextend(computation: BaseComputation) -> None:
     """
     Signed Extend
     """
-    bits, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    bits, value = computation.stack_pop_ints(2)
 
     if bits <= 31:
         testbit = bits * 8 + 7
@@ -180,42 +180,42 @@ def signextend(computation: BaseComputation) -> None:
     else:
         result = value
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def shl(computation: BaseComputation) -> None:
     """
     Bitwise left shift
     """
-    shift_length, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    shift_length, value = computation.stack_pop_ints(2)
 
     if shift_length >= 256:
         result = 0
     else:
         result = (value << shift_length) & constants.UINT_256_MAX
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def shr(computation: BaseComputation) -> None:
     """
     Bitwise right shift
     """
-    shift_length, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    shift_length, value = computation.stack_pop_ints(2)
 
     if shift_length >= 256:
         result = 0
     else:
         result = (value >> shift_length) & constants.UINT_256_MAX
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def sar(computation: BaseComputation) -> None:
     """
     Arithmetic bitwise right shift
     """
-    shift_length, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    shift_length, value = computation.stack_pop_ints(2)
     value = unsigned_to_signed(value)
 
     if shift_length >= 256:
@@ -223,4 +223,4 @@ def sar(computation: BaseComputation) -> None:
     else:
         result = (value >> shift_length) & constants.UINT_256_MAX
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)

--- a/eth/vm/logic/block.py
+++ b/eth/vm/logic/block.py
@@ -1,31 +1,29 @@
-from eth import constants
-
 from eth.vm.computation import BaseComputation
 
 
 def blockhash(computation: BaseComputation) -> None:
-    block_number = computation.stack_pop(type_hint=constants.UINT256)
+    block_number = computation.stack_pop1_int()
 
     block_hash = computation.state.get_ancestor_hash(block_number)
 
-    computation.stack_push(block_hash)
+    computation.stack_push_bytes(block_hash)
 
 
 def coinbase(computation: BaseComputation) -> None:
-    computation.stack_push(computation.state.coinbase)
+    computation.stack_push_bytes(computation.state.coinbase)
 
 
 def timestamp(computation: BaseComputation) -> None:
-    computation.stack_push(computation.state.timestamp)
+    computation.stack_push_int(computation.state.timestamp)
 
 
 def number(computation: BaseComputation) -> None:
-    computation.stack_push(computation.state.block_number)
+    computation.stack_push_int(computation.state.block_number)
 
 
 def difficulty(computation: BaseComputation) -> None:
-    computation.stack_push(computation.state.difficulty)
+    computation.stack_push_int(computation.state.difficulty)
 
 
 def gaslimit(computation: BaseComputation) -> None:
-    computation.stack_push(computation.state.gas_limit)
+    computation.stack_push_int(computation.state.gas_limit)

--- a/eth/vm/logic/call.py
+++ b/eth/vm/logic/call.py
@@ -111,7 +111,7 @@ class BaseCall(Opcode, ABC):
                 err_message,
             )
             computation.return_gas(child_msg_gas)
-            computation.stack_push(0)
+            computation.stack_push_int(0)
         else:
             if code_address:
                 code = computation.state.get_code(code_address)
@@ -137,9 +137,9 @@ class BaseCall(Opcode, ABC):
             child_computation = computation.apply_child_computation(child_msg)
 
             if child_computation.is_error:
-                computation.stack_push(0)
+                computation.stack_push_int(0)
             else:
-                computation.stack_push(1)
+                computation.stack_push_int(1)
 
             if not child_computation.should_erase_return_data:
                 actual_output_size = min(memory_output_size, len(child_computation.output))
@@ -166,8 +166,8 @@ class Call(BaseCall):
         return transfer_gas_fee + create_gas_fee
 
     def get_call_params(self, computation: BaseComputation) -> CallParams:
-        gas = computation.stack_pop(type_hint=constants.UINT256)
-        to = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+        gas = computation.stack_pop1_int()
+        to = force_bytes_to_address(computation.stack_pop1_bytes())
 
         (
             value,
@@ -175,7 +175,7 @@ class Call(BaseCall):
             memory_input_size,
             memory_output_start_position,
             memory_output_size,
-        ) = computation.stack_pop(num_items=5, type_hint=constants.UINT256)
+        ) = computation.stack_pop_ints(5)
 
         return (
             gas,
@@ -201,8 +201,8 @@ class CallCode(BaseCall):
         return constants.GAS_CALLVALUE if value else 0
 
     def get_call_params(self, computation: BaseComputation) -> CallParams:
-        gas = computation.stack_pop(type_hint=constants.UINT256)
-        code_address = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+        gas = computation.stack_pop1_int()
+        code_address = force_bytes_to_address(computation.stack_pop1_bytes())
 
         (
             value,
@@ -210,7 +210,7 @@ class CallCode(BaseCall):
             memory_input_size,
             memory_output_start_position,
             memory_output_size,
-        ) = computation.stack_pop(num_items=5, type_hint=constants.UINT256)
+        ) = computation.stack_pop_ints(5)
 
         to = computation.msg.storage_address
         sender = computation.msg.storage_address
@@ -246,15 +246,15 @@ class DelegateCall(BaseCall):
         return 0
 
     def get_call_params(self, computation: BaseComputation) -> CallParams:
-        gas = computation.stack_pop(type_hint=constants.UINT256)
-        code_address = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+        gas = computation.stack_pop1_int()
+        code_address = force_bytes_to_address(computation.stack_pop1_bytes())
 
         (
             memory_input_start_position,
             memory_input_size,
             memory_output_start_position,
             memory_output_size,
-        ) = computation.stack_pop(num_items=4, type_hint=constants.UINT256)
+        ) = computation.stack_pop_ints(4)
 
         to = computation.msg.storage_address
         sender = computation.msg.sender
@@ -381,15 +381,15 @@ class CallEIP161(CallEIP150):
 #
 class StaticCall(CallEIP161):
     def get_call_params(self, computation: BaseComputation) -> CallParams:
-        gas = computation.stack_pop(type_hint=constants.UINT256)
-        to = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+        gas = computation.stack_pop1_int()
+        to = force_bytes_to_address(computation.stack_pop1_bytes())
 
         (
             memory_input_start_position,
             memory_input_size,
             memory_output_start_position,
             memory_output_size,
-        ) = computation.stack_pop(num_items=4, type_hint=constants.UINT256)
+        ) = computation.stack_pop_ints(4)
 
         return (
             gas,

--- a/eth/vm/logic/comparison.py
+++ b/eth/vm/logic/comparison.py
@@ -12,28 +12,28 @@ def lt(computation: BaseComputation) -> None:
     """
     Lesser Comparison
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(2)
 
     if left < right:
         result = 1
     else:
         result = 0
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def gt(computation: BaseComputation) -> None:
     """
     Greater Comparison
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(2)
 
     if left > right:
         result = 1
     else:
         result = 0
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def slt(computation: BaseComputation) -> None:
@@ -42,7 +42,7 @@ def slt(computation: BaseComputation) -> None:
     """
     left, right = map(
         unsigned_to_signed,
-        computation.stack_pop(num_items=2, type_hint=constants.UINT256),
+        computation.stack_pop_ints(2),
     )
 
     if left < right:
@@ -50,7 +50,7 @@ def slt(computation: BaseComputation) -> None:
     else:
         result = 0
 
-    computation.stack_push(signed_to_unsigned(result))
+    computation.stack_push_int(signed_to_unsigned(result))
 
 
 def sgt(computation: BaseComputation) -> None:
@@ -59,7 +59,7 @@ def sgt(computation: BaseComputation) -> None:
     """
     left, right = map(
         unsigned_to_signed,
-        computation.stack_pop(num_items=2, type_hint=constants.UINT256),
+        computation.stack_pop_ints(2),
     )
 
     if left > right:
@@ -67,90 +67,90 @@ def sgt(computation: BaseComputation) -> None:
     else:
         result = 0
 
-    computation.stack_push(signed_to_unsigned(result))
+    computation.stack_push_int(signed_to_unsigned(result))
 
 
 def eq(computation: BaseComputation) -> None:
     """
     Equality
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(2)
 
     if left == right:
         result = 1
     else:
         result = 0
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def iszero(computation: BaseComputation) -> None:
     """
     Not
     """
-    value = computation.stack_pop(type_hint=constants.UINT256)
+    value = computation.stack_pop1_int()
 
     if value == 0:
         result = 1
     else:
         result = 0
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def and_op(computation: BaseComputation) -> None:
     """
     Bitwise And
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(2)
 
     result = left & right
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def or_op(computation: BaseComputation) -> None:
     """
     Bitwise Or
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(2)
 
     result = left | right
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def xor(computation: BaseComputation) -> None:
     """
     Bitwise XOr
     """
-    left, right = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    left, right = computation.stack_pop_ints(2)
 
     result = left ^ right
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def not_op(computation: BaseComputation) -> None:
     """
     Not
     """
-    value = computation.stack_pop(type_hint=constants.UINT256)
+    value = computation.stack_pop1_int()
 
     result = constants.UINT_256_MAX - value
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)
 
 
 def byte_op(computation: BaseComputation) -> None:
     """
     Bitwise And
     """
-    position, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    position, value = computation.stack_pop_ints(2)
 
     if position >= 32:
         result = 0
     else:
         result = (value // pow(256, 31 - position)) % 256
 
-    computation.stack_push(result)
+    computation.stack_push_int(result)

--- a/eth/vm/logic/context.py
+++ b/eth/vm/logic/context.py
@@ -15,43 +15,43 @@ from eth.vm.computation import BaseComputation
 
 
 def balance(computation: BaseComputation) -> None:
-    addr = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    addr = force_bytes_to_address(computation.stack_pop1_bytes())
     balance = computation.state.get_balance(addr)
-    computation.stack_push(balance)
+    computation.stack_push_int(balance)
 
 
 def origin(computation: BaseComputation) -> None:
-    computation.stack_push(computation.transaction_context.origin)
+    computation.stack_push_bytes(computation.transaction_context.origin)
 
 
 def address(computation: BaseComputation) -> None:
-    computation.stack_push(computation.msg.storage_address)
+    computation.stack_push_bytes(computation.msg.storage_address)
 
 
 def caller(computation: BaseComputation) -> None:
-    computation.stack_push(computation.msg.sender)
+    computation.stack_push_bytes(computation.msg.sender)
 
 
 def callvalue(computation: BaseComputation) -> None:
-    computation.stack_push(computation.msg.value)
+    computation.stack_push_int(computation.msg.value)
 
 
 def calldataload(computation: BaseComputation) -> None:
     """
     Load call data into memory.
     """
-    start_position = computation.stack_pop(type_hint=constants.UINT256)
+    start_position = computation.stack_pop1_int()
 
     value = computation.msg.data_as_bytes[start_position:start_position + 32]
     padded_value = value.ljust(32, b'\x00')
     normalized_value = padded_value.lstrip(b'\x00')
 
-    computation.stack_push(normalized_value)
+    computation.stack_push_bytes(normalized_value)
 
 
 def calldatasize(computation: BaseComputation) -> None:
     size = len(computation.msg.data)
-    computation.stack_push(size)
+    computation.stack_push_int(size)
 
 
 def calldatacopy(computation: BaseComputation) -> None:
@@ -59,7 +59,7 @@ def calldatacopy(computation: BaseComputation) -> None:
         mem_start_position,
         calldata_start_position,
         size,
-    ) = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    ) = computation.stack_pop_ints(3)
 
     computation.extend_memory(mem_start_position, size)
 
@@ -78,7 +78,7 @@ def calldatacopy(computation: BaseComputation) -> None:
 
 def codesize(computation: BaseComputation) -> None:
     size = len(computation.code)
-    computation.stack_push(size)
+    computation.stack_push_int(size)
 
 
 def codecopy(computation: BaseComputation) -> None:
@@ -86,7 +86,7 @@ def codecopy(computation: BaseComputation) -> None:
         mem_start_position,
         code_start_position,
         size,
-    ) = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    ) = computation.stack_pop_ints(3)
 
     computation.extend_memory(mem_start_position, size)
 
@@ -107,23 +107,23 @@ def codecopy(computation: BaseComputation) -> None:
 
 
 def gasprice(computation: BaseComputation) -> None:
-    computation.stack_push(computation.transaction_context.gas_price)
+    computation.stack_push_int(computation.transaction_context.gas_price)
 
 
 def extcodesize(computation: BaseComputation) -> None:
-    account = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    account = force_bytes_to_address(computation.stack_pop1_bytes())
     code_size = len(computation.state.get_code(account))
 
-    computation.stack_push(code_size)
+    computation.stack_push_int(code_size)
 
 
 def extcodecopy(computation: BaseComputation) -> None:
-    account = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    account = force_bytes_to_address(computation.stack_pop1_bytes())
     (
         mem_start_position,
         code_start_position,
         size,
-    ) = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    ) = computation.stack_pop_ints(3)
 
     computation.extend_memory(mem_start_position, size)
 
@@ -148,18 +148,18 @@ def extcodehash(computation: BaseComputation) -> None:
     Return the code hash for a given address.
     EIP: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1052.md
     """
-    account = force_bytes_to_address(computation.stack_pop(type_hint=constants.BYTES))
+    account = force_bytes_to_address(computation.stack_pop1_bytes())
     state = computation.state
 
     if state.account_is_empty(account):
-        computation.stack_push(constants.NULL_BYTE)
+        computation.stack_push_bytes(constants.NULL_BYTE)
     else:
-        computation.stack_push(state.get_code_hash(account))
+        computation.stack_push_bytes(state.get_code_hash(account))
 
 
 def returndatasize(computation: BaseComputation) -> None:
     size = len(computation.return_data)
-    computation.stack_push(size)
+    computation.stack_push_int(size)
 
 
 def returndatacopy(computation: BaseComputation) -> None:
@@ -167,7 +167,7 @@ def returndatacopy(computation: BaseComputation) -> None:
         mem_start_position,
         returndata_start_position,
         size,
-    ) = computation.stack_pop(num_items=3, type_hint=constants.UINT256)
+    ) = computation.stack_pop_ints(3)
 
     if returndata_start_position + size > len(computation.return_data):
         raise OutOfBoundsRead(

--- a/eth/vm/logic/flow.py
+++ b/eth/vm/logic/flow.py
@@ -1,4 +1,3 @@
-from eth import constants
 from eth.exceptions import (
     InvalidJumpDestination,
     InvalidInstruction,
@@ -16,7 +15,7 @@ def stop(computation: BaseComputation) -> None:
 
 
 def jump(computation: BaseComputation) -> None:
-    jump_dest = computation.stack_pop(type_hint=constants.UINT256)
+    jump_dest = computation.stack_pop1_int()
 
     computation.code.pc = jump_dest
 
@@ -30,7 +29,7 @@ def jump(computation: BaseComputation) -> None:
 
 
 def jumpi(computation: BaseComputation) -> None:
-    jump_dest, check_value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    jump_dest, check_value = computation.stack_pop_ints(2)
 
     if check_value:
         computation.code.pc = jump_dest
@@ -51,10 +50,10 @@ def jumpdest(computation: BaseComputation) -> None:
 def pc(computation: BaseComputation) -> None:
     pc = max(computation.code.pc - 1, 0)
 
-    computation.stack_push(pc)
+    computation.stack_push_int(pc)
 
 
 def gas(computation: BaseComputation) -> None:
     gas_remaining = computation.get_gas_remaining()
 
-    computation.stack_push(gas_remaining)
+    computation.stack_push_int(gas_remaining)

--- a/eth/vm/logic/logging.py
+++ b/eth/vm/logic/logging.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import functools
-from typing import List  # noqa: F401
+from typing import Tuple  # noqa: F401
 
 from eth import constants
 
@@ -11,14 +11,14 @@ def log_XX(computation: BaseComputation, topic_count: int) -> None:
     if topic_count < 0 or topic_count > 4:
         raise TypeError("Invalid log topic size.  Must be 0, 1, 2, 3, or 4")
 
-    mem_start_position, size = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    mem_start_position, size = computation.stack_pop_ints(2)
 
     if not topic_count:
-        topics = []  # type: List[int]
+        topics = ()  # type: Tuple[int, ...]
     elif topic_count > 1:
-        topics = computation.stack_pop(num_items=topic_count, type_hint=constants.UINT256)
+        topics = computation.stack_pop_ints(topic_count)
     else:
-        topics = [computation.stack_pop(num_items=topic_count, type_hint=constants.UINT256)]
+        topics = (computation.stack_pop1_int(), )
 
     data_gas_cost = constants.GAS_LOGDATA * size
     topic_gas_cost = constants.GAS_LOGTOPIC * topic_count

--- a/eth/vm/logic/memory.py
+++ b/eth/vm/logic/memory.py
@@ -1,11 +1,9 @@
-from eth import constants
-
 from eth.vm.computation import BaseComputation
 
 
 def mstore(computation: BaseComputation) -> None:
-    start_position = computation.stack_pop(type_hint=constants.UINT256)
-    value = computation.stack_pop(type_hint=constants.BYTES)
+    start_position = computation.stack_pop1_int()
+    value = computation.stack_pop1_bytes()
 
     padded_value = value.rjust(32, b'\x00')
     normalized_value = padded_value[-32:]
@@ -16,8 +14,8 @@ def mstore(computation: BaseComputation) -> None:
 
 
 def mstore8(computation: BaseComputation) -> None:
-    start_position = computation.stack_pop(type_hint=constants.UINT256)
-    value = computation.stack_pop(type_hint=constants.BYTES)
+    start_position = computation.stack_pop1_int()
+    value = computation.stack_pop1_bytes()
 
     padded_value = value.rjust(1, b'\x00')
     normalized_value = padded_value[-1:]
@@ -28,13 +26,13 @@ def mstore8(computation: BaseComputation) -> None:
 
 
 def mload(computation: BaseComputation) -> None:
-    start_position = computation.stack_pop(type_hint=constants.UINT256)
+    start_position = computation.stack_pop1_int()
 
     computation.extend_memory(start_position, 32)
 
     value = computation.memory_read_bytes(start_position, 32)
-    computation.stack_push(value)
+    computation.stack_push_bytes(value)
 
 
 def msize(computation: BaseComputation) -> None:
-    computation.stack_push(len(computation._memory))
+    computation.stack_push_int(len(computation._memory))

--- a/eth/vm/logic/sha3.py
+++ b/eth/vm/logic/sha3.py
@@ -8,7 +8,7 @@ from eth.vm.computation import BaseComputation
 
 
 def sha3(computation: BaseComputation) -> None:
-    start_position, size = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    start_position, size = computation.stack_pop_ints(2)
 
     computation.extend_memory(start_position, size)
 
@@ -20,4 +20,4 @@ def sha3(computation: BaseComputation) -> None:
 
     result = keccak(sha3_bytes)
 
-    computation.stack_push(result)
+    computation.stack_push_bytes(result)

--- a/eth/vm/logic/stack.py
+++ b/eth/vm/logic/stack.py
@@ -1,22 +1,19 @@
 import functools
 
-from eth import constants
-
 from eth.vm.computation import BaseComputation
 
 
 def pop(computation: BaseComputation) -> None:
-    computation.stack_pop(type_hint=constants.ANY)
+    computation.stack_pop1_any()
 
 
 def push_XX(computation: BaseComputation, size: int) -> None:
     raw_value = computation.code.read(size)
 
-    if not raw_value.strip(b'\x00'):
-        computation.stack_push(0)
-    else:
-        padded_value = raw_value.ljust(size, b'\x00')
-        computation.stack_push(padded_value)
+    computation.stack_push_bytes(
+        # padded value
+        raw_value.ljust(size, b'\x00')
+    )
 
 
 push1 = functools.partial(push_XX, size=1)

--- a/eth/vm/logic/storage.py
+++ b/eth/vm/logic/storage.py
@@ -7,7 +7,7 @@ from eth.vm.computation import BaseComputation
 
 
 def sstore(computation: BaseComputation) -> None:
-    slot, value = computation.stack_pop(num_items=2, type_hint=constants.UINT256)
+    slot, value = computation.stack_pop_ints(2)
 
     current_value = computation.state.get_storage(
         address=computation.msg.storage_address,
@@ -51,10 +51,10 @@ def sstore(computation: BaseComputation) -> None:
 
 
 def sload(computation: BaseComputation) -> None:
-    slot = computation.stack_pop(type_hint=constants.UINT256)
+    slot = computation.stack_pop1_int()
 
     value = computation.state.get_storage(
         address=computation.msg.storage_address,
         slot=slot,
     )
-    computation.stack_push(value)
+    computation.stack_push_int(value)

--- a/eth/vm/stack.py
+++ b/eth/vm/stack.py
@@ -1,16 +1,17 @@
 import logging
 
 from eth_utils import (
-    int_to_big_endian,
     big_endian_to_int,
+    int_to_big_endian,
+    ValidationError,
 )
-from eth import constants
 from eth.exceptions import (
     InsufficientStack,
     FullStack,
 )
 from eth.validation import (
-    validate_stack_item,
+    validate_stack_bytes,
+    validate_stack_int,
 )
 
 from typing import (  # noqa: F401
@@ -22,69 +23,241 @@ from typing import (  # noqa: F401
 from eth_typing import Hash32  # noqa: F401
 
 
+def _busted_type(item_type: type, value: Union[int, bytes]) -> ValidationError:
+    return ValidationError(
+        "Stack must always be bytes or int, got {!r} type, val {!r}".format(
+            item_type,
+            value,
+        )
+    )
+
+
 class Stack(object):
     """
     VM Stack
     """
-    __slots__ = ['values']
+    __slots__ = ['values', '_append', '_pop_typed', '__len__']
     logger = logging.getLogger('eth.vm.stack.Stack')
 
+    #
+    # Performance Note: Operations that push to the stack have the data in some natural form:
+    #   integer or bytes. Whatever operation is pulling from the stack, also has its preferred
+    #   representation to work with. Typically, those two representations line up (pushed & pulled)
+    #   so we save a notable amount of conversion time by storing heterogenous data on the stack,
+    #   and converting only when necessary.
+    #
+
     def __init__(self) -> None:
-        self.values = []  # type: List[Union[int, bytes]]
+        values = []  # type: List[Tuple[type, Union[int, bytes]]]
+        self.values = values
+        # caching optimizations to avoid an attribute lookup on self.values
+        # This doesn't use `cached_property`, because it doesn't play nice with slots
+        self._append = values.append
+        self._pop_typed = values.pop
+        self.__len__ = values.__len__
 
-    def __len__(self) -> int:
-        return len(self.values)
-
-    def push(self, value: Union[int, bytes]) -> None:
+    def push_int(self, value: int) -> None:
         """
-        Push an item onto the stack.
+        Push an integer item onto the stack.
         """
         if len(self.values) > 1023:
             raise FullStack('Stack limit reached')
 
-        validate_stack_item(value)
+        validate_stack_int(value)
 
-        self.values.append(value)
+        self._append((int, value))
 
-    def pop(self,
-            num_items: int,
-            type_hint: str) -> Union[int, bytes, Tuple[Union[int, bytes], ...]]:
+    def push_bytes(self, value: bytes) -> None:
         """
-        Pop an item off the stack.
-
-        Note: This function is optimized for speed over readability.
+        Push a bytes item onto the stack.
         """
-        try:
-            if num_items == 1:
-                return next(self._pop(num_items, type_hint))
-            else:
-                return tuple(self._pop(num_items, type_hint))
-        except IndexError:
-            raise InsufficientStack("No stack items")
+        if len(self.values) > 1023:
+            raise FullStack('Stack limit reached')
 
-    def _pop(self, num_items: int, type_hint: str) -> Generator[Union[int, bytes], None, None]:
-        for _ in range(num_items):
-            if type_hint == constants.UINT256:
-                value = self.values.pop()
-                if isinstance(value, int):
-                    yield value
-                else:
-                    yield big_endian_to_int(value)
-            elif type_hint == constants.BYTES:
-                value = self.values.pop()
-                if isinstance(value, bytes):
-                    yield value
-                else:
-                    yield int_to_big_endian(value)
-            elif type_hint == constants.ANY:
-                yield self.values.pop()
+        validate_stack_bytes(value)
+
+        self._append((bytes, value))
+
+    def pop1_bytes(self) -> bytes:
+        """
+        Pop and return a bytes element from the stack.
+
+        Raise `eth.exceptions.InsufficientStack` if the stack was empty.
+        """
+
+        #
+        # Note: This function is optimized for speed over readability.
+        # Knowing the popped type means that we can pop *very* quickly
+        # when the popped type matches the pushed type.
+        #
+        if not self.values:
+            raise InsufficientStack(
+                "Wanted 1 stack item, only had %d",
+                len(self.values),
+            )
+        else:
+            item_type, popped = self._pop_typed()
+            if item_type is int:
+                return int_to_big_endian(popped)  # type: ignore
+            elif item_type is bytes:
+                return popped  # type: ignore
             else:
-                raise TypeError(
-                    "Unknown type_hint: {0}.  Must be one of {1}".format(
-                        type_hint,
-                        ", ".join((constants.UINT256, constants.BYTES)),
-                    )
-                )
+                raise _busted_type(item_type, popped)
+
+    def pop1_int(self) -> int:
+        """
+        Pop and return an integer from the stack.
+
+        Raise `eth.exceptions.InsufficientStack` if the stack was empty.
+        """
+
+        #
+        # Note: This function is optimized for speed over readability.
+        #
+        if not self.values:
+            raise InsufficientStack(
+                "Wanted 1 stack item, only had %d",
+                len(self.values),
+            )
+        else:
+            item_type, popped = self._pop_typed()
+            if item_type is int:
+                return popped  # type: ignore
+            elif item_type is bytes:
+                return big_endian_to_int(popped)  # type: ignore
+            else:
+                raise _busted_type(item_type, popped)
+
+    def pop1_any(self) -> Union[int, bytes]:
+        """
+        Pop and return an element from the stack.
+        The type of each element will be int or bytes, depending on whether it was
+        pushed with push_bytes or push_int.
+
+        Raise `eth.exceptions.InsufficientStack` if the stack was empty.
+        """
+
+        #
+        # Note: This function is optimized for speed over readability.
+        #
+        if not self.values:
+            raise InsufficientStack(
+                "Wanted 1 stack item, only had %d",
+                len(self.values),
+            )
+        else:
+            _, popped = self._pop_typed()
+            return popped
+
+    def pop_any(self, num_items: int) -> Tuple[Union[int, bytes], ...]:
+        """
+        Pop and return a tuple of items of length ``num_items`` from the stack.
+        The type of each element will be int or bytes, depending on whether it was
+        pushed with stack_push_bytes or stack_push_int.
+
+        Raise `eth.exceptions.InsufficientStack` if there are not enough items on
+        the stack.
+
+        Items are ordered with the top of the stack as the first item in the tuple.
+        """
+
+        #
+        # Note: This function is optimized for speed over readability.
+        #
+        if num_items > len(self.values):
+            raise InsufficientStack(
+                "Wanted %d stack items, only had %d",
+                num_items,
+                len(self.values),
+            )
+        else:
+            neg_num_items = -1 * num_items
+
+            # Quickest way to pop off multiple values from the end, in place
+            all_popped = reversed(self.values[neg_num_items:])
+            del self.values[neg_num_items:]
+
+            # This doesn't use the @to_tuple(generator) pattern, for added performance
+            return tuple(val for _, val in all_popped)
+
+    def pop_ints(self, num_items: int) -> Tuple[int, ...]:
+        """
+        Pop and return a tuple of integers of length ``num_items`` from the stack.
+
+        Raise `eth.exceptions.InsufficientStack` if there are not enough items on
+        the stack.
+
+        Items are ordered with the top of the stack as the first item in the tuple.
+        """
+
+        #
+        # Note: This function is optimized for speed over readability.
+        #
+        if num_items > len(self.values):
+            raise InsufficientStack(
+                "Wanted %d stack items, only had %d",
+                num_items,
+                len(self.values),
+            )
+        else:
+            neg_num_items = -1 * num_items
+
+            # Quickest way to pop off multiple values from the end, in place
+            all_popped = reversed(self.values[neg_num_items:])
+            del self.values[neg_num_items:]
+
+            type_cast_popped = []
+
+            # Convert any non-matching types to the requested type (int)
+            # This doesn't use the @to_tuple(generator) pattern, for added performance
+            for item_type, popped in all_popped:
+                if item_type is int:
+                    type_cast_popped.append(popped)
+                elif item_type is bytes:
+                    type_cast_popped.append(big_endian_to_int(popped))  # type: ignore
+                else:
+                    raise _busted_type(item_type, popped)
+
+            return tuple(type_cast_popped)  # type: ignore
+
+    def pop_bytes(self, num_items: int) -> Tuple[bytes, ...]:
+        """
+        Pop and return a tuple of bytes of length ``num_items`` from the stack.
+
+        Raise `eth.exceptions.InsufficientStack` if there are not enough items on
+        the stack.
+
+        Items are ordered with the top of the stack as the first item in the tuple.
+        """
+
+        #
+        # Note: This function is optimized for speed over readability.
+        #
+        if num_items > len(self.values):
+            raise InsufficientStack(
+                "Wanted %d stack items, only had %d",
+                num_items,
+                len(self.values),
+            )
+        else:
+            neg_num_items = -1 * num_items
+
+            all_popped = reversed(self.values[neg_num_items:])
+            del self.values[neg_num_items:]
+
+            type_cast_popped = []
+
+            # Convert any non-matching types to the requested type (int)
+            # This doesn't use the @to_tuple(generator) pattern, for added performance
+            for item_type, popped in all_popped:
+                if item_type is int:
+                    type_cast_popped.append(int_to_big_endian(popped))  # type: ignore
+                elif item_type is bytes:
+                    type_cast_popped.append(popped)  # type: ignore
+                else:
+                    raise _busted_type(item_type, popped)
+
+            return tuple(type_cast_popped)
 
     def swap(self, position: int) -> None:
         """
@@ -100,8 +273,11 @@ class Stack(object):
         """
         Perform a DUP operation on the stack.
         """
-        idx = -1 * position
+        if len(self.values) > 1023:
+            raise FullStack('Stack limit reached')
+
+        peek_index = -1 * position
         try:
-            self.push(self.values[idx])
+            self._append(self.values[peek_index])
         except IndexError:
             raise InsufficientStack("Insufficient stack items for DUP{0}".format(position))

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -104,11 +104,49 @@ def prepare_general_computation(vm_class, create_address=None, code=b''):
 )
 def test_add(vm_class, val1, val2, expected):
     computation = prepare_general_computation(vm_class)
-    computation.stack_push(val1)
-    computation.stack_push(val2)
+    computation.stack_push_int(val1)
+    computation.stack_push_int(val2)
     computation.opcodes[opcode_values.ADD](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result = computation.stack_pop1_int()
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    'opcode_value, expected',
+    (
+        (opcode_values.COINBASE, b'\0' * 20),
+        # (opcode_values.TIMESTAMP, 1556826898),
+        (opcode_values.NUMBER, 0),
+        (opcode_values.DIFFICULTY, 17179869184),
+        (opcode_values.GASLIMIT, 5000),
+    )
+)
+def test_nullary_opcodes(VM, opcode_value, expected):
+    computation = prepare_general_computation(VM)
+    computation.opcodes[opcode_value](computation)
+
+    result = computation.stack_pop1_any()
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    'val1, expected',
+    (
+        (0, b''),
+        (1, b''),
+        (255, b''),
+        (256, b''),
+    )
+)
+def test_blockhash(VM, val1, expected):
+    computation = prepare_general_computation(VM)
+    computation.stack_push_int(val1)
+    computation.opcodes[opcode_values.BLOCKHASH](computation)
+
+    result = computation.stack_pop1_any()
 
     assert result == expected
 
@@ -125,11 +163,11 @@ def test_add(vm_class, val1, val2, expected):
 )
 def test_mul(vm_class, val1, val2, expected):
     computation = prepare_general_computation(vm_class)
-    computation.stack_push(val1)
-    computation.stack_push(val2)
+    computation.stack_push_int(val1)
+    computation.stack_push_int(val2)
     computation.opcodes[opcode_values.MUL](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result = computation.stack_pop1_int()
 
     assert result == expected
 
@@ -151,11 +189,11 @@ def test_mul(vm_class, val1, val2, expected):
 )
 def test_exp(vm_class, base, exponent, expected):
     computation = prepare_general_computation(vm_class)
-    computation.stack_push(exponent)
-    computation.stack_push(base)
+    computation.stack_push_int(exponent)
+    computation.stack_push_int(base)
     computation.opcodes[opcode_values.EXP](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result = computation.stack_pop1_int()
 
     assert result == expected
 
@@ -234,11 +272,11 @@ def test_exp(vm_class, base, exponent, expected):
 )
 def test_shl(vm_class, val1, val2, expected):
     computation = prepare_general_computation(vm_class)
-    computation.stack_push(decode_hex(val1))
-    computation.stack_push(decode_hex(val2))
+    computation.stack_push_bytes(decode_hex(val1))
+    computation.stack_push_bytes(decode_hex(val2))
     computation.opcodes[opcode_values.SHL](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result = computation.stack_pop1_int()
 
     assert encode_hex(pad32(int_to_big_endian(result))) == expected
 
@@ -317,11 +355,11 @@ def test_shl(vm_class, val1, val2, expected):
 )
 def test_shr(vm_class, val1, val2, expected):
     computation = prepare_general_computation(vm_class)
-    computation.stack_push(decode_hex(val1))
-    computation.stack_push(decode_hex(val2))
+    computation.stack_push_bytes(decode_hex(val1))
+    computation.stack_push_bytes(decode_hex(val2))
     computation.opcodes[opcode_values.SHR](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result = computation.stack_pop1_int()
     assert encode_hex(pad32(int_to_big_endian(result))) == expected
 
 
@@ -430,11 +468,11 @@ def test_shr(vm_class, val1, val2, expected):
 )
 def test_sar(vm_class, val1, val2, expected):
     computation = prepare_general_computation(vm_class)
-    computation.stack_push(decode_hex(val1))
-    computation.stack_push(decode_hex(val2))
+    computation.stack_push_bytes(decode_hex(val1))
+    computation.stack_push_bytes(decode_hex(val2))
     computation.opcodes[opcode_values.SAR](computation)
 
-    result = computation.stack_pop(type_hint=constants.UINT256)
+    result = computation.stack_pop1_int()
     assert encode_hex(pad32(int_to_big_endian(result))) == expected
 
 
@@ -467,10 +505,10 @@ def test_sar(vm_class, val1, val2, expected):
 def test_extcodehash(vm_class, address, expected):
     computation = prepare_general_computation(vm_class)
 
-    computation.stack_push(decode_hex(address))
+    computation.stack_push_bytes(decode_hex(address))
     computation.opcodes[opcode_values.EXTCODEHASH](computation)
 
-    result = computation.stack_pop(type_hint=constants.BYTES)
+    result = computation.stack_pop1_bytes()
     assert encode_hex(pad32(result)) == expected
 
 

--- a/tests/core/stack/test_stack.py
+++ b/tests/core/stack/test_stack.py
@@ -11,11 +11,6 @@ from eth.exceptions import (
     FullStack,
     InsufficientStack,
 )
-from eth.constants import (
-    UINT256,
-    BYTES,
-    SECPK1_N,
-)
 
 
 @pytest.fixture
@@ -26,35 +21,48 @@ def stack():
 @pytest.mark.parametrize(
     ("value,is_valid"),
     (
+        (b'abcde', True),
+        (b'100100100100100100100100100100100', False),
+    )
+)
+def test_push_only_pushes_valid_stack_bytes(stack, value, is_valid):
+    if is_valid:
+        stack.push_bytes(value)
+        assert stack.pop1_any() == value
+    else:
+        with pytest.raises(ValidationError):
+            stack.push_bytes(value)
+
+
+@pytest.mark.parametrize(
+    ("value,is_valid"),
+    (
         (-1, False),
         (0, True),
         (1, True),
         (2**256 - 1, True),
         (2**256, False),
-        ('abcde', False),
-        (b'abcde', True),
-        (b'100100100100100100100100100100100', False),
     )
 )
-def test_push_only_pushes_valid_stack_items(stack, value, is_valid):
+def test_push_only_pushes_valid_stack_ints(stack, value, is_valid):
     if is_valid:
-        stack.push(value)
-        assert stack.values == [value]
+        stack.push_int(value)
+        assert stack.pop1_any() == value
     else:
         with pytest.raises(ValidationError):
-            stack.push(value)
+            stack.push_int(value)
 
 
 def test_push_does_not_allow_stack_to_exceed_1024_items(stack):
     for num in range(1024):
-        stack.push(num)
+        stack.push_int(num)
     assert len(stack.values) == 1024
     with pytest.raises(FullStack):
-        stack.push(1025)
+        stack.push_int(1025)
 
 
 def test_dup_does_not_allow_stack_to_exceed_1024_items(stack):
-    stack.push(1)
+    stack.push_int(1)
     for _ in range(1023):
         stack.dup(1)
     assert len(stack.values) == 1024
@@ -63,59 +71,79 @@ def test_dup_does_not_allow_stack_to_exceed_1024_items(stack):
 
 
 @pytest.mark.parametrize(
-    ("items,type_hint"),
+    ("items, stack_method"),
     (
-        ([1], UINT256),
-        ([1, 2, 3], UINT256),
-        ([b'1', b'10', b'101', b'1010'], BYTES)
+        ([1], 'push_int'),
+        ([1, 2, 3], 'push_int'),
+        ([b'1', b'10', b'101', b'1010'], 'push_bytes')
     )
 )
-def test_pop_returns_latest_stack_item(stack, items, type_hint):
+def test_pop_returns_latest_stack_item(stack, items, stack_method):
+    method = getattr(stack, stack_method)
     for each in items:
-        stack.push(each)
-    assert stack.pop(num_items=1, type_hint=type_hint) == items[-1]
+        method(each)
+    assert stack.pop1_any() == items[-1]
 
 
 @pytest.mark.parametrize(
-    ("value,type_hint,type,is_valid"),
+    ("value, push_method, pop_method, expect_result"),
     (
-        (1, UINT256, int, True),
-        (b'101', BYTES, bytes, True),
-        (1, SECPK1_N, int, False)
+        (1, 'push_int', 'pop_ints', (1, )),
+        (1, 'push_int', 'pop_any', (1, )),
+        (1, 'push_int', 'pop_bytes', (b'\x01', )),
+        (1, 'push_int', 'pop1_int', 1),
+        (1, 'push_int', 'pop1_any', 1),
+        (1, 'push_int', 'pop1_bytes', b'\x01'),
+        (b'\x09', 'push_bytes', 'pop_ints', (9, )),
+        (b'\x09', 'push_bytes', 'pop_any', (b'\x09', )),
+        (b'\x09', 'push_bytes', 'pop_bytes', (b'\x09', )),
+        (b'\x09', 'push_bytes', 'pop1_int', 9),
+        (b'\x09', 'push_bytes', 'pop1_any', b'\x09'),
+        (b'\x09', 'push_bytes', 'pop1_bytes', b'\x09'),
     )
 )
-def test_pop_typecasts_correctly_based_off_type_hint(stack, value, type_hint, type, is_valid):
-    stack.push(value)
-    if is_valid:
-        assert isinstance(stack.pop(num_items=1, type_hint=type_hint), type)
+def test_pop_different_types(stack, value, push_method, pop_method, expect_result):
+    push = getattr(stack, push_method)
+    push(value)
+
+    pop = getattr(stack, pop_method)
+
+    if '1' in pop_method:
+        assert pop() == expect_result
     else:
-        with pytest.raises(TypeError):
-            stack.pop(type_hint=type_hint)
+        assert pop(1) == expect_result
+
+
+def _validate_stack_integers(stack, expected_values):
+    popped = stack.pop_any(len(stack))
+    assert popped == tuple(reversed(expected_values))
+    for val in reversed(popped):
+        stack.push_int(val)
 
 
 def test_swap_operates_correctly(stack):
     for num in range(5):
-        stack.push(num)
-    assert stack.values == [0, 1, 2, 3, 4]
+        stack.push_int(num)
+    _validate_stack_integers(stack, [0, 1, 2, 3, 4])
     stack.swap(3)
-    assert stack.values == [0, 4, 2, 3, 1]
+    _validate_stack_integers(stack, [0, 4, 2, 3, 1])
     stack.swap(1)
-    assert stack.values == [0, 4, 2, 1, 3]
+    _validate_stack_integers(stack, [0, 4, 2, 1, 3])
 
 
 def test_dup_operates_correctly(stack):
     for num in range(5):
-        stack.push(num)
-    assert stack.values == [0, 1, 2, 3, 4]
+        stack.push_int(num)
+    _validate_stack_integers(stack, [0, 1, 2, 3, 4])
     stack.dup(1)
-    assert stack.values == [0, 1, 2, 3, 4, 4]
+    _validate_stack_integers(stack, [0, 1, 2, 3, 4, 4])
     stack.dup(5)
-    assert stack.values == [0, 1, 2, 3, 4, 4, 1]
+    _validate_stack_integers(stack, [0, 1, 2, 3, 4, 4, 1])
 
 
 def test_pop_raises_InsufficientStack_appropriately(stack):
     with pytest.raises(InsufficientStack):
-        stack.pop(num_items=1, type_hint=UINT256)
+        stack.pop1_int()
 
 
 def test_swap_raises_InsufficientStack_appropriately(stack):

--- a/tests/core/validation/test_eth1_validation.py
+++ b/tests/core/validation/test_eth1_validation.py
@@ -23,7 +23,8 @@ from eth.validation import (
     validate_lt_secpk1n,
     validate_lt_secpk1n2,
     validate_multiple_of,
-    validate_stack_item,
+    validate_stack_bytes,
+    validate_stack_int,
     validate_uint256,
     validate_unique,
     validate_vm_block_numbers,
@@ -301,11 +302,6 @@ def test_validate_uint256(value, is_valid):
 @pytest.mark.parametrize(
     "value,is_valid",
     (
-        ('a', False),
-        (b'', True),
-        (b'a', True),
-        (b'10010010010010010010010010010010', True),
-        (b'100100100100100100100100100100100', False),
         (-1, False),
         (0, True),
         (10, True),
@@ -313,12 +309,29 @@ def test_validate_uint256(value, is_valid):
         ((2**256) - 1, True),
     ),
 )
-def test_validate_stack_item(value, is_valid):
+def test_validate_stack_int(value, is_valid):
     if is_valid:
-            validate_stack_item(value)
+        validate_stack_int(value)
     else:
         with pytest.raises(ValidationError):
-            validate_stack_item(value)
+            validate_stack_int(value)
+
+
+@pytest.mark.parametrize(
+    "value,is_valid",
+    (
+        (b'', True),
+        (b'a', True),
+        (b'10010010010010010010010010010010', True),
+        (b'100100100100100100100100100100100', False),
+    ),
+)
+def test_validate_stack_bytes(value, is_valid):
+    if is_valid:
+        validate_stack_bytes(value)
+    else:
+        with pytest.raises(ValidationError):
+            validate_stack_bytes(value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
```
    EVM stack push, pop, and dup ~8.9% speedup
    
    Percent of total import_block() time
    ====================================
    
    In eth/vm/stack.py:
    
          old      new     saved
    push  5.99% -> 3.69% = 2.30%
    pop   8.63% -> 4.90% = 3.73%
    dup   1.76% -> 0.69% = 1.07%
    ----------------------------------
    Total lift             7.1%
    
    In eth/vm/computation.py:
    
                old      new    saved
    stack_push  0.98% -> ~0% =  0.98%
    stack_pop   0.87% -> ~0% =  0.87%
    ----------------------------------
    Total lift                  1.85%
    
    Tested import_block() against mainnet blocks:
    (7620447, 7620450, 7620453, 7620454)
```

(Note: performance measured on top of #1777)

### How was it fixed?

There are a few important changes here:
- switch push and pop to use explicit type signatures, which avoids a lot of dynamic checks
  - split out a single pop from multiple popped values
  - split out int/bytes/any into separate methods
- skip some explicit type checks, count on mypy to catch any issues
- store the value type explicitly to do a much faster `is` check (rather than calling `isinstance()` so much)
- ~~push was causing a lot of `CodeStream` reads that were slow. Skipped the method overhead and attribute lookup by exposing the internal `read`.~~

This seemed to surface some typing issues that I went ahead and fixed up (one of the method signatures had `Any` as a return value, for example -- with that removed, mypy spit some warnings).

TODO
- [x] drop `CodeStream` changes and rebase on #1777
- [x] re-measure performance lift
- [x] squash
- [x] more docs (some are probably stale now)
- [x] ~~(maybe) update some more of the opcode tests to use the `VM` fixture instead of explicitly listing vms.~~ (or maybe not if this PR is already feeling too big)
- [x] resolve `CodeStream` conflicts with #1770

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/apgytvwzu5p11.jpg)
