### PR TITLE
Py evm 1466

### DIFF
--- a/eth/vm/forks/spurious_dragon/constants.py
+++ b/eth/vm/forks/spurious_dragon/constants.py
@@ -10,4 +10,4 @@ GAS_EXPBYTE_EIP160 = 50
 
 
 # https://github.com/ethereum/EIPs/issues/170
-EIP170_CODE_SIZE_LIMIT = 24577
+EIP170_CODE_SIZE_LIMIT = 24576

--- a/tests/core/vm/test_spurious_dragon_computation.py
+++ b/tests/core/vm/test_spurious_dragon_computation.py
@@ -1,0 +1,85 @@
+import pytest
+
+from eth_utils import (
+    to_canonical_address,
+)
+
+from eth.vm.message import (
+    Message,
+)
+
+from eth.vm.forks.spurious_dragon.computation import (
+    SpuriousDragonComputation,
+)
+
+from eth.vm.transaction_context import (
+    BaseTransactionContext,
+)
+
+
+NORMALIZED_ADDRESS_A = "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6"
+NORMALIZED_ADDRESS_B = "0xcd1722f3947def4cf144679da39c4c32bdc35681"
+CANONICAL_ADDRESS_A = to_canonical_address("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6")
+CANONICAL_ADDRESS_B = to_canonical_address("0xcd1722f3947def4cf144679da39c4c32bdc35681")
+CONTRACT_CODE_A = b""
+CONTRACT_CODE_B = b""
+CONTRACT_CODE_C = b""
+
+
+@pytest.fixture
+def state(chain_without_block_validation):
+    state = chain_without_block_validation.get_vm().state
+    state.account_db.set_balance(CANONICAL_ADDRESS_A, 1000)
+    return state
+
+
+@pytest.fixture
+def transaction_context():
+    tx_context = BaseTransactionContext(
+        gas_price=1,
+        origin=CANONICAL_ADDRESS_B,
+    )
+    return tx_context
+
+
+def test_code_size_limit(transaction_context, state):
+    """
+    CONTRACT_CODE_A size is greater than EIP170_CODE_SIZE_LIMIT
+    """
+    message_contract_code_a = Message(
+        to=CANONICAL_ADDRESS_A,
+        sender=CANONICAL_ADDRESS_B,
+        value=100,
+        data=b'',
+        code=CONTRACT_CODE_A,
+        gas=100,
+    )
+    computation = SpuriousDragonComputation(
+        state=state,
+        message=message_contract_code_a,
+        transaction_context=transaction_context,
+    )
+
+    """
+    TODO: CONTRACT_CODE_B size is equal to EIP170_CODE_SIZE_LIMIT
+    """
+    message_contract_code_b = Message(
+        to=CANONICAL_ADDRESS_A,
+        sender=CANONICAL_ADDRESS_B,
+        value=100,
+        data=b'',
+        code=CONTRACT_CODE_B,
+        gas=100,
+    )
+
+    """
+    TODO: CONTRACT_CODE_C size is lower than EIP170_CODE_SIZE_LIMIT
+    """
+    message_contract_code_c = Message(
+        to=CANONICAL_ADDRESS_A,
+        sender=CANONICAL_ADDRESS_B,
+        value=100,
+        data=b'',
+        code=CONTRACT_CODE_C,
+        gas=100,
+    )

--- a/tests/core/vm/test_spurious_dragon_computation.py
+++ b/tests/core/vm/test_spurious_dragon_computation.py
@@ -1,85 +1,80 @@
-import pytest
+from unittest import mock
 
+import pytest
 from eth_utils import (
     to_canonical_address,
 )
 
-from eth.vm.message import (
-    Message,
+from eth import (
+    Chain,
 )
-
+from eth.vm.computation import (
+    BaseComputation,
+)
 from eth.vm.forks.spurious_dragon.computation import (
     SpuriousDragonComputation,
 )
-
+from eth.vm.forks.spurious_dragon.constants import (
+    EIP170_CODE_SIZE_LIMIT
+)
+from eth.vm.message import (
+    Message,
+)
 from eth.vm.transaction_context import (
     BaseTransactionContext,
 )
 
-
 NORMALIZED_ADDRESS_A = "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6"
 NORMALIZED_ADDRESS_B = "0xcd1722f3947def4cf144679da39c4c32bdc35681"
-CANONICAL_ADDRESS_A = to_canonical_address("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6")
-CANONICAL_ADDRESS_B = to_canonical_address("0xcd1722f3947def4cf144679da39c4c32bdc35681")
-CONTRACT_CODE_A = b""
-CONTRACT_CODE_B = b""
-CONTRACT_CODE_C = b""
+CANONICAL_ADDRESS_A = to_canonical_address(NORMALIZED_ADDRESS_A)
+CANONICAL_ADDRESS_B = to_canonical_address(NORMALIZED_ADDRESS_B)
 
 
 @pytest.fixture
-def state(chain_without_block_validation):
-    state = chain_without_block_validation.get_vm().state
-    state.account_db.set_balance(CANONICAL_ADDRESS_A, 1000)
-    return state
-
-
-@pytest.fixture
-def transaction_context():
-    tx_context = BaseTransactionContext(
-        gas_price=1,
-        origin=CANONICAL_ADDRESS_B,
-    )
-    return tx_context
-
-
-def test_code_size_limit(transaction_context, state):
-    """
-    CONTRACT_CODE_A size is greater than EIP170_CODE_SIZE_LIMIT
-    """
-    message_contract_code_a = Message(
-        to=CANONICAL_ADDRESS_A,
-        sender=CANONICAL_ADDRESS_B,
-        value=100,
+def make_computation():
+    message = Message(
+        to=CANONICAL_ADDRESS_B,
+        sender=CANONICAL_ADDRESS_A,
+        value=1,
         data=b'',
-        code=CONTRACT_CODE_A,
-        gas=100,
+        code=b'',
+        gas=5000000,
     )
-    computation = SpuriousDragonComputation(
-        state=state,
-        message=message_contract_code_a,
-        transaction_context=transaction_context,
-    )
+    transaction_context = BaseTransactionContext(gas_price=1, origin=CANONICAL_ADDRESS_B, )
 
-    """
-    TODO: CONTRACT_CODE_B size is equal to EIP170_CODE_SIZE_LIMIT
-    """
-    message_contract_code_b = Message(
-        to=CANONICAL_ADDRESS_A,
-        sender=CANONICAL_ADDRESS_B,
-        value=100,
-        data=b'',
-        code=CONTRACT_CODE_B,
-        gas=100,
-    )
+    def _make_computation(chain) -> BaseComputation:
+        state = chain.get_vm().state
+        state.account_db.set_balance(CANONICAL_ADDRESS_A, 1000)
+        computation = SpuriousDragonComputation(
+            state=state,
+            message=message,
+            transaction_context=transaction_context,
+        )
 
-    """
-    TODO: CONTRACT_CODE_C size is lower than EIP170_CODE_SIZE_LIMIT
-    """
-    message_contract_code_c = Message(
-        to=CANONICAL_ADDRESS_A,
-        sender=CANONICAL_ADDRESS_B,
-        value=100,
-        data=b'',
-        code=CONTRACT_CODE_C,
-        gas=100,
-    )
+        return computation
+
+    return _make_computation
+
+
+@pytest.mark.parametrize('chain_without_block_validation', [Chain, ], indirect=True)
+@pytest.mark.parametrize(
+    'computation_output',
+    [
+        b'\x00' * (EIP170_CODE_SIZE_LIMIT + 1),
+        b'\x00' * EIP170_CODE_SIZE_LIMIT,
+        b'\x00' * (EIP170_CODE_SIZE_LIMIT - 1),
+    ]
+)
+def test_computation_output_size_limit(chain_without_block_validation,
+                                       make_computation,
+                                       computation_output):
+    computation: BaseComputation = make_computation(chain_without_block_validation)
+    computation.output = computation_output
+
+    with mock.patch.object(SpuriousDragonComputation, 'apply_message', return_value=computation):
+        computation.apply_create_message()
+
+        if len(computation_output) >= EIP170_CODE_SIZE_LIMIT:
+            assert computation.is_error
+        else:
+            assert not computation.is_error


### PR DESCRIPTION
### What was wrong?

EIP170 states that the contract size limit was changed to 2**14 + 2**13 which is 24,576 bytes. The following line implementations the constant for EIP170, but it is off by one.

Issue Reference: #1466

### How was it fixed?
Contract limit size was changed by @glaksmono, I have improved the tests 
- Update the contract limit size to follow EIP170
- Add tests against the contract size limit

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i2.wp.com/bestlifeonline.com/wp-content/uploads/2018/10/red-panda-raising-fist.jpg?fit=500%2C333&ssl=1)
