### PR TITLE
Faster JournalDB committing

### DIFF
--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -2,7 +2,6 @@ from abc import (
     ABC,
     abstractmethod
 )
-from uuid import UUID
 import logging
 from lru import LRU
 from typing import (  # noqa: F401
@@ -20,6 +19,7 @@ from eth_typing import (
 )
 from eth_utils import (
     encode_hex,
+    to_checksum_address,
     to_tuple,
     ValidationError,
 )
@@ -46,6 +46,9 @@ from eth.db.journal import (
 )
 from eth.db.storage import (
     AccountStorageDB,
+)
+from eth.db.typing import (
+    JournalDBCheckpoint,
 )
 from eth.rlp.accounts import (
     Account,
@@ -153,15 +156,15 @@ class BaseAccountDB(ABC):
     # Record and discard API
     #
     @abstractmethod
-    def record(self) -> UUID:
+    def record(self) -> JournalDBCheckpoint:
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def discard(self, changeset: UUID) -> None:
+    def discard(self, changeset: JournalDBCheckpoint) -> None:
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def commit(self, changeset: UUID) -> None:
+    def commit(self, changeset: JournalDBCheckpoint) -> None:
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
@@ -455,7 +458,7 @@ class AccountDB(BaseAccountDB):
     #
     # Record and discard API
     #
-    def record(self) -> UUID:
+    def record(self) -> JournalDBCheckpoint:
         changeset_id = self._journaldb.record()
         self._journaltrie.record(changeset_id)
 
@@ -463,14 +466,14 @@ class AccountDB(BaseAccountDB):
             store.record(changeset_id)
         return changeset_id
 
-    def discard(self, changeset: UUID) -> None:
+    def discard(self, changeset: JournalDBCheckpoint) -> None:
         self._journaldb.discard(changeset)
         self._journaltrie.discard(changeset)
         self._account_cache.clear()
         for _, store in self._dirty_account_stores():
             store.discard(changeset)
 
-    def commit(self, changeset: UUID) -> None:
+    def commit(self, changeset: JournalDBCheckpoint) -> None:
         self._journaldb.commit(changeset)
         self._journaltrie.commit(changeset)
         for _, store in self._dirty_account_stores():
@@ -534,21 +537,22 @@ class AccountDB(BaseAccountDB):
             )
 
     def _log_pending_accounts(self) -> None:
-        accounts_displayed = set()  # type: Set[bytes]
-        queued_changes = self._journaltrie.journal.journal_data.items()
-        # mypy bug for ordered dict reversibility: https://github.com/python/typeshed/issues/2078
-        for _, accounts in reversed(queued_changes):
-            for address in accounts:
-                if address in accounts_displayed:
-                    continue
-                else:
-                    accounts_displayed.add(address)
-                    account = self._get_account(Address(address))
-                    self.logger.debug2(
-                        "Account %s: balance %d, nonce %d, storage root %s, code hash %s",
-                        encode_hex(address),
-                        account.balance,
-                        account.nonce,
-                        encode_hex(account.storage_root),
-                        encode_hex(account.code_hash),
-                    )
+        diff = self._journaltrie.diff()
+        for address in sorted(diff.pending_keys()):
+            account = self._get_account(Address(address))
+            self.logger.debug2(
+                "Pending Account %s: balance %d, nonce %d, storage root %s, code hash %s",
+                to_checksum_address(address),
+                account.balance,
+                account.nonce,
+                encode_hex(account.storage_root),
+                encode_hex(account.code_hash),
+            )
+        for deleted_address in sorted(diff.deleted_keys()):
+            cast_deleted_address = Address(deleted_address)
+            self.logger.debug2(
+                "Deleted Account %s, empty? %s, exists? %s",
+                to_checksum_address(deleted_address),
+                self.account_is_empty(cast_deleted_address),
+                self.account_exists(cast_deleted_address),
+            )

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -160,11 +160,11 @@ class BaseAccountDB(ABC):
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def discard(self, changeset: JournalDBCheckpoint) -> None:
+    def discard(self, checkpoint: JournalDBCheckpoint) -> None:
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def commit(self, changeset: JournalDBCheckpoint) -> None:
+    def commit(self, checkpoint: JournalDBCheckpoint) -> None:
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
@@ -459,25 +459,25 @@ class AccountDB(BaseAccountDB):
     # Record and discard API
     #
     def record(self) -> JournalDBCheckpoint:
-        changeset_id = self._journaldb.record()
-        self._journaltrie.record(changeset_id)
+        checkpoint = self._journaldb.record()
+        self._journaltrie.record(checkpoint)
 
         for _, store in self._dirty_account_stores():
-            store.record(changeset_id)
-        return changeset_id
+            store.record(checkpoint)
+        return checkpoint
 
-    def discard(self, changeset: JournalDBCheckpoint) -> None:
-        self._journaldb.discard(changeset)
-        self._journaltrie.discard(changeset)
+    def discard(self, checkpoint: JournalDBCheckpoint) -> None:
+        self._journaldb.discard(checkpoint)
+        self._journaltrie.discard(checkpoint)
         self._account_cache.clear()
         for _, store in self._dirty_account_stores():
-            store.discard(changeset)
+            store.discard(checkpoint)
 
-    def commit(self, changeset: JournalDBCheckpoint) -> None:
-        self._journaldb.commit(changeset)
-        self._journaltrie.commit(changeset)
+    def commit(self, checkpoint: JournalDBCheckpoint) -> None:
+        self._journaldb.commit(checkpoint)
+        self._journaltrie.commit(checkpoint)
         for _, store in self._dirty_account_stores():
-            store.commit(changeset)
+            store.commit(checkpoint)
 
     def make_state_root(self) -> Hash32:
         for _, store in self._dirty_account_stores():

--- a/eth/db/journal.py
+++ b/eth/db/journal.py
@@ -2,21 +2,19 @@ import collections
 from itertools import (
     count,
 )
-from typing import cast, Dict, Set, Union  # noqa: F401
-import uuid
+from typing import Callable, cast, Dict, List, Set, Union  # noqa: F401
 
 from eth_utils.toolz import (
     first,
-    merge,
     nth,
 )
 from eth_utils import (
-    to_tuple,
     ValidationError,
 )
 
-from eth.db.backends.base import BaseDB
-from eth.db.diff import DBDiff, DBDiffTracker
+from .backends.base import BaseDB
+from .diff import DBDiff, DBDiffTracker
+from .typing import JournalDBCheckpoint
 
 
 class DeletedEntry:
@@ -28,22 +26,17 @@ class DeletedEntry:
 # 1. key in wrapped
 # 2. key modified in journal
 # 3. key deleted
-DELETED_ENTRY = DeletedEntry()
+DELETE_WRAPPED = DeletedEntry()
 
 # 1. key not in wrapped
 # 2. key created in journal
 # 3. key deleted
-ERASE_CREATED_ENTRY = DeletedEntry()
+REVERT_TO_WRAPPED = DeletedEntry()
 
+ChangesetValue = Union[bytes, DeletedEntry]
+ChangesetDict = Dict[bytes, ChangesetValue]
 
-class ValueDelta:
-    pass
-
-
-REVERT_TO_ORIGINAL = ValueDelta()
-
-
-id_generator = count()
+get_next_checkpoint_id = cast(Callable[[], JournalDBCheckpoint], count().__next__)
 
 
 class Journal(BaseDB):
@@ -52,21 +45,41 @@ class Journal(BaseDB):
     of database keys and values.  The values are tracked changes which give
     the information needed to revert a changeset to an old checkpoint.
 
-    Changesets are referenced by an internally-generated integer.
+    Changesets are referenced by an internally-generated integer. This is *not* threadsafe.
     """
-    __slots__ = ['_journal_data', '_clears_at', '_current_values', '_ignore_wrapped_db']
+    __slots__ = [
+        '_journal_data',
+        '_clears_at',
+        '_current_values',
+        '_ignore_wrapped_db',
+        '_checkpoint_stack',
+    ]
+
+    #
+    # This is a high-use class, where we sometimes prefere optimization over readability.
+    # It's most important to optimize for record, commit, and persist, which ard the most commonly
+    # used methods.
+    #
 
     def __init__(self) -> None:
-        # contains a mapping from all of the `uuid4` changeset_ids
+        # contains a mapping from all of the int changeset_ids
         # to a dictionary of key:value pairs that describe how to rewind from the current values
         # to the given checkpoint
-        self._journal_data = collections.OrderedDict()  # type: collections.OrderedDict[uuid.UUID, Dict[bytes, Union[bytes, DeletedEntry]]]  # noqa E501
-        self._clears_at = set()  # type: Set[uuid.UUID]
-        self._current_values = {}  # Dict[bytes, Union[bytes, DeletedEntry]]
-        self._ignore_wrapped_db = False  # if there is a clear journaled, then treat wrapped DB as empty
+        self._journal_data = collections.OrderedDict()  # type: collections.OrderedDict[JournalDBCheckpoint, ChangesetDict]  # noqa E501
+        self._clears_at = set()  # type: Set[JournalDBCheckpoint]
+
+        # If the journal was persisted right now, these would be the current changes to push:
+        self._current_values = {}  # type: ChangesetDict
+
+        # If a clear was called, then any missing keys should be treated as missing
+        self._ignore_wrapped_db = False
+
+        # To speed up commits, we leave in old recorded checkpoints on commit and keep a separate
+        # list of active checkpoints.
+        self._checkpoint_stack = []  # type: List[JournalDBCheckpoint]
 
     @property
-    def root_changeset_id(self) -> uuid.UUID:
+    def root_changeset_id(self) -> JournalDBCheckpoint:
         """
         Returns the id of the root changeset
         """
@@ -77,10 +90,10 @@ class Journal(BaseDB):
         """
         :return: whether there are any explicitly committed checkpoints
         """
-        return len(self._journal_data) < 2
+        return len(self._checkpoint_stack) < 2
 
     @property
-    def latest_id(self) -> uuid.UUID:
+    def last_changeset_index(self) -> JournalDBCheckpoint:
         """
         Returns the id of the latest changeset
         """
@@ -88,29 +101,17 @@ class Journal(BaseDB):
         # Interestingly, an attempt to cache this value caused a slowdown.
         return first(reversed(self._journal_data.keys()))
 
-    @property
-    def latest(self) -> Dict[bytes, Union[bytes, DeletedEntry]]:
-        """
-        Returns the dictionary of db keys and values for the latest changeset.
-        """
-        return self._journal_data[self.latest_id]
+    def has_changeset(self, changeset_id: JournalDBCheckpoint) -> bool:
+        # another option would be to enforce monotonically-increasing changeset ids, so we can do:
+        # checkpoint_idx = bisect_left(self._checkpoint_stack, changeset_id)
+        # (then validate against length and value at index)
+        return changeset_id in self._checkpoint_stack
 
-    @latest.setter
-    def latest(self, value: Dict[bytes, Union[bytes, DeletedEntry]]) -> None:
+    def record_changeset(
+            self,
+            custom_changeset_id: JournalDBCheckpoint = None) -> JournalDBCheckpoint:
         """
-        Setter for updating the *latest* changeset.
-        """
-        self._journal_data[self.latest_id] = value
-
-    def is_empty(self) -> bool:
-        return len(self._journal_data) == 0
-
-    def has_changeset(self, changeset_id: uuid.UUID) -> bool:
-        return changeset_id in self._journal_data
-
-    def record_changeset(self, custom_changeset_id: uuid.UUID = None) -> uuid.UUID:
-        """
-        Creates a new changeset. Changesets are referenced by a random uuid4
+        Creates a new changeset. Changesets are referenced by a random int
         to prevent collisions between multiple changesets.
         """
         if custom_changeset_id is not None:
@@ -121,49 +122,48 @@ class Journal(BaseDB):
             else:
                 changeset_id = custom_changeset_id
         else:
-            changeset_id = next(id_generator)
+            changeset_id = get_next_checkpoint_id()
 
         self._journal_data[changeset_id] = {}
+        self._checkpoint_stack.append(changeset_id)
         return changeset_id
 
-    def discard(self, discard_through_checkpoint_id):
-        for checkpoint_id, rollback_data in self._rollbacks_through(discard_through_checkpoint_id):
-            for old_key, old_value in rollback_data.items():
-                if old_value is REVERT_TO_ORIGINAL:
-                    del self._current_values[old_key]
-                else:
-                    self._current_values[old_key] = old_value
-
-            del self._journal_data[checkpoint_id]
-
-            if checkpoint_id in self._clears_at:
-                self._clears_at.remove(checkpoint_id)
-                self._ignore_wrapped_db = False
-
-        if self._clears_at:
-            # if there is still a clear in older locations, then reinitiate the clear flag
-            self._ignore_wrapped_db = True
-
-    @to_tuple
-    def _rollbacks_through(self, through_checkpoint_id):
-        for checkpoint_id, rollback_data in reversed(self._journal_data.items()):
-            yield checkpoint_id, rollback_data
+    def discard(self, through_checkpoint_id: JournalDBCheckpoint) -> None:
+        while self._checkpoint_stack:
+            checkpoint_id = self._checkpoint_stack.pop()
             if checkpoint_id == through_checkpoint_id:
                 break
         else:
             # checkpoint not found!
             raise ValidationError("No checkpoint %s was found" % through_checkpoint_id)
 
-    def _drop_rollbacks(self, drop_through_checkpoint_id: uuid.UUID) -> Dict[bytes, Union[bytes, DeletedEntry]]:
-        had_clear = False
-        for checkpoint_id, _ in self._rollbacks_through(drop_through_checkpoint_id):
-            del self._journal_data[checkpoint_id]
+        # This might be optimized further by iterating the other direction and
+        # ignoring any follow-up rollbacks on the same variable.
+        for _ in range(len(self._journal_data)):
+            checkpoint_id, rollback_data = self._journal_data.popitem()
+
+            for old_key, old_value in rollback_data.items():
+                if old_value is REVERT_TO_WRAPPED:
+                    # The current value may not exist, if it was a delete followed by a clear,
+                    # so pop it off, or ignore if it is already missing
+                    self._current_values.pop(old_key, None)
+                elif old_value is DELETE_WRAPPED:
+                    self._current_values[old_key] = old_value
+                elif type(old_value) is bytes:
+                    self._current_values[old_key] = old_value
+                else:
+                    raise ValidationError("Unexpected value, must be bytes: %r" % old_value)
 
             if checkpoint_id in self._clears_at:
                 self._clears_at.remove(checkpoint_id)
-                had_clear = True
+                self._ignore_wrapped_db = False
 
-        return had_clear
+            if checkpoint_id == through_checkpoint_id:
+                break
+
+        if self._clears_at:
+            # if there is still a clear in older locations, then reinitiate the clear flag
+            self._ignore_wrapped_db = True
 
     def clear(self) -> None:
         """
@@ -171,13 +171,13 @@ class Journal(BaseDB):
         We build a special empty changeset just for marking that all previous data should
         be ignored.
         """
-        changeset_id = next(id_generator)
+        changeset_id = get_next_checkpoint_id()
         self._journal_data[changeset_id] = self._current_values
         self._current_values = {}
         self._ignore_wrapped_db = True
         self._clears_at.add(changeset_id)
 
-    def has_clear(self, check_changeset_id: uuid.UUID) -> bool:
+    def has_clear(self, check_changeset_id: JournalDBCheckpoint) -> bool:
         for changeset_id in reversed(self._journal_data.keys()):
             if changeset_id in self._clears_at:
                 return True
@@ -185,29 +185,37 @@ class Journal(BaseDB):
                 return False
         raise ValidationError("Changeset ID %s is not in the journal" % check_changeset_id)
 
-    def commit_changeset(self, changeset_id: uuid.UUID) -> Dict[bytes, Union[bytes, DeletedEntry]]:
+    def commit_changeset(self, commit_id: JournalDBCheckpoint) -> ChangesetDict:
         """
         Collapses all changes for the given changeset into the previous
         changesets if it exists.
         """
-        does_clear = self._drop_rollbacks(changeset_id)
-        if self.is_empty():
+        # Another option would be to enforce monotonically-increasing changeset ids, so we can do:
+        # checkpoint_idx = bisect_left(self._checkpoint_stack, commit_id)
+        # (then validate against length and value at index)
+        for positions_before_last, checkpoint in enumerate(reversed(self._checkpoint_stack)):
+            if checkpoint == commit_id:
+                checkpoint_idx = -1 - positions_before_last
+                break
+        else:
+            raise ValidationError("No checkpoint %s was found" % commit_id)
+
+        if checkpoint_idx == -1 * len(self._checkpoint_stack):
             raise ValidationError(
                 "Should not commit root changeset with commit_changeset, use pop_all() instead"
             )
-        if does_clear:
-            # if there was a clear and more changesets underneath then clear the latest
-            # rollback, and replace with a new clear changeset
-            self.latest = {}
-            self._clears_at.add(self.latest_id)
-            self.record_changeset()
+
+        # delete committed checkpoints from the stack (but keep rollbacks for future discards)
+        del self._checkpoint_stack[checkpoint_idx:]
+
         return self._current_values
 
-    def pop_all(self):
+    def pop_all(self) -> ChangesetDict:
         final_changes = self._current_values
         self._journal_data.clear()
         self._clears_at.clear()
         self._current_values = {}
+        self._checkpoint_stack.clear()
         self.record_changeset()
         return final_changes
 
@@ -215,13 +223,13 @@ class Journal(BaseDB):
         if self.is_flattened:
             return
 
-        changeset_id_after_root = nth(1, self._journal_data.keys())
+        changeset_id_after_root = nth(1, self._checkpoint_stack)
         self.commit_changeset(changeset_id_after_root)
 
     #
     # Database API
     #
-    def __getitem__(self, key: bytes) -> Union[bytes, DeletedEntry]:    # type: ignore # Breaks LSP
+    def __getitem__(self, key: bytes) -> ChangesetValue:    # type: ignore # Breaks LSP
         """
         For key lookups we need to iterate through the changesets in reverse
         order, returning from the first one in which the key is present.
@@ -229,44 +237,44 @@ class Journal(BaseDB):
         # the default result (the value if not in the local values) depends on whether there
         # was a clear
         if self._ignore_wrapped_db:
-            default_result = ERASE_CREATED_ENTRY
+            default_result = REVERT_TO_WRAPPED
         else:
             default_result = None  # indicate that caller should check wrapped database
         return self._current_values.get(key, default_result)
 
     def __setitem__(self, key: bytes, value: bytes) -> None:
         # if the value has not been changed since wrapping, then simply revert to original value
-        revert_changeset = self.latest
+        revert_changeset = self._journal_data[self.last_changeset_index]
         if key not in revert_changeset:
-            revert_changeset[key] = self._current_values.get(key, REVERT_TO_ORIGINAL)
+            revert_changeset[key] = self._current_values.get(key, REVERT_TO_WRAPPED)
         self._current_values[key] = value
 
     def _exists(self, key: bytes) -> bool:
         val = self.get(key)
-        return val is not None and val not in (ERASE_CREATED_ENTRY, DELETED_ENTRY)
+        return val is not None and val not in (REVERT_TO_WRAPPED, DELETE_WRAPPED)
 
     def __delitem__(self, key: bytes) -> None:
         raise NotImplementedError("You must delete with one of delete_local or delete_wrapped")
 
     def delete_wrapped(self, key: bytes) -> None:
-        revert_changeset = self.latest
+        revert_changeset = self._journal_data[self.last_changeset_index]
         if key not in revert_changeset:
-            revert_changeset[key] = self._current_values.get(key, REVERT_TO_ORIGINAL)
-        self._current_values[key] = DELETED_ENTRY
+            revert_changeset[key] = self._current_values.get(key, REVERT_TO_WRAPPED)
+        self._current_values[key] = DELETE_WRAPPED
 
     def delete_local(self, key: bytes) -> None:
-        revert_changeset = self.latest
+        revert_changeset = self._journal_data[self.last_changeset_index]
         if key not in revert_changeset:
-            revert_changeset[key] = self._current_values.get(key, REVERT_TO_ORIGINAL)
-        self._current_values[key] = ERASE_CREATED_ENTRY
+            revert_changeset[key] = self._current_values.get(key, REVERT_TO_WRAPPED)
+        self._current_values[key] = REVERT_TO_WRAPPED
 
     def diff(self) -> DBDiff:
         tracker = DBDiffTracker()
 
         for key, value in self._current_values.items():
-            if value is DELETED_ENTRY:
+            if value is DELETE_WRAPPED:
                 del tracker[key]
-            elif value is ERASE_CREATED_ENTRY:
+            elif value is REVERT_TO_WRAPPED:
                 pass
             else:
                 tracker[key] = value  # type: ignore  # cast(bytes, value)
@@ -293,21 +301,24 @@ class JournalDB(BaseDB):
     the same changeset will not increase the journal size since we only need
     to track latest value for any given key within any given changeset.
     """
-    __slots__ = ['_wrapped_db', '_journal']
+    __slots__ = ['_wrapped_db', '_journal', 'record', 'commit']
 
     def __init__(self, wrapped_db: BaseDB) -> None:
         self._wrapped_db = wrapped_db
+        self._journal = Journal()
+        self.record = self._journal.record_changeset
+        self.commit = self._journal.commit_changeset
         self.reset()
 
     def __getitem__(self, key: bytes) -> bytes:
 
         val = self._journal[key]
-        if val is DELETED_ENTRY:
+        if val is DELETE_WRAPPED:
             raise KeyError(
                 key,
                 "item is deleted in JournalDB, and will be deleted from the wrapped DB",
             )
-        elif val is ERASE_CREATED_ENTRY:
+        elif val is REVERT_TO_WRAPPED:
             raise KeyError(
                 key,
                 "item is deleted in JournalDB, and is presumed gone from the wrapped DB",
@@ -328,7 +339,7 @@ class JournalDB(BaseDB):
 
     def _exists(self, key: bytes) -> bool:
         val = self._journal[key]
-        if val in (ERASE_CREATED_ENTRY, DELETED_ENTRY):
+        if val in (REVERT_TO_WRAPPED, DELETE_WRAPPED):
             return False
         elif val is None:
             return key in self._wrapped_db
@@ -365,41 +376,22 @@ class JournalDB(BaseDB):
     #
     # Snapshot API
     #
-    def has_changeset(self, changeset_id: uuid.UUID) -> bool:
+    def has_changeset(self, changeset_id: JournalDBCheckpoint) -> bool:
         return self._journal.has_changeset(changeset_id)
 
-    def record(self, custom_changeset_id: uuid.UUID = None) -> uuid.UUID:
-        """
-        Starts a new recording and returns an id for the associated changeset
-        """
-        return self._journal.record_changeset(custom_changeset_id)
-
-    def discard(self, changeset_id: uuid.UUID) -> None:
+    def discard(self, changeset_id: JournalDBCheckpoint) -> None:
         """
         Throws away all journaled data starting at the given changeset
         """
         self._journal.discard(changeset_id)
 
-    def commit(self, changeset_id: uuid.UUID) -> None:
-        """
-        Commits a given changeset. This merges the given changeset and all
-        subsequent changesets into the previous changeset giving precidence
-        to later changesets in case of any conflicting keys.
-        """
-        if changeset_id == self._journal.root_changeset_id:
-            raise ValidationError(
-                "Tried to commit the root changeset. Callers should not keep references "
-                "to the root changeset. Maybe you meant to use persist()?"
-            )
-        self._journal.commit_changeset(changeset_id)
-
     def _reapply_changeset_to_journal(
             self,
-            journal_data: Dict[bytes, Union[bytes, DeletedEntry]]) -> None:
+            journal_data: ChangesetDict) -> None:
         for key, value in journal_data.items():
-            if value is DELETED_ENTRY:
+            if value is DELETE_WRAPPED:
                 self._journal.delete_wrapped(key)
-            elif value is ERASE_CREATED_ENTRY:
+            elif value is REVERT_TO_WRAPPED:
                 self._journal.delete_local(key)
             else:
                 self._journal[key] = cast(bytes, value)
@@ -413,9 +405,9 @@ class JournalDB(BaseDB):
 
         for key, value in journal_data.items():
             try:
-                if value is DELETED_ENTRY:
+                if value is DELETE_WRAPPED:
                     del self._wrapped_db[key]
-                elif value is ERASE_CREATED_ENTRY:
+                elif value is REVERT_TO_WRAPPED:
                     pass
                 else:
                     self._wrapped_db[key] = cast(bytes, value)
@@ -433,8 +425,7 @@ class JournalDB(BaseDB):
         """
         Reset the entire journal.
         """
-        self._journal = Journal()
-        self.record()
+        self._journal.pop_all()
 
     def diff(self) -> DBDiff:
         """

--- a/eth/db/slow_journal.py
+++ b/eth/db/slow_journal.py
@@ -1,0 +1,448 @@
+import collections
+from typing import cast, Dict, Set, Union  # noqa: F401
+import uuid
+
+from eth_utils.toolz import (
+    first,
+    merge,
+    nth,
+)
+from eth_utils import (
+    ValidationError,
+)
+
+from eth.db.backends.base import BaseDB
+from eth.db.diff import DBDiff, DBDiffTracker
+
+
+class DeletedEntry:
+    pass
+
+
+# Track two different kinds of deletion:
+
+# 1. key in wrapped
+# 2. key modified in journal
+# 3. key deleted
+DELETED_ENTRY = DeletedEntry()
+
+# 1. key not in wrapped
+# 2. key created in journal
+# 3. key deleted
+ERASE_CREATED_ENTRY = DeletedEntry()
+
+
+class Journal(BaseDB):
+    """
+    A Journal is an ordered list of changesets.  A changeset is a dictionary
+    of database keys and values.  The values are tracked changes that were
+    written after the changeset was created
+
+    Changesets are referenced by a random uuid4.
+    """
+
+    def __init__(self) -> None:
+        # contains a mapping from all of the `uuid4` changeset_ids
+        # to a dictionary of key:value pairs with the recorded changes
+        # that belong to the changeset
+        self.journal_data = collections.OrderedDict()  # type: collections.OrderedDict[uuid.UUID, Dict[bytes, Union[bytes, DeletedEntry]]]  # noqa E501
+        self._clears_at = set()  # type: Set[uuid.UUID]
+
+    @property
+    def root_changeset_id(self) -> uuid.UUID:
+        """
+        Returns the id of the root changeset
+        """
+        return first(self.journal_data.keys())
+
+    @property
+    def is_flattened(self) -> bool:
+        """
+        :return: whether there are any explicitly committed checkpoints
+        """
+        return len(self.journal_data) < 2
+
+    @property
+    def latest_id(self) -> uuid.UUID:
+        """
+        Returns the id of the latest changeset
+        """
+        # last() was iterating through all values, so first(reversed()) gives a 12.5x speedup
+        return first(reversed(self.journal_data.keys()))
+
+    @property
+    def latest(self) -> Dict[bytes, Union[bytes, DeletedEntry]]:
+        """
+        Returns the dictionary of db keys and values for the latest changeset.
+        """
+        return self.journal_data[self.latest_id]
+
+    @latest.setter
+    def latest(self, value: Dict[bytes, Union[bytes, DeletedEntry]]) -> None:
+        """
+        Setter for updating the *latest* changeset.
+        """
+        self.journal_data[self.latest_id] = value
+
+    def is_empty(self) -> bool:
+        return len(self.journal_data) == 0
+
+    def has_changeset(self, changeset_id: uuid.UUID) -> bool:
+        return changeset_id in self.journal_data
+
+    def record_changeset(self, custom_changeset_id: uuid.UUID = None) -> uuid.UUID:
+        """
+        Creates a new changeset. Changesets are referenced by a random uuid4
+        to prevent collisions between multiple changesets.
+        """
+        if custom_changeset_id is not None:
+            if custom_changeset_id in self.journal_data:
+                raise ValidationError(
+                    "Tried to record with an existing changeset id: %r" % custom_changeset_id
+                )
+            else:
+                changeset_id = custom_changeset_id
+        else:
+            changeset_id = uuid.uuid4()
+
+        self.journal_data[changeset_id] = {}
+        return changeset_id
+
+    def pop_changeset(self, changeset_id: uuid.UUID) -> Dict[bytes, Union[bytes, DeletedEntry]]:
+        """
+        Returns all changes from the given changeset.  This includes all of
+        the changes from any subsequent changeset, giving precedence to
+        later changesets.
+        """
+        if changeset_id not in self.journal_data:
+            raise KeyError(changeset_id, "Unknown changeset in JournalDB")
+
+        all_ids = tuple(self.journal_data.keys())
+        changeset_idx = all_ids.index(changeset_id)
+        changesets_to_pop = all_ids[changeset_idx:]
+        popped_clears = tuple(idx for idx in changesets_to_pop if idx in self._clears_at)
+        if popped_clears:
+            last_clear_idx = changesets_to_pop.index(popped_clears[-1])
+            changesets_to_drop = changesets_to_pop[:last_clear_idx]
+            changesets_to_merge = changesets_to_pop[last_clear_idx:]
+        else:
+            changesets_to_drop = ()
+            changesets_to_merge = changesets_to_pop
+
+        # we pull all of the changesets *after* the changeset we are
+        # reverting to and collapse them to a single set of keys (giving
+        # precedence to later changesets)
+        changeset_data = merge(*(
+            self.journal_data.pop(c_id)
+            for c_id
+            in changesets_to_merge
+        ))
+
+        # drop the changes on the floor if they came before a clear that is being committed
+        for changeset_id in changesets_to_drop:
+            self.journal_data.pop(changeset_id)
+
+        self._clears_at.difference_update(popped_clears)
+        return changeset_data
+
+    def clear(self) -> None:
+        """
+        Treat as if the *underlying* database will also be cleared by some other mechanism.
+        We build a special empty changeset just for marking that all previous data should
+        be ignored.
+        """
+        # these internal records are used as a way to tell the difference between
+        # changes that came before and after the clear
+        self.record_changeset()
+        self._clears_at.add(self.latest_id)
+        self.record_changeset()
+
+    def has_clear(self, check_changeset_id: uuid.UUID) -> bool:
+        for changeset_id in reversed(self.journal_data.keys()):
+            if changeset_id in self._clears_at:
+                return True
+            elif check_changeset_id == changeset_id:
+                return False
+        raise ValidationError("Changeset ID %s is not in the journal" % check_changeset_id)
+
+    def commit_changeset(self, changeset_id: uuid.UUID) -> Dict[bytes, Union[bytes, DeletedEntry]]:
+        """
+        Collapses all changes for the given changeset into the previous
+        changesets if it exists.
+        """
+        does_clear = self.has_clear(changeset_id)
+        changeset_data = self.pop_changeset(changeset_id)
+        if not self.is_empty():
+            # we only have to assign changeset data into the latest changeset if
+            # there is one.
+            if does_clear:
+                # if there was a clear and more changesets underneath then clear the latest
+                # changeset, and replace with a new clear changeset
+                self.latest = {}
+                self._clears_at.add(self.latest_id)
+                self.record_changeset()
+                self.latest = changeset_data
+            else:
+                # otherwise, merge in all the current data
+                self.latest = merge(
+                    self.latest,
+                    changeset_data,
+                )
+        return changeset_data
+
+    def flatten(self) -> None:
+        if self.is_flattened:
+            return
+
+        changeset_id_after_root = nth(1, self.journal_data.keys())
+        self.commit_changeset(changeset_id_after_root)
+
+    #
+    # Database API
+    #
+    def __getitem__(self, key: bytes) -> Union[bytes, DeletedEntry]:    # type: ignore # Breaks LSP
+        """
+        For key lookups we need to iterate through the changesets in reverse
+        order, returning from the first one in which the key is present.
+        """
+        # Ignored from mypy because of https://github.com/python/typeshed/issues/2078
+        for changeset_id, changeset_data in reversed(self.journal_data.items()):
+            if changeset_id in self._clears_at:
+                return ERASE_CREATED_ENTRY
+            elif key in changeset_data:
+                return changeset_data[key]
+            else:
+                continue
+
+        return None
+
+    def __setitem__(self, key: bytes, value: bytes) -> None:
+        self.latest[key] = value
+
+    def _exists(self, key: bytes) -> bool:
+        val = self.get(key)
+        return val is not None and val not in (ERASE_CREATED_ENTRY, DELETED_ENTRY)
+
+    def __delitem__(self, key: bytes) -> None:
+        raise NotImplementedError("You must delete with one of delete_local or delete_wrapped")
+
+    def delete_wrapped(self, key: bytes) -> None:
+        self.latest[key] = DELETED_ENTRY
+
+    def delete_local(self, key: bytes) -> None:
+        self.latest[key] = ERASE_CREATED_ENTRY
+
+    def diff(self) -> DBDiff:
+        tracker = DBDiffTracker()
+        visited_keys = set()  # type: Set[bytes]
+
+        # Iterate in reverse, so you can skip over any keys from old checkpoints.
+        # This is required so that when a key is created and then deleted in the journal,
+        #   we don't add the delete to the diff. (We simply omit the change altogether)
+        for changeset_id, changeset in reversed(self.journal_data.items()):
+            if changeset_id in self._clears_at:
+                break
+
+            for key, value in changeset.items():
+                if key in visited_keys:
+                    # this old change has already been tracked
+                    continue
+                elif value is DELETED_ENTRY:
+                    del tracker[key]
+                elif value is ERASE_CREATED_ENTRY:
+                    pass
+                else:
+                    tracker[key] = cast(bytes, value)
+
+                visited_keys.add(key)
+
+        return tracker.diff()
+
+
+class JournalDB(BaseDB):
+    """
+    A wrapper around the basic DB objects that keeps a journal of all changes.
+    Each time a recording is started, the underlying journal creates a new
+    changeset and assigns an id to it. The journal then keeps track of all changes
+    that go into this changeset.
+
+    Discarding a changeset simply throws it away inculding all subsequent changesets
+    that may have followed. Commiting a changeset merges the given changeset and all
+    subsequent changesets into the previous changeset giving precidence to later
+    changesets in case of conflicting keys.
+
+    Nothing is written to the underlying db until `persist()` is called.
+
+    The added memory footprint for a JournalDB is one key/value stored per
+    database key which is changed.  Subsequent changes to the same key within
+    the same changeset will not increase the journal size since we only need
+    to track latest value for any given key within any given changeset.
+    """
+    wrapped_db = None
+    journal = None  # type: Journal
+
+    def __init__(self, wrapped_db: BaseDB) -> None:
+        self.wrapped_db = wrapped_db
+        self.reset()
+
+    def __getitem__(self, key: bytes) -> bytes:
+
+        val = self.journal[key]
+        if val is DELETED_ENTRY:
+            raise KeyError(
+                key,
+                "item is deleted in JournalDB, and will be deleted from the wrapped DB",
+            )
+        elif val is ERASE_CREATED_ENTRY:
+            raise KeyError(
+                key,
+                "item is deleted in JournalDB, and is presumed gone from the wrapped DB",
+            )
+        elif val is None:
+            return self.wrapped_db[key]
+        else:
+            # mypy doesn't allow custom type guards yet so we need to cast here
+            # even though we know it can only be `bytes` at this point.
+            return cast(bytes, val)
+
+    def __setitem__(self, key: bytes, value: bytes) -> None:
+        """
+        - replacing an existing value
+        - setting a value that does not exist
+        """
+        self.journal[key] = value
+
+    def _exists(self, key: bytes) -> bool:
+        val = self.journal[key]
+        if val in (ERASE_CREATED_ENTRY, DELETED_ENTRY):
+            return False
+        elif val is None:
+            return key in self.wrapped_db
+        else:
+            return True
+
+    def clear(self) -> None:
+        """
+        Remove all keys. Immediately after a clear, *all* getitem requests will return a KeyError.
+        That includes the changes pending persist and any data in the underlying database.
+
+        (This action is journaled, like all other actions)
+
+        clear will *not* persist the emptying of all keys in the underlying DB.
+        It only prevents any updates (or deletes!) before it from being persisted.
+
+        Any caller that wants to use clear must also make sure that the underlying database
+        reflects their desired end state (maybe emptied, maybe not).
+        """
+        self.journal.clear()
+
+    def has_clear(self) -> bool:
+        return self.journal.has_clear(self.journal.root_changeset_id)
+
+    def __delitem__(self, key: bytes) -> None:
+        if key in self.wrapped_db:
+            self.journal.delete_wrapped(key)
+        else:
+            if key in self.journal:
+                self.journal.delete_local(key)
+            else:
+                raise KeyError(key, "key could not be deleted in JournalDB, because it was missing")
+
+    #
+    # Snapshot API
+    #
+    def _validate_changeset(self, changeset_id: uuid.UUID) -> None:
+        """
+        Checks to be sure the changeset is known by the journal
+        """
+        if not self.journal.has_changeset(changeset_id):
+            raise ValidationError("Changeset not found in journal: {0}".format(
+                str(changeset_id)
+            ))
+
+    def has_changeset(self, changeset_id: uuid.UUID) -> bool:
+        return self.journal.has_changeset(changeset_id)
+
+    def record(self, custom_changeset_id: uuid.UUID = None) -> uuid.UUID:
+        """
+        Starts a new recording and returns an id for the associated changeset
+        """
+        return self.journal.record_changeset(custom_changeset_id)
+
+    def discard(self, changeset_id: uuid.UUID) -> None:
+        """
+        Throws away all journaled data starting at the given changeset
+        """
+        self._validate_changeset(changeset_id)
+        self.journal.pop_changeset(changeset_id)
+
+    def commit(self, changeset_id: uuid.UUID) -> None:
+        """
+        Commits a given changeset. This merges the given changeset and all
+        subsequent changesets into the previous changeset giving precidence
+        to later changesets in case of any conflicting keys.
+        """
+        self._validate_changeset(changeset_id)
+        if changeset_id == self.journal.root_changeset_id:
+            raise ValidationError(
+                "Tried to commit the root changeset. Callers should not keep references "
+                "to the root changeset. Maybe you meant to use persist()?"
+            )
+        self.journal.commit_changeset(changeset_id)
+
+    def _reapply_changeset_to_journal(
+            self,
+            changeset_id: uuid.UUID,
+            journal_data: Dict[bytes, Union[bytes, DeletedEntry]]) -> None:
+        self.record(changeset_id)
+        for key, value in journal_data.items():
+            if value is DELETED_ENTRY:
+                self.journal.delete_wrapped(key)
+            elif value is ERASE_CREATED_ENTRY:
+                self.journal.delete_local(key)
+            else:
+                self.journal[key] = cast(bytes, value)
+
+    def persist(self) -> None:
+        """
+        Persist all changes in underlying db. After all changes have been written the
+        JournalDB starts a new recording.
+        """
+        root_changeset = self.journal.root_changeset_id
+        journal_data = self.journal.commit_changeset(root_changeset)
+
+        # Ensure the journal automatically restarts recording after
+        # it has been persisted to the underlying db
+        self.reset()
+
+        for key, value in journal_data.items():
+            try:
+                if value is DELETED_ENTRY:
+                    del self.wrapped_db[key]
+                elif value is ERASE_CREATED_ENTRY:
+                    pass
+                else:
+                    self.wrapped_db[key] = cast(bytes, value)
+            except Exception:
+                self._reapply_changeset_to_journal(root_changeset, journal_data)
+                raise
+
+    def flatten(self) -> None:
+        """
+        Commit everything possible without persisting
+        """
+        self.journal.flatten()
+
+    def reset(self) -> None:
+        """
+        Reset the entire journal.
+        """
+        self.journal = Journal()
+        self.record()
+
+    def diff(self) -> DBDiff:
+        """
+        Generate a DBDiff of all pending changes.
+        These are the changes that would occur if :meth:`persist()` were called.
+        """
+        return self.journal.diff()

--- a/eth/db/storage.py
+++ b/eth/db/storage.py
@@ -215,24 +215,24 @@ class AccountStorageDB:
         self._journal_storage.clear()
         self._storage_cache.reset_cache()
 
-    def record(self, changeset: JournalDBCheckpoint) -> None:
-        self._journal_storage.record(changeset)
+    def record(self, checkpoint: JournalDBCheckpoint) -> None:
+        self._journal_storage.record(checkpoint)
 
-    def discard(self, changeset: JournalDBCheckpoint) -> None:
-        self.logger.debug2('discard checkpoint %r', changeset)
-        if self._journal_storage.has_changeset(changeset):
-            self._journal_storage.discard(changeset)
+    def discard(self, checkpoint: JournalDBCheckpoint) -> None:
+        self.logger.debug2('discard checkpoint %r', checkpoint)
+        if self._journal_storage.has_checkpoint(checkpoint):
+            self._journal_storage.discard(checkpoint)
         else:
-            # if the changeset comes before this account started tracking,
+            # if the checkpoint comes before this account started tracking,
             #    then simply reset to the beginning
             self._journal_storage.reset()
         self._storage_cache.reset_cache()
 
-    def commit(self, changeset: JournalDBCheckpoint) -> None:
-        if self._journal_storage.has_changeset(changeset):
-            self._journal_storage.commit(changeset)
+    def commit(self, checkpoint: JournalDBCheckpoint) -> None:
+        if self._journal_storage.has_checkpoint(checkpoint):
+            self._journal_storage.commit(checkpoint)
         else:
-            # if the changeset comes before this account started tracking,
+            # if the checkpoint comes before this account started tracking,
             #    then flatten all changes, without persisting
             self._journal_storage.flatten()
 

--- a/eth/db/storage.py
+++ b/eth/db/storage.py
@@ -6,7 +6,6 @@ from typing import (  # noqa: F401
     Set,
     Tuple,
 )
-from uuid import UUID
 
 from eth_hash.auto import keccak
 from eth_typing import (
@@ -38,6 +37,9 @@ from eth.db.cache import (
 )
 from eth.db.journal import (
     JournalDB,
+)
+from eth.db.typing import (
+    JournalDBCheckpoint,
 )
 from eth.tools.logging import (
     ExtendedDebugLogger
@@ -213,10 +215,10 @@ class AccountStorageDB:
         self._journal_storage.clear()
         self._storage_cache.reset_cache()
 
-    def record(self, changeset: UUID) -> None:
+    def record(self, changeset: JournalDBCheckpoint) -> None:
         self._journal_storage.record(changeset)
 
-    def discard(self, changeset: UUID) -> None:
+    def discard(self, changeset: JournalDBCheckpoint) -> None:
         self.logger.debug2('discard checkpoint %r', changeset)
         if self._journal_storage.has_changeset(changeset):
             self._journal_storage.discard(changeset)
@@ -226,7 +228,7 @@ class AccountStorageDB:
             self._journal_storage.reset()
         self._storage_cache.reset_cache()
 
-    def commit(self, changeset: UUID) -> None:
+    def commit(self, changeset: JournalDBCheckpoint) -> None:
         if self._journal_storage.has_changeset(changeset):
             self._journal_storage.commit(changeset)
         else:

--- a/eth/db/typing.py
+++ b/eth/db/typing.py
@@ -1,0 +1,3 @@
+from typing import NewType
+
+JournalDBCheckpoint = NewType('JournalDBCheckpoint', int)

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -227,7 +227,7 @@ class BaseState(Configurable, ABC):
         Perform a full snapshot of the current state.
 
         Snapshots are a combination of the :attr:`~state_root` at the time of the
-        snapshot and the id of the changeset from the journaled DB.
+        snapshot and the checkpoint from the journaled DB.
         """
         return self.state_root, self._account_db.record()
 
@@ -245,7 +245,7 @@ class BaseState(Configurable, ABC):
     def commit(self, snapshot: Tuple[Hash32, UUID]) -> None:
         """
         Commit the journal to the point where the snapshot was taken.  This
-        will merge in any changesets that were recorded *after* the snapshot changeset.
+        merges in any changes that were recorded since the snapshot.
         """
         _, account_snapshot = snapshot
         self._account_db.commit(account_snapshot)

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -560,10 +560,7 @@ def test_journal_persist_set_KeyError_then_persist():
     assert b'failing-to-set-key' in memory_db
 
 
-def test_journal_db_diff_respects_clear():
-    memory_db = MemoryDB({})
-    journal_db = JournalDB(memory_db)
-
+def test_journal_db_diff_respects_clear(journal_db):
     journal_db[b'first'] = b'val'
     journal_db.clear()
 
@@ -571,10 +568,25 @@ def test_journal_db_diff_respects_clear():
     assert len(pending) == 0
 
 
-def test_journal_db_rejects_committing_root():
-    memory_db = MemoryDB({})
-    journal_db = JournalDB(memory_db)
-
+def test_journal_db_rejects_committing_root(journal_db):
     root = journal_db._journal.root_changeset_id
     with pytest.raises(ValidationError):
         journal_db.commit(root)
+
+
+def test_journal_db_commit_missing_changeset(journal_db):
+    checkpoint = journal_db.record()
+    journal_db.commit(checkpoint)
+
+    # checkpoint doesn't exist anymore
+    with pytest.raises(ValidationError):
+        journal_db.commit(checkpoint)
+
+
+def test_journal_db_discard_missing_changeset(journal_db):
+    checkpoint = journal_db.record()
+    journal_db.discard(checkpoint)
+
+    # checkpoint doesn't exist anymore
+    with pytest.raises(ValidationError):
+        journal_db.discard(checkpoint)


### PR DESCRIPTION
### What was wrong?

JournalDB was taking a lot of time to handle the checkpoint/rollback machinery. ~8.3% of the import block timing

Fixes #1775

### How was it fixed?

- Switch from uuid -> int checkpoints
- Switch underlying data structure to a single "latest" data, with dicts for rollback
- Use `__slots__` for faster attribute and method lookups
- Move some validation down from `JournalDB` into `Journal`, where it can often validate almost for free
- Some targeted in-lining
- Don't re-initialize `Journal`, just reset it, which enables...
- Pass through a couple method calls direct from `JournalDB` to `Journal`
(Unfortunately, the neat `@cached_property` trick doesn't work with slots, so this goes back to the `self.method = self.journal.method` approach)

So far, total time spent in journal dropped to 1.4% of the run.

This 6.9% speedup *seems* to be under-reporting the total speedup, which looks more like a 20% speedup based on eyeballing total runtime. But the variance is too high to really get a feel, so I'll use the more conservative number.

TODO
- [x] lint
- [x] some refactors
- [x] maybe some more low-hanging fruit
- [x] hypothesis test against old `JournalDB`
- [x] if ^ doesn't work, hunt down consensus failure manually
- [x] commit history cleanup

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://2ap93t1x1l6e2f6gfo3ag4vw.wpengine.netdna-cdn.com/wp-content/uploads/2014/12/Sea_lion-5.jpg)
