### PR TITLE
Move create_execution_context from BlockHeader to VM

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -676,13 +676,40 @@ class StackManipulationAPI(ABC):
 
 
 class ExecutionContextAPI(ABC):
-    coinbase: Address
-    timestamp: int
-    block_number: BlockNumber
-    difficulty: int
-    gas_limit: int
-    prev_hashes: Sequence[Hash32]
-    chain_id: int
+    @property
+    @abstractmethod
+    def coinbase(self) -> Address:
+        ...
+
+    @property
+    @abstractmethod
+    def timestamp(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def block_number(self) -> BlockNumber:
+        ...
+
+    @property
+    @abstractmethod
+    def difficulty(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def gas_limit(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def prev_hashes(self) -> Iterable[Hash32]:
+        ...
+
+    @property
+    @abstractmethod
+    def chain_id(self) -> int:
+        ...
 
 
 class ComputationAPI(ContextManager['ComputationAPI'], StackManipulationAPI):
@@ -1394,6 +1421,13 @@ class VirtualMachineAPI(ConfigurableAPI):
                           header: BlockHeaderAPI,
                           transaction: SignedTransactionAPI
                           ) -> Tuple[ReceiptAPI, ComputationAPI]:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def create_execution_context(header: BlockHeaderAPI,
+                                 prev_hashes: Iterable[Hash32],
+                                 chain_context: ChainContextAPI) -> ExecutionContextAPI:
         ...
 
     @abstractmethod

--- a/eth/rlp/headers.py
+++ b/eth/rlp/headers.py
@@ -1,7 +1,6 @@
 import time
 from typing import (
     Dict,
-    Iterable,
     overload,
 )
 
@@ -37,14 +36,6 @@ from eth.constants import (
     BLANK_ROOT_HASH,
 )
 from eth.typing import HeaderParams
-
-from eth.vm.chain_context import (
-    ChainContext,
-)
-
-from eth.vm.execution_context import (
-    ExecutionContext,
-)
 
 from .sedes import (
     address,
@@ -204,20 +195,6 @@ class BlockHeader(BlockHeaderAPI):
 
         header = cls(**header_kwargs)
         return header
-
-    def create_execution_context(self,
-                                 prev_hashes: Iterable[Hash32],
-                                 chain_context: ChainContext) -> ExecutionContext:
-
-        return ExecutionContext(
-            coinbase=self.coinbase,
-            timestamp=self.timestamp,
-            block_number=self.block_number,
-            difficulty=self.difficulty,
-            gas_limit=self.gas_limit,
-            prev_hashes=prev_hashes,
-            chain_id=chain_context.chain_id,
-        )
 
     @property
     def is_genesis(self) -> bool:

--- a/eth/vm/execution_context.py
+++ b/eth/vm/execution_context.py
@@ -8,10 +8,11 @@ from eth_typing import (
     Hash32,
 )
 
+from eth.abc import ExecutionContextAPI
 from eth._utils.generator import CachedIterable
 
 
-class ExecutionContext:
+class ExecutionContext(ExecutionContextAPI):
     _coinbase = None
 
     _timestamp = None


### PR DESCRIPTION
### What was wrong?

This is a first fall out from #1855 which adds support for *Clique Consensus*.

Currently the `create_execution_context` method is sitting on the `BlockHeader`. The purpose if this method is to create an `ExecutionContext` for the VM to operate on. This defines things such as who is the coinbase. Since Clique repurposes some of the header fields, we need to be able to replace `create_execution_context` with an implementation that fits the scheme.

With the method being implemented on `BlockHeader`, replacing it isn't straight forward. 

### How was it fixed?

1. Move the method from `BlockHeader` to `VM`
2. Change it to be a `staticmethod` and take in the `header`
3. Fix some typing issues that were exposed by this task

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-22.jpg)
