### PR TITLE
Delete StateRootNotFound, execute_transaction()

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -1303,9 +1303,13 @@ class StateAPI(ConfigurableAPI):
     # Execution
     #
     @abstractmethod
-    def apply_transaction(
-            self,
-            transaction: SignedTransactionAPI) -> ComputationAPI:
+    def apply_transaction(self, transaction: SignedTransactionAPI) -> ComputationAPI:
+        """
+        Apply transaction to the vm state
+
+        :param transaction: the transaction to apply
+        :return: the computation
+        """
         ...
 
     @abstractmethod
@@ -1319,10 +1323,6 @@ class StateAPI(ConfigurableAPI):
 
     @abstractmethod
     def override_transaction_context(self, gas_price: int) -> ContextManager[None]:
-        ...
-
-    @abstractmethod
-    def execute_transaction(self, transaction: SignedTransactionAPI) -> ComputationAPI:
         ...
 
     @abstractmethod

--- a/eth/estimators/gas.py
+++ b/eth/estimators/gas.py
@@ -16,7 +16,7 @@ def _get_computation_error(state: StateAPI, transaction: SignedTransactionAPI) -
     snapshot = state.snapshot()
 
     try:
-        computation = state.execute_transaction(transaction)
+        computation = state.apply_transaction(transaction)
         if computation.is_error:
             return computation.error
         else:

--- a/eth/vm/forks/frontier/state.py
+++ b/eth/vm/forks/frontier/state.py
@@ -190,7 +190,7 @@ class FrontierState(BaseState):
     account_db_class: Type[AccountDatabaseAPI] = AccountDB
     transaction_executor_class: Type[TransactionExecutorAPI] = FrontierTransactionExecutor
 
-    def execute_transaction(self, transaction: SignedTransactionAPI) -> ComputationAPI:
+    def apply_transaction(self, transaction: SignedTransactionAPI) -> ComputationAPI:
         executor = self.get_transaction_executor()
         return executor(transaction)
 

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -26,10 +26,8 @@ from eth.abc import (
     TransactionExecutorAPI,
 )
 from eth.constants import (
-    BLANK_ROOT_HASH,
     MAX_PREV_HEADER_DEPTH,
 )
-from eth.exceptions import StateRootNotFound
 from eth.tools.logging import (
     ExtendedDebugLogger,
 )
@@ -286,20 +284,6 @@ class BaseState(Configurable, StateAPI):
     #
     # Execution
     #
-    def apply_transaction(
-            self,
-            transaction: SignedTransactionAPI) -> ComputationAPI:
-        """
-        Apply transaction to the vm state
-
-        :param transaction: the transaction to apply
-        :return: the computation
-        """
-        if self.state_root != BLANK_ROOT_HASH and not self._account_db.has_root(self.state_root):
-            raise StateRootNotFound(self.state_root)
-        else:
-            return self.execute_transaction(transaction)
-
     def get_transaction_executor(self) -> TransactionExecutorAPI:
         return self.transaction_executor_class(self)
 
@@ -307,7 +291,7 @@ class BaseState(Configurable, StateAPI):
                                      transaction: SignedTransactionAPI) -> ComputationAPI:
         with self.override_transaction_context(gas_price=transaction.gas_price):
             free_transaction = transaction.copy(gas_price=0)
-            return self.execute_transaction(free_transaction)
+            return self.apply_transaction(free_transaction)
 
     @contextlib.contextmanager
     def override_transaction_context(self, gas_price: int) -> Iterator[None]:

--- a/newsfragments/1809.removal.rst
+++ b/newsfragments/1809.removal.rst
@@ -1,0 +1,2 @@
+Drop StateRootNotFound as an over-specialized version of EVMMissingData.
+Drop VMState.execute_transaction() as redundant to VMState.apply_transaction().


### PR DESCRIPTION
### What was wrong?

When handling missing node exceptions `StateRootNotFound` is an easy one to miss and only comes up very rarely. It's an unnecessary specialization of other exceptions now, IMO.

### How was it fixed?

The exception is an overly-custom version of the MissingTrieNode
exceptions. Just let those bubble up now.

Now `execute_transaction()` is exactly the same as `apply_transaction()`, so
drop the method (and save the method overhead).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.vimeocdn.com/video/715721084_780x439.jpg)
