### PR TITLE
Expose and test petersburg_at and latest_mainnet_at

### DIFF
--- a/eth/tools/builder/chain/__init__.py
+++ b/eth/tools/builder/chain/__init__.py
@@ -23,6 +23,7 @@ from .builders import (  # noqa: F401
     spurious_dragon_at,
     tangerine_whistle_at,
     constantinople_at,
+    petersburg_at,
     istanbul_at,
 )
 
@@ -33,7 +34,7 @@ mainnet_fork_at_fns = (
     homestead_at,
     spurious_dragon_at,
     tangerine_whistle_at,
-    constantinople_at,
+    petersburg_at,
     istanbul_at,
 )
 

--- a/eth/tools/builder/chain/__init__.py
+++ b/eth/tools/builder/chain/__init__.py
@@ -25,6 +25,7 @@ from .builders import (  # noqa: F401
     constantinople_at,
     petersburg_at,
     istanbul_at,
+    latest_mainnet_at,
 )
 
 

--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -141,6 +141,7 @@ def fork_at(vm_class: Type[BaseVM], at_block: int, chain_class: Type[BaseChain])
     * :func:`~eth.tools.builder.chain.spurious_dragon_at`
     * :func:`~eth.tools.builder.chain.byzantium_at`
     * :func:`~eth.tools.builder.chain.constantinople_at`
+    * :func:`~eth.tools.builder.chain.petersburg_at`
     """
     if chain_class.vm_configuration is not None:
         base_configuration = chain_class.vm_configuration

--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -142,6 +142,8 @@ def fork_at(vm_class: Type[BaseVM], at_block: int, chain_class: Type[BaseChain])
     * :func:`~eth.tools.builder.chain.byzantium_at`
     * :func:`~eth.tools.builder.chain.constantinople_at`
     * :func:`~eth.tools.builder.chain.petersburg_at`
+    * :func:`~eth.tools.builder.chain.istanbul_at`
+    * :func:`~eth.tools.builder.chain.latest_mainnet_at` - whatever the latest mainnet VM is
     """
     if chain_class.vm_configuration is not None:
         base_configuration = chain_class.vm_configuration
@@ -234,6 +236,8 @@ byzantium_at = fork_at(ByzantiumVM)
 constantinople_at = fork_at(ConstantinopleVM)
 petersburg_at = fork_at(PetersburgVM)
 istanbul_at = fork_at(IstanbulVM)
+
+latest_mainnet_at = petersburg_at
 
 GENESIS_DEFAULTS = cast(
     Tuple[Tuple[str, Union[int, None, bytes, Address, Hash32]], ...],

--- a/tests/core/builder-tools/test_chain_construction.py
+++ b/tests/core/builder-tools/test_chain_construction.py
@@ -16,6 +16,7 @@ from eth.tools.builder.chain import (
     genesis,
     homestead_at,
     istanbul_at,
+    latest_mainnet_at,
     name,
     petersburg_at,
     spurious_dragon_at,
@@ -81,6 +82,7 @@ def test_chain_builder_construct_chain_vm_configuration_multiple_forks():
         (constantinople_at, ConstantinopleVM),
         (petersburg_at, PetersburgVM),
         (istanbul_at, IstanbulVM),
+        (latest_mainnet_at, PetersburgVM),  # this will change whenever the next upgrade is locked
     )
 )
 def test_chain_builder_construct_chain_fork_specific_helpers(fork_fn, vm_class):

--- a/tests/core/builder-tools/test_chain_construction.py
+++ b/tests/core/builder-tools/test_chain_construction.py
@@ -17,6 +17,7 @@ from eth.tools.builder.chain import (
     homestead_at,
     istanbul_at,
     name,
+    petersburg_at,
     spurious_dragon_at,
     tangerine_whistle_at,
 )
@@ -27,6 +28,7 @@ from eth.vm.forks import (
     SpuriousDragonVM,
     ByzantiumVM,
     ConstantinopleVM,
+    PetersburgVM,
     IstanbulVM,
 )
 
@@ -77,6 +79,7 @@ def test_chain_builder_construct_chain_vm_configuration_multiple_forks():
         (spurious_dragon_at, SpuriousDragonVM),
         (byzantium_at, ByzantiumVM),
         (constantinople_at, ConstantinopleVM),
+        (petersburg_at, PetersburgVM),
         (istanbul_at, IstanbulVM),
     )
 )

--- a/tests/core/vm/test_rewards.py
+++ b/tests/core/vm/test_rewards.py
@@ -20,6 +20,7 @@ from eth.tools.builder.chain import (
     spurious_dragon_at,
     tangerine_whistle_at,
     constantinople_at,
+    petersburg_at,
     genesis,
 )
 
@@ -33,6 +34,7 @@ from eth.tools.builder.chain import (
         (spurious_dragon_at, 15.15625, 4.375),
         (byzantium_at, 9.09375, 2.625),
         (constantinople_at, 6.0625, 1.75),
+        (petersburg_at, 6.0625, 1.75),
     )
 )
 def test_rewards(vm_fn, miner_1_balance, miner_2_balance):
@@ -130,6 +132,13 @@ def test_rewards(vm_fn, miner_1_balance, miner_2_balance):
         (constantinople_at, 6, 20.0625, 1.25),
         (constantinople_at, 7, 20.0625, 1.5),
         (constantinople_at, 8, 20.0625, 1.75),
+
+        (petersburg_at, 3, 20.0625, 0.5),
+        (petersburg_at, 4, 20.0625, 0.75),
+        (petersburg_at, 5, 20.0625, 1),
+        (petersburg_at, 6, 20.0625, 1.25),
+        (petersburg_at, 7, 20.0625, 1.5),
+        (petersburg_at, 8, 20.0625, 1.75),
     )
 )
 def test_rewards_uncle_created_at_different_generations(
@@ -192,6 +201,7 @@ def test_rewards_uncle_created_at_different_generations(
         spurious_dragon_at,
         byzantium_at,
         constantinople_at,
+        petersburg_at,
     )
 )
 def test_uncle_block_inclusion_validity(vm_fn):
@@ -237,6 +247,7 @@ def test_uncle_block_inclusion_validity(vm_fn):
         (tangerine_whistle_at, spurious_dragon_at, 50.15625, 1.25),
         (spurious_dragon_at, byzantium_at, 36.09375, 0.75),
         (byzantium_at, constantinople_at, 23.0625, 0.5),
+        (byzantium_at, petersburg_at, 23.0625, 0.5),
     )
 )
 def test_rewards_nephew_uncle_different_vm(


### PR DESCRIPTION
### What was wrong?

`petersburg_at` wasn't exposed in `eth.tools.builder.chain`.

No easy way to use the chain builder to always test the latest VM. (Every network upgrade would require updating the tests explicitly)

### How was it fixed?

Exposed `petersburg_at()` and `latest_mainnet_at()`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/szcykal2t19z.jpg)
