### PR TITLE
More consistent use of BlockNumber type

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -245,7 +245,7 @@ class BlockAPI(rlp.Serializable, ABC):
 
     @property
     @abstractmethod
-    def number(self) -> int:
+    def number(self) -> BlockNumber:
         ...
 
     @property
@@ -678,7 +678,7 @@ class StackManipulationAPI(ABC):
 class ExecutionContextAPI(ABC):
     coinbase: Address
     timestamp: int
-    block_number: int
+    block_number: BlockNumber
     difficulty: int
     gas_limit: int
     prev_hashes: Sequence[Hash32]
@@ -1173,7 +1173,7 @@ class StateAPI(ConfigurableAPI):
 
     @property
     @abstractmethod
-    def block_number(self) -> int:
+    def block_number(self) -> BlockNumber:
         ...
 
     @property
@@ -1298,7 +1298,7 @@ class StateAPI(ConfigurableAPI):
     # Access self.prev_hashes (Read-only)
     #
     @abstractmethod
-    def get_ancestor_hash(self, block_number: int) -> Hash32:
+    def get_ancestor_hash(self, block_number: BlockNumber) -> Hash32:
         ...
 
     #
@@ -1557,7 +1557,7 @@ class VirtualMachineAPI(ConfigurableAPI):
 
     @staticmethod
     @abstractmethod
-    def get_uncle_reward(block_number: int, uncle: BlockAPI) -> int:
+    def get_uncle_reward(block_number: BlockNumber, uncle: BlockAPI) -> int:
         """
         Return the reward which should be given to the miner of the given `uncle`.
 
@@ -1655,7 +1655,7 @@ class VirtualMachineAPI(ConfigurableAPI):
 class HeaderChainAPI(ABC):
     header: BlockHeaderAPI
     chain_id: int
-    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...]
+    vm_configuration: Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...]
 
     @abstractmethod
     def __init__(self, base_db: AtomicDatabaseAPI, header: BlockHeaderAPI = None) -> None:
@@ -1709,7 +1709,7 @@ class HeaderChainAPI(ABC):
 
 
 class ChainAPI(ConfigurableAPI):
-    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...]
+    vm_configuration: Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...]
     chain_id: int
     chaindb: ChainDatabaseAPI
 

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -113,7 +113,7 @@ class BaseChain(Configurable, ChainAPI):
     """
     chaindb: ChainDatabaseAPI = None
     chaindb_class: Type[ChainDatabaseAPI] = None
-    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...] = None
+    vm_configuration: Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...] = None
     chain_id: int = None
 
     @classmethod

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -3,6 +3,7 @@ from typing import (
     Type,
 )
 
+from eth_typing import BlockNumber
 from eth_utils import (
     decode_hex,
     encode_hex,
@@ -77,7 +78,7 @@ class MainnetHomesteadVM(MainnetDAOValidatorVM):
 
 
 MAINNET_FORK_BLOCKS = (
-    0,
+    eth_constants.GENESIS_BLOCK_NUMBER,
     HOMESTEAD_MAINNET_BLOCK,
     TANGERINE_WHISTLE_MAINNET_BLOCK,
     SPURIOUS_DRAGON_MAINNET_BLOCK,
@@ -98,7 +99,10 @@ MAINNET_VM_CONFIGURATION = tuple(zip(MAINNET_FORK_BLOCKS, MAINNET_VMS))
 
 class BaseMainnetChain:
     chain_id = MAINNET_CHAIN_ID
-    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...] = MAINNET_VM_CONFIGURATION
+    vm_configuration: Tuple[
+        Tuple[BlockNumber, Type[VirtualMachineAPI]],
+        ...
+    ] = MAINNET_VM_CONFIGURATION
 
 
 class MainnetChain(BaseMainnetChain, Chain):

--- a/eth/chains/ropsten/__init__.py
+++ b/eth/chains/ropsten/__init__.py
@@ -1,4 +1,5 @@
 from typing import Tuple, Type
+from eth_typing import BlockNumber
 from eth_utils import decode_hex
 
 from .constants import (
@@ -34,7 +35,10 @@ ROPSTEN_VM_CONFIGURATION = (
 
 
 class BaseRopstenChain:
-    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...] = ROPSTEN_VM_CONFIGURATION
+    vm_configuration: Tuple[
+        Tuple[BlockNumber, Type[VirtualMachineAPI]],
+        ...
+    ] = ROPSTEN_VM_CONFIGURATION
     chain_id: int = ROPSTEN_CHAIN_ID
 
 
@@ -50,7 +54,7 @@ ROPSTEN_GENESIS_HEADER = BlockHeader(
     bloom=0,
     mix_hash=constants.ZERO_HASH32,
     nonce=constants.GENESIS_NONCE,
-    block_number=0,
+    block_number=constants.GENESIS_BLOCK_NUMBER,
     parent_hash=constants.ZERO_HASH32,
     receipt_root=constants.BLANK_ROOT_HASH,
     uncles_hash=constants.EMPTY_UNCLE_HASH,

--- a/eth/chains/tester/__init__.py
+++ b/eth/chains/tester/__init__.py
@@ -9,6 +9,7 @@ from typing import (
     Union,
 )
 
+from eth_typing import BlockNumber
 from eth_utils.toolz import (
     assoc,
     last,
@@ -24,6 +25,7 @@ from eth.abc import (
     BlockHeaderAPI,
     VirtualMachineAPI,
 )
+from eth.constants import GENESIS_BLOCK_NUMBER
 from eth.chains.base import Chain
 from eth.chains.mainnet import MainnetChain
 from eth.validation import (
@@ -53,8 +55,8 @@ MAINNET_VMS = collections.OrderedDict(
     in MainnetChain.vm_configuration
 )
 
-ForkStartBlocks = Sequence[Tuple[int, Union[str, Type[VirtualMachineAPI]]]]
-VMStartBlock = Tuple[int, Type[VirtualMachineAPI]]
+ForkStartBlocks = Sequence[Tuple[BlockNumber, Union[str, Type[VirtualMachineAPI]]]]
+VMStartBlock = Tuple[BlockNumber, Type[VirtualMachineAPI]]
 
 
 @to_tuple
@@ -74,7 +76,7 @@ def _generate_vm_configuration(*fork_start_blocks: ForkStartBlocks,
     # if no configuration was passed in, initialize the chain with the *latest*
     # Mainnet VM rules active at block 0.
     if not fork_start_blocks:
-        yield (0, last(MAINNET_VMS.values()))
+        yield (GENESIS_BLOCK_NUMBER, last(MAINNET_VMS.values()))
         return
 
     # Validate that there are no fork names which are not represented in the
@@ -103,7 +105,7 @@ def _generate_vm_configuration(*fork_start_blocks: ForkStartBlocks,
     # If no VM is set to start at block 0, default to the frontier VM
     start_blocks = set(start_block for start_block, _ in fork_start_blocks)
     if 0 not in start_blocks:
-        yield 0, MAINNET_VMS['frontier']
+        yield GENESIS_BLOCK_NUMBER, MAINNET_VMS['frontier']
 
     ordered_fork_start_blocks = sorted(fork_start_blocks, key=operator.itemgetter(0))
 
@@ -132,7 +134,7 @@ def _generate_vm_configuration(*fork_start_blocks: ForkStartBlocks,
 
 
 class BaseMainnetTesterChain(Chain):
-    vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...] = _generate_vm_configuration()
+    vm_configuration: Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...] = _generate_vm_configuration()  # noqa: E501
 
 
 class MainnetTesterChain(BaseMainnetTesterChain):

--- a/eth/constants.py
+++ b/eth/constants.py
@@ -1,5 +1,6 @@
 from eth_typing import (
     Address,
+    BlockNumber,
     Hash32
 )
 
@@ -152,7 +153,7 @@ EMPTY_UNCLE_HASH = Hash32(b'\x1d\xccM\xe8\xde\xc7]z\xab\x85\xb5g\xb6\xcc\xd4\x1a
 #
 # Genesis Data
 #
-GENESIS_BLOCK_NUMBER = 0
+GENESIS_BLOCK_NUMBER = BlockNumber(0)
 GENESIS_DIFFICULTY = 17179869184
 GENESIS_GAS_LIMIT = 5000
 GENESIS_PARENT_HASH = ZERO_HASH32

--- a/eth/rlp/headers.py
+++ b/eth/rlp/headers.py
@@ -14,6 +14,7 @@ from rlp.sedes import (
 
 from eth_typing import (
     Address,
+    BlockNumber,
     Hash32,
 )
 
@@ -97,7 +98,7 @@ class BlockHeader(BlockHeaderAPI):
     @overload  # noqa: F811
     def __init__(self,
                  difficulty: int,
-                 block_number: int,
+                 block_number: BlockNumber,
                  gas_limit: int,
                  timestamp: int=None,
                  coinbase: Address=ZERO_ADDRESS,
@@ -115,7 +116,7 @@ class BlockHeader(BlockHeaderAPI):
 
     def __init__(self,              # type: ignore  # noqa: F811
                  difficulty: int,
-                 block_number: int,
+                 block_number: BlockNumber,
                  gas_limit: int,
                  timestamp: int=None,
                  coinbase: Address=ZERO_ADDRESS,

--- a/eth/typing.py
+++ b/eth/typing.py
@@ -95,4 +95,4 @@ class StaticMethod(Generic[TFunc]):
         self._func = value
 
 
-HeaderParams = Union[Optional[int], bytes, Address, Hash32]
+HeaderParams = Union[Optional[int], BlockNumber, bytes, Address, Hash32]

--- a/eth/vm/execution_context.py
+++ b/eth/vm/execution_context.py
@@ -4,6 +4,7 @@ from typing import (
 
 from eth_typing import (
     Address,
+    BlockNumber,
     Hash32,
 )
 
@@ -24,7 +25,7 @@ class ExecutionContext:
             self,
             coinbase: Address,
             timestamp: int,
-            block_number: int,
+            block_number: BlockNumber,
             difficulty: int,
             gas_limit: int,
             prev_hashes: Iterable[Hash32],
@@ -46,7 +47,7 @@ class ExecutionContext:
         return self._timestamp
 
     @property
-    def block_number(self) -> int:
+    def block_number(self) -> BlockNumber:
         return self._block_number
 
     @property

--- a/eth/vm/forks/frontier/blocks.py
+++ b/eth/vm/forks/frontier/blocks.py
@@ -14,6 +14,7 @@ from eth_bloom import (
 )
 
 from eth_typing import (
+    BlockNumber,
     Hash32,
 )
 
@@ -75,7 +76,7 @@ class FrontierBlock(BaseBlock):
     # Helpers
     #
     @property
-    def number(self) -> int:
+    def number(self) -> BlockNumber:
         return self.header.block_number
 
     @property

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from eth_typing import (
     Address,
+    BlockNumber,
     Hash32,
 )
 from eth_utils import (
@@ -96,7 +97,7 @@ class BaseState(Configurable, StateAPI):
         return self.execution_context.timestamp
 
     @property
-    def block_number(self) -> int:
+    def block_number(self) -> BlockNumber:
         """
         Return the current ``block_number`` from the current :attr:`~execution_context`
         """

--- a/newsfragments/1850.bugfix.rst
+++ b/newsfragments/1850.bugfix.rst
@@ -1,0 +1,1 @@
+Update codebase to more consistently use the ``eth_typing.BlockNumber`` type.


### PR DESCRIPTION
fixes #1847

### What was wrong?

The `eth.constants.GENESIS_BLOCK_NUMBER` was not typed as `eth_typing.BlockNumber`.  Nor were many other variables that should have been `BlockNumber` types.

### How was it fixed?

Updated all the places I could find where block numbers are used and made them into proper `BlockNumber` types.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![pets-halloween-willjpg-5d1761894278a2952](https://user-images.githubusercontent.com/824194/65066638-f94a2b80-d941-11e9-8fdc-5d6fe98fc343.jpg)

