### PR TITLE
Revert storage after selfdestruct

### DIFF
--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -290,11 +290,14 @@ class AccountDB(AccountDatabaseAPI):
     def delete_account(self, address: Address) -> None:
         validate_canonical_address(address, title="Storage Address")
 
+        # We must wipe the storage first, because if it's the first time we load it,
+        #   then we want to load it with the original storage root hash, not the
+        #   empty one. (in case of a later revert, we don't want to poison the storage cache)
+        self._wipe_storage(address)
+
         if address in self._account_cache:
             del self._account_cache[address]
         del self._journaltrie[address]
-
-        self._wipe_storage(address)
 
     def account_exists(self, address: Address) -> bool:
         validate_canonical_address(address, title="Storage Address")

--- a/eth/db/journal.py
+++ b/eth/db/journal.py
@@ -226,6 +226,7 @@ class Journal(BaseDB):
         self._current_values = {}
         self._checkpoint_stack.clear()
         self.record_checkpoint()
+        self._ignore_wrapped_db = False
         return final_changes
 
     def flatten(self) -> None:

--- a/newsfragments/1865.bugfix.rst
+++ b/newsfragments/1865.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for storage reads, after a revert, after a self-destruct. They were incorrectly returning 0.


### PR DESCRIPTION
### What was wrong?

Fix #1865 

### How was it fixed?

Two fixes for two different scenarios:
- If creating the storage DB for the first time just to wipe it, then make sure it has the original storage root hash.
- If completely resetting the journal, make sure that any current `clear` (like a storage wipe) gets fully reset (which means it should read through to the underlying if the key is missing from the journal) See more commentary in the PR

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://besthqwallpapers.com/Uploads/20-9-2017/21117/thumb2-cocker-spaniel-puppies-cute-animals-small-dogs-suitcase.jpg)
