### PR TITLE
Make checkpoint header the canonical head

### DIFF
--- a/eth/db/header.py
+++ b/eth/db/header.py
@@ -167,6 +167,10 @@ class HeaderDB(HeaderDatabaseAPI):
             return self._persist_header_chain(db, headers, genesis_parent_hash)
 
     def persist_checkpoint_header(self, header: BlockHeaderAPI, score: int) -> None:
+        """
+        Persist a checkpoint header with a trusted score. Persisting the checkpoint header
+        automatically sets it as the new canonical head.
+        """
         with self.db.atomic_batch() as db:
             return self._persist_checkpoint_header(db, header, score)
 
@@ -199,6 +203,7 @@ class HeaderDB(HeaderDatabaseAPI):
         )
         previous_score = score - header.difficulty
         cls._set_hash_scores_to_db(db, header, previous_score)
+        cls._set_as_canonical_chain_head(db, header.hash, header.parent_hash)
 
     @classmethod
     def _persist_header_chain(

--- a/newsfragments/1830.bugfix.rst
+++ b/newsfragments/1830.bugfix.rst
@@ -1,0 +1,1 @@
+Make sure ``persist_checkpoint_header`` sets the given header as canonical head.

--- a/tests/database/test_header_db.py
+++ b/tests/database/test_header_db.py
@@ -97,6 +97,8 @@ def test_headerdb_persist_disconnected_headers(headerdb, genesis_header):
     # Persist the checkpoint header with a trusted score
     headerdb.persist_checkpoint_header(pseudo_genesis, score_at_pseudo_genesis)
 
+    assert_headers_eq(headerdb.get_canonical_head(), pseudo_genesis)
+
     headers_from_pseudo_genesis = (headers[8], headers[9],)
 
     headerdb.persist_header_chain(headers_from_pseudo_genesis, pseudo_genesis.parent_hash)


### PR DESCRIPTION
### What was wrong?

We recently added support to persist checkpoint headers, in other words, headers, not connected to genesis, persisted with a score that we trust.

However, previously, when we set `persist_checkpoint_header` it did not make that checkpoint header the canonical head.

The feature is used for checkpointed beam sync (https://github.com/ethereum/trinity/pull/921) 
and in a previous version of that PR it didn't mattered if that API call would make the checkpoint header the new canonical head or not.

The reason for that is because eventually a header on top would be persisted with `persist_header_chain(headers, genesis_parent_hash)` and then that would move the canonical head to the latest header.

But with a refactored https://github.com/ethereum/trinity/pull/921 this turned out to be a problem because we now assume that calling `persist_checkpoint_header` would also make that checkpoint header the new canonical head (Which strikes me as a logical thing).


### How was it fixed?

This makes the persisted header the new canonical head without any further checking. I'm not entirely sure but I can't think of a case where we would **not** want to make that checkpoint header the new canonical head.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.awesomelycute.com/gallery/2014/02/cutest-wild-animals-2950.jpg)
