### PR TITLE
Make Istanbul inherit from Petersburg instead of Constantinople

### DIFF
--- a/eth/vm/forks/istanbul/blocks.py
+++ b/eth/vm/forks/istanbul/blocks.py
@@ -4,8 +4,8 @@ from rlp.sedes import (
 from eth.rlp.headers import (
     BlockHeader,
 )
-from eth.vm.forks.constantinople.blocks import (
-    ConstantinopleBlock,
+from eth.vm.forks.petersburg.blocks import (
+    PetersburgBlock,
 )
 
 from .transactions import (
@@ -13,7 +13,7 @@ from .transactions import (
 )
 
 
-class IstanbulBlock(ConstantinopleBlock):
+class IstanbulBlock(PetersburgBlock):
     transaction_class = IstanbulTransaction
     fields = [
         ('header', BlockHeader),

--- a/eth/vm/forks/istanbul/computation.py
+++ b/eth/vm/forks/istanbul/computation.py
@@ -6,11 +6,15 @@ from eth import precompiles
 from eth._utils.address import (
     force_bytes_to_address,
 )
-from eth.vm.forks.constantinople.computation import (
-    CONSTANTINOPLE_PRECOMPILES
+from eth.vm.forks.petersburg.computation import (
+    PETERSBURG_PRECOMPILES
 )
-from eth.vm.forks.constantinople.computation import (
-    ConstantinopleComputation
+from eth.vm.forks.petersburg.computation import (
+    PetersburgComputation,
+)
+from eth.vm.gas_meter import (
+    allow_negative_refund_strategy,
+    GasMeter,
 )
 
 from .constants import (
@@ -22,7 +26,7 @@ from .constants import (
 from .opcodes import ISTANBUL_OPCODES
 
 ISTANBUL_PRECOMPILES = merge(
-    CONSTANTINOPLE_PRECOMPILES,
+    PETERSBURG_PRECOMPILES,
     {
         force_bytes_to_address(b'\x06'): precompiles.ecadd(gas_cost=GAS_ECADD),
         force_bytes_to_address(b'\x07'): precompiles.ecmul(gas_cost=GAS_ECMUL),
@@ -35,11 +39,17 @@ ISTANBUL_PRECOMPILES = merge(
 )
 
 
-class IstanbulComputation(ConstantinopleComputation):
+class IstanbulComputation(PetersburgComputation):
     """
     A class for all execution computations in the ``Istanbul`` fork.
-    Inherits from :class:`~eth.vm.forks.constantinople.computation.ConstantinopleComputation`
+    Inherits from :class:`~eth.vm.forks.constantinople.petersburg.PetersburgComputation`
     """
     # Override
     opcodes = ISTANBUL_OPCODES
     _precompiles = ISTANBUL_PRECOMPILES
+
+    def get_gas_meter(self) -> GasMeter:
+        return GasMeter(
+            self.msg.gas,
+            allow_negative_refund_strategy
+        )

--- a/eth/vm/forks/istanbul/headers.py
+++ b/eth/vm/forks/istanbul/headers.py
@@ -1,4 +1,4 @@
-from eth.vm.forks.constantinople.headers import (
+from eth.vm.forks.petersburg.headers import (
     configure_header,
     create_header_from_parent,
     compute_difficulty,

--- a/eth/vm/forks/istanbul/opcodes.py
+++ b/eth/vm/forks/istanbul/opcodes.py
@@ -10,8 +10,8 @@ from eth.vm import (
 from eth.vm.forks.byzantium.opcodes import (
     ensure_no_static
 )
-from eth.vm.forks.constantinople.opcodes import (
-    CONSTANTINOPLE_OPCODES,
+from eth.vm.forks.petersburg.opcodes import (
+    PETERSBURG_OPCODES,
 )
 from eth.vm.forks.istanbul.constants import (
     GAS_BALANCE_EIP1884,
@@ -65,6 +65,6 @@ UPDATED_OPCODES = {
 }
 
 ISTANBUL_OPCODES = merge(
-    copy.deepcopy(CONSTANTINOPLE_OPCODES),
+    copy.deepcopy(PETERSBURG_OPCODES),
     UPDATED_OPCODES,
 )

--- a/eth/vm/forks/istanbul/state.py
+++ b/eth/vm/forks/istanbul/state.py
@@ -1,9 +1,9 @@
-from eth.vm.forks.constantinople.state import (
-    ConstantinopleState
+from eth.vm.forks.petersburg.state import (
+    PetersburgState
 )
 
 from .computation import IstanbulComputation
 
 
-class IstanbulState(ConstantinopleState):
+class IstanbulState(PetersburgState):
     computation_class = IstanbulComputation

--- a/eth/vm/forks/istanbul/transactions.py
+++ b/eth/vm/forks/istanbul/transactions.py
@@ -3,9 +3,9 @@ from functools import partial
 from eth_keys.datatypes import PrivateKey
 from eth_typing import Address
 
-from eth.vm.forks.constantinople.transactions import (
-    ConstantinopleTransaction,
-    ConstantinopleUnsignedTransaction,
+from eth.vm.forks.petersburg.transactions import (
+    PetersburgTransaction,
+    PetersburgUnsignedTransaction,
 )
 
 from eth._utils.transactions import (
@@ -28,7 +28,7 @@ ISTANBUL_TX_GAS_SCHEDULE = HOMESTEAD_TX_GAS_SCHEDULE._replace(
 istanbul_get_intrinsic_gas = partial(calculate_intrinsic_gas, ISTANBUL_TX_GAS_SCHEDULE)
 
 
-class IstanbulTransaction(ConstantinopleTransaction):
+class IstanbulTransaction(PetersburgTransaction):
     @classmethod
     def create_unsigned_transaction(cls,
                                     *,
@@ -44,7 +44,7 @@ class IstanbulTransaction(ConstantinopleTransaction):
         return istanbul_get_intrinsic_gas(self)
 
 
-class IstanbulUnsignedTransaction(ConstantinopleUnsignedTransaction):
+class IstanbulUnsignedTransaction(PetersburgUnsignedTransaction):
     def as_signed_transaction(self,
                               private_key: PrivateKey,
                               chain_id: int=None) -> IstanbulTransaction:


### PR DESCRIPTION
### What was wrong?

`Istanbul` was inheriting everything from `Constantinople` instead of `Petersburg`.
This is incorrect as `Istanbul` is a descendant of `Petersburg` and not `Constantinople`.


### How was it fixed?

Made Istanbul inherit from Petersburg instead of Constantinople

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] <strike>Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)</strike> (Doesn't need release notes IMO as this hasn't been released yet)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/06i1965tg4k31.png)
