### PR TITLE
Exception with more context when trie data missing

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -771,8 +771,8 @@ class Chain(BaseChain):
         if block.is_genesis:
             raise ValidationError("Cannot validate genesis block this way")
         VM_class = self.get_vm_class_for_block_number(BlockNumber(block.number))
-        parent_block = self.get_block_by_hash(block.header.parent_hash)
-        VM_class.validate_header(block.header, parent_block.header, check_seal=True)
+        parent_header = self.get_block_header_by_hash(block.header.parent_hash)
+        VM_class.validate_header(block.header, parent_header, check_seal=True)
         self.validate_uncles(block)
         self.validate_gaslimit(block.header)
 

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -531,6 +531,7 @@ class AccountDB(BaseAccountDB):
             self._apply_account_diff_without_proof(diff, memory_trie)
 
         self._journalbatch.clear()
+        self._trie_cache.reset_cache()
 
         return self.state_root
 

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -17,6 +17,7 @@ from eth_typing import (
     Address,
     Hash32
 )
+
 from eth_utils import (
     encode_hex,
     to_checksum_address,
@@ -26,6 +27,7 @@ from eth_utils import (
 import rlp
 from trie import (
     HexaryTrie,
+    exceptions as trie_exceptions,
 )
 
 from eth.constants import (
@@ -33,6 +35,7 @@ from eth.constants import (
     EMPTY_SHA3,
 )
 from eth.db.backends.base import (
+    BaseDB,
     BaseAtomicDB,
 )
 from eth.db.batch import (
@@ -40,6 +43,9 @@ from eth.db.batch import (
 )
 from eth.db.cache import (
     CacheDB,
+)
+from eth.db.diff import (
+    DBDiff,
 )
 from eth.db.journal import (
     JournalDB,
@@ -49,6 +55,10 @@ from eth.db.storage import (
 )
 from eth.db.typing import (
     JournalDBCheckpoint,
+)
+from eth.vm.interrupt import (
+    MissingAccountTrieNode,
+    MissingBytecode,
 )
 from eth.rlp.accounts import (
     Account,
@@ -240,14 +250,16 @@ class AccountDB(BaseAccountDB):
         """
         self._raw_store_db = db
         self._batchdb = BatchDB(db)
-        self._batchtrie = BatchDB(db)
+        self._batchtrie = BatchDB(db, read_through_deletes=True)
         self._journaldb = JournalDB(self._batchdb)
         self._trie = HashTrie(HexaryTrie(self._batchtrie, state_root, prune=True))
         self._trie_cache = CacheDB(self._trie)
-        self._journaltrie = JournalDB(self._trie_cache)
+        self._journalbatch = BatchDB(self._trie_cache)
+        self._journaltrie = JournalDB(self._journalbatch)
         self._account_cache = LRU(2048)
         self._account_stores = {}  # type: Dict[Address, AccountStorageDB]
         self._dirty_accounts = set()  # type: Set[Address]
+        self._root_hash_at_last_persist = state_root
 
     @property
     def state_root(self) -> Hash32:
@@ -380,10 +392,14 @@ class AccountDB(BaseAccountDB):
     def get_code(self, address: Address) -> bytes:
         validate_canonical_address(address, title="Storage Address")
 
-        try:
-            return self._journaldb[self.get_code_hash(address)]
-        except KeyError:
-            return b""
+        code_hash = self.get_code_hash(address)
+        if code_hash == EMPTY_SHA3:
+            return b''
+        else:
+            try:
+                return self._journaldb[code_hash]
+            except KeyError:
+                raise MissingBytecode(code_hash) from KeyError
 
     def set_code(self, address: Address, code: bytes) -> None:
         validate_canonical_address(address, title="Storage Address")
@@ -424,7 +440,8 @@ class AccountDB(BaseAccountDB):
 
     def account_exists(self, address: Address) -> bool:
         validate_canonical_address(address, title="Storage Address")
-        return self._journaltrie.get(address, b'') != b''
+        account_rlp = self._get_encoded_account(address, from_journal=True)
+        return account_rlp != b''
 
     def touch_account(self, address: Address) -> None:
         validate_canonical_address(address, title="Storage Address")
@@ -438,10 +455,23 @@ class AccountDB(BaseAccountDB):
     #
     # Internal
     #
+    def _get_encoded_account(self, address: Address, from_journal: bool=True) -> bytes:
+        lookup_trie = self._journaltrie if from_journal else self._trie_cache
+
+        try:
+            return lookup_trie[address]
+        except trie_exceptions.MissingTrieNode as exc:
+            raise MissingAccountTrieNode(*exc.args) from exc
+        except KeyError:
+            # In case the account is deleted in the JournalDB
+            return b''
+
     def _get_account(self, address: Address, from_journal: bool=True) -> Account:
         if from_journal and address in self._account_cache:
             return self._account_cache[address]
-        rlp_account = (self._journaltrie if from_journal else self._trie_cache).get(address, b'')
+
+        rlp_account = self._get_encoded_account(address, from_journal)
+
         if rlp_account:
             account = rlp.decode(rlp_account, sedes=Account)
         else:
@@ -493,6 +523,15 @@ class AccountDB(BaseAccountDB):
 
         self._journaldb.persist()
         self._journaltrie.persist()
+
+        diff = self._journalbatch.diff()
+        # In addition to squashing (which is redundant here), this context manager causes
+        # an atomic commit of the changes, so exceptions will revert the trie
+        with self._trie.squash_changes() as memory_trie:
+            self._apply_account_diff_without_proof(diff, memory_trie)
+
+        self._journalbatch.clear()
+
         return self.state_root
 
     def persist(self) -> None:
@@ -520,9 +559,12 @@ class AccountDB(BaseAccountDB):
 
         # persist accounts
         self._validate_generated_root()
+        new_root_hash = self.state_root
+        self.logger.debug2("Persisting new state root: 0x%s", new_root_hash.hex())
         with self._raw_store_db.atomic_batch() as write_batch:
             self._batchtrie.commit_to(write_batch, apply_deletes=False)
             self._batchdb.commit_to(write_batch, apply_deletes=False)
+        self._root_hash_at_last_persist = new_root_hash
 
     def _validate_generated_root(self) -> None:
         db_diff = self._journaldb.diff()
@@ -556,3 +598,35 @@ class AccountDB(BaseAccountDB):
                 self.account_is_empty(cast_deleted_address),
                 self.account_exists(cast_deleted_address),
             )
+
+    def _apply_account_diff_without_proof(self, diff: DBDiff, trie: BaseDB) -> None:
+        """
+        Apply diff of trie updates, when original nodes might be missing.
+        Note that doing this naively will raise exceptions about missing nodes
+        from *intermediate* tries, which other clients do not maintain.
+        This application instead reorders updates to get nodes from the original trie.
+        """
+        deletions = diff.deleted_keys()
+        for index, delete_key in enumerate(deletions):
+            try:
+                del trie[delete_key]
+            except trie_exceptions.MissingTrieNode as exc:
+                self.logger.debug("Missing node on account index %d: %s", index, exc)
+                raise MissingAccountTrieNode(
+                    exc.missing_node_hash,
+                    self._root_hash_at_last_persist,
+                    exc.requested_key,
+                ) from exc
+
+        # AFAICT sets never have this problem at update time, because they are always
+        # retrieved by get first
+        for key, val in diff.pending_items():
+            try:
+                trie[key] = val
+            except trie_exceptions.MissingTrieNode as exc:
+                self.logger.warning("Missing node on account update (unexpected): %s", exc)
+                raise MissingAccountTrieNode(
+                    exc.missing_node_hash,
+                    self._root_hash_at_last_persist,
+                    exc.requested_key,
+                ) from exc

--- a/eth/db/diff.py
+++ b/eth/db/diff.py
@@ -199,7 +199,6 @@ class DBDiff(ABC_Mapping):
                     except EVMMissingData:
                         raise
                     except KeyError:
-                        # TODO stop silently swallowing this key error
                         pass
                 else:
                     pass

--- a/eth/db/diff.py
+++ b/eth/db/diff.py
@@ -17,6 +17,7 @@ from eth_utils import (
 )
 
 from eth.db.backends.base import BaseDB
+from eth.vm.interrupt import EVMMissingData
 
 if TYPE_CHECKING:
     ABC_Mutable_Mapping = MutableMapping[bytes, Union[bytes, 'MissingReason']]
@@ -195,7 +196,10 @@ class DBDiff(ABC_Mapping):
                 if apply_deletes:
                     try:
                         del db[key]
+                    except EVMMissingData:
+                        raise
                     except KeyError:
+                        # TODO stop silently swallowing this key error
                         pass
                 else:
                     pass

--- a/eth/db/hash_trie.py
+++ b/eth/db/hash_trie.py
@@ -1,4 +1,11 @@
+import contextlib
+from typing import (
+    cast,
+    Iterator,
+)
+
 from eth_hash.auto import keccak
+from trie import HexaryTrie
 
 from eth.db.keymap import (
     KeyMapDB,
@@ -7,3 +14,8 @@ from eth.db.keymap import (
 
 class HashTrie(KeyMapDB):
     keymap = keccak
+
+    @contextlib.contextmanager
+    def squash_changes(self) -> Iterator['HashTrie']:
+        with cast(HexaryTrie, self._db).squash_changes() as memory_trie:
+            yield type(self)(memory_trie)

--- a/eth/exceptions.py
+++ b/eth/exceptions.py
@@ -1,3 +1,6 @@
+from eth_typing import Hash32
+
+
 class PyEVMError(Exception):
     """
     Base class for all py-evm errors.
@@ -16,7 +19,9 @@ class StateRootNotFound(PyEVMError):
     """
     Raised when the requested state root is not present in our DB.
     """
-    pass
+    @property
+    def missing_state_root(self) -> Hash32:
+        return self.args[0]
 
 
 class HeaderNotFound(PyEVMError):

--- a/eth/rlp/headers.py
+++ b/eth/rlp/headers.py
@@ -144,9 +144,7 @@ class BlockHeader(rlp.Serializable):
             nonce=nonce,
         )
 
-    #TODO implement long repr in Serializeable (or is it already there??)
-    # implement this short version, too:
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return '<BlockHeader #{0} {1}>'.format(
             self.block_number,
             encode_hex(self.hash)[2:10],

--- a/eth/rlp/headers.py
+++ b/eth/rlp/headers.py
@@ -144,6 +144,8 @@ class BlockHeader(rlp.Serializable):
             nonce=nonce,
         )
 
+    #TODO implement long repr in Serializeable (or is it already there??)
+    # implement this short version, too:
     def __repr__(self) -> str:
         return '<BlockHeader #{0} {1}>'.format(
             self.block_number,

--- a/eth/vm/forks/frontier/validation.py
+++ b/eth/vm/forks/frontier/validation.py
@@ -18,7 +18,11 @@ def validate_frontier_transaction(state: BaseState,
 
     if sender_balance < gas_cost:
         raise ValidationError(
-            "Sender account balance cannot afford txn gas: `{0}`".format(transaction.sender)
+            "Sender {} cannot afford txn gas {} with account balance {}".format(
+                transaction.sender,
+                gas_cost,
+                sender_balance,
+            )
         )
 
     total_cost = transaction.value + gas_cost

--- a/eth/vm/interrupt.py
+++ b/eth/vm/interrupt.py
@@ -1,0 +1,118 @@
+from eth_typing import (
+    Address,
+    Hash32,
+)
+from eth_utils import (
+    encode_hex,
+)
+from trie.exceptions import (
+    MissingTrieNode,
+)
+
+from eth.exceptions import (
+    PyEVMError,
+)
+
+
+class EVMMissingData(PyEVMError):
+    pass
+
+
+class MissingAccountTrieNode(EVMMissingData, MissingTrieNode):
+    """
+    Raised when a storage trie node is missing from the DB
+    """
+    @property
+    def state_root_hash(self) -> Hash32:
+        return self.root_hash
+
+    @property
+    def address_hash(self) -> Hash32:
+        return self.requested_key
+
+    def __repr__(self) -> str:
+        return "MissingAccountTrieNode: {}".format(self)
+
+    def __str__(self) -> str:
+        superclass_str = EVMMissingData.__str__(self)
+        return (
+            "State trie database is missing node for hash {}, which is needed to look up account "
+            "with address hash {} at root hash {} -- {}".format(
+                encode_hex(self.missing_node_hash),
+                encode_hex(self.address_hash),
+                encode_hex(self.state_root_hash),
+                superclass_str,
+            )
+        )
+
+
+class MissingStorageTrieNode(EVMMissingData, MissingTrieNode):
+    """
+    Raised when a storage trie node is missing from the DB
+    """
+    def __init__(
+            self,
+            missing_node_hash: Hash32,
+            storage_root_hash: Hash32,
+            requested_key: Hash32,
+            account_address: Address,
+            *args: bytes) -> None:
+        if not isinstance(account_address, bytes):
+            raise TypeError("Account address must be bytes, was: %r" % account_address)
+
+        super().__init__(
+            missing_node_hash,
+            storage_root_hash,
+            requested_key,
+            account_address,
+            *args,
+        )
+
+    @property
+    def storage_root_hash(self) -> Hash32:
+        return self.root_hash
+
+    @property
+    def account_address(self) -> Address:
+        return self.args[3]
+
+    def __repr__(self) -> str:
+        return "MissingStorageTrieNode: {}".format(self)
+
+    def __str__(self) -> str:
+        superclass_str = EVMMissingData.__str__(self)
+        return (
+            "Storage trie database is missing hash {} needed to look up key {} "
+            "at root hash {} in account address {} -- {}".format(
+                encode_hex(self.missing_node_hash),
+                encode_hex(self.requested_key),
+                encode_hex(self.root_hash),
+                encode_hex(self.account_address),
+                superclass_str,
+            )
+        )
+
+
+class MissingBytecode(EVMMissingData):
+    """
+    Raised when the bytecode is missing from the database for a known bytecode hash.
+    """
+    def __init__(self, missing_code_hash: Hash32) -> None:
+        if not isinstance(missing_code_hash, bytes):
+            raise TypeError("Missing code hash must be bytes, was: %r" % missing_code_hash)
+
+        super().__init__(missing_code_hash)
+
+    @property
+    def missing_code_hash(self) -> Hash32:
+        return self.args[0]
+
+    def __repr__(self) -> str:
+        return "MissingBytecode: {}".format(self)
+
+    def __str__(self) -> str:
+        superclass_str = EVMMissingData.__str__(self)
+        return "Database is missing bytecode for code hash {} -- {}".format(
+            encode_hex(self.missing_code_hash),
+            superclass_str,
+        )

--- a/eth/vm/interrupt.py
+++ b/eth/vm/interrupt.py
@@ -20,7 +20,7 @@ class EVMMissingData(PyEVMError):
 
 class MissingAccountTrieNode(EVMMissingData, MissingTrieNode):
     """
-    Raised when a storage trie node is missing from the DB
+    Raised when a main state trie node is missing from the DB, to get an account RLP
     """
     @property
     def state_root_hash(self) -> Hash32:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ deps = {
         "py-ecc>=1.4.7,<2.0.0",
         "pyethash>=0.1.27,<1.0.0",
         "rlp>=1.1.0,<2.0.0",
-        "trie>=1.3.8,<2.0.0",
+        "trie>=1.4.0,<2.0.0",
     ],
     # The eth-extra sections is for libraries that the evm does not
     # explicitly need to function and hence should not depend on.

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -657,7 +657,10 @@ def test_sstore(vm_class, code, gas_used, refund, original):
 
     computation.state.set_balance(CANONICAL_ADDRESS_B, 100000000000)
     computation.state.set_storage(CANONICAL_ADDRESS_B, 0, original)
+    assert computation.state.get_storage(CANONICAL_ADDRESS_B, 0) == original
     computation.state.persist()
+    assert computation.state.get_storage(CANONICAL_ADDRESS_B, 0, from_journal=True) == original
+    assert computation.state.get_storage(CANONICAL_ADDRESS_B, 0, from_journal=False) == original
 
     comp = computation.apply_message()
     assert comp.get_gas_refund() == refund

--- a/tests/core/vm/test_interrupt.py
+++ b/tests/core/vm/test_interrupt.py
@@ -1,0 +1,145 @@
+import pytest
+
+from eth_hash.auto import keccak
+from eth_utils import (
+    int_to_big_endian,
+)
+
+from eth.vm.interrupt import (
+    MissingAccountTrieNode,
+    MissingBytecode,
+    MissingStorageTrieNode,
+)
+
+
+@pytest.fixture
+def address_with_balance():
+    return b'1' * 20
+
+
+@pytest.fixture
+def address_with_balance_hash(address_with_balance):
+    return keccak(address_with_balance)
+
+
+@pytest.fixture
+def balance():
+    return 10**18
+
+
+@pytest.fixture
+def address_with_bytecode():
+    return b'2' * 20
+
+
+@pytest.fixture
+def bytecode():
+    return b'aoeu'
+
+
+@pytest.fixture
+def bytecode_hash(bytecode):
+    return keccak(bytecode)
+
+
+@pytest.fixture
+def address_with_storage():
+    return b'3' * 20
+
+
+@pytest.fixture
+def address_with_storage_hash(address_with_storage):
+    return keccak(address_with_storage)
+
+
+@pytest.fixture
+def genesis_state(
+        address_with_balance,
+        balance,
+        address_with_bytecode,
+        bytecode,
+        address_with_storage):
+    return {
+        address_with_balance: {
+            'balance': balance,
+            'code': b'',
+            'nonce': 0,
+            'storage': {},
+        },
+        address_with_bytecode: {
+            'balance': 0,
+            'code': bytecode,
+            'nonce': 0,
+            'storage': {},
+        },
+        address_with_storage: {
+            'balance': 0,
+            'code': b'',
+            'nonce': 0,
+            'storage': {i: i for i in range(100)},
+        },
+    }
+
+
+@pytest.fixture
+def chain(chain_without_block_validation):
+    return chain_without_block_validation
+
+
+def test_bytecode_missing_interrupt(chain, bytecode, bytecode_hash, address_with_bytecode):
+    # confirm test setup
+    retrieved_bytecode = chain.get_vm().state.get_code(address_with_bytecode)
+    assert retrieved_bytecode == bytecode
+    assert bytecode == chain.chaindb.db[bytecode_hash]
+
+    # manually remove bytecode from database
+    del chain.chaindb.db[bytecode_hash]
+
+    with pytest.raises(MissingBytecode) as excinfo:
+        chain.get_vm().state.get_code(address_with_bytecode)
+
+    raised_exception = excinfo.value
+    assert raised_exception.missing_code_hash == bytecode_hash
+
+
+def test_account_missing_interrupt(chain, balance, address_with_balance, address_with_balance_hash):
+    # confirm test setup
+    retrieved_balance = chain.get_vm().state.get_balance(address_with_balance)
+    assert retrieved_balance == balance
+    expected_state_root = chain.get_vm().state.state_root
+
+    # manually remove trie node with account from database
+    # found by trie inspection:
+    node_hash = b"\n\x01TS\x99\x15\xc0\\\xf1\x1f\xfe\x91\xe59\xe9\xaev.\xac#'\xaf\x07)0\x16Y\xda\xdd\x81\xa8\xb3"  # noqa: E501
+    del chain.chaindb.db[node_hash]
+
+    with pytest.raises(MissingAccountTrieNode) as excinfo:
+        chain.get_vm().state.get_balance(address_with_balance)
+
+    raised_exception = excinfo.value
+    assert raised_exception.missing_node_hash == node_hash
+    assert raised_exception.state_root_hash == expected_state_root
+    assert raised_exception.address_hash == address_with_balance_hash
+
+
+def test_storage_missing_interrupt(chain, address_with_storage, address_with_storage_hash):
+    # confirm test setup
+    test_slot = 42
+    retrieved_storage_value = chain.get_vm().state.get_storage(address_with_storage, test_slot)
+    assert retrieved_storage_value == test_slot
+    expected_storage_root = chain.get_vm().state._account_db._get_storage_root(address_with_storage)
+    expected_slot_hash = keccak(int_to_big_endian(test_slot).rjust(32, b'\0'))
+
+    # manually remove trie node with account from database
+    # found by trie inspection:
+    node_hash = b'bG\\-\x92\xa3\xe4\xd4\xd1\xd5\xe4\xc0r\xbc\xae\x9f\x01\xe7\xdc\xcf\xe3\x96\x9c??+\xb2o\xd5J4\xed'  # noqa: E501
+    del chain.chaindb.db[node_hash]
+
+    with pytest.raises(MissingStorageTrieNode) as excinfo:
+        chain.get_vm().state.get_storage(address_with_storage, test_slot)
+
+    raised_exception = excinfo.value
+    assert raised_exception.missing_node_hash == node_hash
+    assert raised_exception.storage_root_hash == expected_storage_root
+    assert raised_exception.account_address == address_with_storage
+    assert raised_exception.requested_key == expected_slot_hash


### PR DESCRIPTION
### What was wrong?

Beam Sync involves intentionally executing transactions without the full state, including some state that might be necessary to execute. There are currently issues when we fail out of execution in the middle with `MissingTrieNode` (like leaving behind partial state). Also, Beam Sync is if we only learn about the one particular missing trie node. Including data about which account and storage slot are requested speeds things up considerably.

### How was it fixed?

- Add new exceptions in `eth.vm.interrupt`. They are intentionally not in `eth.exceptions` because they are aware of (and import from) other `eth` modules. These are full-blown classes with references back to data, rather than simple exceptions.
  - `MissingAccountTrieNode`
  - `MissingStorageTrieNode`
  - `MissingBytecode`
- Add `HashTrie.squash_changes()`, which proxies through to `HexaryTrie` (used for atomicity of trie update)
- Bonus minor optimization: only load parent header for validation, instead of full parent block
- More context about transaction failures due to being unable to afford gas
- More context about failures during PoW verification

TODO:
- [x] hunt down consensus error
- [x] drop state root from `MissingStorageTrieNode`, since `StorageLookup` no longer has access to `AccountDB`
- [x] pass the account address instead of the hash of the address, in the interrupt exceptions
- [x] ~~stop silently swallowing `KeyError` in `DBDiff`~~ issue #1779 
- [x] ~~add issue to rlp to have a default `rlp.Serializeable.__repr__` that does something reasonable~~ -- opened PR https://github.com/ethereum/pyrlp/pull/117
- [x] type annotations
- [x] test exceptions are raised with the expected values when a trie node is missing
- [x] squash
- [x] ~~document journal batch~~ *Removed it instead*
- [x] document and remove warning when handling `MissingTrieNode` due to adding a new account
- [x] remove TODO that's superseded by new issue
- [x] fix typo in MissingAccountTrieNode docs
- [ ] re-squash

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRPFPbDslQPfmOT2lh6pLkwrlGzTVyo1SDgabBFDC-MYcccsN0U)
