### PR TITLE
rename get_intrinsic_gas method to <fork>_get_intrinsic_gas

### DIFF
--- a/eth/vm/forks/frontier/transactions.py
+++ b/eth/vm/forks/frontier/transactions.py
@@ -46,7 +46,7 @@ FRONTIER_TX_GAS_SCHEDULE = IntrinsicGasSchedule(
 )
 
 
-get_intrinsic_gas = partial(calculate_intrinsic_gas, FRONTIER_TX_GAS_SCHEDULE)
+frontier_get_intrinsic_gas = partial(calculate_intrinsic_gas, FRONTIER_TX_GAS_SCHEDULE)
 
 
 class FrontierTransaction(BaseTransaction):
@@ -89,7 +89,7 @@ class FrontierTransaction(BaseTransaction):
         return extract_transaction_sender(self)
 
     def get_intrinsic_gas(self) -> int:
-        return get_intrinsic_gas(self)
+        return frontier_get_intrinsic_gas(self)
 
     def get_message_for_signing(self) -> bytes:
         return rlp.encode(FrontierUnsignedTransaction(
@@ -140,4 +140,4 @@ class FrontierUnsignedTransaction(BaseUnsignedTransaction):
         )
 
     def get_intrinsic_gas(self) -> int:
-        return get_intrinsic_gas(self)
+        return frontier_get_intrinsic_gas(self)

--- a/eth/vm/forks/homestead/transactions.py
+++ b/eth/vm/forks/homestead/transactions.py
@@ -28,7 +28,7 @@ HOMESTEAD_TX_GAS_SCHEDULE = FRONTIER_TX_GAS_SCHEDULE._replace(
 )
 
 
-get_intrinsic_gas = partial(calculate_intrinsic_gas, HOMESTEAD_TX_GAS_SCHEDULE)
+homestead_get_intrinsic_gas = partial(calculate_intrinsic_gas, HOMESTEAD_TX_GAS_SCHEDULE)
 
 
 class HomesteadTransaction(FrontierTransaction):
@@ -37,7 +37,7 @@ class HomesteadTransaction(FrontierTransaction):
         validate_lt_secpk1n2(self.s, title="Transaction.s")
 
     def get_intrinsic_gas(self) -> int:
-        return get_intrinsic_gas(self)
+        return homestead_get_intrinsic_gas(self)
 
     def get_message_for_signing(self) -> bytes:
         return rlp.encode(HomesteadUnsignedTransaction(
@@ -77,4 +77,4 @@ class HomesteadUnsignedTransaction(FrontierUnsignedTransaction):
         )
 
     def get_intrinsic_gas(self) -> int:
-        return get_intrinsic_gas(self)
+        return homestead_get_intrinsic_gas(self)

--- a/eth/vm/forks/istanbul/transactions.py
+++ b/eth/vm/forks/istanbul/transactions.py
@@ -25,7 +25,7 @@ ISTANBUL_TX_GAS_SCHEDULE = HOMESTEAD_TX_GAS_SCHEDULE._replace(
 )
 
 
-get_intrinsic_gas = partial(calculate_intrinsic_gas, ISTANBUL_TX_GAS_SCHEDULE)
+istanbul_get_intrinsic_gas = partial(calculate_intrinsic_gas, ISTANBUL_TX_GAS_SCHEDULE)
 
 
 class IstanbulTransaction(ConstantinopleTransaction):
@@ -41,7 +41,7 @@ class IstanbulTransaction(ConstantinopleTransaction):
         return IstanbulUnsignedTransaction(nonce, gas_price, gas, to, value, data)
 
     def get_intrinsic_gas(self) -> int:
-        return get_intrinsic_gas(self)
+        return istanbul_get_intrinsic_gas(self)
 
 
 class IstanbulUnsignedTransaction(ConstantinopleUnsignedTransaction):
@@ -62,4 +62,4 @@ class IstanbulUnsignedTransaction(ConstantinopleUnsignedTransaction):
         )
 
     def get_intrinsic_gas(self) -> int:
-        return get_intrinsic_gas(self)
+        return istanbul_get_intrinsic_gas(self)


### PR DESCRIPTION
### What was wrong?

addreses https://github.com/ethereum/py-evm/pull/1832#discussion_r317845185

### How was it fixed?
renamed get_intrinsic_gas method to <fork>_get_intrinsic_gas

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] <strike>Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)</strike>(Don't think its worthwile writing release notes for this simple change )

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/ufuv70eyf4j31.jpg)
