### PR TITLE
Use python 3.6+ type annotations.

### DIFF
--- a/eth/_utils/datatypes.py
+++ b/eth/_utils/datatypes.py
@@ -95,7 +95,7 @@ class Configurable(object):
         sub_overrides_by_prop = _get_sub_overrides_by_prop(overrides)
 
         for key, sub_overrides in sub_overrides_by_prop.items():
-            sub_cls = None  # type: Configurable
+            sub_cls: Configurable = None
             if key in local_overrides:
                 sub_cls = local_overrides[key]
             elif hasattr(cls, key):

--- a/eth/_utils/env.py
+++ b/eth/_utils/env.py
@@ -5,10 +5,8 @@ extracting environment variables.
 
 import os
 
-from typing import (  # noqa: F401
+from typing import (
     Any,
-    Callable,
-    Dict,
     Iterable,
     List,
     Type,
@@ -222,7 +220,7 @@ def get(name: str,
     :param type: The type of variable expected.
     :param type: str or type
     """
-    fns = {
+    fns: Dict[Union[str, Type[Any]], Callable[..., Any]] = {
         'int': env_int,
         int: env_int,
 
@@ -237,7 +235,7 @@ def get(name: str,
 
         'list': env_list,
         list: env_list,
-    }  # type: Dict[Union[str, Type[Any]], Callable[..., Any]]
+    }
 
     fn = fns.get(type, env_string)
     return fn(name, default=default, required=required)

--- a/eth/_utils/env.py
+++ b/eth/_utils/env.py
@@ -7,6 +7,8 @@ import os
 
 from typing import (
     Any,
+    Callable,
+    Dict,
     Iterable,
     List,
     Type,

--- a/eth/_utils/generator.py
+++ b/eth/_utils/generator.py
@@ -1,9 +1,8 @@
 import itertools
-from typing import (  # noqa: F401
+from typing import (
     Generic,
     Iterable,
     Iterator,
-    List,
     TypeVar,
 )
 
@@ -13,7 +12,7 @@ TItem = TypeVar('TItem')
 
 class CachedIterable(Generic[TItem], Iterable[TItem]):
     def __init__(self, iterable: Iterable[TItem]) -> None:
-        self._cached_results = []  # type: List[TItem]
+        self._cached_results: List[TItem] = []
         self._iterator = iter(iterable)
 
     def __iter__(self) -> Iterator[TItem]:

--- a/eth/_utils/generator.py
+++ b/eth/_utils/generator.py
@@ -3,6 +3,7 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
+    List,
     TypeVar,
 )
 

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -6,22 +6,13 @@ from abc import (
 )
 import operator
 import random
-from typing import (  # noqa: F401
+from typing import (
     Any,
     Callable,
-    cast,
     Dict,
-    Generator,
     Iterable,
-    Iterator,
-    List,
-    Optional,
     Tuple,
     Type,
-    TYPE_CHECKING,
-    Union,
-    TypeVar,
-    Generic,
 )
 
 import logging
@@ -37,6 +28,10 @@ from eth_utils import (
 from eth_utils.toolz import (
     concatv,
     sliding_window,
+)
+
+from eth.vm.base import (
+    BaseVM,
 )
 
 from eth.constants import (
@@ -119,20 +114,15 @@ with catch_and_ignore_import_warning():
         take,
     )
 
-if TYPE_CHECKING:
-    from eth.vm.base import (     # noqa: F401
-        BaseVM,
-    )
-
 
 class BaseChain(Configurable, ABC):
     """
     The base class for all Chain objects
     """
-    chaindb = None  # type: BaseChainDB
-    chaindb_class = None  # type: Type[BaseChainDB]
-    vm_configuration = None  # type: Tuple[Tuple[int, Type[BaseVM]], ...]
-    chain_id = None  # type: int
+    chaindb: BaseChainDB = None
+    chaindb_class: Type[BaseChainDB] = None
+    vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...] = None
+    chain_id: int = None
 
     @abstractmethod
     def __init__(self) -> None:
@@ -372,9 +362,9 @@ class Chain(BaseChain):
     current block number.
     """
     logger = logging.getLogger("eth.chain.chain.Chain")
-    gas_estimator = None  # type: StaticMethod[Callable[[BaseState, BaseOrSpoofTransaction], int]]
+    gas_estimator: StaticMethod[Callable[[BaseState, BaseOrSpoofTransaction], int]] = None
 
-    chaindb_class = ChainDB  # type: Type[BaseChainDB]
+    chaindb_class: Type[BaseChainDB] = ChainDB
 
     def __init__(self, base_db: BaseAtomicDB) -> None:
         if not self.vm_configuration:
@@ -878,7 +868,7 @@ def _extract_uncle_hashes(blocks: Iterable[BaseBlock]) -> Iterable[Hash32]:
 
 
 class MiningChain(Chain):
-    header = None  # type: BlockHeader
+    header: BlockHeader = None
 
     def __init__(self, base_db: BaseAtomicDB, header: BlockHeader=None) -> None:
         super().__init__(base_db)

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -72,7 +72,7 @@ from eth.rlp.transactions import (
     BaseUnsignedTransaction,
 )
 
-from eth.typing import (  # noqa: F401
+from eth.typing import (
     AccountState,
     BaseOrSpoofTransaction,
     StaticMethod,
@@ -98,7 +98,7 @@ from eth.validation import (
     validate_vm_configuration,
 )
 from eth.vm.computation import BaseComputation
-from eth.vm.state import BaseState  # noqa: F401
+from eth.vm.state import BaseState
 
 from eth._warnings import catch_and_ignore_import_warning
 with catch_and_ignore_import_warning():

--- a/eth/chains/header.py
+++ b/eth/chains/header.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import (      # noqa: F401
-    Any,
+from typing import (
     cast,
-    Dict,
     Tuple,
     Type,
 )
@@ -28,14 +26,14 @@ from eth.vm.base import BaseVM  # noqa: F401
 
 
 class BaseHeaderChain(Configurable, ABC):
-    _base_db = None  # type: BaseDB
+    _base_db: BaseDB = None
 
-    _headerdb_class = None  # type: Type[BaseHeaderDB]
-    _headerdb = None  # type: BaseHeaderDB
+    _headerdb_class: Type[BaseHeaderDB] = None
+    _headerdb: BaseHeaderDB = None
 
-    header = None  # type: BlockHeader
-    chain_id = None  # type: int
-    vm_configuration = None  # type: Tuple[Tuple[int, Type[BaseVM]], ...]
+    header: BlockHeader = None
+    chain_id: int = None
+    vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...] = None
 
     @abstractmethod
     def __init__(self, base_db: BaseDB, header: BlockHeader=None) -> None:
@@ -89,7 +87,7 @@ class BaseHeaderChain(Configurable, ABC):
 
 
 class HeaderChain(BaseHeaderChain):
-    _headerdb_class = HeaderDB  # type: Type[BaseHeaderDB]
+    _headerdb_class: Type[BaseHeaderDB] = HeaderDB
 
     def __init__(self, base_db: BaseDB, header: BlockHeader=None) -> None:
         self.base_db = base_db

--- a/eth/chains/header.py
+++ b/eth/chains/header.py
@@ -14,7 +14,7 @@ from eth.db.backends.base import (
     BaseAtomicDB,
     BaseDB,
 )
-from eth.db.header import (  # noqa: F401
+from eth.db.header import (
     BaseHeaderDB,
     HeaderDB,
 )
@@ -22,7 +22,7 @@ from eth.rlp.headers import BlockHeader
 from eth._utils.datatypes import (
     Configurable,
 )
-from eth.vm.base import BaseVM  # noqa: F401
+from eth.vm.base import BaseVM
 
 
 class BaseHeaderChain(Configurable, ABC):

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -25,7 +25,7 @@ from eth.chains.base import (
     Chain,
 )
 from eth.rlp.headers import BlockHeader
-from eth.vm.base import BaseVM  # noqa: F401
+from eth.vm.base import BaseVM
 from eth.vm.forks import (
     ByzantiumVM,
     FrontierVM,

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -1,7 +1,6 @@
-from typing import (    # noqa: F401
+from typing import (
     Tuple,
     Type,
-    TypeVar,
 )
 
 from eth_utils import (
@@ -96,7 +95,7 @@ MAINNET_VM_CONFIGURATION = tuple(zip(MAINNET_FORK_BLOCKS, MAINNET_VMS))
 
 class BaseMainnetChain:
     chain_id = MAINNET_CHAIN_ID
-    vm_configuration = MAINNET_VM_CONFIGURATION  # type: Tuple[Tuple[int, Type[BaseVM]], ...]
+    vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...] = MAINNET_VM_CONFIGURATION
 
 
 class MainnetChain(BaseMainnetChain, Chain):

--- a/eth/chains/ropsten/__init__.py
+++ b/eth/chains/ropsten/__init__.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Type  # noqa: F401
+from typing import Tuple, Type
 from eth_utils import decode_hex
 
 from .constants import (
@@ -13,7 +13,7 @@ from eth import constants
 
 from eth.chains.base import Chain
 from eth.rlp.headers import BlockHeader
-from eth.vm.base import BaseVM  # noqa: F401
+from eth.vm.base import BaseVM
 from eth.vm.forks import (
     ByzantiumVM,
     ConstantinopleVM,

--- a/eth/chains/ropsten/__init__.py
+++ b/eth/chains/ropsten/__init__.py
@@ -34,8 +34,8 @@ ROPSTEN_VM_CONFIGURATION = (
 
 
 class BaseRopstenChain:
-    vm_configuration = ROPSTEN_VM_CONFIGURATION  # type: Tuple[Tuple[int, Type[BaseVM]], ...]  # noqa: E501
-    chain_id = ROPSTEN_CHAIN_ID  # type: int
+    vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...] = ROPSTEN_VM_CONFIGURATION
+    chain_id: int = ROPSTEN_CHAIN_ID
 
 
 class RopstenChain(BaseRopstenChain, Chain):

--- a/eth/chains/tester/__init__.py
+++ b/eth/chains/tester/__init__.py
@@ -134,7 +134,7 @@ def _generate_vm_configuration(*fork_start_blocks: ForkStartBlocks,
 
 
 class BaseMainnetTesterChain(Chain):
-    vm_configuration = _generate_vm_configuration()  # type: Tuple[Tuple[int, Type[BaseVM]], ...]
+    vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...] = _generate_vm_configuration()
 
 
 class MainnetTesterChain(BaseMainnetTesterChain):

--- a/eth/consensus/pow.py
+++ b/eth/consensus/pow.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import (  # noqa: F401
+from typing import (
     Tuple
 )
 

--- a/eth/consensus/pow.py
+++ b/eth/consensus/pow.py
@@ -1,7 +1,5 @@
 from collections import OrderedDict
 from typing import (  # noqa: F401
-    Dict,
-    List,
     Tuple
 )
 
@@ -31,7 +29,7 @@ from eth.validation import (
 
 
 # Type annotation here is to ensure we don't accidentally use strings instead of bytes.
-cache_by_epoch = OrderedDict()  # type: OrderedDict[int, bytearray]
+cache_by_epoch: 'OrderedDict[int, bytearray]' = OrderedDict()
 CACHE_MAX_ITEMS = 10
 
 

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -6,7 +6,9 @@ import logging
 from lru import LRU
 from typing import (
     cast,
+    Dict,
     Iterable,
+    Set,
     Tuple,
 )
 

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -4,11 +4,9 @@ from abc import (
 )
 import logging
 from lru import LRU
-from typing import (  # noqa: F401
+from typing import (
     cast,
-    Dict,
     Iterable,
-    Set,
     Tuple,
 )
 
@@ -256,8 +254,8 @@ class AccountDB(BaseAccountDB):
         self._trie_cache = CacheDB(self._trie)
         self._journaltrie = JournalDB(self._trie_cache)
         self._account_cache = LRU(2048)
-        self._account_stores = {}  # type: Dict[Address, AccountStorageDB]
-        self._dirty_accounts = set()  # type: Set[Address]
+        self._account_stores: Dict[Address, AccountStorageDB] = {}
+        self._dirty_accounts: Set[Address] = set()
         self._root_hash_at_last_persist = state_root
 
     @property

--- a/eth/db/atomic.py
+++ b/eth/db/atomic.py
@@ -25,8 +25,8 @@ class AtomicDB(BaseAtomicDB):
     """
     logger = logging.getLogger("eth.db.AtomicDB")
 
-    wrapped_db = None  # type: BaseDB
-    _track_diff = None  # type: DBDiffTracker
+    wrapped_db: BaseDB = None
+    _track_diff: DBDiffTracker = None
 
     def __init__(self, wrapped_db: BaseDB = None) -> None:
         if wrapped_db is None:
@@ -59,8 +59,8 @@ class AtomicDBWriteBatch(BaseDB):
     """
     logger = logging.getLogger("eth.db.AtomicDBWriteBatch")
 
-    _write_target_db = None  # type: BaseDB
-    _track_diff = None  # type: DBDiffTracker
+    _write_target_db: BaseDB = None
+    _track_diff: DBDiffTracker = None
 
     def __init__(self, write_target_db: BaseDB) -> None:
         self._write_target_db = write_target_db
@@ -120,7 +120,7 @@ class AtomicDBWriteBatch(BaseDB):
         Although this is technically an external API, it (and this whole class) is only intended
         to be used by AtomicDB.
         """
-        readable_write_batch = cls(write_target_db)     # type: AtomicDBWriteBatch
+        readable_write_batch: AtomicDBWriteBatch = cls(write_target_db)
         try:
             yield readable_write_batch
         except Exception:

--- a/eth/db/backends/memory.py
+++ b/eth/db/backends/memory.py
@@ -9,7 +9,7 @@ from .base import (
 
 
 class MemoryDB(BaseDB):
-    kv_store = None  # type: Dict[bytes, bytes]
+    kv_store: Dict[bytes, bytes] = None
 
     def __init__(self, kv_store: Dict[bytes, bytes] = None) -> None:
         if kv_store is None:

--- a/eth/db/batch.py
+++ b/eth/db/batch.py
@@ -23,8 +23,8 @@ class BatchDB(BaseDB):
     """
     logger = logging.getLogger("eth.db.BatchDB")
 
-    wrapped_db = None  # type: BaseDB
-    _track_diff = None  # type: DBDiffTracker
+    wrapped_db: BaseDB = None
+    _track_diff: DBDiffTracker = None
 
     def __init__(self, wrapped_db: BaseDB, read_through_deletes: bool = False) -> None:
         self.wrapped_db = wrapped_db

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Tuple,
     Type,
+    TYPE_CHECKING,
 )
 
 from eth_typing import (
@@ -55,6 +56,12 @@ with catch_and_ignore_import_warning():
         to_list,
         to_tuple,
         ValidationError,
+    )
+
+if TYPE_CHECKING:
+    from eth.rlp.blocks import (  # noqa: F401
+        BaseBlock,
+        BaseTransaction
     )
 
 

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -10,7 +10,6 @@ from typing import (
     List,
     Tuple,
     Type,
-    TYPE_CHECKING,
 )
 
 from eth_typing import (
@@ -58,12 +57,6 @@ with catch_and_ignore_import_warning():
         ValidationError,
     )
 
-if TYPE_CHECKING:
-    from eth.rlp.blocks import (  # noqa: F401
-        BaseBlock,
-        BaseTransaction
-    )
-
 
 class TransactionKey(rlp.Serializable):
     fields = [
@@ -73,7 +66,7 @@ class TransactionKey(rlp.Serializable):
 
 
 class BaseChainDB(BaseHeaderDB):
-    db = None  # type: BaseAtomicDB
+    db: BaseAtomicDB = None
 
     @abstractmethod
     def __init__(self, db: BaseAtomicDB) -> None:

--- a/eth/db/diff.py
+++ b/eth/db/diff.py
@@ -68,7 +68,7 @@ class DBDiffTracker(ABC_Mutable_Mapping):
     get the :class:`DBDiff` with :meth:`DBDiffTracker.diff` and use the attached methods.
     """
     def __init__(self) -> None:
-        self._changes = {}  # type: Dict[bytes, Union[bytes, MissingReason]]
+        self._changes: Dict[bytes, Union[bytes, MissingReason]] = {}
 
     def __contains__(self, key: bytes) -> bool:  # type: ignore # Breaks LSP
         result = self._changes.get(key, NEVER_INSERTED)
@@ -109,7 +109,7 @@ class DBDiff(ABC_Mapping):
     The primary usage is to apply these changes to your underlying
     database with :meth:`apply_to`.
     """
-    _changes = None  # type: Dict[bytes, Union[bytes, MissingReason]]
+    _changes: Dict[bytes, Union[bytes, MissingReason]] = None
 
     def __init__(self, changes: Dict[bytes, Union[bytes, MissingReason]] = None) -> None:
         if changes is None:

--- a/eth/db/header.py
+++ b/eth/db/header.py
@@ -42,7 +42,7 @@ from eth.validation import (
 
 
 class BaseHeaderDB(ABC):
-    db = None  # type: BaseAtomicDB
+    db: BaseAtomicDB = None
 
     def __init__(self, db: BaseAtomicDB) -> None:
         self.db = db

--- a/eth/db/journal.py
+++ b/eth/db/journal.py
@@ -2,7 +2,7 @@ import collections
 from itertools import (
     count,
 )
-from typing import Callable, cast, Dict, Union
+from typing import Callable, cast, Dict, List, Set, Union
 
 from eth_utils.toolz import (
     first,

--- a/eth/db/journal.py
+++ b/eth/db/journal.py
@@ -2,7 +2,7 @@ import collections
 from itertools import (
     count,
 )
-from typing import Callable, cast, Dict, List, Set, Union  # noqa: F401
+from typing import Callable, cast, Dict, Union
 
 from eth_utils.toolz import (
     first,
@@ -67,23 +67,23 @@ class Journal(BaseDB):
 
     def __init__(self) -> None:
         # If the journal was persisted right now, these would be the current changes to push:
-        self._current_values = {}  # type: ChangesetDict
+        self._current_values: ChangesetDict = {}
 
         # contains a mapping from all of the int checkpoints
         # to a dictionary of key:value pairs that are used to rewind from the current values
         # to the given checkpoint
-        self._journal_data = collections.OrderedDict()  # type: collections.OrderedDict[JournalDBCheckpoint, ChangesetDict]  # noqa E501
+        self._journal_data: collections.OrderedDict[JournalDBCheckpoint, ChangesetDict] = collections.OrderedDict()  # noqa E501
 
         # Clears are special operations that enforce that the underlying database and current
         # changes are completely emptied out. Clears are also committable & discardable.
-        self._clears_at = set()  # type: Set[JournalDBCheckpoint]
+        self._clears_at: Set[JournalDBCheckpoint] = set()
 
         # If a clear was called, then any missing keys should be treated as missing
         self._ignore_wrapped_db = False
 
         # To speed up commits, we leave in old recorded checkpoints in self._journal_data, even
         # on commit. Instead of dropping them, we keep a separate list of active checkpoints.
-        self._checkpoint_stack = []  # type: List[JournalDBCheckpoint]
+        self._checkpoint_stack: List[JournalDBCheckpoint] = []
 
     @property
     def root_checkpoint(self) -> JournalDBCheckpoint:

--- a/eth/db/slow_journal.py
+++ b/eth/db/slow_journal.py
@@ -1,5 +1,5 @@
 import collections
-from typing import cast, Dict, Set, Union  # noqa: F401
+from typing import cast, Dict, Union
 import uuid
 
 from eth_utils.toolz import (
@@ -45,8 +45,8 @@ class Journal(BaseDB):
         # contains a mapping from all of the `uuid4` changeset_ids
         # to a dictionary of key:value pairs with the recorded changes
         # that belong to the changeset
-        self.journal_data = collections.OrderedDict()  # type: collections.OrderedDict[uuid.UUID, Dict[bytes, Union[bytes, DeletedEntry]]]  # noqa E501
-        self._clears_at = set()  # type: Set[uuid.UUID]
+        self.journal_data: collections.OrderedDict[uuid.UUID, Dict[bytes, Union[bytes, DeletedEntry]]] = collections.OrderedDict()  # noqa E501
+        self._clears_at: Set[uuid.UUID] = set()
 
     @property
     def root_changeset_id(self) -> uuid.UUID:
@@ -234,7 +234,7 @@ class Journal(BaseDB):
 
     def diff(self) -> DBDiff:
         tracker = DBDiffTracker()
-        visited_keys = set()  # type: Set[bytes]
+        visited_keys: Set[bytes] = set()
 
         # Iterate in reverse, so you can skip over any keys from old checkpoints.
         # This is required so that when a key is created and then deleted in the journal,
@@ -279,7 +279,7 @@ class JournalDB(BaseDB):
     to track latest value for any given key within any given changeset.
     """
     wrapped_db = None
-    journal = None  # type: Journal
+    journal: Journal = None
 
     def __init__(self, wrapped_db: BaseDB) -> None:
         self.wrapped_db = wrapped_db

--- a/eth/db/slow_journal.py
+++ b/eth/db/slow_journal.py
@@ -1,5 +1,5 @@
 import collections
-from typing import cast, Dict, Union
+from typing import cast, Dict, Set, Union
 import uuid
 
 from eth_utils.toolz import (

--- a/eth/db/storage.py
+++ b/eth/db/storage.py
@@ -1,10 +1,6 @@
 import logging
-from typing import (  # noqa: F401
+from typing import (
     cast,
-    Dict,
-    Iterable,
-    Set,
-    Tuple,
 )
 
 from eth_hash.auto import keccak
@@ -63,7 +59,7 @@ class StorageLookup(BaseDB):
         self._starting_root_hash = storage_root
         self._address = address
         self._write_trie = None
-        self._trie_nodes_batch = None  # type: BatchDB
+        self._trie_nodes_batch: BatchDB = None
 
     def _get_write_trie(self) -> HexaryTrie:
         if self._trie_nodes_batch is None:

--- a/eth/db/trie.py
+++ b/eth/db/trie.py
@@ -28,7 +28,7 @@ def make_trie_root_and_nodes(items: TransactionsOrReceipts) -> TrieRootAndData:
 # use a relatively small cache size here.
 @functools.lru_cache(128)
 def _make_trie_root_and_nodes(items: Tuple[bytes, ...]) -> TrieRootAndData:
-    kv_store = {}  # type: Dict[Hash32, bytes]
+    kv_store: Dict[Hash32, bytes] = {}
     trie = HexaryTrie(kv_store, BLANK_ROOT_HASH)
     with trie.squash_changes() as memory_trie:
         for index, item in enumerate(items):

--- a/eth/rlp/blocks.py
+++ b/eth/rlp/blocks.py
@@ -23,7 +23,7 @@ from .headers import BlockHeader
 
 
 class BaseBlock(rlp.Serializable, Configurable, ABC):
-    transaction_class = None  # type: Type[BaseTransaction]
+    transaction_class: Type[BaseTransaction] = None
 
     @classmethod
     def get_transaction_class(cls) -> Type[BaseTransaction]:

--- a/eth/rlp/blocks.py
+++ b/eth/rlp/blocks.py
@@ -2,7 +2,7 @@ from abc import (
     ABC,
     abstractmethod
 )
-from typing import (  # noqa: F401
+from typing import (
     Type
 )
 

--- a/eth/tools/_utils/normalization.py
+++ b/eth/tools/_utils/normalization.py
@@ -516,7 +516,7 @@ def normalize_block_header(header: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def normalize_block(block: Dict[str, Any]) -> Dict[str, Any]:
-    normalized_block = {}  # type: Dict[str, Any]
+    normalized_block: Dict[str, Any] = {}
 
     try:
         normalized_block['rlp'] = decode_hex(block['rlp'])

--- a/eth/tools/_utils/slow_code_stream.py
+++ b/eth/tools/_utils/slow_code_stream.py
@@ -22,8 +22,8 @@ class SlowCodeStream(object):
     stream = None
     _length_cache = None
     _raw_code_bytes = None
-    invalid_positions = None  # type: Set[int]
-    valid_positions = None  # type: Set[int]
+    invalid_positions: Set[int] = None
+    valid_positions: Set[int] = None
 
     logger = logging.getLogger('eth.vm.SlowCodeStream')
 

--- a/eth/tools/_utils/slow_code_stream.py
+++ b/eth/tools/_utils/slow_code_stream.py
@@ -1,7 +1,7 @@
 import contextlib
 import io
 import logging
-from typing import (  # noqa: F401
+from typing import (
     Iterator,
     Set
 )

--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -373,7 +373,7 @@ def genesis(chain_class: BaseChain,
     and chain state.
     """
     if state is None:
-        genesis_state = {}  # type: AccountState
+        genesis_state: AccountState = {}
     else:
         genesis_state = _fill_and_normalize_state(state)
 
@@ -385,7 +385,7 @@ def genesis(chain_class: BaseChain,
         genesis_params = merge(genesis_params_defaults, params)
 
     if db is None:
-        base_db = AtomicDB()  # type: BaseAtomicDB
+        base_db: BaseAtomicDB = AtomicDB()
     else:
         base_db = db
 

--- a/eth/tools/fixtures/fillers/common.py
+++ b/eth/tools/fixtures/fillers/common.py
@@ -5,12 +5,10 @@ from functools import (
     partial,
     wraps,
 )
-from typing import (  # noqa: F401
+from typing import (
     Any,
     Callable,
     Dict,
-    List,
-    Sequence,
 )
 from eth_utils.toolz import (
     assoc,
@@ -68,7 +66,7 @@ DEFAULT_MAIN_ENVIRONMENT = {
 }
 
 
-DEFAULT_MAIN_TRANSACTION = {
+DEFAULT_MAIN_TRANSACTION: TransactionDict = {
     "data": b"",
     "gasLimit": 100000,
     "gasPrice": 0,
@@ -76,7 +74,7 @@ DEFAULT_MAIN_TRANSACTION = {
     "secretKey": decode_hex("0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"),
     "to": to_canonical_address("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6"),
     "value": 0
-}   # type: TransactionDict
+}
 
 
 def get_default_transaction(networks: Any) -> TransactionDict:
@@ -192,7 +190,7 @@ def _expect(post_state: Dict[str, Any],
 
     test_name = get_test_name(filler)
     test = filler[test_name]
-    test_update = {test_name: {}}  # type: Dict[str, Dict[Any, Any]]
+    test_update: Dict[str, Dict[Any, Any]] = {test_name: {}}
 
     pre_state = test.get("pre", {})
     post_state = normalize_state(post_state or {})

--- a/eth/tools/fixtures/fillers/state.py
+++ b/eth/tools/fixtures/fillers/state.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import (
     Any,
     Dict,
+    List,
 )
 
 from eth_utils import encode_hex

--- a/eth/tools/fixtures/fillers/state.py
+++ b/eth/tools/fixtures/fillers/state.py
@@ -1,9 +1,7 @@
 from collections import defaultdict
-from typing import (  # noqa: F401
+from typing import (
     Any,
     Dict,
-    List,
-    Sequence,
 )
 
 from eth_utils import encode_hex
@@ -69,7 +67,7 @@ def fill_state_test(filler: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     pre_state = normalize_state(test["pre"])
     transaction_group = normalize_transaction_group(test["transaction"])
 
-    post = defaultdict(list)  # type: Dict[int, List[Dict[str, str]]]
+    post: Dict[int, List[Dict[str, str]]] = defaultdict(list)
     for expect in test["expect"]:
         indexes = expect["indexes"]
         networks = normalize_networks(expect["networks"])

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -15,6 +15,8 @@ from typing import (
     Type,
 )
 
+from typing import Set
+
 from eth_hash.auto import keccak
 from eth_typing import (
     Address,
@@ -81,6 +83,7 @@ from eth.vm.computation import BaseComputation
 
 class BaseVM(Configurable, ABC):
     block_class: Type[BaseBlock] = None
+    fork: str = None  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
     chaindb: BaseChainDB = None  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
     _state_class: Type[BaseState] = None
 

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -39,7 +39,7 @@ from eth.db.backends.base import (
     BaseAtomicDB,
 )
 from eth.db.trie import make_trie_root_and_nodes
-from eth.db.chain import BaseChainDB  # noqa: F401
+from eth.db.chain import BaseChainDB
 from eth.exceptions import (
     HeaderNotFound,
 )
@@ -84,7 +84,7 @@ from eth.vm.computation import BaseComputation
 class BaseVM(Configurable, ABC):
     block_class: Type[BaseBlock] = None
     fork: str = None  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
-    chaindb: BaseChainDB = None  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
+    chaindb: BaseChainDB = None
     _state_class: Type[BaseState] = None
 
     @abstractmethod

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -14,7 +14,6 @@ from typing import (
     Tuple,
     Type,
 )
-from typing import Set  # noqa: F401
 
 from eth_hash.auto import keccak
 from eth_typing import (
@@ -81,11 +80,9 @@ from eth.vm.computation import BaseComputation
 
 
 class BaseVM(Configurable, ABC):
-    get_block = None  # type: BaseBlock
-    block_class = None  # type: Type[BaseBlock]
-    fork = None  # type: str
-    chaindb = None  # type: BaseChainDB
-    _state_class = None  # type: Type[BaseState]
+    block_class: Type[BaseBlock] = None
+    chaindb: BaseChainDB = None  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
+    _state_class: Type[BaseState] = None
 
     @abstractmethod
     def __init__(self, header: BlockHeader, chaindb: BaseChainDB) -> None:
@@ -816,7 +813,7 @@ class VM(BaseVM):
     #
     @classmethod
     def validate_receipt(cls, receipt: Receipt) -> None:
-        already_checked = set()  # type: Set[Hash32]
+        already_checked: Set[Hash32] = set()
 
         for log_idx, log in enumerate(receipt.logs):
             if log.address in already_checked:

--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -1,8 +1,7 @@
 import contextlib
 import logging
-from typing import (  # noqa: F401
+from typing import (
     Iterator,
-    Set
 )
 
 from eth.validation import (
@@ -26,8 +25,8 @@ class CodeStream:
         self.pc = 0
         self._raw_code_bytes = code_bytes
         self._length_cache = len(code_bytes)
-        self.invalid_positions = set()  # type: Set[int]
-        self.valid_positions = set()  # type: Set[int]
+        self.invalid_positions: Set[int] = set()
+        self.valid_positions: Set[int] = set()
 
     def read(self, size: int) -> bytes:
         old_pc = self.pc

--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -2,6 +2,7 @@ import contextlib
 import logging
 from typing import (
     Iterator,
+    Set
 )
 
 from eth.validation import (

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -4,7 +4,7 @@ from abc import (
 )
 import itertools
 import logging
-from typing import (  # noqa: F401
+from typing import (
     Any,
     Callable,
     cast,
@@ -62,7 +62,7 @@ from eth.vm.memory import (
 from eth.vm.message import (
     Message,
 )
-from eth.vm.opcode import (  # noqa: F401
+from eth.vm.opcode import (
     Opcode
 )
 from eth.vm.stack import (

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -203,18 +203,18 @@ class BaseComputation(Configurable, BaseStackManipulation, ABC):
 
     code = None
 
-    children = None  # type: List[BaseComputation]
+    children: List['BaseComputation'] = None
 
     _output = b''
     return_data = b''
-    _error = None  # type: VMError
+    _error: VMError = None
 
-    _log_entries = None  # type: List[Tuple[int, Address, Tuple[int, ...], bytes]]
-    accounts_to_delete = None  # type: Dict[Address, Address]
+    _log_entries: List[Tuple[int, Address, Tuple[int, ...], bytes]] = None
+    accounts_to_delete: Dict[Address, Address] = None
 
     # VM configuration
-    opcodes = None  # type: Dict[int, Any]
-    _precompiles = None  # type: Dict[Address, Callable[['BaseComputation'], 'BaseComputation']]
+    opcodes: Dict[int, Any] = None
+    _precompiles: Dict[Address, Callable[['BaseComputation'], 'BaseComputation']] = None
 
     logger = cast(ExtendedDebugLogger, logging.getLogger('eth.vm.computation.Computation'))
 

--- a/eth/vm/forks/byzantium/__init__.py
+++ b/eth/vm/forks/byzantium/__init__.py
@@ -1,4 +1,4 @@
-from typing import (  # noqa: F401
+from typing import (
     Type,
 )
 
@@ -16,7 +16,7 @@ from eth_utils import (
 from eth.constants import (
     MAX_UNCLE_DEPTH,
 )
-from eth.rlp.blocks import BaseBlock  # noqa: F401
+from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransaction
@@ -26,7 +26,7 @@ from eth.validation import (
 from eth.vm.forks.spurious_dragon import SpuriousDragonVM
 from eth.vm.forks.frontier import make_frontier_receipt
 from eth.vm.computation import BaseComputation
-from eth.vm.state import BaseState  # noqa: F401
+from eth.vm.state import BaseState
 
 from .blocks import ByzantiumBlock
 from .constants import (

--- a/eth/vm/forks/byzantium/__init__.py
+++ b/eth/vm/forks/byzantium/__init__.py
@@ -60,8 +60,8 @@ class ByzantiumVM(SpuriousDragonVM):
     fork = 'byzantium'
 
     # classes
-    block_class = ByzantiumBlock  # type: Type[BaseBlock]
-    _state_class = ByzantiumState  # type: Type[BaseState]
+    block_class: Type[BaseBlock] = ByzantiumBlock
+    _state_class: Type[BaseState] = ByzantiumState
 
     # Methods
     create_header_from_parent = staticmethod(create_byzantium_header_from_parent)   # type: ignore

--- a/eth/vm/forks/constantinople/__init__.py
+++ b/eth/vm/forks/constantinople/__init__.py
@@ -1,13 +1,13 @@
-from typing import (  # noqa: F401
+from typing import (
     Type,
 )
 
-from eth.rlp.blocks import BaseBlock  # noqa: F401
+from eth.rlp.blocks import BaseBlock
 from eth.vm.forks.byzantium import (
     ByzantiumVM,
     get_uncle_reward,
 )
-from eth.vm.state import BaseState  # noqa: F401
+from eth.vm.state import BaseState
 
 from .blocks import ConstantinopleBlock
 from .constants import EIP1234_BLOCK_REWARD

--- a/eth/vm/forks/constantinople/__init__.py
+++ b/eth/vm/forks/constantinople/__init__.py
@@ -24,8 +24,8 @@ class ConstantinopleVM(ByzantiumVM):
     fork = 'constantinople'
 
     # classes
-    block_class = ConstantinopleBlock  # type: Type[BaseBlock]
-    _state_class = ConstantinopleState  # type: Type[BaseState]
+    block_class: Type[BaseBlock] = ConstantinopleBlock
+    _state_class: Type[BaseState] = ConstantinopleState
 
     # Methods
     create_header_from_parent = staticmethod(create_constantinople_header_from_parent)  # type: ignore  # noqa: E501

--- a/eth/vm/forks/frontier/__init__.py
+++ b/eth/vm/forks/frontier/__init__.py
@@ -64,11 +64,11 @@ def make_frontier_receipt(base_header: BlockHeader,
 
 class FrontierVM(VM):
     # fork name
-    fork = 'frontier'  # type: str
+    fork: str = 'frontier'  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
 
     # classes
-    block_class = FrontierBlock  # type: Type[BaseBlock]
-    _state_class = FrontierState  # type: Type[BaseState]
+    block_class: Type[BaseBlock] = FrontierBlock
+    _state_class: Type[BaseState] = FrontierState
 
     # methods
     create_header_from_parent = staticmethod(create_frontier_header_from_parent)    # type: ignore

--- a/eth/vm/forks/frontier/__init__.py
+++ b/eth/vm/forks/frontier/__init__.py
@@ -1,4 +1,4 @@
-from typing import Type  # noqa: F401
+from typing import Type
 
 from eth_bloom import (
     BloomFilter,
@@ -10,7 +10,7 @@ from eth.constants import (
     ZERO_HASH32,
 )
 
-from eth.rlp.blocks import BaseBlock  # noqa: F401
+from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
 from eth.rlp.logs import Log
 from eth.rlp.receipts import Receipt
@@ -18,7 +18,7 @@ from eth.rlp.transactions import BaseTransaction
 
 from eth.vm.base import VM
 from eth.vm.computation import BaseComputation
-from eth.vm.state import BaseState  # noqa: F401
+from eth.vm.state import BaseState
 
 from .blocks import FrontierBlock
 from .state import FrontierState

--- a/eth/vm/forks/frontier/blocks.py
+++ b/eth/vm/forks/frontier/blocks.py
@@ -1,6 +1,5 @@
-from typing import (  # noqa: F401
+from typing import (
     Iterable,
-    List,
     Type,
 )
 
@@ -106,7 +105,7 @@ class FrontierBlock(BaseBlock):
         Returns the block denoted by the given block header.
         """
         if header.uncles_hash == EMPTY_UNCLE_HASH:
-            uncles = []  # type: List[BlockHeader]
+            uncles: List[BlockHeader] = []
         else:
             uncles = chaindb.get_block_uncles(header.uncles_hash)
 

--- a/eth/vm/forks/frontier/blocks.py
+++ b/eth/vm/forks/frontier/blocks.py
@@ -1,5 +1,6 @@
 from typing import (
     Iterable,
+    List,
     Type,
 )
 

--- a/eth/vm/forks/frontier/state.py
+++ b/eth/vm/forks/frontier/state.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from typing import Type, Union  # noqa: F401
 
 from eth_hash.auto import keccak
 from eth_utils import (
@@ -35,8 +34,7 @@ from eth.vm.state import (
 
 from .computation import FrontierComputation
 from .constants import REFUND_SELFDESTRUCT
-from .transaction_context import (  # noqa: F401
-    BaseTransactionContext,
+from .transaction_context import (
     FrontierTransactionContext
 )
 from .validation import validate_frontier_transaction
@@ -189,7 +187,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
 
 class FrontierState(BaseState):
     computation_class = FrontierComputation
-    transaction_context_class = FrontierTransactionContext  # type: Type[BaseTransactionContext]
+    transaction_context_class = FrontierTransactionContext  # Type[BaseTransactionContext]
     account_db_class = AccountDB  # Type[BaseAccountDB]
     transaction_executor = FrontierTransactionExecutor  # Type[BaseTransactionExecutor]
 

--- a/eth/vm/forks/homestead/__init__.py
+++ b/eth/vm/forks/homestead/__init__.py
@@ -1,6 +1,6 @@
-from typing import Optional, Type  # noqa: F401
-from eth.rlp.blocks import BaseBlock  # noqa: F401
-from eth.vm.state import BaseState  # noqa: F401
+from typing import Optional, Type
+from eth.rlp.blocks import BaseBlock
+from eth.vm.state import BaseState
 
 from eth_typing import BlockNumber
 

--- a/eth/vm/forks/homestead/__init__.py
+++ b/eth/vm/forks/homestead/__init__.py
@@ -17,7 +17,7 @@ from .state import HomesteadState
 
 class MetaHomesteadVM(FrontierVM):
     support_dao_fork = True
-    _dao_fork_block_number = None  # type: Optional[BlockNumber]
+    _dao_fork_block_number: Optional[BlockNumber] = None
 
     @classmethod
     def get_dao_fork_block_number(cls) -> BlockNumber:
@@ -28,11 +28,11 @@ class MetaHomesteadVM(FrontierVM):
 
 class HomesteadVM(MetaHomesteadVM):
     # fork name
-    fork = 'homestead'  # type: str
+    fork: str = 'homestead'  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
 
     # classes
-    block_class = HomesteadBlock  # type: Type[BaseBlock]
-    _state_class = HomesteadState  # type: Type[BaseState]
+    block_class: Type[BaseBlock] = HomesteadBlock
+    _state_class: Type[BaseState] = HomesteadState
 
     # method overrides
     create_header_from_parent = staticmethod(create_homestead_header_from_parent)   # type: ignore

--- a/eth/vm/forks/istanbul/__init__.py
+++ b/eth/vm/forks/istanbul/__init__.py
@@ -22,8 +22,8 @@ class IstanbulVM(ConstantinopleVM):
     fork = 'istanbul'
 
     # classes
-    block_class = IstanbulBlock  # type: Type[BaseBlock]
-    _state_class = IstanbulState  # type: Type[BaseState]
+    block_class: Type[BaseBlock] = IstanbulBlock
+    _state_class: Type[BaseState] = IstanbulState
 
     # Methods
     create_header_from_parent = staticmethod(create_istanbul_header_from_parent)  # type: ignore  # noqa: E501

--- a/eth/vm/forks/istanbul/__init__.py
+++ b/eth/vm/forks/istanbul/__init__.py
@@ -1,12 +1,12 @@
-from typing import (  # noqa: F401
+from typing import (
     Type,
 )
 
-from eth.rlp.blocks import BaseBlock  # noqa: F401
+from eth.rlp.blocks import BaseBlock
 from eth.vm.forks.constantinople import (
     ConstantinopleVM,
 )
-from eth.vm.state import BaseState  # noqa: F401
+from eth.vm.state import BaseState
 
 from .blocks import IstanbulBlock
 from .headers import (
@@ -26,6 +26,6 @@ class IstanbulVM(ConstantinopleVM):
     _state_class: Type[BaseState] = IstanbulState
 
     # Methods
-    create_header_from_parent = staticmethod(create_istanbul_header_from_parent)  # type: ignore  # noqa: E501
+    create_header_from_parent = staticmethod(create_istanbul_header_from_parent)  # type: ignore
     compute_difficulty = staticmethod(compute_istanbul_difficulty)    # type: ignore
     configure_header = configure_istanbul_header

--- a/eth/vm/forks/petersburg/__init__.py
+++ b/eth/vm/forks/petersburg/__init__.py
@@ -24,8 +24,8 @@ class PetersburgVM(ByzantiumVM):
     fork = 'petersburg'
 
     # classes
-    block_class = PetersburgBlock  # type: Type[BaseBlock]
-    _state_class = PetersburgState  # type: Type[BaseState]
+    block_class: Type[BaseBlock] = PetersburgBlock
+    _state_class: Type[BaseState] = PetersburgState
 
     # Methods
     create_header_from_parent = staticmethod(create_petersburg_header_from_parent)  # type: ignore  # noqa: E501

--- a/eth/vm/forks/petersburg/__init__.py
+++ b/eth/vm/forks/petersburg/__init__.py
@@ -1,13 +1,13 @@
-from typing import (  # noqa: F401
+from typing import (
     Type,
 )
 
-from eth.rlp.blocks import BaseBlock  # noqa: F401
+from eth.rlp.blocks import BaseBlock
 from eth.vm.forks.byzantium import (
     ByzantiumVM,
     get_uncle_reward,
 )
-from eth.vm.state import BaseState  # noqa: F401
+from eth.vm.state import BaseState
 
 from .blocks import PetersburgBlock
 from .constants import EIP1234_BLOCK_REWARD
@@ -28,7 +28,7 @@ class PetersburgVM(ByzantiumVM):
     _state_class: Type[BaseState] = PetersburgState
 
     # Methods
-    create_header_from_parent = staticmethod(create_petersburg_header_from_parent)  # type: ignore  # noqa: E501
+    create_header_from_parent = staticmethod(create_petersburg_header_from_parent)  # type: ignore
     compute_difficulty = staticmethod(compute_petersburg_difficulty)    # type: ignore
     configure_header = configure_petersburg_header
     get_uncle_reward = staticmethod(get_uncle_reward(EIP1234_BLOCK_REWARD))

--- a/eth/vm/forks/spurious_dragon/__init__.py
+++ b/eth/vm/forks/spurious_dragon/__init__.py
@@ -1,6 +1,6 @@
-from typing import Type  # noqa: F401
-from eth.rlp.blocks import BaseBlock  # noqa: F401
-from eth.vm.state import BaseState  # noqa: F401
+from typing import Type
+from eth.rlp.blocks import BaseBlock
+from eth.vm.state import BaseState
 
 from ..tangerine_whistle import TangerineWhistleVM
 

--- a/eth/vm/forks/spurious_dragon/__init__.py
+++ b/eth/vm/forks/spurious_dragon/__init__.py
@@ -10,8 +10,8 @@ from .state import SpuriousDragonState
 
 class SpuriousDragonVM(TangerineWhistleVM):
     # fork name
-    fork = 'spurious-dragon'  # type: str
+    fork: str = 'spurious-dragon'  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
 
     # classes
-    block_class = SpuriousDragonBlock  # type: Type[BaseBlock]
-    _state_class = SpuriousDragonState  # type: Type[BaseState]
+    block_class: Type[BaseBlock] = SpuriousDragonBlock
+    _state_class: Type[BaseState] = SpuriousDragonState

--- a/eth/vm/forks/tangerine_whistle/__init__.py
+++ b/eth/vm/forks/tangerine_whistle/__init__.py
@@ -8,10 +8,10 @@ from .state import TangerineWhistleState
 
 class TangerineWhistleVM(HomesteadVM):
     # fork name
-    fork = 'tangerine-whistle'  # type: str
+    fork: str = 'tangerine-whistle'  # noqa
 
     # classes
-    _state_class = TangerineWhistleState  # type: Type[BaseState]
+    _state_class: Type[BaseState] = TangerineWhistleState
 
     # Don't bother with any DAO logic in Tangerine VM or later
     # This is how we skip DAO logic on Ropsten, for example

--- a/eth/vm/forks/tangerine_whistle/__init__.py
+++ b/eth/vm/forks/tangerine_whistle/__init__.py
@@ -1,5 +1,5 @@
-from typing import Type  # noqa: F401
-from eth.vm.state import BaseState  # noqa: F401
+from typing import Type
+from eth.vm.state import BaseState
 
 from eth.vm.forks.homestead import HomesteadVM
 

--- a/eth/vm/gas_meter.py
+++ b/eth/vm/gas_meter.py
@@ -33,10 +33,10 @@ RefundStrategy = Callable[[int, int], int]
 
 class GasMeter(object):
 
-    start_gas = None  # type: int
+    start_gas: int = None
 
-    gas_refunded = None  # type: int
-    gas_remaining = None  # type: int
+    gas_refunded: int = None
+    gas_remaining: int = None
 
     logger = cast(ExtendedDebugLogger, logging.getLogger('eth.gas.GasMeter'))
 

--- a/eth/vm/logic/logging.py
+++ b/eth/vm/logic/logging.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import functools
-
+from typing import Tuple
 from eth import constants
 
 from eth.vm.computation import BaseComputation

--- a/eth/vm/logic/logging.py
+++ b/eth/vm/logic/logging.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import functools
-from typing import Tuple  # noqa: F401
 
 from eth import constants
 
@@ -14,7 +13,7 @@ def log_XX(computation: BaseComputation, topic_count: int) -> None:
     mem_start_position, size = computation.stack_pop_ints(2)
 
     if not topic_count:
-        topics = ()  # type: Tuple[int, ...]
+        topics: Tuple[int, ...] = ()
     elif topic_count > 1:
         topics = computation.stack_pop_ints(topic_count)
     else:

--- a/eth/vm/message.py
+++ b/eth/vm/message.py
@@ -43,7 +43,7 @@ class Message(object):
                  should_transfer_value: bool=True,
                  is_static: bool=False) -> None:
         validate_uint256(gas, title="Message.gas")
-        self.gas = gas  # type: int
+        self.gas: int = gas
 
         if to != CREATE_CONTRACT_ADDRESS:
             validate_canonical_address(to, title="Message.to")

--- a/eth/vm/opcode.py
+++ b/eth/vm/opcode.py
@@ -12,23 +12,18 @@ from typing import (
     cast,
     Type,
     TypeVar,
-    TYPE_CHECKING,
 )
 
 from eth.tools.logging import ExtendedDebugLogger
 
 from eth._utils.datatypes import Configurable
 
-if TYPE_CHECKING:
-    from computation import BaseComputation     # noqa: F401
-
-
 T = TypeVar('T')
 
 
 class Opcode(Configurable, ABC):
-    mnemonic = None  # type: str
-    gas_cost = None  # type: int
+    mnemonic: str = None
+    gas_cost: int = None
 
     def __init__(self) -> None:
         if self.mnemonic is None:

--- a/eth/vm/opcode.py
+++ b/eth/vm/opcode.py
@@ -12,11 +12,15 @@ from typing import (
     cast,
     Type,
     TypeVar,
+    TYPE_CHECKING,
 )
 
 from eth.tools.logging import ExtendedDebugLogger
 
 from eth._utils.datatypes import Configurable
+
+if TYPE_CHECKING:
+    from computation import BaseComputation  # noqa: F401
 
 T = TypeVar('T')
 

--- a/eth/vm/stack.py
+++ b/eth/vm/stack.py
@@ -14,13 +14,10 @@ from eth.validation import (
     validate_stack_int,
 )
 
-from typing import (  # noqa: F401
-    Generator,
-    List,
+from typing import (
     Tuple,
     Union
 )
-from eth_typing import Hash32  # noqa: F401
 
 
 def _busted_type(item_type: type, value: Union[int, bytes]) -> ValidationError:
@@ -48,7 +45,7 @@ class Stack(object):
     #
 
     def __init__(self) -> None:
-        values = []  # type: List[Tuple[type, Union[int, bytes]]]
+        values: List[Tuple[type, Union[int, bytes]]] = []
         self.values = values
         # caching optimizations to avoid an attribute lookup on self.values
         # This doesn't use `cached_property`, because it doesn't play nice with slots

--- a/eth/vm/stack.py
+++ b/eth/vm/stack.py
@@ -15,6 +15,7 @@ from eth.validation import (
 )
 
 from typing import (
+    List,
     Tuple,
     Union
 )

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -9,6 +9,7 @@ from typing import (
     Iterator,
     Tuple,
     Type,
+    TYPE_CHECKING,
 )
 from uuid import UUID
 
@@ -42,6 +43,17 @@ from eth.vm.execution_context import (
     ExecutionContext,
 )
 from eth.vm.message import Message
+
+if TYPE_CHECKING:
+    from eth.computation import (  # noqa: F401
+        BaseComputation,
+    )
+    from eth.rlp.transactions import (  # noqa: F401
+        BaseTransaction,
+    )
+    from eth.vm.transaction_context import (  # noqa: F401
+        BaseTransactionContext,
+    )
 
 
 class BaseState(Configurable, ABC):

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -4,14 +4,11 @@ from abc import (
 )
 import contextlib
 import logging
-from typing import (  # noqa: F401
+from typing import (
     cast,
-    Callable,
     Iterator,
     Tuple,
     Type,
-    TYPE_CHECKING,
-    Union,
 )
 from uuid import UUID
 
@@ -25,9 +22,8 @@ from eth.constants import (
     BLANK_ROOT_HASH,
     MAX_PREV_HEADER_DEPTH,
 )
-from eth.db.account import (  # noqa: F401
+from eth.db.account import (
     BaseAccountDB,
-    AccountDB,
 )
 from eth.db.backends.base import (
     BaseAtomicDB,
@@ -46,18 +42,6 @@ from eth.vm.execution_context import (
     ExecutionContext,
 )
 from eth.vm.message import Message
-
-if TYPE_CHECKING:
-    from eth.computation import (  # noqa: F401
-        BaseComputation,
-    )
-    from eth.rlp.transactions import (  # noqa: F401
-        BaseTransaction,
-    )
-
-    from eth.vm.transaction_context import (  # noqa: F401
-        BaseTransactionContext,
-    )
 
 
 class BaseState(Configurable, ABC):
@@ -81,10 +65,10 @@ class BaseState(Configurable, ABC):
     #
     __slots__ = ['_db', 'execution_context', '_account_db']
 
-    computation_class = None  # type: Type[BaseComputation]
-    transaction_context_class = None  # type: Type[BaseTransactionContext]
-    account_db_class = None  # type: Type[BaseAccountDB]
-    transaction_executor = None  # type: Type[BaseTransactionExecutor]
+    computation_class: Type['BaseComputation'] = None
+    transaction_context_class: Type['BaseTransactionContext'] = None
+    account_db_class: Type['BaseAccountDB'] = None
+    transaction_executor: Type['BaseTransactionExecutor'] = None
 
     def __init__(
             self,


### PR DESCRIPTION
### What was wrong?

Currently using python 3.5 annotations.

Fixes #1786 

### How was it fixed?
Replace all 3.5 annotation with new type annotations.

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/py-evm/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6551094/59620081-e1d18b80-9123-11e9-99f5-5ea059d8bf81.png)
