### PR TITLE
eth-keys shouldn't be allowed to minor bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ deps = {
     'eth': [
         "cached-property>=1.5.1,<2",
         "eth-bloom>=1.0.3,<2.0.0",
-        "eth-keys>=0.2.1,<1.0.0",
+        "eth-keys>=0.2.1,<0.3.0",
         "eth-typing>=2.0.0,<3.0.0",
         "eth-utils>=1.5.2,<2.0.0",
         "lru-dict>=1.1.6",


### PR DESCRIPTION
It's causing dependency conflicts with other libraries that are
requiring eth-keys <0.3 -- since semver allows breaking changes in minor
releases in a v0 major release, it makes more sense to constrain at the
minor version here.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/72/cf/f7/72cff7cbc84e2413e2f4e407d54611bb--bamboo-baby-pandas.jpg)
