### PR TITLE
Implement eth.abc module with abstract base classes for public APIs

### DIFF
--- a/docs/api/api.abc.rst
+++ b/docs/api/api.abc.rst
@@ -1,0 +1,227 @@
+ABC
+===
+
+Abstract base classes for documented interfaces
+
+MiningHeaderAPI
+---------------
+
+.. autoclass:: eth.abc.MiningHeaderAPI
+  :members:
+
+
+BlockHeaderAPI
+--------------
+
+.. autoclass:: eth.abc.BlockHeaderAPI
+  :members:
+
+
+LogAPI
+------
+
+.. autoclass:: eth.abc.LogAPI
+  :members:
+
+
+ReceiptAPI
+----------
+
+.. autoclass:: eth.abc.ReceiptAPI
+  :members:
+
+
+BaseTransactionAPI
+------------------
+
+.. autoclass:: eth.abc.BaseTransactionAPI
+  :members:
+
+
+TransactionFieldsAPI
+--------------------
+
+.. autoclass:: eth.abc.TransactionFieldsAPI
+  :members:
+
+
+UnsignedTransactionAPI
+----------------------
+
+.. autoclass:: eth.abc.UnsignedTransactionAPI
+  :members:
+
+
+SignedTransactionAPI
+--------------------
+
+.. autoclass:: eth.abc.SignedTransactionAPI
+  :members:
+
+
+BlockAPI
+--------
+
+.. autoclass:: eth.abc.BlockAPI
+  :members:
+
+
+DatabaseAPI
+-----------
+
+.. autoclass:: eth.abc.DatabaseAPI
+  :members:
+
+
+AtomicDatabaseAPI
+-----------------
+
+.. autoclass:: eth.abc.AtomicDatabaseAPI
+  :members:
+
+
+HeaderDatabaseAPI
+-----------------
+
+.. autoclass:: eth.abc.HeaderDatabaseAPI
+  :members:
+
+
+ChainDatabaseAPI
+----------------
+
+.. autoclass:: eth.abc.ChainDatabaseAPI
+  :members:
+
+
+GasMeterAPI
+-----------
+
+.. autoclass:: eth.abc.GasMeterAPI
+  :members:
+
+
+MessageAPI
+----------
+
+.. autoclass:: eth.abc.MessageAPI
+  :members:
+
+
+OpcodeAPI
+---------
+
+.. autoclass:: eth.abc.OpcodeAPI
+  :members:
+
+
+TransactionContextAPI
+---------------------
+
+.. autoclass:: eth.abc.TransactionContextAPI
+  :members:
+
+
+MemoryAPI
+---------
+
+.. autoclass:: eth.abc.MemoryAPI
+  :members:
+
+
+StackAPI
+--------
+
+.. autoclass:: eth.abc.StackAPI
+  :members:
+
+
+CodeStreamAPI
+-------------
+
+.. autoclass:: eth.abc.CodeStreamAPI
+  :members:
+
+
+StackManipulationAPI
+--------------------
+
+.. autoclass:: eth.abc.StackManipulationAPI
+  :members:
+
+
+ExecutionContextAPI
+-------------------
+
+.. autoclass:: eth.abc.ExecutionContextAPI
+  :members:
+
+
+ComputationAPI
+--------------
+
+.. autoclass:: eth.abc.ComputationAPI
+  :members:
+
+
+AccountStorageDatabaseAPI
+-------------------------
+
+.. autoclass:: eth.abc.AccountStorageDatabaseAPI
+  :members:
+
+
+AccountDatabaseAPI
+------------------
+
+.. autoclass:: eth.abc.AccountDatabaseAPI
+  :members:
+
+
+TransactionExecutorAPI
+----------------------
+
+.. autoclass:: eth.abc.TransactionExecutorAPI
+  :members:
+
+
+ConfigurableAPI
+---------------
+
+.. autoclass:: eth.abc.ConfigurableAPI
+  :members:
+
+
+StateAPI
+--------
+
+.. autoclass:: eth.abc.StateAPI
+  :members:
+
+
+VirtualMachineAPI
+-----------------
+
+.. autoclass:: eth.abc.VirtualMachineAPI
+  :members:
+
+
+HeaderChainAPI
+--------------
+
+.. autoclass:: eth.abc.HeaderChainAPI
+  :members:
+
+
+ChainAPI
+--------
+
+.. autoclass:: eth.abc.ChainAPI
+  :members:
+
+
+MiningChainAPI
+--------------
+
+.. autoclass:: eth.abc.MiningChainAPI
+  :members:

--- a/docs/api/db/api.db.account.rst
+++ b/docs/api/db/api.db.account.rst
@@ -1,12 +1,6 @@
 Account
 ========
 
-BaseAccountDB
--------------
-
-.. autoclass:: eth.db.account.BaseAccountDB
-  :members:
-
 AccountDB
 -------------
 

--- a/docs/api/db/api.db.chain.rst
+++ b/docs/api/db/api.db.chain.rst
@@ -1,12 +1,6 @@
 Chain
 =====
 
-BaseChainDB
-~~~~~~~~~~~
-
-.. autoclass:: eth.db.chain.BaseChainDB
-  :members:
-
 ChainDB
 ~~~~~~~
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -12,6 +12,7 @@ This section aims to provide a detailed description of all APIs. If you are look
    :name: toc-api-eth
 
    
+   api.abc
    api.chain
    api.db
    api.exceptions

--- a/docs/api/vm/api.vm.vm.rst
+++ b/docs/api/vm/api.vm.vm.rst
@@ -1,13 +1,6 @@
 VM
 ==
 
-BaseVM
-------
-
-.. autoclass:: eth.vm.base.BaseVM
-  :members:
-
-
 VM
 --
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -65,7 +65,7 @@ All parameters as well as the return type of defs are expected to be typed with 
 
 .. code:: python
 
-    def __init__(self, wrapped_db: BaseDB) -> None:
+    def __init__(self, wrapped_db: DatabaseAPI) -> None:
         self.wrapped_db = wrapped_db
         self.reset()
 

--- a/eth/_utils/datatypes.py
+++ b/eth/_utils/datatypes.py
@@ -11,6 +11,8 @@ from eth_utils import (
 
 from typing import Any, Dict, Tuple, Type, TypeVar, Iterator, List
 
+from eth.abc import ConfigurableAPI
+
 
 def _is_local_prop(prop: str) -> bool:
     return len(prop.split('.')) == 1
@@ -64,7 +66,7 @@ def _get_top_level_keys(overrides: Dict[str, Any]) -> Iterator[str]:
 T = TypeVar('T')
 
 
-class Configurable(object):
+class Configurable(ConfigurableAPI):
     """
     Base class for simple inline subclassing
     """

--- a/eth/_utils/db.py
+++ b/eth/_utils/db.py
@@ -1,40 +1,32 @@
-from typing import (
-    TYPE_CHECKING,
-)
-
 from eth_typing import (
     Hash32,
 )
 
-from eth.rlp.headers import (
-    BlockHeader,
+from eth.abc import (
+    BlockHeaderAPI,
+    ChainDatabaseAPI,
+    StateAPI,
 )
 from eth.typing import (
     AccountState,
 )
-from eth.vm.state import (
-    BaseState,
-)
-
-if TYPE_CHECKING:
-    from eth.db.chain import BaseChainDB  # noqa: F401
 
 
-def get_parent_header(block_header: BlockHeader, db: 'BaseChainDB') -> BlockHeader:
+def get_parent_header(block_header: BlockHeaderAPI, db: ChainDatabaseAPI) -> BlockHeaderAPI:
     """
     Returns the header for the parent block.
     """
     return db.get_block_header_by_hash(block_header.parent_hash)
 
 
-def get_block_header_by_hash(block_hash: Hash32, db: 'BaseChainDB') -> BlockHeader:
+def get_block_header_by_hash(block_hash: Hash32, db: ChainDatabaseAPI) -> BlockHeaderAPI:
     """
     Returns the header for the parent block.
     """
     return db.get_block_header_by_hash(block_hash)
 
 
-def apply_state_dict(state: BaseState, state_dict: AccountState) -> None:
+def apply_state_dict(state: StateAPI, state_dict: AccountState) -> None:
     for account, account_data in state_dict.items():
         state.set_balance(account, account_data["balance"])
         state.set_nonce(account, account_data["nonce"])

--- a/eth/_utils/spoof.py
+++ b/eth/_utils/spoof.py
@@ -14,9 +14,9 @@ from eth.constants import (
     DEFAULT_SPOOF_S,
 )
 
-from eth.rlp.transactions import (
-    BaseTransaction,
-    BaseUnsignedTransaction,
+from eth.abc import (
+    SignedTransactionAPI,
+    UnsignedTransactionAPI,
 )
 
 SPOOF_ATTRIBUTES_DEFAULTS = {
@@ -31,7 +31,7 @@ T = TypeVar('T', bound='SpoofAttributes')
 class SpoofAttributes:
     def __init__(
             self,
-            spoof_target: Union[BaseTransaction, BaseUnsignedTransaction],
+            spoof_target: Union[SignedTransactionAPI, UnsignedTransactionAPI],
             **overrides: Any) -> None:
         self.spoof_target = spoof_target
         self.overrides = overrides

--- a/eth/abc.py
+++ b/eth/abc.py
@@ -1,0 +1,1904 @@
+from abc import (
+    ABC,
+    abstractmethod
+)
+from typing import (
+    Any,
+    Callable,
+    ContextManager,
+    Dict,
+    Iterable,
+    Iterator,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+from uuid import UUID
+
+import rlp
+
+from eth_bloom import BloomFilter
+
+from eth_typing import (
+    Address,
+    BlockNumber,
+    Hash32,
+)
+
+from eth_keys.datatypes import PrivateKey
+
+from eth.constants import (
+    BLANK_ROOT_HASH,
+)
+from eth.exceptions import VMError
+from eth.typing import (
+    BytesOrView,
+    JournalDBCheckpoint,
+    AccountState,
+    HeaderParams,
+)
+
+from eth.tools.logging import ExtendedDebugLogger
+
+
+T = TypeVar('T')
+
+
+class MiningHeaderAPI(rlp.Serializable, ABC):
+    parent_hash: Hash32
+    uncles_hash: Hash32
+    coinbase: Address
+    state_root: Hash32
+    transaction_root: Hash32
+    receipt_root: Hash32
+    bloom: int
+    difficulty: int
+    block_number: BlockNumber
+    gas_limit: int
+    gas_used: int
+    timestamp: int
+    extra_data: bytes
+
+
+class BlockHeaderAPI(MiningHeaderAPI):
+    mix_hash: Hash32
+    nonce: bytes
+
+
+class LogAPI(rlp.Serializable, ABC):
+    address: Address
+    topics: Sequence[int]
+    data: bytes
+
+    @property
+    @abstractmethod
+    def bloomables(self) -> Tuple[bytes, ...]:
+        ...
+
+
+class ReceiptAPI(rlp.Serializable, ABC):
+    state_root: bytes
+    gas_used: int
+    bloom: int
+    logs: Sequence[LogAPI]
+
+    @property
+    @abstractmethod
+    def bloom_filter(self) -> BloomFilter:
+        ...
+
+
+class BaseTransactionAPI(ABC):
+    @abstractmethod
+    def validate(self) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def intrinsic_gas(self) -> int:
+        ...
+
+    @abstractmethod
+    def get_intrinsic_gas(self) -> int:
+        ...
+
+    @abstractmethod
+    def gas_used_by(self, computation: 'ComputationAPI') -> int:
+        ...
+
+    @abstractmethod
+    def copy(self: T, **overrides: Any) -> T:
+        ...
+
+
+class TransactionFieldsAPI(ABC):
+    nonce: int
+    gas_price: int
+    gas: int
+    to: Address
+    value: int
+    data: bytes
+    v: int
+    r: int
+    s: int
+
+    @property
+    @abstractmethod
+    def hash(self) -> bytes:
+        ...
+
+
+class UnsignedTransactionAPI(rlp.Serializable, BaseTransactionAPI):
+    nonce: int
+    gas_price: int
+    gas: int
+    to: Address
+    value: int
+    data: bytes
+
+    #
+    # API that must be implemented by all Transaction subclasses.
+    #
+    @abstractmethod
+    def as_signed_transaction(self, private_key: PrivateKey) -> 'SignedTransactionAPI':
+        """
+        Return a version of this transaction which has been signed using the
+        provided `private_key`
+        """
+        ...
+
+
+class SignedTransactionAPI(rlp.Serializable, BaseTransactionAPI, TransactionFieldsAPI):
+    @classmethod
+    @abstractmethod
+    def from_base_transaction(cls, transaction: 'SignedTransactionAPI') -> 'SignedTransactionAPI':
+        ...
+
+    @property
+    @abstractmethod
+    def sender(self) -> Address:
+        ...
+
+    # +-------------------------------------------------------------+
+    # | API that must be implemented by all Transaction subclasses. |
+    # +-------------------------------------------------------------+
+
+    #
+    # Validation
+    #
+    @abstractmethod
+    def validate(self) -> None:
+        ...
+
+    #
+    # Signature and Sender
+    #
+    @property
+    @abstractmethod
+    def is_signature_valid(self) -> bool:
+        ...
+
+    @abstractmethod
+    def check_signature_validity(self) -> None:
+        """
+        Checks signature validity, raising a ValidationError if the signature
+        is invalid.
+        """
+        ...
+
+    @abstractmethod
+    def get_sender(self) -> Address:
+        """
+        Get the 20-byte address which sent this transaction.
+
+        This can be a slow operation. ``transaction.sender`` is always preferred.
+        """
+        ...
+
+    #
+    # Conversion to and creation of unsigned transactions.
+    #
+    @abstractmethod
+    def get_message_for_signing(self) -> bytes:
+        """
+        Return the bytestring that should be signed in order to create a signed transactions
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def create_unsigned_transaction(cls,
+                                    *,
+                                    nonce: int,
+                                    gas_price: int,
+                                    gas: int,
+                                    to: Address,
+                                    value: int,
+                                    data: bytes) -> UnsignedTransactionAPI:
+        """
+        Create an unsigned transaction.
+        """
+        ...
+
+
+class BlockAPI(rlp.Serializable, ABC):
+    transaction_class: Type[SignedTransactionAPI] = None
+
+    @classmethod
+    @abstractmethod
+    def get_transaction_class(cls) -> Type[SignedTransactionAPI]:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_header(cls, header: BlockHeaderAPI, chaindb: 'ChainDatabaseAPI') -> 'BlockAPI':
+        ...
+
+    @property
+    @abstractmethod
+    def hash(self) -> Hash32:
+        ...
+
+    @property
+    @abstractmethod
+    def number(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def is_genesis(self) -> bool:
+        ...
+
+
+class DatabaseAPI(MutableMapping[bytes, bytes], ABC):
+    @abstractmethod
+    def set(self, key: bytes, value: bytes) -> None:
+        ...
+
+    @abstractmethod
+    def exists(self, key: bytes) -> bool:
+        ...
+
+    @abstractmethod
+    def delete(self, key: bytes) -> None:
+        ...
+
+
+class AtomicDatabaseAPI(DatabaseAPI):
+    @abstractmethod
+    def atomic_batch(self) -> ContextManager[DatabaseAPI]:
+        ...
+
+
+class HeaderDatabaseAPI(ABC):
+    db: AtomicDatabaseAPI
+
+    @abstractmethod
+    def __init__(self, db: AtomicDatabaseAPI) -> None:
+        ...
+
+    #
+    # Canonical Chain API
+    #
+    @abstractmethod
+    def get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
+        ...
+
+    @abstractmethod
+    def get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
+    def get_canonical_head(self) -> BlockHeaderAPI:
+        ...
+
+    #
+    # Header API
+    #
+    @abstractmethod
+    def get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
+    def get_score(self, block_hash: Hash32) -> int:
+        ...
+
+    @abstractmethod
+    def header_exists(self, block_hash: Hash32) -> bool:
+        ...
+
+    @abstractmethod
+    def persist_header(self,
+                       header: BlockHeaderAPI
+                       ) -> Tuple[Tuple[BlockHeaderAPI, ...], Tuple[BlockHeaderAPI, ...]]:
+        ...
+
+    @abstractmethod
+    def persist_header_chain(self,
+                             headers: Sequence[BlockHeaderAPI]
+                             ) -> Tuple[Tuple[BlockHeaderAPI, ...], Tuple[BlockHeaderAPI, ...]]:
+        ...
+
+
+class ChainDatabaseAPI(HeaderDatabaseAPI):
+    #
+    # Header API
+    #
+    @abstractmethod
+    def get_block_uncles(self, uncles_hash: Hash32) -> Tuple[BlockHeaderAPI, ...]:
+        ...
+
+    #
+    # Block API
+    #
+    @abstractmethod
+    def persist_block(self,
+                      block: BlockAPI
+                      ) -> Tuple[Tuple[Hash32, ...], Tuple[Hash32, ...]]:
+        ...
+
+    @abstractmethod
+    def persist_uncles(self, uncles: Tuple[BlockHeaderAPI]) -> Hash32:
+        ...
+
+    #
+    # Transaction API
+    #
+    @abstractmethod
+    def add_receipt(self,
+                    block_header: BlockHeaderAPI,
+                    index_key: int, receipt: ReceiptAPI) -> Hash32:
+        ...
+
+    @abstractmethod
+    def add_transaction(self,
+                        block_header: BlockHeaderAPI,
+                        index_key: int, transaction: SignedTransactionAPI) -> Hash32:
+        ...
+
+    @abstractmethod
+    def get_block_transactions(
+            self,
+            block_header: BlockHeaderAPI,
+            transaction_class: Type[SignedTransactionAPI]) -> Sequence[SignedTransactionAPI]:
+        ...
+
+    @abstractmethod
+    def get_block_transaction_hashes(self, block_header: BlockHeaderAPI) -> Tuple[Hash32, ...]:
+        ...
+
+    @abstractmethod
+    def get_receipt_by_index(self,
+                             block_number: BlockNumber,
+                             receipt_index: int) -> ReceiptAPI:
+        ...
+
+    @abstractmethod
+    def get_receipts(self,
+                     header: BlockHeaderAPI,
+                     receipt_class: Type[ReceiptAPI]) -> Tuple[ReceiptAPI, ...]:
+        ...
+
+    @abstractmethod
+    def get_transaction_by_index(
+            self,
+            block_number: BlockNumber,
+            transaction_index: int,
+            transaction_class: Type[SignedTransactionAPI]) -> SignedTransactionAPI:
+        ...
+
+    @abstractmethod
+    def get_transaction_index(self, transaction_hash: Hash32) -> Tuple[BlockNumber, int]:
+        ...
+
+    #
+    # Raw Database API
+    #
+    @abstractmethod
+    def exists(self, key: bytes) -> bool:
+        ...
+
+    @abstractmethod
+    def get(self, key: bytes) -> bytes:
+        ...
+
+    @abstractmethod
+    def persist_trie_data_dict(self, trie_data_dict: Dict[Hash32, bytes]) -> None:
+        ...
+
+
+class GasMeterAPI(ABC):
+    gas_refunded: int
+    gas_remaining: int
+
+    #
+    # Write API
+    #
+    @abstractmethod
+    def consume_gas(self, amount: int, reason: str) -> None:
+        ...
+
+    @abstractmethod
+    def return_gas(self, amount: int) -> None:
+        ...
+
+    @abstractmethod
+    def refund_gas(self, amount: int) -> None:
+        ...
+
+
+class MessageAPI(ABC):
+    """
+    A message for VM computation.
+    """
+    code: bytes
+    _code_address: Address
+    create_address: Address
+    data: BytesOrView
+    depth: int
+    gas: int
+    is_static: bool
+    sender: Address
+    should_transfer_value: bool
+    _storage_address: Address
+    to: Address
+    value: int
+
+    __slots__ = [
+        'code',
+        '_code_address',
+        'create_address',
+        'data',
+        'depth',
+        'gas',
+        'is_static',
+        'sender',
+        'should_transfer_value',
+        '_storage_address'
+        'to',
+        'value',
+    ]
+
+    @property
+    @abstractmethod
+    def code_address(self) -> Address:
+        ...
+
+    @property
+    @abstractmethod
+    def storage_address(self) -> Address:
+        ...
+
+    @property
+    @abstractmethod
+    def is_create(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def data_as_bytes(self) -> bytes:
+        ...
+
+
+class OpcodeAPI(ABC):
+    mnemonic: str
+
+    @abstractmethod
+    def __call__(self, computation: 'ComputationAPI') -> None:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def as_opcode(cls: Type[T],
+                  logic_fn: Callable[['ComputationAPI'], None],
+                  mnemonic: str,
+                  gas_cost: int) -> Type[T]:
+        ...
+
+    @abstractmethod
+    def __copy__(self) -> 'OpcodeAPI':
+        ...
+
+    @abstractmethod
+    def __deepcopy__(self, memo: Any) -> 'OpcodeAPI':
+        ...
+
+
+class TransactionContextAPI(ABC):
+    @abstractmethod
+    def __init__(self, gas_price: int, origin: Address) -> None:
+        ...
+
+    @abstractmethod
+    def get_next_log_counter(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def gas_price(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def origin(self) -> Address:
+        ...
+
+
+class MemoryAPI(ABC):
+    @abstractmethod
+    def extend(self, start_position: int, size: int) -> None:
+        ...
+
+    @abstractmethod
+    def __len__(self) -> int:
+        ...
+
+    @abstractmethod
+    def write(self, start_position: int, size: int, value: bytes) -> None:
+        ...
+
+    @abstractmethod
+    def read(self, start_position: int, size: int) -> memoryview:
+        ...
+
+    @abstractmethod
+    def read_bytes(self, start_position: int, size: int) -> bytes:
+        ...
+
+
+class StackAPI(ABC):
+    @abstractmethod
+    def push_int(self, value: int) -> None:
+        ...
+
+    @abstractmethod
+    def push_bytes(self, value: bytes) -> None:
+        ...
+
+    @abstractmethod
+    def pop1_bytes(self) -> bytes:
+        ...
+
+    @abstractmethod
+    def pop1_int(self) -> int:
+        ...
+
+    @abstractmethod
+    def pop1_any(self) -> Union[int, bytes]:
+        ...
+
+    @abstractmethod
+    def pop_any(self, num_items: int) -> Tuple[Union[int, bytes], ...]:
+        ...
+
+    @abstractmethod
+    def pop_ints(self, num_items: int) -> Tuple[int, ...]:
+        ...
+
+    @abstractmethod
+    def pop_bytes(self, num_items: int) -> Tuple[bytes, ...]:
+        ...
+
+    @abstractmethod
+    def swap(self, position: int) -> None:
+        ...
+
+    @abstractmethod
+    def dup(self, position: int) -> None:
+        ...
+
+
+class CodeStreamAPI(ABC):
+    pc: int
+
+    @abstractmethod
+    def read(self, size: int) -> bytes:
+        ...
+
+    @abstractmethod
+    def __len__(self) -> int:
+        ...
+
+    @abstractmethod
+    def __getitem__(self, i: int) -> int:
+        ...
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[int]:
+        ...
+
+    @abstractmethod
+    def peek(self) -> int:
+        ...
+
+    @abstractmethod
+    def seek(self, pc: int) -> ContextManager['CodeStreamAPI']:
+        ...
+
+    @abstractmethod
+    def is_valid_opcode(self, position: int) -> bool:
+        ...
+
+
+class StackManipulationAPI(ABC):
+    @abstractmethod
+    def stack_pop_ints(self, num_items: int) -> Tuple[int, ...]:
+        ...
+
+    @abstractmethod
+    def stack_pop_bytes(self, num_items: int) -> Tuple[bytes, ...]:
+        ...
+
+    @abstractmethod
+    def stack_pop_any(self, num_items: int) -> Tuple[Union[int, bytes], ...]:
+        ...
+
+    @abstractmethod
+    def stack_pop1_int(self) -> int:
+        ...
+
+    @abstractmethod
+    def stack_pop1_bytes(self) -> bytes:
+        ...
+
+    @abstractmethod
+    def stack_pop1_any(self) -> Union[int, bytes]:
+        ...
+
+    @abstractmethod
+    def stack_push_int(self, value: int) -> None:
+        ...
+
+    @abstractmethod
+    def stack_push_bytes(self, value: bytes) -> None:
+        ...
+
+
+class ExecutionContextAPI(ABC):
+    coinbase: Address
+    timestamp: int
+    block_number: int
+    difficulty: int
+    gas_limit: int
+    prev_hashes: Sequence[Hash32]
+
+
+class ComputationAPI(ContextManager['ComputationAPI'], StackManipulationAPI):
+    msg: MessageAPI
+    logger: ExtendedDebugLogger
+    code: CodeStreamAPI
+    opcodes: Dict[int, OpcodeAPI] = None
+    state: 'StateAPI'
+    return_data: bytes
+
+    @abstractmethod
+    def __init__(self,
+                 state: 'StateAPI',
+                 message: MessageAPI,
+                 transaction_context: TransactionContextAPI) -> None:
+        ...
+
+    #
+    # Convenience
+    #
+    @property
+    @abstractmethod
+    def is_origin_computation(self) -> bool:
+        ...
+
+    #
+    # Error handling
+    #
+    @property
+    @abstractmethod
+    def is_success(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def is_error(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def error(self) -> VMError:
+        ...
+
+    @error.setter
+    def error(self, value: VMError) -> None:
+        # See: https://github.com/python/mypy/issues/4165
+        # Since we can't also decorate this with abstract method we want to be
+        # sure that the setter doesn't actually get used as a noop.
+        raise NotImplementedError
+
+    @abstractmethod
+    def raise_if_error(self) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def should_burn_gas(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def should_return_gas(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def should_erase_return_data(self) -> bool:
+        ...
+
+    #
+    # Memory Management
+    #
+    @abstractmethod
+    def extend_memory(self, start_position: int, size: int) -> None:
+        ...
+
+    @abstractmethod
+    def memory_write(self, start_position: int, size: int, value: bytes) -> None:
+        ...
+
+    @abstractmethod
+    def memory_read(self, start_position: int, size: int) -> memoryview:
+        ...
+
+    @abstractmethod
+    def memory_read_bytes(self, start_position: int, size: int) -> bytes:
+        ...
+
+    #
+    # Gas Consumption
+    #
+    @abstractmethod
+    def get_gas_meter(self) -> GasMeterAPI:
+        ...
+
+    @abstractmethod
+    def consume_gas(self, amount: int, reason: str) -> None:
+        ...
+
+    @abstractmethod
+    def return_gas(self, amount: int) -> None:
+        ...
+
+    @abstractmethod
+    def refund_gas(self, amount: int) -> None:
+        ...
+
+    @abstractmethod
+    def get_gas_refund(self) -> int:
+        ...
+
+    @abstractmethod
+    def get_gas_used(self) -> int:
+        ...
+
+    @abstractmethod
+    def get_gas_remaining(self) -> int:
+        ...
+
+    #
+    # Stack management
+    #
+    @abstractmethod
+    def stack_swap(self, position: int) -> None:
+        ...
+
+    @abstractmethod
+    def stack_dup(self, position: int) -> None:
+        ...
+
+    #
+    # Computation result
+    #
+    @property
+    @abstractmethod
+    def output(self) -> bytes:
+        ...
+
+    @output.setter
+    def output(self, value: bytes) -> None:
+        # See: https://github.com/python/mypy/issues/4165
+        # Since we can't also decorate this with abstract method we want to be
+        # sure that the setter doesn't actually get used as a noop.
+        raise NotImplementedError
+
+    #
+    # Runtime operations
+    #
+    @abstractmethod
+    def prepare_child_message(self,
+                              gas: int,
+                              to: Address,
+                              value: int,
+                              data: BytesOrView,
+                              code: bytes,
+                              **kwargs: Any) -> MessageAPI:
+        ...
+
+    @abstractmethod
+    def apply_child_computation(self, child_msg: MessageAPI) -> 'ComputationAPI':
+        ...
+
+    @abstractmethod
+    def generate_child_computation(self, child_msg: MessageAPI) -> 'ComputationAPI':
+        ...
+
+    @abstractmethod
+    def add_child_computation(self, child_computation: 'ComputationAPI') -> None:
+        ...
+
+    #
+    # Account management
+    #
+    @abstractmethod
+    def register_account_for_deletion(self, beneficiary: Address) -> None:
+        ...
+
+    @abstractmethod
+    def get_accounts_for_deletion(self) -> Tuple[Tuple[Address, Address], ...]:
+        ...
+
+    #
+    # EVM logging
+    #
+    @abstractmethod
+    def add_log_entry(self, account: Address, topics: Tuple[int, ...], data: bytes) -> None:
+        ...
+
+    @abstractmethod
+    def get_raw_log_entries(self) -> Tuple[Tuple[int, bytes, Tuple[int, ...], bytes], ...]:
+        ...
+
+    @abstractmethod
+    def get_log_entries(self) -> Tuple[Tuple[bytes, Tuple[int, ...], bytes], ...]:
+        ...
+
+    #
+    # State Transition
+    #
+    @abstractmethod
+    def apply_message(self) -> 'ComputationAPI':
+        ...
+
+    @abstractmethod
+    def apply_create_message(self) -> 'ComputationAPI':
+        ...
+
+    @classmethod
+    @abstractmethod
+    def apply_computation(cls,
+                          state: 'StateAPI',
+                          message: MessageAPI,
+                          transaction_context: TransactionContextAPI) -> 'ComputationAPI':
+        ...
+
+    #
+    # Opcode API
+    #
+    @property
+    @abstractmethod
+    def precompiles(self) -> Dict[Address, Callable[['ComputationAPI'], None]]:
+        ...
+
+    @abstractmethod
+    def get_opcode_fn(self, opcode: int) -> OpcodeAPI:
+        ...
+
+
+class AccountStorageDatabaseAPI(ABC):
+    @abstractmethod
+    def get(self, slot: int, from_journal: bool=True) -> int:
+        ...
+
+    @abstractmethod
+    def set(self, slot: int, value: int) -> None:
+        ...
+
+    @abstractmethod
+    def delete(self) -> None:
+        ...
+
+    @abstractmethod
+    def record(self, checkpoint: JournalDBCheckpoint) -> None:
+        ...
+
+    @abstractmethod
+    def discard(self, checkpoint: JournalDBCheckpoint) -> None:
+        ...
+
+    @abstractmethod
+    def commit(self, checkpoint: JournalDBCheckpoint) -> None:
+        ...
+
+    @abstractmethod
+    def make_storage_root(self) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def has_changed_root(self) -> bool:
+        ...
+
+    @abstractmethod
+    def get_changed_root(self) -> Hash32:
+        ...
+
+    @abstractmethod
+    def persist(self, db: DatabaseAPI) -> None:
+        ...
+
+
+class AccountDatabaseAPI(ABC):
+    @abstractmethod
+    def __init__(self, db: AtomicDatabaseAPI, state_root: Hash32 = BLANK_ROOT_HASH) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def state_root(self) -> Hash32:
+        ...
+
+    @abstractmethod
+    def has_root(self, state_root: bytes) -> bool:
+        ...
+
+    #
+    # Storage
+    #
+    @abstractmethod
+    def get_storage(self, address: Address, slot: int, from_journal: bool=True) -> int:
+        ...
+
+    @abstractmethod
+    def set_storage(self, address: Address, slot: int, value: int) -> None:
+        ...
+
+    @abstractmethod
+    def delete_storage(self, address: Address) -> None:
+        ...
+
+    #
+    # Balance
+    #
+    @abstractmethod
+    def get_balance(self, address: Address) -> int:
+        ...
+
+    @abstractmethod
+    def set_balance(self, address: Address, balance: int) -> None:
+        ...
+
+    #
+    # Nonce
+    #
+    @abstractmethod
+    def get_nonce(self, address: Address) -> int:
+        ...
+
+    @abstractmethod
+    def set_nonce(self, address: Address, nonce: int) -> None:
+        ...
+
+    @abstractmethod
+    def increment_nonce(self, address: Address) -> None:
+        ...
+
+    #
+    # Code
+    #
+    @abstractmethod
+    def set_code(self, address: Address, code: bytes) -> None:
+        ...
+
+    @abstractmethod
+    def get_code(self, address: Address) -> bytes:
+        ...
+
+    @abstractmethod
+    def get_code_hash(self, address: Address) -> Hash32:
+        ...
+
+    @abstractmethod
+    def delete_code(self, address: Address) -> None:
+        ...
+
+    #
+    # Account Methods
+    #
+    @abstractmethod
+    def account_has_code_or_nonce(self, address: Address) -> bool:
+        ...
+
+    @abstractmethod
+    def delete_account(self, address: Address) -> None:
+        ...
+
+    @abstractmethod
+    def account_exists(self, address: Address) -> bool:
+        ...
+
+    @abstractmethod
+    def touch_account(self, address: Address) -> None:
+        ...
+
+    @abstractmethod
+    def account_is_empty(self, address: Address) -> bool:
+        ...
+
+    #
+    # Record and discard API
+    #
+    @abstractmethod
+    def record(self) -> JournalDBCheckpoint:
+        ...
+
+    @abstractmethod
+    def discard(self, checkpoint: JournalDBCheckpoint) -> None:
+        ...
+
+    @abstractmethod
+    def commit(self, checkpoint: JournalDBCheckpoint) -> None:
+        ...
+
+    @abstractmethod
+    def make_state_root(self) -> Hash32:
+        """
+        Generate the state root with all the current changes in AccountDB
+
+        Current changes include every pending change to storage, as well as all account changes.
+        After generating all the required tries, the final account state root is returned.
+
+        This is an expensive operation, so should be called as little as possible. For example,
+        pre-Byzantium, this is called after every transaction, because we need the state root
+        in each receipt. Byzantium+, we only need state roots at the end of the block,
+        so we *only* call it right before persistance.
+
+        :return: the new state root
+        """
+        ...
+
+    @abstractmethod
+    def persist(self) -> None:
+        """
+        Send changes to underlying database, including the trie state
+        so that it will forever be possible to read the trie from this checkpoint.
+
+        :meth:`make_state_root` must be explicitly called before this method.
+        Otherwise persist will raise a ValidationError.
+        """
+        ...
+
+
+class TransactionExecutorAPI(ABC):
+    @abstractmethod
+    def __init__(self, vm_state: 'StateAPI') -> None:
+        ...
+
+    @abstractmethod
+    def __call__(self, transaction: SignedTransactionAPI) -> 'ComputationAPI':
+        ...
+
+    @abstractmethod
+    def validate_transaction(self, transaction: SignedTransactionAPI) -> None:
+        ...
+
+    @abstractmethod
+    def build_evm_message(self, transaction: SignedTransactionAPI) -> MessageAPI:
+        ...
+
+    @abstractmethod
+    def build_computation(self,
+                          message: MessageAPI,
+                          transaction: SignedTransactionAPI) -> 'ComputationAPI':
+        ...
+
+    @abstractmethod
+    def finalize_computation(self,
+                             transaction: SignedTransactionAPI,
+                             computation: 'ComputationAPI') -> 'ComputationAPI':
+        ...
+
+
+class ConfigurableAPI(ABC):
+    @classmethod
+    def configure(cls: Type[T],
+                  __name__: str=None,
+                  **overrides: Any) -> Type[T]:
+        ...
+
+
+class StateAPI(ConfigurableAPI):
+    #
+    # Set from __init__
+    #
+    execution_context: ExecutionContextAPI
+
+    computation_class: Type[ComputationAPI]
+    transaction_context_class: Type[TransactionContextAPI]
+    account_db_class: Type[AccountDatabaseAPI]
+    transaction_executor_class: Type[TransactionExecutorAPI] = None
+
+    @abstractmethod
+    def __init__(
+            self,
+            db: AtomicDatabaseAPI,
+            execution_context: ExecutionContextAPI,
+            state_root: bytes) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def logger(self) -> ExtendedDebugLogger:
+        ...
+
+    #
+    # Block Object Properties (in opcodes)
+    #
+    @property
+    @abstractmethod
+    def coinbase(self) -> Address:
+        ...
+
+    @property
+    @abstractmethod
+    def timestamp(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def block_number(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def difficulty(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def gas_limit(self) -> int:
+        ...
+
+    #
+    # Access to account db
+    #
+    @classmethod
+    @abstractmethod
+    def get_account_db_class(cls) -> Type[AccountDatabaseAPI]:
+        ...
+
+    @property
+    @abstractmethod
+    def state_root(self) -> Hash32:
+        ...
+
+    @abstractmethod
+    def make_state_root(self) -> Hash32:
+        ...
+
+    @abstractmethod
+    def get_storage(self, address: Address, slot: int, from_journal: bool=True) -> int:
+        ...
+
+    @abstractmethod
+    def set_storage(self, address: Address, slot: int, value: int) -> None:
+        ...
+
+    @abstractmethod
+    def delete_storage(self, address: Address) -> None:
+        ...
+
+    @abstractmethod
+    def delete_account(self, address: Address) -> None:
+        ...
+
+    @abstractmethod
+    def get_balance(self, address: Address) -> int:
+        ...
+
+    @abstractmethod
+    def set_balance(self, address: Address, balance: int) -> None:
+        ...
+
+    @abstractmethod
+    def delta_balance(self, address: Address, delta: int) -> None:
+        ...
+
+    @abstractmethod
+    def get_nonce(self, address: Address) -> int:
+        ...
+
+    @abstractmethod
+    def set_nonce(self, address: Address, nonce: int) -> None:
+        ...
+
+    @abstractmethod
+    def increment_nonce(self, address: Address) -> None:
+        ...
+
+    @abstractmethod
+    def get_code(self, address: Address) -> bytes:
+        ...
+
+    @abstractmethod
+    def set_code(self, address: Address, code: bytes) -> None:
+        ...
+
+    @abstractmethod
+    def get_code_hash(self, address: Address) -> Hash32:
+        ...
+
+    @abstractmethod
+    def delete_code(self, address: Address) -> None:
+        ...
+
+    @abstractmethod
+    def has_code_or_nonce(self, address: Address) -> bool:
+        ...
+
+    @abstractmethod
+    def account_exists(self, address: Address) -> bool:
+        ...
+
+    @abstractmethod
+    def touch_account(self, address: Address) -> None:
+        ...
+
+    @abstractmethod
+    def account_is_empty(self, address: Address) -> bool:
+        ...
+
+    #
+    # Access self._chaindb
+    #
+    @abstractmethod
+    def snapshot(self) -> Tuple[Hash32, UUID]:
+        ...
+
+    @abstractmethod
+    def revert(self, snapshot: Tuple[Hash32, UUID]) -> None:
+        ...
+
+    @abstractmethod
+    def commit(self, snapshot: Tuple[Hash32, UUID]) -> None:
+        ...
+
+    @abstractmethod
+    def persist(self) -> None:
+        ...
+
+    #
+    # Access self.prev_hashes (Read-only)
+    #
+    @abstractmethod
+    def get_ancestor_hash(self, block_number: int) -> Hash32:
+        ...
+
+    #
+    # Computation
+    #
+    @abstractmethod
+    def get_computation(self,
+                        message: MessageAPI,
+                        transaction_context: TransactionContextAPI) -> ComputationAPI:
+        ...
+
+    #
+    # Transaction context
+    #
+    @classmethod
+    @abstractmethod
+    def get_transaction_context_class(cls) -> Type[TransactionContextAPI]:
+        ...
+
+    #
+    # Execution
+    #
+    @abstractmethod
+    def apply_transaction(
+            self,
+            transaction: SignedTransactionAPI) -> ComputationAPI:
+        ...
+
+    @abstractmethod
+    def get_transaction_executor(self) -> TransactionExecutorAPI:
+        ...
+
+    @abstractmethod
+    def costless_execute_transaction(self,
+                                     transaction: SignedTransactionAPI) -> ComputationAPI:
+        ...
+
+    @abstractmethod
+    def override_transaction_context(self, gas_price: int) -> ContextManager[None]:
+        ...
+
+    @abstractmethod
+    def execute_transaction(self, transaction: SignedTransactionAPI) -> ComputationAPI:
+        ...
+
+    @abstractmethod
+    def validate_transaction(self, transaction: SignedTransactionAPI) -> None:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def get_transaction_context(cls,
+                                transaction: SignedTransactionAPI) -> TransactionContextAPI:
+        ...
+
+
+class VirtualMachineAPI(ConfigurableAPI):
+    fork: str  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
+    chaindb: ChainDatabaseAPI
+
+    @abstractmethod
+    def __init__(self, header: BlockHeaderAPI, chaindb: ChainDatabaseAPI) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def state(self) -> StateAPI:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def build_state(cls,
+                    db: AtomicDatabaseAPI,
+                    header: BlockHeaderAPI,
+                    previous_hashes: Iterable[Hash32] = ()
+                    ) -> StateAPI:
+        ...
+
+    @abstractmethod
+    def get_header(self) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
+    def get_block(self) -> BlockAPI:
+        ...
+
+    #
+    # Execution
+    #
+    @abstractmethod
+    def apply_transaction(self,
+                          header: BlockHeaderAPI,
+                          transaction: SignedTransactionAPI
+                          ) -> Tuple[ReceiptAPI, ComputationAPI]:
+        ...
+
+    @abstractmethod
+    def execute_bytecode(self,
+                         origin: Address,
+                         gas_price: int,
+                         gas: int,
+                         to: Address,
+                         sender: Address,
+                         value: int,
+                         data: bytes,
+                         code: bytes,
+                         code_address: Address = None) -> ComputationAPI:
+        ...
+
+    @abstractmethod
+    def apply_all_transactions(
+        self,
+        transactions: Sequence[SignedTransactionAPI],
+        base_header: BlockHeaderAPI
+    ) -> Tuple[BlockHeaderAPI, Tuple[ReceiptAPI, ...], Tuple[ComputationAPI, ...]]:
+        ...
+
+    @abstractmethod
+    def make_receipt(self,
+                     base_header: BlockHeaderAPI,
+                     transaction: SignedTransactionAPI,
+                     computation: ComputationAPI,
+                     state: StateAPI) -> ReceiptAPI:
+        """
+        Generate the receipt resulting from applying the transaction.
+
+        :param base_header: the header of the block before the transaction was applied.
+        :param transaction: the transaction used to generate the receipt
+        :param computation: the result of running the transaction computation
+        :param state: the resulting state, after executing the computation
+
+        :return: receipt
+        """
+        ...
+
+    #
+    # Mining
+    #
+    @abstractmethod
+    def import_block(self, block: BlockAPI) -> BlockAPI:
+        ...
+
+    @abstractmethod
+    def mine_block(self, *args: Any, **kwargs: Any) -> BlockAPI:
+        ...
+
+    @abstractmethod
+    def set_block_transactions(self,
+                               base_block: BlockAPI,
+                               new_header: BlockHeaderAPI,
+                               transactions: Sequence[SignedTransactionAPI],
+                               receipts: Sequence[ReceiptAPI]) -> BlockAPI:
+        ...
+
+    #
+    # Finalization
+    #
+    @abstractmethod
+    def finalize_block(self, block: BlockAPI) -> BlockAPI:
+        ...
+
+    @abstractmethod
+    def pack_block(self, block: BlockAPI, *args: Any, **kwargs: Any) -> BlockAPI:
+        ...
+
+    #
+    # Headers
+    #
+    @abstractmethod
+    def add_receipt_to_header(self,
+                              old_header: BlockHeaderAPI,
+                              receipt: ReceiptAPI) -> BlockHeaderAPI:
+        """
+        Apply the receipt to the old header, and return the resulting header. This may have
+        storage-related side-effects. For example, pre-Byzantium, the state root hash
+        is included in the receipt, and so must be stored into the database.
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def compute_difficulty(cls, parent_header: BlockHeaderAPI, timestamp: int) -> int:
+        """
+        Compute the difficulty for a block header.
+
+        :param parent_header: the parent header
+        :param timestamp: the timestamp of the child header
+        """
+        ...
+
+    @abstractmethod
+    def configure_header(self, **header_params: Any) -> BlockHeaderAPI:
+        """
+        Setup the current header with the provided parameters.  This can be
+        used to set fields like the gas limit or timestamp to value different
+        than their computed defaults.
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def create_header_from_parent(cls,
+                                  parent_header: BlockHeaderAPI,
+                                  **header_params: Any) -> BlockHeaderAPI:
+        """
+        Creates and initializes a new block header from the provided
+        `parent_header`.
+        """
+        ...
+
+    #
+    # Blocks
+    #
+    @classmethod
+    @abstractmethod
+    def generate_block_from_parent_header_and_coinbase(cls,
+                                                       parent_header: BlockHeaderAPI,
+                                                       coinbase: Address) -> BlockAPI:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def get_block_class(cls) -> Type[BlockAPI]:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def get_block_reward() -> int:
+        """
+        Return the amount in **wei** that should be given to a miner as a reward
+        for this block.
+
+          .. note::
+            This is an abstract method that must be implemented in subclasses
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def get_nephew_reward(cls) -> int:
+        """
+        Return the reward which should be given to the miner of the given `nephew`.
+
+          .. note::
+            This is an abstract method that must be implemented in subclasses
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def get_prev_hashes(cls,
+                        last_block_hash: Hash32,
+                        chaindb: ChainDatabaseAPI) -> Optional[Iterable[Hash32]]:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def get_uncle_reward(block_number: int, uncle: BlockAPI) -> int:
+        """
+        Return the reward which should be given to the miner of the given `uncle`.
+
+          .. note::
+            This is an abstract method that must be implemented in subclasses
+        """
+        ...
+
+    #
+    # Transactions
+    #
+    @abstractmethod
+    def create_transaction(self, *args: Any, **kwargs: Any) -> SignedTransactionAPI:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def create_unsigned_transaction(cls,
+                                    *,
+                                    nonce: int,
+                                    gas_price: int,
+                                    gas: int,
+                                    to: Address,
+                                    value: int,
+                                    data: bytes) -> UnsignedTransactionAPI:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def get_transaction_class(cls) -> Type[SignedTransactionAPI]:
+        ...
+
+    #
+    # Validate
+    #
+    @classmethod
+    @abstractmethod
+    def validate_receipt(self, receipt: ReceiptAPI) -> None:
+        ...
+
+    @abstractmethod
+    def validate_block(self, block: BlockAPI) -> None:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def validate_header(cls,
+                        header: BlockHeaderAPI,
+                        parent_header: BlockHeaderAPI,
+                        check_seal: bool = True
+                        ) -> None:
+        ...
+
+    @abstractmethod
+    def validate_transaction_against_header(self,
+                                            base_header: BlockHeaderAPI,
+                                            transaction: SignedTransactionAPI) -> None:
+        """
+        Validate that the given transaction is valid to apply to the given header.
+
+        :param base_header: header before applying the transaction
+        :param transaction: the transaction to validate
+
+        :raises: ValidationError if the transaction is not valid to apply
+        """
+        ...
+
+    @classmethod
+    @abstractmethod
+    def validate_seal(cls, header: BlockHeaderAPI) -> None:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def validate_uncle(cls,
+                       block: BlockAPI,
+                       uncle: BlockHeaderAPI,
+                       uncle_parent: BlockHeaderAPI
+                       ) -> None:
+        ...
+
+    #
+    # State
+    #
+    @classmethod
+    @abstractmethod
+    def get_state_class(cls) -> Type[StateAPI]:
+        ...
+
+    @abstractmethod
+    def state_in_temp_block(self) -> ContextManager[StateAPI]:
+        ...
+
+
+class HeaderChainAPI(ABC):
+    header: BlockHeaderAPI
+    chain_id: int
+    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...]
+
+    @abstractmethod
+    def __init__(self, base_db: AtomicDatabaseAPI, header: BlockHeaderAPI = None) -> None:
+        ...
+
+    #
+    # Chain Initialization API
+    #
+    @classmethod
+    @abstractmethod
+    def from_genesis_header(cls,
+                            base_db: AtomicDatabaseAPI,
+                            genesis_header: BlockHeaderAPI) -> 'HeaderChainAPI':
+        ...
+
+    #
+    # Helpers
+    #
+    @classmethod
+    @abstractmethod
+    def get_headerdb_class(cls) -> Type[HeaderDatabaseAPI]:
+        ...
+
+    #
+    # Canonical Chain API
+    #
+    @abstractmethod
+    def get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
+    def get_canonical_head(self) -> BlockHeaderAPI:
+        ...
+
+    #
+    # Header API
+    #
+    @abstractmethod
+    def get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
+    def header_exists(self, block_hash: Hash32) -> bool:
+        ...
+
+    @abstractmethod
+    def import_header(self,
+                      header: BlockHeaderAPI,
+                      ) -> Tuple[Tuple[BlockHeaderAPI, ...], Tuple[BlockHeaderAPI, ...]]:
+        ...
+
+
+class ChainAPI(ConfigurableAPI):
+    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...]
+    chain_id: int
+    chaindb: ChainDatabaseAPI
+
+    #
+    # Helpers
+    #
+    @classmethod
+    @abstractmethod
+    def get_chaindb_class(cls) -> Type[ChainDatabaseAPI]:
+        ...
+
+    #
+    # Chain API
+    #
+    @classmethod
+    @abstractmethod
+    def from_genesis(cls,
+                     base_db: AtomicDatabaseAPI,
+                     genesis_params: Dict[str, HeaderParams],
+                     genesis_state: AccountState=None) -> 'ChainAPI':
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_genesis_header(cls,
+                            base_db: AtomicDatabaseAPI,
+                            genesis_header: BlockHeaderAPI) -> 'ChainAPI':
+        ...
+
+    #
+    # VM API
+    #
+    @classmethod
+    def get_vm_class(cls, header: BlockHeaderAPI) -> Type[VirtualMachineAPI]:
+        """
+        Returns the VM instance for the given block number.
+        """
+        ...
+
+    @abstractmethod
+    def get_vm(self, header: BlockHeaderAPI = None) -> VirtualMachineAPI:
+        ...
+
+    @classmethod
+    def get_vm_class_for_block_number(cls, block_number: BlockNumber) -> Type[VirtualMachineAPI]:
+        ...
+
+    #
+    # Header API
+    #
+    @abstractmethod
+    def create_header_from_parent(self,
+                                  parent_header: BlockHeaderAPI,
+                                  **header_params: HeaderParams) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
+    def get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
+    def get_canonical_head(self) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
+    def get_score(self, block_hash: Hash32) -> int:
+        ...
+
+    #
+    # Block API
+    #
+    @abstractmethod
+    def get_ancestors(self, limit: int, header: BlockHeaderAPI) -> Tuple[BlockAPI, ...]:
+        ...
+
+    @abstractmethod
+    def get_block(self) -> BlockAPI:
+        ...
+
+    @abstractmethod
+    def get_block_by_hash(self, block_hash: Hash32) -> BlockAPI:
+        ...
+
+    @abstractmethod
+    def get_block_by_header(self, block_header: BlockHeaderAPI) -> BlockAPI:
+        ...
+
+    @abstractmethod
+    def get_canonical_block_by_number(self, block_number: BlockNumber) -> BlockAPI:
+        ...
+
+    @abstractmethod
+    def get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
+        ...
+
+    @abstractmethod
+    def build_block_with_transactions(
+            self,
+            transactions: Tuple[SignedTransactionAPI, ...],
+            parent_header: BlockHeaderAPI = None
+    ) -> Tuple[BlockAPI, Tuple[ReceiptAPI, ...], Tuple[ComputationAPI, ...]]:
+        ...
+
+    #
+    # Transaction API
+    #
+    @abstractmethod
+    def create_transaction(self, *args: Any, **kwargs: Any) -> SignedTransactionAPI:
+        ...
+
+    @abstractmethod
+    def create_unsigned_transaction(cls,
+                                    *,
+                                    nonce: int,
+                                    gas_price: int,
+                                    gas: int,
+                                    to: Address,
+                                    value: int,
+                                    data: bytes) -> UnsignedTransactionAPI:
+        ...
+
+    @abstractmethod
+    def get_canonical_transaction(self, transaction_hash: Hash32) -> SignedTransactionAPI:
+        ...
+
+    @abstractmethod
+    def get_transaction_receipt(self, transaction_hash: Hash32) -> ReceiptAPI:
+        ...
+
+    #
+    # Execution API
+    #
+    @abstractmethod
+    def get_transaction_result(
+            self,
+            transaction: SignedTransactionAPI,
+            at_header: BlockHeaderAPI) -> bytes:
+        ...
+
+    @abstractmethod
+    def estimate_gas(
+            self,
+            transaction: SignedTransactionAPI,
+            at_header: BlockHeaderAPI = None) -> int:
+        ...
+
+    @abstractmethod
+    def import_block(self,
+                     block: BlockAPI,
+                     perform_validation: bool=True,
+                     ) -> Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]:
+        ...
+
+    #
+    # Validation API
+    #
+    @abstractmethod
+    def validate_receipt(self, receipt: ReceiptAPI, at_header: BlockHeaderAPI) -> None:
+        ...
+
+    @abstractmethod
+    def validate_block(self, block: BlockAPI) -> None:
+        ...
+
+    @abstractmethod
+    def validate_seal(self, header: BlockHeaderAPI) -> None:
+        ...
+
+    @abstractmethod
+    def validate_gaslimit(self, header: BlockHeaderAPI) -> None:
+        ...
+
+    @abstractmethod
+    def validate_uncles(self, block: BlockAPI) -> None:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def validate_chain(
+            cls,
+            root: BlockHeaderAPI,
+            descendants: Tuple[BlockHeaderAPI, ...],
+            seal_check_random_sample_rate: int = 1) -> None:
+        ...
+
+
+class MiningChainAPI(ChainAPI):
+    header: BlockHeaderAPI
+
+    @abstractmethod
+    def __init__(self, base_db: AtomicDatabaseAPI, header: BlockHeaderAPI = None) -> None:
+        ...
+
+    @abstractmethod
+    def apply_transaction(self,
+                          transaction: SignedTransactionAPI
+                          ) -> Tuple[BlockAPI, ReceiptAPI, ComputationAPI]:
+        ...
+
+    @abstractmethod
+    def import_block(self,
+                     block: BlockAPI,
+                     perform_validation: bool=True
+                     ) -> Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]:
+        ...
+
+    @abstractmethod
+    def mine_block(self, *args: Any, **kwargs: Any) -> BlockAPI:
+        ...
+
+    def get_vm(self, at_header: BlockHeaderAPI = None) -> VirtualMachineAPI:
+        ...

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -21,11 +21,14 @@ from .constants import (
 )
 from eth import constants as eth_constants
 
+from eth.abc import (
+    BlockHeaderAPI,
+    VirtualMachineAPI,
+)
 from eth.chains.base import (
     Chain,
 )
 from eth.rlp.headers import BlockHeader
-from eth.vm.base import BaseVM
 from eth.vm.forks import (
     ByzantiumVM,
     FrontierVM,
@@ -41,8 +44,8 @@ class MainnetDAOValidatorVM(HomesteadVM):
 
     @classmethod
     def validate_header(cls,
-                        header: BlockHeader,
-                        previous_header: BlockHeader,
+                        header: BlockHeaderAPI,
+                        previous_header: BlockHeaderAPI,
                         check_seal: bool=True) -> None:
 
         super().validate_header(header, previous_header, check_seal)
@@ -95,7 +98,7 @@ MAINNET_VM_CONFIGURATION = tuple(zip(MAINNET_FORK_BLOCKS, MAINNET_VMS))
 
 class BaseMainnetChain:
     chain_id = MAINNET_CHAIN_ID
-    vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...] = MAINNET_VM_CONFIGURATION
+    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...] = MAINNET_VM_CONFIGURATION
 
 
 class MainnetChain(BaseMainnetChain, Chain):

--- a/eth/chains/ropsten/__init__.py
+++ b/eth/chains/ropsten/__init__.py
@@ -11,9 +11,9 @@ from .constants import (
 )
 from eth import constants
 
+from eth.abc import VirtualMachineAPI
 from eth.chains.base import Chain
 from eth.rlp.headers import BlockHeader
-from eth.vm.base import BaseVM
 from eth.vm.forks import (
     ByzantiumVM,
     ConstantinopleVM,
@@ -34,7 +34,7 @@ ROPSTEN_VM_CONFIGURATION = (
 
 
 class BaseRopstenChain:
-    vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...] = ROPSTEN_VM_CONFIGURATION
+    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...] = ROPSTEN_VM_CONFIGURATION
     chain_id: int = ROPSTEN_CHAIN_ID
 
 

--- a/eth/chains/tester/__init__.py
+++ b/eth/chains/tester/__init__.py
@@ -19,25 +19,23 @@ from eth_utils import (
     ValidationError,
 )
 
+from eth.abc import (
+    BlockAPI,
+    BlockHeaderAPI,
+    VirtualMachineAPI,
+)
 from eth.chains.base import Chain
 from eth.chains.mainnet import MainnetChain
-from eth.rlp.blocks import (
-    BaseBlock,
-)
-from eth.rlp.headers import (
-    BlockHeader
-)
 from eth.validation import (
     validate_gte,
 )
-from eth.vm.base import BaseVM
 from eth.vm.forks.homestead import HomesteadVM
 
 
 class MaintainGasLimitMixin(object):
     @classmethod
     def create_header_from_parent(cls,
-                                  parent_header: BlockHeader,
+                                  parent_header: BlockHeaderAPI,
                                   **header_params: Any) -> 'MaintainGasLimitMixin':
         """
         Call the parent class method maintaining the same gas_limit as the
@@ -55,8 +53,8 @@ MAINNET_VMS = collections.OrderedDict(
     in MainnetChain.vm_configuration
 )
 
-ForkStartBlocks = Sequence[Tuple[int, Union[str, Type[BaseVM]]]]
-VMStartBlock = Tuple[int, Type[BaseVM]]
+ForkStartBlocks = Sequence[Tuple[int, Union[str, Type[VirtualMachineAPI]]]]
+VMStartBlock = Tuple[int, Type[VirtualMachineAPI]]
 
 
 @to_tuple
@@ -112,7 +110,7 @@ def _generate_vm_configuration(*fork_start_blocks: ForkStartBlocks,
     # Iterate over the parameters, generating a tuple of 2-tuples in the form:
     # (start_block, vm_class)
     for start_block, fork in ordered_fork_start_blocks:
-        if isinstance(fork, type) and issubclass(fork, BaseVM):
+        if isinstance(fork, type) and issubclass(fork, VirtualMachineAPI):
             vm_class = fork
         elif isinstance(fork, str):
             vm_class = MAINNET_VMS[fork]
@@ -134,7 +132,7 @@ def _generate_vm_configuration(*fork_start_blocks: ForkStartBlocks,
 
 
 class BaseMainnetTesterChain(Chain):
-    vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...] = _generate_vm_configuration()
+    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...] = _generate_vm_configuration()
 
 
 class MainnetTesterChain(BaseMainnetTesterChain):
@@ -147,7 +145,7 @@ class MainnetTesterChain(BaseMainnetTesterChain):
     configuration of fork rules.
     """
     @classmethod
-    def validate_seal(cls, block: BaseBlock) -> None:
+    def validate_seal(cls, block: BlockAPI) -> None:
         """
         We don't validate the proof of work seal on the tester chain.
         """

--- a/eth/db/__init__.py
+++ b/eth/db/__init__.py
@@ -7,21 +7,22 @@ from typing import (
 
 from eth_utils import import_string
 
-from eth.db.backends.base import BaseAtomicDB
+from eth.abc import AtomicDatabaseAPI
 
 
 DEFAULT_DB_BACKEND = 'eth.db.atomic.AtomicDB'
 
 
-def get_db_backend_class(import_path: str = None) -> Type[BaseAtomicDB]:
+def get_db_backend_class(import_path: str = None) -> Type[AtomicDatabaseAPI]:
     if import_path is None:
         import_path = os.environ.get(
             'CHAIN_DB_BACKEND_CLASS',
             DEFAULT_DB_BACKEND,
         )
-    return cast(Type[BaseAtomicDB], import_string(import_path))
+    return cast(Type[AtomicDatabaseAPI], import_string(import_path))
 
 
-def get_db_backend(import_path: str = None, **init_kwargs: Any) -> BaseAtomicDB:
+def get_db_backend(import_path: str = None, **init_kwargs: Any) -> AtomicDatabaseAPI:
     backend_class = get_db_backend_class(import_path)
-    return backend_class(**init_kwargs)
+    # mypy doesn't understand the constructor  of AtomicDatabaseAPI
+    return backend_class(**init_kwargs)  # type: ignore

--- a/eth/db/backends/base.py
+++ b/eth/db/backends/base.py
@@ -1,24 +1,14 @@
-from abc import (
-    ABC,
-    abstractmethod
-)
-from collections.abc import (
-    MutableMapping,
-)
-
 from typing import (
-    Any,
     Iterator,
-    TYPE_CHECKING,
 )
 
-if TYPE_CHECKING:
-    MM = MutableMapping[bytes, bytes]
-else:
-    MM = MutableMapping
+from eth.abc import (
+    AtomicDatabaseAPI,
+    DatabaseAPI,
+)
 
 
-class BaseDB(MM, ABC):
+class BaseDB(DatabaseAPI):
     """
     This is an abstract key/value lookup with all :class:`bytes` values,
     with some convenience methods for databases. As much as possible,
@@ -33,13 +23,6 @@ class BaseDB(MM, ABC):
     Subclasses may optionally implement an _exists method
     that is type-checked for key and value.
     """
-
-    @abstractmethod
-    def __init__(self) -> None:
-        raise NotImplementedError(
-            "The `init` method must be implemented by subclasses of BaseDB"
-        )
-
     def set(self, key: bytes, value: bytes) -> None:
         self[key] = value
 
@@ -66,7 +49,7 @@ class BaseDB(MM, ABC):
         raise NotImplementedError("By default, DB classes cannot return the total number of keys.")
 
 
-class BaseAtomicDB(BaseDB):
+class BaseAtomicDB(BaseDB, AtomicDatabaseAPI):
     """
     This is an abstract key/value lookup that permits batching of updates, such that the batch of
     changes are atomically saved. They are either all saved, or none are.
@@ -91,6 +74,4 @@ class BaseAtomicDB(BaseDB):
             # when exiting the context, the values are saved either key and key2 will both be saved,
             # or neither will
     """
-    @abstractmethod
-    def atomic_batch(self) -> Any:
-        raise NotImplementedError
+    pass

--- a/eth/db/backends/level.py
+++ b/eth/db/backends/level.py
@@ -8,6 +8,7 @@ from typing import (
 
 from eth_utils import ValidationError
 
+from eth.abc import DatabaseAPI
 from eth.db.diff import (
     DBDiffTracker,
     DiffMissingError,
@@ -81,7 +82,7 @@ class LevelDBWriteBatch(BaseDB):
     """
     logger = logging.getLogger("eth.db.backends.LevelDBWriteBatch")
 
-    def __init__(self, original_read_db: BaseDB, write_batch: 'plyvel.WriteBatch') -> None:
+    def __init__(self, original_read_db: DatabaseAPI, write_batch: 'plyvel.WriteBatch') -> None:
         self._original_read_db = original_read_db
         self._write_batch = write_batch
         # keep track of the temporary changes made

--- a/eth/db/batch.py
+++ b/eth/db/batch.py
@@ -4,6 +4,7 @@ from eth_utils import (
     ValidationError,
 )
 
+from eth.abc import DatabaseAPI
 from eth.db.diff import (
     DBDiff,
     DBDiffTracker,
@@ -23,10 +24,10 @@ class BatchDB(BaseDB):
     """
     logger = logging.getLogger("eth.db.BatchDB")
 
-    wrapped_db: BaseDB = None
+    wrapped_db: DatabaseAPI = None
     _track_diff: DBDiffTracker = None
 
-    def __init__(self, wrapped_db: BaseDB, read_through_deletes: bool = False) -> None:
+    def __init__(self, wrapped_db: DatabaseAPI, read_through_deletes: bool = False) -> None:
         self.wrapped_db = wrapped_db
         self._track_diff = DBDiffTracker()
         self._read_through_deletes = read_through_deletes
@@ -48,7 +49,7 @@ class BatchDB(BaseDB):
     def commit(self, apply_deletes: bool = True) -> None:
         self.commit_to(self.wrapped_db, apply_deletes)
 
-    def commit_to(self, target_db: BaseDB, apply_deletes: bool = True) -> None:
+    def commit_to(self, target_db: DatabaseAPI, apply_deletes: bool = True) -> None:
         if apply_deletes and self._read_through_deletes:
             raise ValidationError("BatchDB should never apply deletes when reading through deletes")
         diff = self.diff()

--- a/eth/db/cache.py
+++ b/eth/db/cache.py
@@ -1,5 +1,6 @@
 from lru import LRU
 
+from eth.abc import DatabaseAPI
 from eth.db.backends.base import BaseDB
 
 
@@ -8,7 +9,7 @@ class CacheDB(BaseDB):
     Set and get decoded RLP objects, where the underlying db stores
     encoded objects.
     """
-    def __init__(self, db: BaseDB, cache_size: int=2048) -> None:
+    def __init__(self, db: DatabaseAPI, cache_size: int=2048) -> None:
         self._db = db
         self._cache_size = cache_size
         self.reset_cache()

--- a/eth/db/diff.py
+++ b/eth/db/diff.py
@@ -16,7 +16,7 @@ from eth_utils import (
     to_tuple,
 )
 
-from eth.db.backends.base import BaseDB
+from eth.abc import DatabaseAPI
 from eth.vm.interrupt import EVMMissingData
 
 if TYPE_CHECKING:
@@ -54,7 +54,7 @@ class DiffMissingError(KeyError):
 
 class DBDiffTracker(ABC_Mutable_Mapping):
     """
-    Records changes to a :class:`~eth.db.BaseDB`
+    Records changes to a :class:`~eth.abc.DatabaseAPI`
 
     If no value is available for a key, it could be for one of two reasons:
     - the key was never updated during tracking
@@ -182,7 +182,7 @@ class DBDiff(ABC_Mapping):
                 yield key, value  # type: ignore # value can only be DELETED or actual new value
 
     def apply_to(self,
-                 db: Union[BaseDB, ABC_Mutable_Mapping],
+                 db: Union[DatabaseAPI, ABC_Mutable_Mapping],
                  apply_deletes: bool = True) -> None:
         """
         Apply the changes in this diff to the given database.

--- a/eth/db/journal.py
+++ b/eth/db/journal.py
@@ -12,9 +12,11 @@ from eth_utils import (
     ValidationError,
 )
 
+from eth.abc import DatabaseAPI
+from eth.typing import JournalDBCheckpoint
+
 from .backends.base import BaseDB
 from .diff import DBDiff, DBDiffTracker
-from .typing import JournalDBCheckpoint
 
 
 class DeletedEntry:
@@ -309,7 +311,7 @@ class JournalDB(BaseDB):
     """
     __slots__ = ['_wrapped_db', '_journal', 'record', 'commit']
 
-    def __init__(self, wrapped_db: BaseDB) -> None:
+    def __init__(self, wrapped_db: DatabaseAPI) -> None:
         self._wrapped_db = wrapped_db
         self._journal = Journal()
         self.record = self._journal.record_checkpoint

--- a/eth/db/keymap.py
+++ b/eth/db/keymap.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
 )
 
+from eth.abc import DatabaseAPI
 from eth.db.backends.base import BaseDB
 
 
@@ -14,7 +15,7 @@ class KeyMapDB(BaseDB):
     Modify keys when accessing the database, according to the
     abstract keymap function set in the subclass.
     """
-    def __init__(self, db: BaseDB) -> None:
+    def __init__(self, db: DatabaseAPI) -> None:
         self._db = db
 
     @staticmethod

--- a/eth/db/slow_journal.py
+++ b/eth/db/slow_journal.py
@@ -11,6 +11,7 @@ from eth_utils import (
     ValidationError,
 )
 
+from eth.abc import DatabaseAPI
 from eth.db.backends.base import BaseDB
 from eth.db.diff import DBDiff, DBDiffTracker
 
@@ -281,7 +282,7 @@ class JournalDB(BaseDB):
     wrapped_db = None
     journal: Journal = None
 
-    def __init__(self, wrapped_db: BaseDB) -> None:
+    def __init__(self, wrapped_db: DatabaseAPI) -> None:
         self.wrapped_db = wrapped_db
         self.reset()
 

--- a/eth/db/trie.py
+++ b/eth/db/trie.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Dict, Tuple, Union
+from typing import Dict, Sequence, Tuple, Union
 
 import rlp
 from trie import (
@@ -8,13 +8,15 @@ from trie import (
 
 from eth_typing import Hash32
 
+from eth.abc import (
+    ReceiptAPI,
+    SignedTransactionAPI,
+)
 from eth.constants import (
     BLANK_ROOT_HASH,
 )
-from eth.rlp.receipts import Receipt
-from eth.rlp.transactions import BaseTransaction
 
-TransactionsOrReceipts = Union[Tuple[Receipt, ...], Tuple[BaseTransaction, ...]]
+TransactionsOrReceipts = Union[Sequence[ReceiptAPI], Sequence[SignedTransactionAPI]]
 TrieRootAndData = Tuple[Hash32, Dict[Hash32, bytes]]
 
 

--- a/eth/db/typing.py
+++ b/eth/db/typing.py
@@ -1,3 +1,0 @@
-from typing import NewType
-
-JournalDBCheckpoint = NewType('JournalDBCheckpoint', int)

--- a/eth/estimators/__init__.py
+++ b/eth/estimators/__init__.py
@@ -4,23 +4,21 @@ from typing import (
     cast,
 )
 
-from eth.typing import (
-    BaseOrSpoofTransaction,
+from eth.abc import (
+    SignedTransactionAPI,
+    StateAPI,
 )
 from eth._utils.module_loading import (
     import_string,
 )
-from eth.vm.state import (
-    BaseState,
-)
 
 
-def get_gas_estimator() -> Callable[[BaseState, BaseOrSpoofTransaction], int]:
+def get_gas_estimator() -> Callable[[StateAPI, SignedTransactionAPI], int]:
     import_path = os.environ.get(
         'GAS_ESTIMATOR_BACKEND_FUNC',
         'eth.estimators.gas.binary_gas_search_intrinsic_tolerance',
     )
     return cast(
-        Callable[[BaseState, BaseOrSpoofTransaction], int],
+        Callable[[StateAPI, SignedTransactionAPI], int],
         import_string(import_path)
     )

--- a/eth/rlp/blocks.py
+++ b/eth/rlp/blocks.py
@@ -1,53 +1,25 @@
-from abc import (
-    ABC,
-    abstractmethod
-)
 from typing import (
     Type
-)
-
-import rlp
-
-from eth_typing import (
-    Hash32
 )
 
 from eth._utils.datatypes import (
     Configurable,
 )
 
-from eth.db.chain import BaseChainDB
+from eth.abc import (
+    BlockAPI,
+    SignedTransactionAPI,
+)
 
-from .transactions import BaseTransaction
-from .headers import BlockHeader
 
-
-class BaseBlock(rlp.Serializable, Configurable, ABC):
-    transaction_class: Type[BaseTransaction] = None
+class BaseBlock(Configurable, BlockAPI):
+    transaction_class: Type[SignedTransactionAPI] = None
 
     @classmethod
-    def get_transaction_class(cls) -> Type[BaseTransaction]:
+    def get_transaction_class(cls) -> Type[SignedTransactionAPI]:
         if cls.transaction_class is None:
             raise AttributeError("Block subclasses must declare a transaction_class")
         return cls.transaction_class
-
-    @classmethod
-    @abstractmethod
-    def from_header(cls, header: BlockHeader, chaindb: BaseChainDB) -> 'BaseBlock':
-        """
-        Returns the block denoted by the given block header.
-        """
-        raise NotImplementedError("Must be implemented by subclasses")
-
-    @property
-    @abstractmethod
-    def hash(self) -> Hash32:
-        raise NotImplementedError("Must be implemented by subclasses")
-
-    @property
-    @abstractmethod
-    def number(self) -> int:
-        raise NotImplementedError("Must be implemented by subclasses")
 
     @property
     def is_genesis(self) -> bool:

--- a/eth/rlp/headers.py
+++ b/eth/rlp/headers.py
@@ -1,8 +1,7 @@
 import time
 from typing import (
+    Dict,
     Iterable,
-    Optional,
-    Union,
     overload,
 )
 
@@ -24,6 +23,10 @@ from eth_utils import (
     encode_hex,
 )
 
+from eth.abc import (
+    BlockHeaderAPI,
+    MiningHeaderAPI,
+)
 from eth.constants import (
     ZERO_ADDRESS,
     ZERO_HASH32,
@@ -32,7 +35,7 @@ from eth.constants import (
     GENESIS_PARENT_HASH,
     BLANK_ROOT_HASH,
 )
-
+from eth.typing import HeaderParams
 from eth.vm.execution_context import (
     ExecutionContext,
 )
@@ -45,7 +48,7 @@ from .sedes import (
 )
 
 
-class MiningHeader(rlp.Serializable):
+class MiningHeader(MiningHeaderAPI):
     fields = [
         ('parent_hash', hash32),
         ('uncles_hash', hash32),
@@ -63,10 +66,7 @@ class MiningHeader(rlp.Serializable):
     ]
 
 
-HeaderParams = Union[Optional[int], bytes, Address, Hash32]
-
-
-class BlockHeader(rlp.Serializable):
+class BlockHeader(BlockHeaderAPI):
     fields = [
         ('parent_hash', hash32),
         ('uncles_hash', hash32),
@@ -168,7 +168,7 @@ class BlockHeader(rlp.Serializable):
 
     @classmethod
     def from_parent(cls,
-                    parent: 'BlockHeader',
+                    parent: BlockHeaderAPI,
                     gas_limit: int,
                     difficulty: int,
                     timestamp: int,
@@ -176,12 +176,12 @@ class BlockHeader(rlp.Serializable):
                     nonce: bytes=None,
                     extra_data: bytes=None,
                     transaction_root: bytes=None,
-                    receipt_root: bytes=None) -> 'BlockHeader':
+                    receipt_root: bytes=None) -> BlockHeaderAPI:
         """
         Initialize a new block header with the `parent` header as the block's
         parent hash.
         """
-        header_kwargs = {
+        header_kwargs: Dict[str, HeaderParams] = {
             'parent_hash': parent.hash,
             'coinbase': coinbase,
             'state_root': parent.state_root,

--- a/eth/rlp/logs.py
+++ b/eth/rlp/logs.py
@@ -1,4 +1,3 @@
-import rlp
 from rlp.sedes import (
     CountableList,
     binary,
@@ -8,13 +7,15 @@ from typing import (
     Tuple,
 )
 
+from eth.abc import LogAPI
+
 from .sedes import (
     address,
     uint32,
 )
 
 
-class Log(rlp.Serializable):
+class Log(LogAPI):
     fields = [
         ('address', address),
         ('topics', CountableList(uint32)),

--- a/eth/rlp/receipts.py
+++ b/eth/rlp/receipts.py
@@ -1,6 +1,5 @@
 import itertools
 
-import rlp
 from rlp.sedes import (
     big_endian_int,
     CountableList,
@@ -9,16 +8,18 @@ from rlp.sedes import (
 
 from eth_bloom import BloomFilter
 
+from typing import Iterable
+
+from eth.abc import ReceiptAPI
+
 from .sedes import (
     uint256,
 )
 
 from .logs import Log
 
-from typing import Iterable
 
-
-class Receipt(rlp.Serializable):
+class Receipt(ReceiptAPI):
 
     fields = [
         ('state_root', binary),

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -18,13 +18,13 @@ from eth_utils import (
 )
 
 from eth import MainnetChain
+from eth.abc import (
+    BlockAPI,
+    ChainAPI,
+    StateAPI,
+    VirtualMachineAPI,
+)
 from eth.db.atomic import AtomicDB
-from eth.rlp.blocks import (
-    BaseBlock,
-)
-from eth.chains.base import (
-    BaseChain,
-)
 from eth.chains.mainnet import (
     MainnetDAOValidatorVM,
 )
@@ -37,9 +37,6 @@ from eth.typing import (
 from eth._utils.state import (
     diff_state,
 )
-from eth.vm.base import (
-    BaseVM,
-)
 from eth.vm.forks import (
     PetersburgVM,
     ConstantinopleVM,
@@ -49,15 +46,12 @@ from eth.vm.forks import (
     HomesteadVM as BaseHomesteadVM,
     SpuriousDragonVM,
 )
-from eth.vm.state import (
-    BaseState,
-)
 
 
 #
 # State Setup
 #
-def setup_state(desired_state: AccountState, state: BaseState) -> None:
+def setup_state(desired_state: AccountState, state: StateAPI) -> None:
     for account, account_data in desired_state.items():
         for slot, value in account_data['storage'].items():
             state.set_storage(account, slot, value)
@@ -72,7 +66,7 @@ def setup_state(desired_state: AccountState, state: BaseState) -> None:
     state.persist()
 
 
-def verify_state(expected_state: AccountState, state: BaseState) -> None:
+def verify_state(expected_state: AccountState, state: StateAPI) -> None:
     diff = diff_state(expected_state, state)
     if diff:
         error_messages = []
@@ -105,7 +99,7 @@ def verify_state(expected_state: AccountState, state: BaseState) -> None:
         )
 
 
-def chain_vm_configuration(fixture: Dict[str, Any]) -> Iterable[Tuple[int, Type[BaseVM]]]:
+def chain_vm_configuration(fixture: Dict[str, Any]) -> Iterable[Tuple[int, Type[VirtualMachineAPI]]]:  # noqa: E501
     network = fixture['network']
 
     if network == 'Frontier':
@@ -192,7 +186,7 @@ def genesis_params_from_fixture(fixture: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def new_chain_from_fixture(fixture: Dict[str, Any],
-                           chain_cls: Type[BaseChain]=MainnetChain) -> BaseChain:
+                           chain_cls: Type[ChainAPI] = MainnetChain) -> ChainAPI:
     base_db = AtomicDB()
 
     vm_config = chain_vm_configuration(fixture)
@@ -214,8 +208,8 @@ def new_chain_from_fixture(fixture: Dict[str, Any],
 
 def apply_fixture_block_to_chain(
         block_fixture: Dict[str, Any],
-        chain: BaseChain,
-        perform_validation: bool=True) -> Tuple[BaseBlock, BaseBlock, BaseBlock]:
+        chain: ChainAPI,
+        perform_validation: bool=True) -> Tuple[BlockAPI, BlockAPI, BlockAPI]:
     """
     :return: (premined_block, mined_block, rlp_encoded_mined_block)
     """

--- a/eth/typing.py
+++ b/eth/typing.py
@@ -5,6 +5,7 @@ from typing import (
     Generic,
     Iterable,
     List,
+    Optional,
     NewType,
     Sequence,
     Tuple,
@@ -25,12 +26,10 @@ from mypy_extensions import (
 )
 
 if TYPE_CHECKING:
-    from eth.rlp.transactions import BaseTransaction  # noqa: F401
-    from eth.vm.spoof import SpoofTransaction  # noqa: F401
-    from eth.vm.base import BaseVM  # noqa: F401
+    from eth.abc import VirtualMachineAPI  # noqa: F401
 
 
-# TODO: Move into eth_typing
+JournalDBCheckpoint = NewType('JournalDBCheckpoint', int)
 
 AccountDetails = TypedDict('AccountDetails',
                            {'balance': int,
@@ -41,8 +40,6 @@ AccountDetails = TypedDict('AccountDetails',
 AccountState = Dict[Address, AccountDetails]
 
 AccountDiff = Iterable[Tuple[Address, str, Union[int, bytes], Union[int, bytes]]]
-
-BaseOrSpoofTransaction = Union['BaseTransaction', 'SpoofTransaction']
 
 GeneralState = Union[
     AccountState,
@@ -74,7 +71,7 @@ TransactionDict = TypedDict('TransactionDict',
 
 TransactionNormalizer = Callable[[TransactionDict], TransactionDict]
 
-VMFork = Tuple[BlockNumber, Type['BaseVM']]
+VMFork = Tuple[BlockNumber, Type['VirtualMachineAPI']]
 
 VMConfiguration = Sequence[VMFork]
 
@@ -96,3 +93,6 @@ class StaticMethod(Generic[TFunc]):
 
     def __set__(self, oself: Any, value: TFunc) -> None:
         self._func = value
+
+
+HeaderParams = Union[Optional[int], bytes, Address, Hash32]

--- a/eth/validation.py
+++ b/eth/validation.py
@@ -7,7 +7,6 @@ from typing import (
     Sequence,
     Tuple,
     Type,
-    TYPE_CHECKING,
     Union,
 )
 
@@ -25,6 +24,7 @@ from eth_utils.toolz import functoolz
 
 from eth_utils.toolz import itertoolz
 
+from eth.abc import VirtualMachineAPI
 from eth.constants import (
     GAS_LIMIT_ADJUSTMENT_FACTOR,
     GAS_LIMIT_MAXIMUM,
@@ -36,9 +36,6 @@ from eth.constants import (
 from eth.typing import (
     BytesOrView,
 )
-
-if TYPE_CHECKING:
-    from eth.vm.base import BaseVM      # noqa: F401
 
 
 def validate_is_bytes(value: bytes, title: str="Value") -> None:
@@ -243,7 +240,8 @@ def validate_vm_block_numbers(vm_block_numbers: Iterable[int]) -> None:
         validate_block_number(block_number)
 
 
-def validate_vm_configuration(vm_configuration: Tuple[Tuple[int, Type['BaseVM']], ...]) -> None:
+def validate_vm_configuration(vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...],
+                              ) -> None:
     validate_vm_block_numbers(tuple(
         block_number
         for block_number, _

--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -5,15 +5,18 @@ from typing import (
     Set
 )
 
+from eth.abc import CodeStreamAPI
 from eth.validation import (
     validate_is_bytes,
 )
-from eth.vm import opcode_values
+from eth.vm.opcode_values import (
+    PUSH1,
+    PUSH32,
+    STOP,
+)
 
-PUSH1, PUSH32, STOP = opcode_values.PUSH1, opcode_values.PUSH32, opcode_values.STOP
 
-
-class CodeStream:
+class CodeStream(CodeStreamAPI):
     __slots__ = ['_length_cache', '_raw_code_bytes', 'invalid_positions', 'valid_positions', 'pc']
 
     logger = logging.getLogger('eth.vm.CodeStream')

--- a/eth/vm/forks/byzantium/headers.py
+++ b/eth/vm/forks/byzantium/headers.py
@@ -5,6 +5,11 @@ from typing import (
 from eth_utils.toolz import (
     curry,
 )
+
+from eth.abc import (
+    BlockHeaderAPI,
+    VirtualMachineAPI,
+)
 from eth.constants import (
     EMPTY_UNCLE_HASH,
     DIFFICULTY_ADJUSTMENT_DENOMINATOR,
@@ -12,18 +17,12 @@ from eth.constants import (
     BOMB_EXPONENTIAL_PERIOD,
     BOMB_EXPONENTIAL_FREE_PERIODS,
 )
-from eth.rlp.headers import (
-    BlockHeader,
-)
 from eth._utils.db import (
     get_parent_header,
 )
 from eth.validation import (
     validate_gt,
     validate_header_params_for_configuration,
-)
-from eth.vm.base import (
-    BaseVM
 )
 from eth.vm.forks.frontier.headers import (
     create_frontier_header_from_parent,
@@ -37,7 +36,7 @@ from .constants import (
 @curry
 def compute_difficulty(
         bomb_delay: int,
-        parent_header: BlockHeader,
+        parent_header: BlockHeaderAPI,
         timestamp: int) -> int:
     """
     https://github.com/ethereum/EIPs/issues/100
@@ -74,9 +73,9 @@ def compute_difficulty(
 
 
 @curry
-def create_header_from_parent(difficulty_fn: Callable[[BlockHeader, int], int],
-                              parent_header: BlockHeader,
-                              **header_params: Any) -> BlockHeader:
+def create_header_from_parent(difficulty_fn: Callable[[BlockHeaderAPI, int], int],
+                              parent_header: BlockHeaderAPI,
+                              **header_params: Any) -> BlockHeaderAPI:
 
     if 'difficulty' not in header_params:
         header_params.setdefault('timestamp', parent_header.timestamp + 1)
@@ -89,9 +88,9 @@ def create_header_from_parent(difficulty_fn: Callable[[BlockHeader, int], int],
 
 
 @curry
-def configure_header(difficulty_fn: Callable[[BlockHeader, int], int],
-                     vm: BaseVM,
-                     **header_params: Any) -> BlockHeader:
+def configure_header(difficulty_fn: Callable[[BlockHeaderAPI, int], int],
+                     vm: VirtualMachineAPI,
+                     **header_params: Any) -> BlockHeaderAPI:
     validate_header_params_for_configuration(header_params)
 
     with vm.get_header().build_changeset(**header_params) as changeset:

--- a/eth/vm/forks/byzantium/opcodes.py
+++ b/eth/vm/forks/byzantium/opcodes.py
@@ -1,5 +1,6 @@
 import copy
 import functools
+from typing import Dict
 
 from eth_utils.toolz import merge
 
@@ -10,6 +11,7 @@ from typing import (
 
 from eth import constants
 
+from eth.abc import OpcodeAPI
 from eth.exceptions import (
     WriteProtection,
 )
@@ -128,7 +130,7 @@ UPDATED_OPCODES = {
 }
 
 
-BYZANTIUM_OPCODES = merge(
+BYZANTIUM_OPCODES: Dict[int, OpcodeAPI] = merge(
     copy.deepcopy(SPURIOUS_DRAGON_OPCODES),
     UPDATED_OPCODES,
 )

--- a/eth/vm/forks/frontier/computation.py
+++ b/eth/vm/forks/frontier/computation.py
@@ -10,16 +10,17 @@ from eth.constants import (
     STACK_DEPTH_LIMIT,
 )
 
+from eth._utils.address import (
+    force_bytes_to_address,
+)
+from eth.abc import (
+    ComputationAPI,
+)
 from eth.exceptions import (
     OutOfGas,
     InsufficientFunds,
     StackDepthLimit,
 )
-
-from eth._utils.address import (
-    force_bytes_to_address,
-)
-
 from eth.vm.computation import (
     BaseComputation,
 )
@@ -44,7 +45,7 @@ class FrontierComputation(BaseComputation):
     opcodes = FRONTIER_OPCODES
     _precompiles = FRONTIER_PRECOMPILES     # type: ignore # https://github.com/python/mypy/issues/708 # noqa: E501
 
-    def apply_message(self) -> BaseComputation:
+    def apply_message(self) -> ComputationAPI:
         snapshot = self.state.snapshot()
 
         if self.msg.depth > STACK_DEPTH_LIMIT:
@@ -83,7 +84,7 @@ class FrontierComputation(BaseComputation):
 
         return computation
 
-    def apply_create_message(self) -> BaseComputation:
+    def apply_create_message(self) -> ComputationAPI:
         computation = self.apply_message()
 
         if computation.is_error:

--- a/eth/vm/forks/frontier/opcodes.py
+++ b/eth/vm/forks/frontier/opcodes.py
@@ -1,5 +1,8 @@
+from typing import Dict
+
 from eth import constants
 
+from eth.abc import OpcodeAPI
 from eth.vm import mnemonics
 from eth.vm import opcode_values
 from eth.vm.logic import (
@@ -23,7 +26,7 @@ from eth.vm.opcode import (
 )
 
 
-FRONTIER_OPCODES = {
+FRONTIER_OPCODES: Dict[int, OpcodeAPI] = {
     #
     # Arithmetic
     #

--- a/eth/vm/forks/frontier/validation.py
+++ b/eth/vm/forks/frontier/validation.py
@@ -2,17 +2,16 @@ from eth_utils import (
     ValidationError,
 )
 
-from eth.rlp.headers import BlockHeader
-from eth.rlp.transactions import BaseTransaction
-from eth.typing import (
-    BaseOrSpoofTransaction
+from eth.abc import (
+    BlockHeaderAPI,
+    SignedTransactionAPI,
+    StateAPI,
+    VirtualMachineAPI,
 )
-from eth.vm.base import BaseVM
-from eth.vm.state import BaseState
 
 
-def validate_frontier_transaction(state: BaseState,
-                                  transaction: BaseOrSpoofTransaction) -> None:
+def validate_frontier_transaction(state: StateAPI,
+                                  transaction: SignedTransactionAPI) -> None:
     gas_cost = transaction.gas * transaction.gas_price
     sender_balance = state.get_balance(transaction.sender)
 
@@ -34,9 +33,9 @@ def validate_frontier_transaction(state: BaseState,
         raise ValidationError("Invalid transaction nonce")
 
 
-def validate_frontier_transaction_against_header(_vm: BaseVM,
-                                                 base_header: BlockHeader,
-                                                 transaction: BaseTransaction) -> None:
+def validate_frontier_transaction_against_header(_vm: VirtualMachineAPI,
+                                                 base_header: BlockHeaderAPI,
+                                                 transaction: SignedTransactionAPI) -> None:
     if base_header.gas_used + transaction.gas > base_header.gas_limit:
         raise ValidationError(
             "Transaction exceeds gas limit: using {}, bringing total to {}, but limit is {}".format(

--- a/eth/vm/forks/homestead/__init__.py
+++ b/eth/vm/forks/homestead/__init__.py
@@ -1,9 +1,11 @@
 from typing import Optional, Type
-from eth.rlp.blocks import BaseBlock
-from eth.vm.state import BaseState
 
 from eth_typing import BlockNumber
 
+from eth.abc import (
+    BlockAPI,
+    StateAPI,
+)
 from eth.vm.forks.frontier import FrontierVM
 
 from .blocks import HomesteadBlock
@@ -31,8 +33,8 @@ class HomesteadVM(MetaHomesteadVM):
     fork: str = 'homestead'  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
 
     # classes
-    block_class: Type[BaseBlock] = HomesteadBlock
-    _state_class: Type[BaseState] = HomesteadState
+    block_class: Type[BlockAPI] = HomesteadBlock
+    _state_class: Type[StateAPI] = HomesteadState
 
     # method overrides
     create_header_from_parent = staticmethod(create_homestead_header_from_parent)   # type: ignore

--- a/eth/vm/forks/homestead/computation.py
+++ b/eth/vm/forks/homestead/computation.py
@@ -7,7 +7,8 @@ from eth.exceptions import (
 from eth_utils import (
     encode_hex,
 )
-from eth.vm.computation import BaseComputation
+
+from eth.abc import ComputationAPI
 from eth.vm.forks.frontier.computation import (
     FrontierComputation,
 )
@@ -23,7 +24,7 @@ class HomesteadComputation(FrontierComputation):
     # Override
     opcodes = HOMESTEAD_OPCODES
 
-    def apply_create_message(self) -> BaseComputation:
+    def apply_create_message(self) -> ComputationAPI:
         snapshot = self.state.snapshot()
 
         computation = self.apply_message()
@@ -44,7 +45,7 @@ class HomesteadComputation(FrontierComputation):
                 except OutOfGas as err:
                     # Different from Frontier: reverts state on gas failure while
                     # writing contract code.
-                    computation._error = err
+                    computation.error = err
                     self.state.revert(snapshot)
                 else:
                     if self.logger:

--- a/eth/vm/forks/homestead/opcodes.py
+++ b/eth/vm/forks/homestead/opcodes.py
@@ -1,8 +1,10 @@
 import copy
+from typing import Dict
 
 from eth_utils.toolz import merge
 
 from eth import constants
+from eth.abc import OpcodeAPI
 from eth.vm import mnemonics
 from eth.vm import opcode_values
 from eth.vm.logic import (
@@ -21,7 +23,7 @@ NEW_OPCODES = {
 }
 
 
-HOMESTEAD_OPCODES = merge(
+HOMESTEAD_OPCODES: Dict[int, OpcodeAPI] = merge(
     copy.deepcopy(FRONTIER_OPCODES),
     NEW_OPCODES
 )

--- a/eth/vm/forks/homestead/state.py
+++ b/eth/vm/forks/homestead/state.py
@@ -1,3 +1,9 @@
+from typing import Type
+
+from eth.abc import (
+    ComputationAPI,
+    SignedTransactionAPI,
+)
 from eth.vm.forks.frontier.state import (
     FrontierState,
     FrontierTransactionExecutor,
@@ -8,9 +14,10 @@ from .validation import validate_homestead_transaction
 
 
 class HomesteadState(FrontierState):
-    computation_class = HomesteadComputation
+    computation_class: Type[ComputationAPI] = HomesteadComputation
 
-    validate_transaction = validate_homestead_transaction
+    def validate_transaction(self, transaction: SignedTransactionAPI) -> None:
+        validate_homestead_transaction(self, transaction)
 
 
 class HomesteadTransactionExecutor(FrontierTransactionExecutor):

--- a/eth/vm/forks/homestead/validation.py
+++ b/eth/vm/forks/homestead/validation.py
@@ -6,15 +6,17 @@ from eth.constants import (
     SECPK1_N,
 )
 
-from eth.typing import BaseOrSpoofTransaction
+from eth.abc import (
+    SignedTransactionAPI,
+    StateAPI,
+)
 from eth.vm.forks.frontier.validation import (
     validate_frontier_transaction,
 )
-from eth.vm.state import BaseState
 
 
-def validate_homestead_transaction(state: BaseState,
-                                   transaction: BaseOrSpoofTransaction) -> None:
+def validate_homestead_transaction(state: StateAPI,
+                                   transaction: SignedTransactionAPI) -> None:
     if transaction.s > SECPK1_N // 2 or transaction.s == 0:
         raise ValidationError("Invalid signature S value")
 

--- a/eth/vm/forks/petersburg/__init__.py
+++ b/eth/vm/forks/petersburg/__init__.py
@@ -2,12 +2,14 @@ from typing import (
     Type,
 )
 
-from eth.rlp.blocks import BaseBlock
+from eth.abc import (
+    StateAPI,
+    BlockAPI,
+)
 from eth.vm.forks.byzantium import (
     ByzantiumVM,
     get_uncle_reward,
 )
-from eth.vm.state import BaseState
 
 from .blocks import PetersburgBlock
 from .constants import EIP1234_BLOCK_REWARD
@@ -24,8 +26,8 @@ class PetersburgVM(ByzantiumVM):
     fork = 'petersburg'
 
     # classes
-    block_class: Type[BaseBlock] = PetersburgBlock
-    _state_class: Type[BaseState] = PetersburgState
+    block_class: Type[BlockAPI] = PetersburgBlock
+    _state_class: Type[StateAPI] = PetersburgState
 
     # Methods
     create_header_from_parent = staticmethod(create_petersburg_header_from_parent)  # type: ignore

--- a/eth/vm/forks/petersburg/opcodes.py
+++ b/eth/vm/forks/petersburg/opcodes.py
@@ -1,4 +1,6 @@
 import copy
+from typing import Dict
+
 from eth_utils.toolz import (
     merge
 )
@@ -6,6 +8,7 @@ from eth_utils.toolz import (
 from eth import (
     constants
 )
+from eth.abc import OpcodeAPI
 from eth.vm import (
     mnemonics,
     opcode_values,
@@ -54,7 +57,7 @@ UPDATED_OPCODES = {
     )(),
 }
 
-PETERSBURG_OPCODES = merge(
+PETERSBURG_OPCODES: Dict[int, OpcodeAPI] = merge(
     copy.deepcopy(BYZANTIUM_OPCODES),
     UPDATED_OPCODES,
 )

--- a/eth/vm/forks/spurious_dragon/__init__.py
+++ b/eth/vm/forks/spurious_dragon/__init__.py
@@ -1,6 +1,9 @@
 from typing import Type
-from eth.rlp.blocks import BaseBlock
-from eth.vm.state import BaseState
+
+from eth.abc import (
+    BlockAPI,
+    StateAPI,
+)
 
 from ..tangerine_whistle import TangerineWhistleVM
 
@@ -13,5 +16,5 @@ class SpuriousDragonVM(TangerineWhistleVM):
     fork: str = 'spurious-dragon'  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
 
     # classes
-    block_class: Type[BaseBlock] = SpuriousDragonBlock
-    _state_class: Type[BaseState] = SpuriousDragonState
+    block_class: Type[BlockAPI] = SpuriousDragonBlock
+    _state_class: Type[StateAPI] = SpuriousDragonState

--- a/eth/vm/forks/spurious_dragon/computation.py
+++ b/eth/vm/forks/spurious_dragon/computation.py
@@ -4,10 +4,10 @@ from eth_utils import (
 )
 
 from eth import constants
+from eth.abc import ComputationAPI
 from eth.exceptions import (
     OutOfGas,
 )
-from eth.vm.computation import BaseComputation
 from eth.vm.forks.homestead.computation import (
     HomesteadComputation,
 )
@@ -24,7 +24,7 @@ class SpuriousDragonComputation(HomesteadComputation):
     # Override
     opcodes = SPURIOUS_DRAGON_OPCODES
 
-    def apply_create_message(self) -> BaseComputation:
+    def apply_create_message(self) -> ComputationAPI:
         snapshot = self.state.snapshot()
 
         # EIP161 nonce incrementation
@@ -39,7 +39,7 @@ class SpuriousDragonComputation(HomesteadComputation):
             contract_code = computation.output
 
             if contract_code and len(contract_code) >= EIP170_CODE_SIZE_LIMIT:
-                computation._error = OutOfGas(
+                computation.error = OutOfGas(
                     "Contract code size exceeds EIP170 limit of {0}.  Got code of "
                     "size: {1}".format(
                         EIP170_CODE_SIZE_LIMIT,
@@ -57,7 +57,7 @@ class SpuriousDragonComputation(HomesteadComputation):
                 except OutOfGas as err:
                     # Different from Frontier: reverts state on gas failure while
                     # writing contract code.
-                    computation._error = err
+                    computation.error = err
                     self.state.revert(snapshot)
                 else:
                     if self.logger:

--- a/eth/vm/forks/spurious_dragon/opcodes.py
+++ b/eth/vm/forks/spurious_dragon/opcodes.py
@@ -1,7 +1,9 @@
 import copy
+from typing import Dict
 
 from eth_utils.toolz import merge
 
+from eth.abc import OpcodeAPI
 from eth.vm.forks.tangerine_whistle.constants import (
     GAS_SELFDESTRUCT_EIP150,
     GAS_CALL_EIP150
@@ -41,7 +43,7 @@ UPDATED_OPCODES = {
 }
 
 
-SPURIOUS_DRAGON_OPCODES = merge(
+SPURIOUS_DRAGON_OPCODES: Dict[int, OpcodeAPI] = merge(
     copy.deepcopy(TANGERINE_WHISTLE_OPCODES),
     UPDATED_OPCODES,
 )

--- a/eth/vm/forks/spurious_dragon/state.py
+++ b/eth/vm/forks/spurious_dragon/state.py
@@ -1,13 +1,14 @@
+from typing import Type
+
 from eth_utils import (
     encode_hex,
 )
 
-from eth.typing import (
-    BaseOrSpoofTransaction,
+from eth.abc import (
+    ComputationAPI,
+    SignedTransactionAPI,
+    TransactionExecutorAPI,
 )
-
-from eth.vm.computation import BaseComputation
-
 from eth.vm.forks.homestead.state import (
     HomesteadState,
     HomesteadTransactionExecutor,
@@ -19,8 +20,8 @@ from ._utils import collect_touched_accounts
 
 class SpuriousDragonTransactionExecutor(HomesteadTransactionExecutor):
     def finalize_computation(self,
-                             transaction: BaseOrSpoofTransaction,
-                             computation: BaseComputation) -> BaseComputation:
+                             transaction: SignedTransactionAPI,
+                             computation: ComputationAPI) -> ComputationAPI:
         computation = super().finalize_computation(transaction, computation)
 
         #
@@ -44,5 +45,5 @@ class SpuriousDragonTransactionExecutor(HomesteadTransactionExecutor):
 
 
 class SpuriousDragonState(HomesteadState):
-    computation_class = SpuriousDragonComputation
-    transaction_executor = SpuriousDragonTransactionExecutor  # Type[BaseTransactionExecutor]
+    computation_class: Type[ComputationAPI] = SpuriousDragonComputation
+    transaction_executor_class: Type[TransactionExecutorAPI] = SpuriousDragonTransactionExecutor

--- a/eth/vm/forks/tangerine_whistle/__init__.py
+++ b/eth/vm/forks/tangerine_whistle/__init__.py
@@ -1,6 +1,6 @@
 from typing import Type
-from eth.vm.state import BaseState
 
+from eth.abc import StateAPI
 from eth.vm.forks.homestead import HomesteadVM
 
 from .state import TangerineWhistleState
@@ -11,7 +11,7 @@ class TangerineWhistleVM(HomesteadVM):
     fork: str = 'tangerine-whistle'  # noqa
 
     # classes
-    _state_class: Type[BaseState] = TangerineWhistleState
+    _state_class: Type[StateAPI] = TangerineWhistleState
 
     # Don't bother with any DAO logic in Tangerine VM or later
     # This is how we skip DAO logic on Ropsten, for example

--- a/eth/vm/gas_meter.py
+++ b/eth/vm/gas_meter.py
@@ -6,6 +6,8 @@ from typing import (
 from eth_utils import (
     ValidationError,
 )
+
+from eth.abc import GasMeterAPI
 from eth.exceptions import (
     OutOfGas,
 )
@@ -31,7 +33,7 @@ def allow_negative_refund_strategy(gas_refunded_total: int, amount: int) -> int:
 RefundStrategy = Callable[[int, int], int]
 
 
-class GasMeter(object):
+class GasMeter(GasMeterAPI):
 
     start_gas: int = None
 

--- a/eth/vm/logic/invalid.py
+++ b/eth/vm/logic/invalid.py
@@ -1,12 +1,6 @@
-from typing import (
-    TYPE_CHECKING,
-)
-
+from eth.abc import ComputationAPI
 from eth.exceptions import InvalidInstruction
 from eth.vm.opcode import Opcode
-
-if TYPE_CHECKING:
-    from eth.vm.computation import BaseComputation  # noqa: F401
 
 
 class InvalidOpcode(Opcode):
@@ -17,7 +11,7 @@ class InvalidOpcode(Opcode):
         self.value = value
         super().__init__()
 
-    def __call__(self, computation: 'BaseComputation') -> None:
+    def __call__(self, computation: ComputationAPI) -> None:
         raise InvalidInstruction("Invalid opcode 0x{0:x} @ {1}".format(
             self.value,
             computation.code.pc - 1,

--- a/eth/vm/memory.py
+++ b/eth/vm/memory.py
@@ -11,9 +11,10 @@ from eth.validation import (
 from eth._utils.numeric import (
     ceil32,
 )
+from eth.abc import MemoryAPI
 
 
-class Memory(object):
+class Memory(MemoryAPI):
     """
     VM Memory
     """

--- a/eth/vm/message.py
+++ b/eth/vm/message.py
@@ -2,6 +2,7 @@ import logging
 
 from eth_typing import Address
 
+from eth.abc import MessageAPI
 from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
 )
@@ -19,7 +20,7 @@ from eth.validation import (
 )
 
 
-class Message(object):
+class Message(MessageAPI):
     """
     A message for VM computation.
     """

--- a/eth/vm/spoof.py
+++ b/eth/vm/spoof.py
@@ -1,9 +1,11 @@
-from typing import Any
+from typing import Any, Union
 
-from eth.rlp.transactions import BaseTransaction
+from eth.abc import SignedTransactionAPI, UnsignedTransactionAPI
 from eth._utils.spoof import SpoofAttributes
 
 
 class SpoofTransaction(SpoofAttributes):
-    def __init__(self, transaction: BaseTransaction, **overrides: Any) -> None:
+    def __init__(self,
+                 transaction: Union[SignedTransactionAPI, UnsignedTransactionAPI],
+                 **overrides: Any) -> None:
         super().__init__(transaction, **overrides)

--- a/eth/vm/stack.py
+++ b/eth/vm/stack.py
@@ -20,6 +20,8 @@ from typing import (
     Union
 )
 
+from eth.abc import StackAPI
+
 
 def _busted_type(item_type: type, value: Union[int, bytes]) -> ValidationError:
     return ValidationError(
@@ -30,7 +32,7 @@ def _busted_type(item_type: type, value: Union[int, bytes]) -> ValidationError:
     )
 
 
-class Stack(object):
+class Stack(StackAPI):
     """
     VM Stack
     """

--- a/eth/vm/transaction_context.py
+++ b/eth/vm/transaction_context.py
@@ -2,13 +2,14 @@ import itertools
 
 from eth_typing import Address
 
+from eth.abc import TransactionContextAPI
 from eth.validation import (
     validate_canonical_address,
     validate_uint256,
 )
 
 
-class BaseTransactionContext:
+class BaseTransactionContext(TransactionContextAPI):
     """
     This immutable object houses information that remains constant for the entire context of the VM
     execution.

--- a/scripts/benchmark/_utils/chain_plumbing.py
+++ b/scripts/benchmark/_utils/chain_plumbing.py
@@ -26,14 +26,12 @@ from eth_typing import (
 from eth import (
     constants,
 )
+from eth.abc import VirtualMachineAPI
 from eth.chains.base import (
     MiningChain,
 )
 from eth.db.backends.level import (
     LevelDB,
-)
-from eth.vm.base import (
-    BaseVM,
 )
 from eth.chains.mainnet import (
     BaseMainnetChain,
@@ -88,7 +86,7 @@ DEFAULT_GENESIS_STATE = [
 GenesisState = Iterable[Tuple[Address, Dict[str, Any]]]
 
 
-def get_chain(vm: Type[BaseVM], genesis_state: GenesisState) -> Iterable[MiningChain]:
+def get_chain(vm: Type[VirtualMachineAPI], genesis_state: GenesisState) -> Iterable[MiningChain]:
 
     with tempfile.TemporaryDirectory() as temp_dir:
         level_db_obj = LevelDB(Path(temp_dir))


### PR DESCRIPTION
### What was wrong?

While working with the database components of the library in the trinity codebase I found myself wanting real abstract base class APIs to develop against.

### How was it fixed?

Created `eth.abc` and created propert `ABC` base classes for all of the main APIs from the codebase.

This should have near zero API changes.  The places where APIs changed are minor and have to do with some juggling to define the ABC classes for the `rlp.Serializable` objects.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
