### PR TITLE
Drop python3.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,99 +40,6 @@ common: &common
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  py35-lint:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-lint
-  py36-lint:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-lint
-
-  py36-docs:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-docs
-
-  py35-native-blockchain-byzantium:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-native-blockchain-byzantium
-  py35-native-blockchain-constantinople:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-native-blockchain-constantinople
-  py35-native-blockchain-frontier:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-native-blockchain-frontier
-  py35-native-blockchain-homestead:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-native-blockchain-homestead
-  py35-native-blockchain-petersburg:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-native-blockchain-petersburg
-  py35-native-blockchain-tangerine_whistle:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-native-blockchain-tangerine_whistle
-  py35-native-blockchain-spurious_dragon:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-native-blockchain-spurious_dragon
-  py35-native-blockchain-transition:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-native-blockchain-transition
-  py35-vm:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-vm
-  py35-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-core
-  py35-transactions:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-transactions
-  py35-database:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-database
-
   py36-benchmark:
     <<: *common
     docker:
@@ -187,30 +94,42 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-native-blockchain-transition
-  py36-vm:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-vm
   py36-core:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-core
-  py36-transactions:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-transactions
   py36-database:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-database
+  py36-transactions:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-transactions
+  py36-vm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-vm
+  py36-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-lint
+  py36-docs:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-docs
 
   py37-core:
     <<: *common
@@ -218,15 +137,36 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py37-database:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-database
+  py37-transactions:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-transactions
+  py37-vm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-vm
+  py37-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-lint
 
 workflows:
   version: 2
   test:
     jobs:
-      - py37-core
-
-      - py36-docs
-
+      - py36-benchmark
       - py36-native-blockchain-byzantium
       - py36-native-blockchain-constantinople
       - py36-native-blockchain-frontier
@@ -236,23 +176,13 @@ workflows:
       - py36-native-blockchain-spurious_dragon
       - py36-native-blockchain-transition
       - py36-vm
-      - py36-benchmark
+      - py37-vm
       - py36-core
+      - py37-core
       - py36-transactions
+      - py37-transactions
       - py36-database
-
-      - py35-native-blockchain-byzantium
-      - py35-native-blockchain-constantinople
-      - py35-native-blockchain-frontier
-      - py35-native-blockchain-homestead
-      - py35-native-blockchain-petersburg
-      - py35-native-blockchain-tangerine_whistle
-      - py35-native-blockchain-spurious_dragon
-      - py35-native-blockchain-transition
-      - py35-vm
-      - py35-core
-      - py35-transactions
-      - py35-database
-
-      - py35-lint
+      - py37-database
+      - py36-docs
       - py36-lint
+      - py37-lint

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -181,7 +181,7 @@ texinfo_documents = [
 # -- Intersphinx configuration ------------------------------------------------
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.5', None),
+    'python': ('https://docs.python.org/3.6', None),
     'eth-typing': ('https://eth-typing.readthedocs.io/en/latest', None),
 }
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,7 @@
 warn_unused_ignores = True
 warn_unused_configs = True
 warn_redundant_casts = True
+; TODO: Drop ignore-missing-imports after adding type annotations for eth_utils, coincurve & cytoolz
 ignore_missing_imports = True
 strict_optional = False
 check_untyped_defs = True

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,8 +236,7 @@ def pytest_addoption(parser):
 
 @to_tuple
 def load_bytes_from_file(path):
-    # Using str(path) for python3.5 support of pathlib.Path
-    with open(str(path)) as f:
+    with open(path) as f:
         for line in f:
             if line.startswith('#'):
                 continue

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 envlist=
-    py{35,36}-{core,database,transactions,vm}
-    py{36}-{benchmark}
-    py{35,36}-native-blockchain-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,metropolis,transition}
-    py37-{core}
-    py{35,36}-lint
+    py{36,37}-{core,database,transactions,vm}
+    py36-benchmark
+    py36-native-blockchain-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,metropolis,transition}
+    py{36,37}-lint
     py36-docs
 
 [flake8]
@@ -31,13 +30,18 @@ commands=
     native-blockchain-petersburg: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork ConstantinopleFix}
     native-blockchain-metropolis: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Metropolis}
     native-blockchain-transition: pytest {posargs:tests/json-fixtures/test_blockchain.py -k BlockchainTests/TransitionTests}
+    lint: flake8 {toxinidir}/eth {toxinidir}/tests {toxinidir}/scripts
+    lint: mypy -p eth --config-file {toxinidir}/mypy.ini
 
-deps = .[eth-extra,test]
+deps =
+    .[eth-extra,test]
+    lint: .[eth,lint]
 
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
+setenv=
+    lint: MYPYPATH={toxinidir}:{toxinidir}/stubs
 
 
 [testenv:py36-docs]
@@ -55,26 +59,3 @@ commands=
 deps = .[eth-extra,benchmark]
 commands=
     benchmark: {toxinidir}/scripts/benchmark/run.py
-
-
-[common-lint]
-deps = .[eth,lint]
-setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
-commands=
-    flake8 {toxinidir}/eth
-    flake8 {toxinidir}/tests
-    # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
-    mypy -p eth --config-file {toxinidir}/mypy.ini
-
-[testenv:py35-lint]
-deps = {[common-lint]deps}
-setenv = {[common-lint]setenv}
-commands= {[common-lint]commands}
-
-
-[testenv:py36-lint]
-deps = {[common-lint]deps}
-setenv = {[common-lint]setenv}
-commands=
-    {[common-lint]commands}
-    flake8 {toxinidir}/scripts

--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,6 @@ deps =
 basepython =
     py36: python3.6
     py37: python3.7
-setenv=
-    lint: MYPYPATH={toxinidir}:{toxinidir}/stubs
 
 
 [testenv:py36-docs]


### PR DESCRIPTION
### What was wrong?

python3.5 prevents us from using f-strings, native `pathlib.Path()` objects in some places, type annotations, etc. python3.6+ should be available on enough targets, and the most important dependency (trinity) already requires 3.6+.

### How was it fixed?

- Dropped support from pypi classifiers
- Dropped 3.5 tests
- Some test reordering to aim to run the longest tests up-front (to minimize joint test time)
- Update docs links to point to python3.6
- Added py3.7 tests (not really related, just maintenance while touching CI)

### TODO

- [ ] add to release notes

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTelHqE_1QlRJPq6HmuYsJrlwI3g6oV3VohrfLM5cks6oEKwyKYBw)
