### PR TITLE
Improve string representation of blocks

### DIFF
--- a/eth/rlp/blocks.py
+++ b/eth/rlp/blocks.py
@@ -2,6 +2,10 @@ from typing import (
     Type
 )
 
+from eth_utils import (
+    encode_hex,
+)
+
 from eth._utils.datatypes import (
     Configurable,
 )
@@ -29,4 +33,4 @@ class BaseBlock(Configurable, BlockAPI):
         return f'<{self.__class__.__name__}(#{str(self)})>'
 
     def __str__(self) -> str:
-        return f"Block #{self.number}"
+        return f'<{self.__class__.__name__} #{self.number} {encode_hex(self.hash)[2:10]}>'

--- a/newsfragments/1873.feature.rst
+++ b/newsfragments/1873.feature.rst
@@ -1,0 +1,3 @@
+Improve the string representation of blocks to be more information rich and in line with
+that of e.g. `BlockHeader`. Where previously a block would be printed as `Block #2` it
+is now printed as `<FrontierBlock #2 b495a1d7>`.


### PR DESCRIPTION
### What was wrong?

I noticed today that the string representation of blocks looks a bit unusual compared to the other RLP types. E.g. the string representation of a header would be `<BlockHeader #2 b495a1d7>` but the string representation of that same block would just be `Block #2`. It doesn't come with the angle brackets nor does it print the hash.

### How was it fixed?

Changed it so that it now would print `<FrontierBlock #2 b495a1d7>`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
