### PR TITLE
EIP-1108: Reduce EC precompile costs

### DIFF
--- a/eth/precompiles/ecadd.py
+++ b/eth/precompiles/ecadd.py
@@ -9,6 +9,9 @@ from eth_utils import (
     big_endian_to_int,
     int_to_big_endian,
 )
+from eth_utils.toolz import (
+    curry,
+)
 
 from eth import constants
 
@@ -28,8 +31,12 @@ from eth.vm.computation import (
 )
 
 
-def ecadd(computation: BaseComputation) -> BaseComputation:
-    computation.consume_gas(constants.GAS_ECADD, reason='ECADD Precompile')
+@curry
+def ecadd(
+        computation: BaseComputation,
+        gas_cost: int = constants.GAS_ECADD) -> BaseComputation:
+
+    computation.consume_gas(gas_cost, reason='ECADD Precompile')
 
     try:
         result = _ecadd(computation.msg.data_as_bytes)

--- a/eth/precompiles/ecmul.py
+++ b/eth/precompiles/ecmul.py
@@ -9,6 +9,9 @@ from eth_utils import (
     int_to_big_endian,
     ValidationError,
 )
+from eth_utils.toolz import (
+    curry,
+)
 
 from eth import constants
 
@@ -28,8 +31,12 @@ from eth.vm.computation import (
 )
 
 
-def ecmul(computation: BaseComputation) -> BaseComputation:
-    computation.consume_gas(constants.GAS_ECMUL, reason='ECMUL Precompile')
+@curry
+def ecmul(
+        computation: BaseComputation,
+        gas_cost: int = constants.GAS_ECMUL) -> BaseComputation:
+
+    computation.consume_gas(gas_cost, reason='ECMUL Precompile')
 
     try:
         result = _ecmull(computation.msg.data_as_bytes)

--- a/eth/vm/forks/istanbul/computation.py
+++ b/eth/vm/forks/istanbul/computation.py
@@ -1,3 +1,11 @@
+from eth_utils.toolz import (
+    merge,
+)
+
+from eth import precompiles
+from eth._utils.address import (
+    force_bytes_to_address,
+)
 from eth.vm.forks.constantinople.computation import (
     CONSTANTINOPLE_PRECOMPILES
 )
@@ -5,9 +13,25 @@ from eth.vm.forks.constantinople.computation import (
     ConstantinopleComputation
 )
 
+from .constants import (
+    GAS_ECADD,
+    GAS_ECMUL,
+    GAS_ECPAIRING_BASE,
+    GAS_ECPAIRING_PER_POINT,
+)
 from .opcodes import ISTANBUL_OPCODES
 
-ISTANBUL_PRECOMPILES = CONSTANTINOPLE_PRECOMPILES
+ISTANBUL_PRECOMPILES = merge(
+    CONSTANTINOPLE_PRECOMPILES,
+    {
+        force_bytes_to_address(b'\x06'): precompiles.ecadd(gas_cost=GAS_ECADD),
+        force_bytes_to_address(b'\x07'): precompiles.ecmul(gas_cost=GAS_ECMUL),
+        force_bytes_to_address(b'\x08'): precompiles.ecpairing(
+            gas_cost_base=GAS_ECPAIRING_BASE,
+            gas_cost_per_point=GAS_ECPAIRING_PER_POINT,
+        ),
+    },
+)
 
 
 class IstanbulComputation(ConstantinopleComputation):

--- a/eth/vm/forks/istanbul/constants.py
+++ b/eth/vm/forks/istanbul/constants.py
@@ -1,0 +1,10 @@
+
+#
+# New gas costs for some opcodes
+#
+
+# EIP-1108:
+GAS_ECADD = 150
+GAS_ECMUL = 6000
+GAS_ECPAIRING_BASE = 45_000
+GAS_ECPAIRING_PER_POINT = 34_000

--- a/newsfragments/1819.feature.rst
+++ b/newsfragments/1819.feature.rst
@@ -1,0 +1,1 @@
+Add EIP-1108 to Istanbul: Reduce EC precompile costs


### PR DESCRIPTION
### What was wrong?

Fixes #1819

### How was it fixed?

- made the precompiles curry-able
- moved gas price into a keyword argument that defaults to the original byzantium cost
- added modified precompiles to instanbul

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://earthporm.com/wp-content/uploads/2015/04/cute-animals-hokkaido-ezo-japan-30.jpg)
