### PR TITLE
Fix crash when using seal_check_random_sample_rate of 0

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -153,6 +153,8 @@ class BaseChain(Configurable, ChainAPI):
         all_indices = range(len(descendants))
         if seal_check_random_sample_rate == 1:
             indices_to_check_seal = set(all_indices)
+        elif seal_check_random_sample_rate == 0:
+            indices_to_check_seal = set()
         else:
             sample_size = len(all_indices) // seal_check_random_sample_rate
             indices_to_check_seal = set(random.sample(all_indices, sample_size))

--- a/newsfragments/1862.bugfix.rst
+++ b/newsfragments/1862.bugfix.rst
@@ -1,0 +1,4 @@
+Fix issue where Py-EVM crashes when `0` is used as a value for `seal_check_random_sample_rate`.
+Previously, this would lead to a DivideByZero error, whereas now it is recognized as not performing
+any seal check. This is also symmetric to the current *opposite* behavior of passing `1` to check
+every single header instead of taking samples.


### PR DESCRIPTION
### What was wrong?

This is a fallout from #1855 paving the way to *Clique Consensus*

Py-EVM crashes with an DivideByZero error when `0` is used as a value for `seal_check_random_sample_rate`.

### How was it fixed?

Interpret `0` as not performing any checks. This is symmetric to the current *opposite* behavior of passing `1` to check every single header instead of taking samples.

### To-Do

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://list.lisimg.com/image/14044867/300full.jpg)
