### PR TITLE
~20% speedup on "simple value transfer" benchmarks

### DIFF
--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -278,8 +278,8 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
         receipt_db = HexaryTrie(db=self.db, root_hash=header.receipt_root)
         for receipt_idx in itertools.count():
             receipt_key = rlp.encode(receipt_idx)
-            if receipt_key in receipt_db:
-                receipt_data = receipt_db[receipt_key]
+            receipt_data = receipt_db[receipt_key]
+            if receipt_data != b'':
                 yield rlp.decode(receipt_data, sedes=receipt_class)
             else:
                 break
@@ -301,8 +301,8 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
             raise TransactionNotFound("Block {} is not in the canonical chain".format(block_number))
         transaction_db = HexaryTrie(self.db, root_hash=block_header.transaction_root)
         encoded_index = rlp.encode(transaction_index)
-        if encoded_index in transaction_db:
-            encoded_transaction = transaction_db[encoded_index]
+        encoded_transaction = transaction_db[encoded_index]
+        if encoded_transaction != b'':
             return rlp.decode(encoded_transaction, sedes=transaction_class)
         else:
             raise TransactionNotFound(
@@ -341,8 +341,8 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
 
         receipt_db = HexaryTrie(db=self.db, root_hash=block_header.receipt_root)
         receipt_key = rlp.encode(receipt_index)
-        if receipt_key in receipt_db:
-            receipt_data = receipt_db[receipt_key]
+        receipt_data = receipt_db[receipt_key]
+        if receipt_data != b'':
             return rlp.decode(receipt_data, sedes=Receipt)
         else:
             raise ReceiptNotFound(
@@ -356,8 +356,9 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
         transaction_db = HexaryTrie(db, root_hash=transaction_root)
         for transaction_idx in itertools.count():
             transaction_key = rlp.encode(transaction_idx)
-            if transaction_key in transaction_db:
-                yield transaction_db[transaction_key]
+            encoded = transaction_db[transaction_key]
+            if encoded != b'':
+                yield encoded
             else:
                 break
 

--- a/newsfragments/1841.doc.rst
+++ b/newsfragments/1841.doc.rst
@@ -1,0 +1,1 @@
+Add a "Performance improvements" section to the release notes

--- a/newsfragments/1841.performance.rst
+++ b/newsfragments/1841.performance.rst
@@ -1,0 +1,2 @@
+~20% speedup on "simple value transfer" benchmarks, ~10% overall benchmark lift. Optimized retrieval
+of transactions and receipts from the trie database.

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -10,6 +10,7 @@ Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 
 * `feature`
 * `bugfix`
+* `performance`
 * `doc`
 * `removal`
 * `misc`

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -9,6 +9,7 @@ import pathlib
 ALLOWED_EXTENSIONS = {
     '.feature.rst',
     '.bugfix.rst',
+    '.performance.rst',
     '.doc.rst',
     '.removal.rst',
     '.misc.rst',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,33 @@ filename = "docs/release_notes.rst"
 directory = "newsfragments"
 underlines = ["-", "~", "^"]
 issue_format = "`#{issue} <https://github.com/ethereum/py-evm/issues/{issue}>`__"
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bugfixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "performance"
+name = "Performance improvements"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Improved Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removal"
+name = "Deprecations and Removals"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Miscellaneous internal changes"
+showcontent = false


### PR DESCRIPTION
### How did it come up?

I was trying out Intel's vtune, and used the "simple value transfer" benchmarks as a target.

Turns out that both the existence check and retrieving the receipt & transfer were expensive, essentially double the work for no benefit.

### How was it fixed?

Look in the receipt and transaction tries once instead of twice.
Checking if a value is present is nearly as much work as getting the
value.

So now, get the value once, and check if it's empty (same as missing).


(Also added a 'performance' type to towncrier)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://41.media.tumblr.com/bcf2a4b81e26ae10b717760b3e97dd6d/tumblr_njbhpeVxQP1s6twq0o3_1280.jpg)
