### PR TITLE
Expose type data to other packages via PEP561

### DIFF
--- a/newsfragments/1845.feature.rst
+++ b/newsfragments/1845.feature.rst
@@ -1,0 +1,1 @@
+Expose type hint information via PEP561

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
     zip_safe=False,
     keywords='ethereum blockchain evm',
     packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={'eth': ['py.typed']},
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
### What was wrong?

From a 3rd party library perspective, all of the values from py-evm are `Any` types.

### How was it fixed?

Expose type information via PEP561

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![ratsoff](https://user-images.githubusercontent.com/824194/64368128-e2691800-cfd6-11e9-9495-98ba16422ac1.png)

