### PR TITLE
Revert premature optimization for EIP-2294

### DIFF
--- a/eth/vm/chain_context.py
+++ b/eth/vm/chain_context.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from eth.abc import ChainContextAPI
 from eth.validation import (
-    validate_uint64,
+    validate_uint256,
 )
 
 
@@ -17,9 +17,9 @@ class ChainContext(ChainContextAPI):
 
         if chain_id is None:
             chain_id = 0  # Default value (invalid for public networks)
-        # Due to EIP-155's definition of chain IDs, the max number is UINT256_MAX/2 - 36,
-        #   so the recommended space for chain ID is uint64.
-        validate_uint64(chain_id)
+        # Due to EIP-155's definition of Chain ID,
+        # the number that needs to be RLP encoded is `CHAINID * 2 + 36`
+        validate_uint256(chain_id)
         self._chain_id = chain_id
 
     @property

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -886,12 +886,12 @@ def test_sstore_limit_2300(gas_supplied, success, gas_used, refund):
         ),
         (
             IstanbulVM,
-            2 ** 64 - 1,
-            2 ** 64 - 1,
+            2 ** 256 - 1,
+            2 ** 256 - 1,
         ),
         (
             IstanbulVM,
-            2 ** 64,
+            2 ** 256,
             ValidationError,
         ),
     )


### PR DESCRIPTION
### What was wrong?
There was a suggestion to limit the size of Chain ID to 64 bits, however this was a premature proposal and has since been punted to [EIP-2294](https://GitHub.com/Ethereum/EIPs/issues/2294).

### How was it fixed?
Reverted back to `uint256` validation

#### Cute Animal Picture

![koala](https://images-na.ssl-images-amazon.com/images/I/714hj7a%2BvUL._SX425_.jpg)