### PR TITLE
Fix typing of eth.db.base.BaseAtomicDB.atomic_batch

### DIFF
--- a/eth/db/backends/base.py
+++ b/eth/db/backends/base.py
@@ -2,23 +2,15 @@ from abc import (
     ABC,
     abstractmethod
 )
-from collections.abc import (
+
+from typing import (
+    ContextManager,
+    Iterator,
     MutableMapping,
 )
 
-from typing import (
-    Any,
-    Iterator,
-    TYPE_CHECKING,
-)
 
-if TYPE_CHECKING:
-    MM = MutableMapping[bytes, bytes]
-else:
-    MM = MutableMapping
-
-
-class BaseDB(MM, ABC):
+class BaseDB(MutableMapping[bytes, bytes], ABC):
     """
     This is an abstract key/value lookup with all :class:`bytes` values,
     with some convenience methods for databases. As much as possible,
@@ -92,5 +84,5 @@ class BaseAtomicDB(BaseDB):
             # or neither will
     """
     @abstractmethod
-    def atomic_batch(self) -> Any:
+    def atomic_batch(self) -> ContextManager[BaseDB]:
         raise NotImplementedError

--- a/newsfragments/1804.bugfix.rst
+++ b/newsfragments/1804.bugfix.rst
@@ -1,0 +1,1 @@
+Fix typing for ``eth.db.base.BaseAtomicDB.atomic_batch`` method to have more specific type than ``Any``.  Now is specified as returning a ``ContextManager[BaseDB]``.


### PR DESCRIPTION
### What was wrong?

The `eth.db.base.BaseAtomicDB.atomic_batch` method was typed as returning `Any`.

### How was it fixed?

Fixed to return the proper `ContextManager[BaseDB]` type.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
