### PR TITLE
Bugfix: don't crash on re-org of header-only chain

### DIFF
--- a/newsfragments/1810.bugfix.rst
+++ b/newsfragments/1810.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a crash during chain reorganization on a header-only chain (which can happen during Beam Sync)


### PR DESCRIPTION
### What was wrong?

When a chain reorg's, it tries to remove the canonical transactions from the lookup db. If that chain is header-only, it crashes, because the canonical transactions were never inserted.

### How was it fixed?

Catch and drop the exception if canonical transactions were missing. The point was to delete them, so if they are missing: mission accomplished.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/22/a4/39/22a439cfbc8c14ebda84e4dcd9f699d2.jpg)
