### PR TITLE
Refactor net gas metering as prep for EIP-2200

### DIFF
--- a/eth/vm/forks/constantinople/storage.py
+++ b/eth/vm/forks/constantinople/storage.py
@@ -1,71 +1,16 @@
-from eth_utils import (
-    encode_hex,
+from functools import partial
+
+from eth.vm.logic.storage import (
+    net_sstore,
+    NetSStoreGasSchedule,
 )
 
-from eth.vm.computation import BaseComputation
-from eth.vm.forks.constantinople import (
-    constants
+GAS_SCHEDULE_EIP1283 = NetSStoreGasSchedule(
+    base=200,
+    create=20000,
+    update=5000,
+    remove_refund=15000,
 )
 
 
-def sstore_eip1283(computation: BaseComputation) -> None:
-    slot, value = computation.stack_pop_ints(2)
-
-    current_value = computation.state.get_storage(
-        address=computation.msg.storage_address,
-        slot=slot,
-    )
-
-    original_value = computation.state.get_storage(
-        address=computation.msg.storage_address,
-        slot=slot,
-        from_journal=False
-    )
-
-    gas_refund = 0
-
-    if current_value == value:
-        gas_cost = constants.GAS_SSTORE_EIP1283_NOOP
-    else:
-        if original_value == current_value:
-            if original_value == 0:
-                gas_cost = constants.GAS_SSTORE_EIP1283_INIT
-            else:
-                gas_cost = constants.GAS_SSTORE_EIP1283_CLEAN
-
-                if value == 0:
-                    gas_refund += constants.GAS_SSTORE_EIP1283_CLEAR_REFUND
-        else:
-            gas_cost = constants.GAS_SSTORE_EIP1283_NOOP
-
-            if original_value != 0:
-                if current_value == 0:
-                    gas_refund -= constants.GAS_SSTORE_EIP1283_CLEAR_REFUND
-                if value == 0:
-                    gas_refund += constants.GAS_SSTORE_EIP1283_CLEAR_REFUND
-
-            if original_value == value:
-                if original_value == 0:
-                    gas_refund += constants.GAS_SSTORE_EIP1283_RESET_CLEAR_REFUND
-                else:
-                    gas_refund += constants.GAS_SSTORE_EIP1283_RESET_REFUND
-
-    computation.consume_gas(
-        gas_cost,
-        reason="SSTORE: {0}[{1}] -> {2} (current: {3} / original: {4})".format(
-            encode_hex(computation.msg.storage_address),
-            slot,
-            value,
-            current_value,
-            original_value,
-        )
-    )
-
-    if gas_refund:
-        computation.refund_gas(gas_refund)
-
-    computation.state.set_storage(
-        address=computation.msg.storage_address,
-        slot=slot,
-        value=value,
-    )
+sstore_eip1283 = partial(net_sstore, GAS_SCHEDULE_EIP1283)

--- a/eth/vm/logic/storage.py
+++ b/eth/vm/logic/storage.py
@@ -1,3 +1,5 @@
+from typing import NamedTuple
+
 from eth_utils import (
     encode_hex,
 )
@@ -58,3 +60,73 @@ def sload(computation: BaseComputation) -> None:
         slot=slot,
     )
     computation.stack_push_int(value)
+
+
+class NetSStoreGasSchedule(NamedTuple):
+    base: int    # the gas cost when nothing changes (eg~ dirty->dirty, clean->clean, etc)
+    create: int  # a brand new value, where none previously existed, aka init or set
+    update: int  # a change to a value when the value was previously unchanged, aka clean, reset
+    remove_refund: int  # the refund for removing a value, aka: clear_refund
+
+
+def net_sstore(gas_schedule: NetSStoreGasSchedule, computation: BaseComputation) -> None:
+    slot, value = computation.stack_pop_ints(2)
+
+    current_value = computation.state.get_storage(
+        address=computation.msg.storage_address,
+        slot=slot,
+    )
+
+    original_value = computation.state.get_storage(
+        address=computation.msg.storage_address,
+        slot=slot,
+        from_journal=False
+    )
+
+    gas_refund = 0
+
+    if current_value == value:
+        gas_cost = gas_schedule.base
+    else:
+        if original_value == current_value:
+            if original_value == 0:
+                gas_cost = gas_schedule.create
+            else:
+                gas_cost = gas_schedule.update
+
+                if value == 0:
+                    gas_refund += gas_schedule.remove_refund
+        else:
+            gas_cost = gas_schedule.base
+
+            if original_value != 0:
+                if current_value == 0:
+                    gas_refund -= gas_schedule.remove_refund
+                if value == 0:
+                    gas_refund += gas_schedule.remove_refund
+
+            if original_value == value:
+                if original_value == 0:
+                    gas_refund += (gas_schedule.create - gas_schedule.base)
+                else:
+                    gas_refund += (gas_schedule.update - gas_schedule.base)
+
+    computation.consume_gas(
+        gas_cost,
+        reason="SSTORE: {0}[{1}] -> {2} (current: {3} / original: {4})".format(
+            encode_hex(computation.msg.storage_address),
+            slot,
+            value,
+            current_value,
+            original_value,
+        )
+    )
+
+    if gas_refund:
+        computation.refund_gas(gas_refund)
+
+    computation.state.set_storage(
+        address=computation.msg.storage_address,
+        slot=slot,
+        value=value,
+    )


### PR DESCRIPTION
### What was wrong?

There is a lot of shared logic between the original 1283 net gas metering, and the new 2200 net gas metering, but not an easy way to reuse it with a few variables updated.

Related to #1825 

### How was it fixed?

Generalized net gas metering logic to accept a gas schedule as an argument.

You can see where this is headed with something like an Istanbul version of:

```py
from eth.exceptions import OutOfGas
from eth.vm.computation import BaseComputation
from eth.vm.forks.constantinople.storage import (
    GAS_SCHEDULE_EIP1283,
)
from eth.vm.forks.istanbul import (
    constants
)
from eth.vm.logic.storage import (
    net_sstore,
)

GAS_SCHEDULE_EIP2200 = GAS_SCHEDULE_EIP1283._replace(base=constants.GAS_SLOAD_EIP1884)


def sstore_eip2200(computation: BaseComputation) -> None:
    gas_remaining = computation.get_gas_remaining()
    if gas_remaining <= 2300:
        raise OutOfGas(
            "Net-metered SSTORE always fails below 2300 gas, per EIP-2200",
            gas_remaining,
        )
    else:
        return net_sstore(GAS_SCHEDULE_EIP2200, computation)
```

Since adding this ^ depends on merging #1829 , I'm splitting this in two parts. Each one should be a pretty quick review.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~~Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)~~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://secure.i.telegraph.co.uk/multimedia/archive/01429/baby-fennecs_1429778i.jpg)