### PR TITLE
WIP: Add the concept of incompatible schemas

### DIFF
--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -75,10 +75,6 @@ class TransactionKey(rlp.Serializable):
 class BaseChainDB(BaseHeaderDB):
     db: BaseAtomicDB = None
 
-    @abstractmethod
-    def __init__(self, db: BaseAtomicDB) -> None:
-        raise NotImplementedError("ChainDB classes must implement this method")
-
     #
     # Header API
     #
@@ -166,9 +162,6 @@ class BaseChainDB(BaseHeaderDB):
 
 
 class ChainDB(HeaderDB, BaseChainDB):
-    def __init__(self, db: BaseAtomicDB) -> None:
-        self.db = db
-
     #
     # Header API
     #

--- a/eth/db/header.py
+++ b/eth/db/header.py
@@ -33,7 +33,7 @@ from eth.db.backends.base import (
     BaseAtomicDB,
     BaseDB,
 )
-from eth.db.schema import SchemaV1
+from eth.db.schema import SchemaV1, Schemas, ensure_schema
 from eth.rlp.headers import BlockHeader
 from eth.validation import (
     validate_block_number,
@@ -44,8 +44,12 @@ from eth.validation import (
 class BaseHeaderDB(ABC):
     db: BaseAtomicDB = None
 
-    def __init__(self, db: BaseAtomicDB) -> None:
+    def __init__(self, db: BaseAtomicDB,
+                 expected_schema: Schemas = Schemas.DEFAULT) -> None:
         self.db = db
+        self.schema = expected_schema
+
+        ensure_schema(db, expected_schema)
 
     #
     # Canonical Chain API

--- a/eth/exceptions.py
+++ b/eth/exceptions.py
@@ -8,6 +8,18 @@ class PyEVMError(Exception):
     pass
 
 
+class SchemaNotRecognizedError(PyEVMError):
+    """
+    The database uses a schema which this version of py-evm does not support.
+    """
+
+
+class SchemaDoesNotMatchError(PyEVMError):
+    """
+    The database schema does not match the expected schema. It might need to be migrated.
+    """
+
+
 class VMNotFound(PyEVMError):
     """
     Raised when no VM is available for the provided block number.

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -29,6 +29,7 @@ from eth.db.account import (
 from eth.db.backends.base import (
     BaseAtomicDB,
 )
+from eth.db.schema import ensure_schema, Schemas
 from eth.exceptions import StateRootNotFound
 from eth.tools.logging import (
     ExtendedDebugLogger,
@@ -86,10 +87,13 @@ class BaseState(Configurable, ABC):
             self,
             db: BaseAtomicDB,
             execution_context: ExecutionContext,
-            state_root: bytes) -> None:
+            state_root: bytes,
+            expected_schema: Schemas = Schemas.DEFAULT) -> None:
         self._db = db
         self.execution_context = execution_context
         self._account_db = self.get_account_db_class()(db, state_root)
+
+        ensure_schema(db, expected_schema)
 
     #
     # Logging


### PR DESCRIPTION
### What was wrong?

As part of https://github.com/ethereum/trinity/issues/779 py-evm will soon have to support reading and writing databases with a different schema, if the code ever tries to use a database of the wrong kind it might accidentally corrupt it. To prevent that from happening some checks are added which assert that the database is of the expected kind.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
