### PR TITLE
Improve layout of API docs

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -18,3 +18,46 @@ tt, code, pre {
   margin: 0;
   padding: 0;
 }
+
+/* We instruct sphinx to order members groupwise and use the following css to add headlines.
+Notice that while the css differentiates between methods, classmethods and staticmethods,
+unfortunately, sphinx groups these all alphabetically as methods which means we only
+display them as one "methods" group. */
+
+dl.attribute:before {
+  content: "Attributes";
+}
+
+dl.method:before,
+dl.classmethod:before,
+dl.staticmethod:before {
+  content: "Methods";
+}
+
+dl.method:before,
+dl.attribute:before,
+dl.classmethod:before,
+dl.staticmethod:before {
+  background: #e7f2fa;
+  border-top: solid 3px #6ab0de;
+  color: #000;
+  display: inline-block;
+  font-weight: bold;
+  margin: 5px 0 10px 0;
+  padding: 5px;
+}
+
+/* Remove method header if a previous element already introduced it */
+dl.attribute + dl.attribute:before,
+/* We have to treat all these as just "methods" (see comment further above) */
+dl.method + dl.method:before,
+dl.classmethod + dl.method:before,
+dl.staticmethod + dl.method:before,
+dl.method + dl.classmethod:before,
+dl.classmethod + dl.classmethod:before,
+dl.staticmethod + dl.classmethod:before,
+dl.method + dl.staticmethod:before,
+dl.staticmethod + dl.staticmethod:before,
+dl.classmethod + dl.staticmethod:before {
+  display: none;
+}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,20 @@
+tt, code, pre {
+    font-family: monospace, sans-serif;
+    font-size: 96.5%;
+}
+
+.rst-content dl:not(.docutils) tt.descname,
+.rst-content dl:not(.docutils) tt.descclassname,
+.rst-content dl:not(.docutils) tt.descname,
+.rst-content dl:not(.docutils) code.descname,
+.rst-content dl:not(.docutils) tt.descclassname,
+.rst-content dl:not(.docutils) code.descclassname {
+  font-size: 130% !important;
+}
+
+.rst-content dl:not(.docutils) dl dt {
+  background: #fff;
+  border: none;
+  margin: 0;
+  padding: 0;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,7 +114,10 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
+
+def setup(app):
+    app.add_stylesheet("css/custom.css")
 
 # Allows the mod index to function more helpfully (not everything under 'e')
 modindex_common_prefix = ['eth.']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,8 @@ autodoc_default_options = {
     'undoc-members': None,
 }
 
+autodoc_member_order = 'groupwise'
+autodoc_mock_imports = ["snappy"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/newsfragments/1797.doc.rst
+++ b/newsfragments/1797.doc.rst
@@ -1,1 +1,3 @@
 Tweak layout of API docs to improve readability
+
+Group API docs by member (methods, attributes)

--- a/newsfragments/1797.doc.rst
+++ b/newsfragments/1797.doc.rst
@@ -1,0 +1,1 @@
+Tweak layout of API docs to improve readability

--- a/newsfragments/794.doc.rst
+++ b/newsfragments/794.doc.rst
@@ -1,0 +1,3 @@
+In the API docs display class methods, static methods and methods as one group "methods".
+While we ideally wish to separate these, Sphinx keeps them all as one group which we'll
+be following until we find a better option.


### PR DESCRIPTION
### What was wrong?

This builds on top of #1796 to get the changes into the release notes, too.

Now

![image](https://user-images.githubusercontent.com/521109/61065549-33f48c80-a404-11e9-99c0-439b4d41b38c.png)


### How was it fixed?

Then:

![image](https://user-images.githubusercontent.com/521109/61065571-3fe04e80-a404-11e9-9692-3dcd04019084.png)


[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/py-evm/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.worldatlas.com/r/w728-h425-c728x425/upload/94/a8/65/arctic-fox.jpg)
