### PR TITLE
Fix missing abstractmethod decorator on ConfigurableAPI.configure

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -1109,6 +1109,7 @@ class TransactionExecutorAPI(ABC):
 
 class ConfigurableAPI(ABC):
     @classmethod
+    @abstractmethod
     def configure(cls: Type[T],
                   __name__: str=None,
                   **overrides: Any) -> Type[T]:

--- a/newsfragments/1822.bugfix.rst
+++ b/newsfragments/1822.bugfix.rst
@@ -1,0 +1,1 @@
+Add missing ``@abstractmethod`` decorator to ``ConfigurableAPI.configure``.


### PR DESCRIPTION
### What was wrong?

The ABC base class for `ConfigurableAPI` was missing an `abstractmethod` decorator.

### How was it fixed?

Added it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Animals-in-Halloween-Costumes--91469](https://user-images.githubusercontent.com/824194/64369716-2b6e9b80-cfda-11e9-9475-641e0010e881.jpg)

