### PR TITLE
Make the max bytes of extra_data configurable

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -5,6 +5,7 @@ from abc import (
 from typing import (
     Any,
     Callable,
+    ClassVar,
     ContextManager,
     Dict,
     Iterable,
@@ -1358,6 +1359,7 @@ class StateAPI(ConfigurableAPI):
 class VirtualMachineAPI(ConfigurableAPI):
     fork: str  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
     chaindb: ChainDatabaseAPI
+    extra_data_max_bytes: ClassVar[int]
 
     @abstractmethod
     def __init__(self, header: BlockHeaderAPI, chaindb: ChainDatabaseAPI) -> None:

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -3,6 +3,7 @@ import itertools
 import logging
 from typing import (
     Any,
+    ClassVar,
     Iterable,
     Iterator,
     Optional,
@@ -90,6 +91,7 @@ class VM(Configurable, VirtualMachineAPI):
         - ``_state_class``: The :class:`~eth.abc.StateAPI` class used by this VM for execution.
     """
     block_class: Type[BlockAPI] = None
+    extra_data_max_bytes: ClassVar[int] = 32
     fork: str = None  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
     chaindb: ChainDatabaseAPI = None
     _state_class: Type[StateAPI] = None
@@ -549,7 +551,11 @@ class VM(Configurable, VirtualMachineAPI):
             )
 
         if block.is_genesis:
-            validate_length_lte(block.header.extra_data, 32, title="BlockHeader.extra_data")
+            validate_length_lte(
+                block.header.extra_data,
+                self.extra_data_max_bytes,
+                title="BlockHeader.extra_data"
+            )
         else:
             parent_header = get_parent_header(block.header, self.chaindb)
             self.validate_header(block.header, parent_header)
@@ -593,7 +599,8 @@ class VM(Configurable, VirtualMachineAPI):
             # to validate genesis header, check if it equals canonical header at block number 0
             raise ValidationError("Must have access to parent header to validate current header")
         else:
-            validate_length_lte(header.extra_data, 32, title="BlockHeader.extra_data")
+            validate_length_lte(
+                header.extra_data, cls.extra_data_max_bytes, title="BlockHeader.extra_data")
 
             validate_gas_limit(header.gas_limit, parent_header.gas_limit)
 

--- a/newsfragments/1864.feature.rst
+++ b/newsfragments/1864.feature.rst
@@ -1,0 +1,2 @@
+Make the *max length validation* of the `extra_data` field configurable. The reason for that is that
+different consensus engines such as Clique repurpose this field using different max length limits.


### PR DESCRIPTION
### What was wrong?

The validation check for the maximum bytes of the `extra_data` field is currently hardcoded. It needs to be configurable to allow different consensus schemes such as Clique which have a different opinion on the max bytes of this field.

### How was it fixed?

Introduce a `extra_data_max_bytes` class var which defaults to `32` but can be overwritten.

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://wallpaper4rest.com/animals/wallpaper/baby-animal-wallpapers_1-1-800x600.jpg)
