### PR TITLE
Remove explicit pluggy dependency

### DIFF
--- a/newsfragments/1860.bugfix.rst
+++ b/newsfragments/1860.bugfix.rst
@@ -1,0 +1,1 @@
+Resolve version conflict regarding `pluggy` dependency that came up during installation.

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,7 @@ deps = {
         "bumpversion>=0.5.3,<1",
         "wheel",
         "setuptools>=36.2.0",
-        # Fixing this dependency due to: pytest 3.6.4 has requirement
-        # pluggy<0.8,>=0.5, but you'll have pluggy 0.8.0 which is incompatible.
-        "pluggy==0.7.1",
+
         # Fixing this dependency due to: requests 2.20.1 has requirement
         # idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
         "idna==2.7",


### PR DESCRIPTION
### What was wrong?

There's a version conflict on installation because our fixed pluggy version doesn't match the expectations of pytest.

### How was it fixed?

Since, we don't use pluggy directly (it is only a secondary dependency) we can just remove the dependency for now to have it automatically resolve to the required version.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/fe/f0/8a/fef08a4fd6bdb1361b558581a5b88bb4.jpg)
