### PR TITLE
Fix missing Chain.get_vm_class method

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -1723,6 +1723,7 @@ class ChainAPI(ConfigurableAPI):
     # VM API
     #
     @classmethod
+    @abstractmethod
     def get_vm_class(cls, header: BlockHeaderAPI) -> Type[VirtualMachineAPI]:
         """
         Returns the VM instance for the given block number.

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -130,6 +130,10 @@ class BaseChain(Configurable, ChainAPI):
         else:
             raise VMNotFound("No vm available for block #{0}".format(block_number))
 
+    @classmethod
+    def get_vm_class(cls, header: BlockHeaderAPI) -> Type[VirtualMachineAPI]:
+        return cls.get_vm_class_for_block_number(header.block_number)
+
     #
     # Validation API
     #

--- a/newsfragments/1821.bugfix.rst
+++ b/newsfragments/1821.bugfix.rst
@@ -1,0 +1,1 @@
+Add back missing ``Chain.get_vm_class`` method.

--- a/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
+++ b/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
@@ -69,6 +69,15 @@ def test_header_chain_get_vm_class_for_block_number(base_db, genesis_header):
         assert chain.get_vm_class_for_block_number(num) is VM_B
 
 
+def test_header_chain_get_vm_class_using_block_header(base_db, genesis_header):
+    chain = ChainForTesting.from_genesis_header(base_db, genesis_header)
+    assert chain.get_vm_class(genesis_header) is VM_A
+
+    header_at_height_10 = genesis_header.copy(block_number=10)
+
+    assert chain.get_vm_class(header_at_height_10) is VM_B
+
+
 def test_header_chain_invalid_if_no_vm_configuration(base_db, genesis_header):
     chain_class = MiningChain.configure('ChainNoEmptyConfiguration', vm_configuration=())
     with pytest.raises(ValueError):


### PR DESCRIPTION
### What was wrong?

In the refactor to add `eth.abc` the `Chain.get_vm_class` method got lost.

### How was it fixed?

Added it back and added a test for it too.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
