### PR TITLE
Remove Trinity from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,6 @@ In particular Py-EVM aims to:
 
 - be highly flexible to support both research as well as alternate use cases like private chains.
 
-## Trinity
-
-While Py-EVM provides the low level APIs of the Ethereum protocol, it does not aim to implement a
-full or light node directly.
-
-### Goals
-
-- provide a reference implementation for an Ethereum 1.0 node (alpha)
-
-- support "full" and "light" modes
-
-- fully support mainnet as well as several testnets
-
-- provide a reference implementation of an Ethereum 2.0 / Serenity beacon node (pre-alpha)
-
-- provide a reference implementation of an Ethereum 2.0 / Sereneity validator node (pre-alpha)
-
 
 ## Quickstart
 

--- a/newsfragments/1827.doc.rst
+++ b/newsfragments/1827.doc.rst
@@ -1,0 +1,2 @@
+Remove section on Trinity's goals from the Readme. It's been a leftover from when
+Py-EVM and Trinity where hosted in a single repository.


### PR DESCRIPTION
### What was wrong?

The Readme still features Trinity which is confusing.

### How was it fixed?

Remove the section about Trinity.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.listoid.com/image/125/list_2_125_20101203_155517_376.jpg)
