### PR TITLE
Refactor Clique Consensus to handle initialization internally

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -43,6 +43,7 @@ from eth.typing import (
     JournalDBCheckpoint,
     AccountState,
     HeaderParams,
+    VMConfiguration,
 )
 
 
@@ -1638,9 +1639,8 @@ class VirtualMachineAPI(ConfigurableAPI):
     def validate_block(self, block: BlockAPI) -> None:
         ...
 
-    @classmethod
     @abstractmethod
-    def validate_header(cls,
+    def validate_header(self,
                         header: BlockHeaderAPI,
                         parent_header: BlockHeaderAPI,
                         check_seal: bool = True
@@ -1661,9 +1661,8 @@ class VirtualMachineAPI(ConfigurableAPI):
         """
         ...
 
-    @classmethod
     @abstractmethod
-    def validate_seal(cls, header: BlockHeaderAPI) -> None:
+    def validate_seal(self, header: BlockHeaderAPI) -> None:
         ...
 
     @classmethod
@@ -1685,6 +1684,34 @@ class VirtualMachineAPI(ConfigurableAPI):
 
     @abstractmethod
     def state_in_temp_block(self) -> ContextManager[StateAPI]:
+        ...
+
+
+class VirtualMachineModifierAPI(ABC):
+    """
+    Amend a set of VMs for a chain. This allows modifying a chain for different consensus schemes.
+    """
+
+    @abstractmethod
+    def __init__(self, base_db: AtomicDatabaseAPI) -> None:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def amend_vm_configuration_for_chain_class(cls, vm_config: VMConfiguration) -> None:
+        """
+        Make amendments to the ``vm_config`` that are independent of any instance state. These
+        changes are applied across all instances of the chain where this
+        ``VirtualMachineModifierAPI`` is applied on.
+        """
+        ...
+
+    @abstractmethod
+    def amend_vm_for_chain_instance(self, vm: VirtualMachineAPI) -> None:
+        """
+        Make amendments to ``vm`` that are only valid for a specific chain instance. This
+        includes any modifications that depend on stateful data.
+        """
         ...
 
 
@@ -1748,6 +1775,8 @@ class ChainAPI(ConfigurableAPI):
     vm_configuration: Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...]
     chain_id: int
     chaindb: ChainDatabaseAPI
+    consensus_engine_class: Type[VirtualMachineModifierAPI]
+    consensus_engine: VirtualMachineModifierAPI
 
     #
     # Helpers
@@ -1923,10 +1952,9 @@ class ChainAPI(ConfigurableAPI):
     def validate_uncles(self, block: BlockAPI) -> None:
         ...
 
-    @classmethod
     @abstractmethod
     def validate_chain(
-            cls,
+            self,
             root: BlockHeaderAPI,
             descendants: Tuple[BlockHeaderAPI, ...],
             seal_check_random_sample_rate: int = 1) -> None:

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -45,11 +45,15 @@ from eth.abc import (
     ChainAPI,
     ChainDatabaseAPI,
     VirtualMachineAPI,
+    VirtualMachineModifierAPI,
     ReceiptAPI,
     ComputationAPI,
     StateAPI,
     SignedTransactionAPI,
     UnsignedTransactionAPI,
+)
+from eth.consensus.pow import (
+    PowConsensus,
 )
 from eth.constants import (
     EMPTY_UNCLE_HASH,
@@ -113,6 +117,8 @@ class BaseChain(Configurable, ChainAPI):
     chaindb_class: Type[ChainDatabaseAPI] = None
     vm_configuration: Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...] = None
     chain_id: int = None
+    consensus_engine: VirtualMachineModifierAPI = None
+    consensus_engine_class: Type[VirtualMachineModifierAPI] = PowConsensus
 
     @classmethod
     def get_vm_class_for_block_number(cls, block_number: BlockNumber) -> Type[VirtualMachineAPI]:
@@ -136,9 +142,8 @@ class BaseChain(Configurable, ChainAPI):
     #
     # Validation API
     #
-    @classmethod
     def validate_chain(
-            cls,
+            self,
             root: BlockHeaderAPI,
             descendants: Tuple[BlockHeaderAPI, ...],
             seal_check_random_sample_rate: int = 1) -> None:
@@ -168,9 +173,9 @@ class BaseChain(Configurable, ChainAPI):
                     f" but expected {encode_hex(parent.hash)}"
                 )
             should_check_seal = index in indices_to_check_seal
-            vm_class = cls.get_vm_class_for_block_number(child.block_number)
+            vm = self.get_vm(child)
             try:
-                vm_class.validate_header(child, parent, check_seal=should_check_seal)
+                vm.validate_header(child, parent, check_seal=should_check_seal)
             except ValidationError as exc:
                 raise ValidationError(
                     f"{child} is not a valid child of {parent}: {exc}"
@@ -197,10 +202,22 @@ class Chain(BaseChain):
         else:
             validate_vm_configuration(self.vm_configuration)
 
+        if not self.consensus_engine_class:
+            raise ValueError(
+                "The Chain class cannot be instantiated without a `consensus_engine_class`"
+            )
+        else:
+            self.consensus_engine = self.consensus_engine_class(base_db)
+            self.apply_consensus_engine_to_vms(self.consensus_engine)
+
         self.chaindb = self.get_chaindb_class()(base_db)
         self.headerdb = HeaderDB(base_db)
         if self.gas_estimator is None:
             self.gas_estimator = get_gas_estimator()
+
+    @classmethod
+    def apply_consensus_engine_to_vms(cls, consensus_engine: VirtualMachineModifierAPI) -> None:
+        consensus_engine.amend_vm_configuration_for_chain_class(cls.vm_configuration)
 
     #
     # Helpers
@@ -272,7 +289,9 @@ class Chain(BaseChain):
         header = self.ensure_header(at_header)
         vm_class = self.get_vm_class_for_block_number(header.block_number)
         chain_context = ChainContext(self.chain_id)
-        return vm_class(header=header, chaindb=self.chaindb, chain_context=chain_context)
+        vm = vm_class(header=header, chaindb=self.chaindb, chain_context=chain_context)
+        self.consensus_engine.amend_vm_for_chain_instance(vm)
+        return vm
 
     #
     # Header API
@@ -578,9 +597,9 @@ class Chain(BaseChain):
         """
         if block.is_genesis:
             raise ValidationError("Cannot validate genesis block this way")
-        VM_class = self.get_vm_class_for_block_number(BlockNumber(block.number))
+        vm = self.get_vm(block.header)
         parent_header = self.get_block_header_by_hash(block.header.parent_hash)
-        VM_class.validate_header(block.header, parent_header, check_seal=True)
+        vm.validate_header(block.header, parent_header, check_seal=True)
         self.validate_uncles(block)
         self.validate_gaslimit(block.header)
 
@@ -588,8 +607,8 @@ class Chain(BaseChain):
         """
         Validate the seal on the given header.
         """
-        VM_class = self.get_vm_class_for_block_number(BlockNumber(header.block_number))
-        VM_class.validate_seal(header)
+        vm = self.get_vm(header)
+        vm.validate_seal(header)
 
     def validate_gaslimit(self, header: BlockHeaderAPI) -> None:
         """

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -45,8 +45,7 @@ from eth.vm.forks import (
 class MainnetDAOValidatorVM(HomesteadVM):
     """Only on mainnet, TheDAO fork is accompanied by special extra data. Validate those headers"""
 
-    @classmethod
-    def validate_header(cls,
+    def validate_header(self,
                         header: BlockHeaderAPI,
                         previous_header: BlockHeaderAPI,
                         check_seal: bool=True) -> None:
@@ -54,17 +53,17 @@ class MainnetDAOValidatorVM(HomesteadVM):
         super().validate_header(header, previous_header, check_seal)
 
         # The special extra_data is set on the ten headers starting at the fork
-        dao_fork_at = cls.get_dao_fork_block_number()
+        dao_fork_at = self.get_dao_fork_block_number()
         extra_data_block_nums = range(dao_fork_at, dao_fork_at + 10)
 
         if header.block_number in extra_data_block_nums:
-            if cls.support_dao_fork and header.extra_data != DAO_FORK_MAINNET_EXTRA_DATA:
+            if self.support_dao_fork and header.extra_data != DAO_FORK_MAINNET_EXTRA_DATA:
                 raise ValidationError(
                     f"Block {header!r} must have extra data "
                     f"{encode_hex(DAO_FORK_MAINNET_EXTRA_DATA)} not "
                     f"{encode_hex(header.extra_data)} when supporting DAO fork"
                 )
-            elif not cls.support_dao_fork and header.extra_data == DAO_FORK_MAINNET_EXTRA_DATA:
+            elif not self.support_dao_fork and header.extra_data == DAO_FORK_MAINNET_EXTRA_DATA:
                 raise ValidationError(
                     f"Block {header!r} must not have extra data "
                     f"{encode_hex(DAO_FORK_MAINNET_EXTRA_DATA)} when declining the DAO fork"

--- a/eth/chains/tester/__init__.py
+++ b/eth/chains/tester/__init__.py
@@ -146,8 +146,8 @@ class MainnetTesterChain(BaseMainnetTesterChain):
     It exposes one additional API `configure_forks` to allow for in-flight
     configuration of fork rules.
     """
-    @classmethod
-    def validate_seal(cls, block: BlockAPI) -> None:
+
+    def validate_seal(self, block: BlockAPI) -> None:
         """
         We don't validate the proof of work seal on the tester chain.
         """

--- a/eth/consensus/__init__.py
+++ b/eth/consensus/__init__.py
@@ -1,0 +1,3 @@
+from .clique.clique import CliqueConsensus  # noqa: F401
+from .noproof import NoProofConsensus  # noqa: F401
+from .pow import PowConsensus  # noqa: F401

--- a/eth/consensus/noproof.py
+++ b/eth/consensus/noproof.py
@@ -1,0 +1,29 @@
+from eth.abc import (
+    AtomicDatabaseAPI,
+    VirtualMachineAPI,
+    VirtualMachineModifierAPI,
+)
+from eth.typing import (
+    VMConfiguration,
+)
+
+
+class NoProofConsensus(VirtualMachineModifierAPI):
+    """
+    Modify a set of VMs to accept blocks without any validation.
+    """
+
+    def __init__(self, base_db: AtomicDatabaseAPI) -> None:
+        pass
+
+    @classmethod
+    def amend_vm_configuration_for_chain_class(cls, config: VMConfiguration) -> None:
+        """
+        Amend the given ``VMConfiguration`` to operate under the default POW rules.
+        """
+        for pair in config:
+            block_number, vm = pair
+            setattr(vm, 'validate_seal', lambda *_: None)
+
+    def amend_vm_for_chain_instance(self, vm: VirtualMachineAPI) -> None:
+        setattr(vm, 'validate_seal', lambda *_: None)

--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -33,11 +33,11 @@ from eth import constants
 from eth.abc import (
     AtomicDatabaseAPI,
     BlockAPI,
-    BlockHeaderAPI,
     ChainAPI,
     MiningChainAPI,
     VirtualMachineAPI,
 )
+from eth.consensus.noproof import NoProofConsensus
 from eth.db.atomic import AtomicDB
 from eth.db.backends.memory import (
     MemoryDB,
@@ -287,33 +287,6 @@ def enable_pow_mining(chain_class: Type[ChainAPI]) -> Type[ChainAPI]:
     return chain_class.configure(vm_configuration=vm_configuration)
 
 
-class NoChainSealValidationMixin:
-    @classmethod
-    def validate_seal(cls, block: BlockAPI) -> None:
-        pass
-
-
-class NoVMSealValidationMixin:
-    @classmethod
-    def validate_seal(cls, header: BlockHeaderAPI) -> None:
-        pass
-
-
-@to_tuple
-def _mix_in_disable_seal_validation(vm_configuration: VMConfiguration) -> Iterable[VMFork]:
-    for fork_block, vm_class in vm_configuration:
-        if issubclass(vm_class, NoVMSealValidationMixin):
-            # Seal validation already disabled, hence nothing to change
-            vm_class_without_seal_validation = vm_class
-        else:
-            vm_class_without_seal_validation = type(
-                vm_class.__name__,
-                (NoVMSealValidationMixin, vm_class),
-                {},
-            )
-        yield fork_block, vm_class_without_seal_validation
-
-
 @curry
 def disable_pow_check(chain_class: Type[ChainAPI]) -> Type[ChainAPI]:
     """
@@ -325,22 +298,8 @@ def disable_pow_check(chain_class: Type[ChainAPI]) -> Type[ChainAPI]:
         blocks mined this way will not be importable on any chain that does not
         have proof of work disabled.
     """
-    if not chain_class.vm_configuration:
-        raise ValidationError("Chain class has no vm_configuration")
-
-    if issubclass(chain_class, NoChainSealValidationMixin):
-        # Seal validation already disabled, hence nothing to change
-        chain_class_without_seal_validation = chain_class
-    else:
-        chain_class_without_seal_validation = type(
-            chain_class.__name__,
-            (chain_class, NoChainSealValidationMixin),
-            {},
-        )
-    return chain_class_without_seal_validation.configure(  # type: ignore
-        vm_configuration=_mix_in_disable_seal_validation(
-            chain_class_without_seal_validation.vm_configuration  # type: ignore
-        ),
+    return chain_class.configure(
+        consensus_engine_class=NoProofConsensus
     )
 
 

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -39,9 +39,6 @@ from eth.abc import (
     UnsignedTransactionAPI,
     VirtualMachineAPI,
 )
-from eth.consensus.pow import (
-    check_pow,
-)
 from eth.constants import (
     GENESIS_PARENT_HASH,
     MAX_PREV_HEADER_DEPTH,
@@ -607,8 +604,7 @@ class VM(Configurable, VirtualMachineAPI):
                 f" - header uncle_hash: {block.header.uncles_hash}"
             )
 
-    @classmethod
-    def validate_header(cls,
+    def validate_header(self,
                         header: BlockHeaderAPI,
                         parent_header: BlockHeaderAPI,
                         check_seal: bool = True) -> None:
@@ -620,7 +616,7 @@ class VM(Configurable, VirtualMachineAPI):
             raise ValidationError("Must have access to parent header to validate current header")
         else:
             validate_length_lte(
-                header.extra_data, cls.extra_data_max_bytes, title="BlockHeader.extra_data")
+                header.extra_data, self.extra_data_max_bytes, title="BlockHeader.extra_data")
 
             validate_gas_limit(header.gas_limit, parent_header.gas_limit)
 
@@ -642,22 +638,20 @@ class VM(Configurable, VirtualMachineAPI):
 
             if check_seal:
                 try:
-                    cls.validate_seal(header)
+                    self.validate_seal(header)
                 except ValidationError:
-                    cls.cls_logger.warning(
+                    self.cls_logger.warning(
                         "Failed to validate header proof of work on header: %r",
                         header.as_dict()
                     )
                     raise
 
-    @classmethod
-    def validate_seal(cls, header: BlockHeaderAPI) -> None:
+    def validate_seal(self, header: BlockHeaderAPI) -> None:
         """
         Validate the seal on the given header.
         """
-        check_pow(
-            header.block_number, header.mining_hash,
-            header.mix_hash, header.nonce, header.difficulty)
+        # This method is always overwritten by the consensus engine that is set on the chain
+        pass
 
     @classmethod
     def validate_uncle(cls, block: BlockAPI, uncle: BlockAPI, uncle_parent: BlockAPI) -> None:

--- a/newsfragments/1874.feature.rst
+++ b/newsfragments/1874.feature.rst
@@ -1,0 +1,7 @@
+Make handling of different consensus mechanisms more flexible and sound.
+
+Introduce a new property ``consensus_engine_class`` on the ``Chain``. The chain take care
+of instantiating the consensus engine and exposes it as ``consensus_engine``.
+
+Also add ``PowConsensus`` and ``NoProofConsensus`` as engines and refactor ``eth.tools.*`` to
+use these.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from eth.chains.base import (
     Chain,
     MiningChain,
 )
+from eth.consensus.noproof import NoProofConsensus
 from eth.db.atomic import AtomicDB
 from eth.rlp.headers import BlockHeader
 from eth.vm.forks import (
@@ -148,6 +149,7 @@ def _chain_with_block_validation(VM, base_db, genesis_state, chain_cls=Chain):
         vm_configuration=(
             (constants.GENESIS_BLOCK_NUMBER, VM),
         ),
+        consensus_engine_class=NoProofConsensus,
         chain_id=1337,
     )
     chain = klass.from_genesis(base_db, genesis_params, genesis_state)
@@ -207,13 +209,13 @@ def _chain_without_block_validation(request, VM, base_db, genesis_state):
         'import_block': import_block_without_validation,
         'validate_block': lambda self, block: None,
     }
-    VMForTesting = VM.configure(validate_seal=lambda block: None)
     chain_class = request.param
     klass = chain_class.configure(
         __name__='TestChainWithoutBlockValidation',
         vm_configuration=(
-            (constants.GENESIS_BLOCK_NUMBER, VMForTesting),
+            (constants.GENESIS_BLOCK_NUMBER, VM),
         ),
+        consensus_engine_class=NoProofConsensus,
         chain_id=1337,
         **overrides,
     )

--- a/tests/core/builder-tools/test_chain_builder.py
+++ b/tests/core/builder-tools/test_chain_builder.py
@@ -2,11 +2,6 @@ import pytest
 
 from eth_utils import ValidationError
 
-from eth.chains import (
-    MainnetChain,
-    MainnetTesterChain,
-    RopstenChain,
-)
 from eth.chains.base import (
     Chain,
     MiningChain,
@@ -23,9 +18,6 @@ from eth.tools.builder.chain import (
     import_blocks,
     mine_block,
     mine_blocks,
-)
-from eth.tools.builder.chain.builders import (
-    NoChainSealValidationMixin,
 )
 
 
@@ -237,18 +229,3 @@ def test_chain_builder_chain_split(mining_chain):
 
     head_b = chain_b.get_canonical_head()
     assert head_b.block_number == 3
-
-
-@pytest.mark.parametrize(
-    "chain",
-    (
-        MainnetChain,
-        MainnetTesterChain,
-        RopstenChain,
-    )
-)
-def test_disabling_pow_for_already_pow_disabled_chain(chain):
-    pow_disabled_chain = disable_pow_check(chain)
-    assert issubclass(pow_disabled_chain, NoChainSealValidationMixin)
-    again_pow_disabled_chain = disable_pow_check(pow_disabled_chain)
-    assert issubclass(again_pow_disabled_chain, NoChainSealValidationMixin)

--- a/tests/core/consensus/test_clique_consensus.py
+++ b/tests/core/consensus/test_clique_consensus.py
@@ -199,15 +199,12 @@ def paragon_chain_with_clique(base_db):
 
     vms = ((0, PetersburgVM,),)
 
-    clique = CliqueConsensus(base_db)
-
-    vms = clique.amend_vm_configuration(vms)
-
     chain = MiningChain.configure(
         vm_configuration=vms,
         chain_id=5,
+        consensus_engine_class=CliqueConsensus
     ).from_genesis(base_db, PARAGON_GENESIS_PARAMS, PARAGON_GENESIS_STATE)
-    return chain, clique
+    return chain, chain.consensus_engine
 
 
 def test_can_retrieve_root_snapshot(paragon_chain, clique):

--- a/tests/core/consensus/test_consensus_engine.py
+++ b/tests/core/consensus/test_consensus_engine.py
@@ -1,0 +1,86 @@
+import pytest
+
+from eth.abc import VirtualMachineModifierAPI
+from eth.chains.base import MiningChain
+from eth.tools.builder.chain import (
+    genesis,
+)
+from eth.vm.forks.istanbul import IstanbulVM
+
+from eth_utils import (
+    ValidationError,
+)
+
+
+CONSENSUS_DATA_LENGH = 9
+
+WHITELISTED_ROOT = b"root"
+
+ZERO_BYTE = b'\x00'
+
+
+class WhitelistConsensus(VirtualMachineModifierAPI):
+    """
+    A pseudo consensus engine for testing. Each accepted block puts another block on a whitelist.
+    """
+
+    def __init__(self, base_db) -> None:
+        self.base_db = base_db
+
+    @classmethod
+    def amend_vm_configuration_for_chain_class(cls, config):
+        pass
+
+    def get_consensus_data(self, consensus_data):
+        if len(consensus_data) != CONSENSUS_DATA_LENGH:
+            raise ValidationError(
+                f"The `extra_data` field must be of length {CONSENSUS_DATA_LENGH}"
+                f"but was {len(consensus_data)}"
+            )
+
+        return consensus_data[:4], consensus_data[5:]
+
+    def validate_seal(self, header):
+
+        current, following = self.get_consensus_data(header.extra_data)
+
+        if current == WHITELISTED_ROOT or current in self.base_db:
+            self.base_db[following] = ZERO_BYTE
+        else:
+            raise ValidationError(f"Block isn't on whitelist: {current}")
+
+    def amend_vm_for_chain_instance(self, vm):
+        setattr(vm, 'validate_seal', self.validate_seal)
+
+
+def test_stateful_consensus_isnt_shared_across_chain_instances():
+
+    class ChainClass(MiningChain):
+        vm_configuration = (
+            (0, IstanbulVM),
+        )
+        consensus_engine_class = WhitelistConsensus
+
+    chain = genesis(ChainClass)
+
+    chain.mine_block(extra_data=b"root-1000")
+    chain.mine_block(extra_data=b"1000-1001")
+    # we could even mine the same block twice
+    chain.mine_block(extra_data=b"1000-1001")
+
+    # But we can not jump ahead
+    with pytest.raises(ValidationError, match="Block isn't on whitelist"):
+        chain.mine_block(extra_data=b"1002-1003")
+
+    # A different chain but same consensus engine class
+    second_chain = genesis(ChainClass)
+
+    # Should maintain its independent whitelist
+    with pytest.raises(ValidationError, match="Block isn't on whitelist"):
+        second_chain.mine_block(extra_data=b"1000-1001")
+
+    second_chain.mine_block(extra_data=b"root-2000")
+
+    # And the second chain's whitelist should also not interfere with the first one's
+    with pytest.raises(ValidationError, match="Block isn't on whitelist"):
+        chain.mine_block(extra_data=b"2000-2001")

--- a/tests/core/vm/test_clique_validation.py
+++ b/tests/core/vm/test_clique_validation.py
@@ -11,6 +11,7 @@ from eth.consensus.clique import CliqueConsensus
 
 from eth.rlp.headers import BlockHeader
 
+from eth.vm.chain_context import ChainContext
 from eth.vm.forks.petersburg import (
     PetersburgVM,
 )
@@ -51,6 +52,8 @@ def clique(base_db):
 def test_can_validate_header(clique, VM, header, previous_header, valid):
     CliqueVM = VM.configure(
         extra_data_max_bytes=128,
-        validate_seal=lambda header: clique.validate_seal(header),
+        validate_seal=clique.validate_seal,
     )
-    CliqueVM.validate_header(header, previous_header, check_seal=True)
+    chain_context = ChainContext(5)
+    vm = CliqueVM(header=previous_header, chaindb=clique._chain_db, chain_context=chain_context)
+    vm.validate_header(header, previous_header, check_seal=True)

--- a/tests/core/vm/test_mainnet_dao_fork.py
+++ b/tests/core/vm/test_mainnet_dao_fork.py
@@ -11,6 +11,7 @@ from eth.chains.mainnet import (
     MainnetHomesteadVM,
 )
 from eth.rlp.headers import BlockHeader
+from eth.vm.chain_context import ChainContext
 
 
 class ETC_VM(MainnetHomesteadVM):
@@ -280,11 +281,12 @@ def header_pairs(VM, headers, valid):
     ),
 )
 def test_mainnet_dao_fork_header_validation(VM, header, previous_header, valid):
+    vm = VM(header=previous_header, chaindb=None, chain_context=ChainContext(1))
     if valid:
-        VM.validate_header(header, previous_header, check_seal=True)
+        vm.validate_header(header, previous_header, check_seal=True)
     else:
         try:
-            VM.validate_header(header, previous_header, check_seal=True)
+            vm.validate_header(header, previous_header, check_seal=True)
         except ValidationError:
             pass
         else:


### PR DESCRIPTION
### What was wrong?

The current clique implementation requires attaching a DB to the chain *class* (not chain *instance*). This is problematic (see [discussion](https://github.com/ethereum/trinity/pull/1196#discussion_r344919981) in Trinity)

It is also flawed as it is leaking a stateful consensus engine instance on different chain instances that should be independent.

For instance:

```python

chain = GoerliChain()
second_chain = GoerliChain()

# this may add a signer which is now leaking to the second_chain instance
chain.validate_seal(...)  
```

### How was it fixed?

1. This introduces a `VirtualMachineModifierAPI` interface defined as

```python
class VirtualMachineModifierAPI(ABC):

    @abstractmethod
    def __init__(self, base_db: AtomicDatabaseAPI) -> None:
        ...

    @classmethod
    @abstractmethod
    def amend_vm_configuration_for_chain_class(
            cls,
            config: VMConfiguration) -> Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...]:
        """
        Make amendments to the ``VMConfiguration`` such as redefining its methods for different
        consensus schemes.
        """
        ...

    @abstractmethod
    def amend_vm_class_for_chain_instance(
            self,
            vm_class: Type[VirtualMachineAPI]) -> Type[VirtualMachineAPI]:
        """
        Make amendments to a VM class that are not supposed to be shared across different chain
        instances.
        """
        ...
```

The `amend_vm_configuration_for_chain_class` defines a `classmethod` which can perform all kind of class relevant actions on the `VMConfiguration`. This includes things like setting `extra_data_max_bytes` to `65535` which is safe to share across all `GoerliChain` instances.

But it also defines an instance method `amend_vm_class_for_chain_instance` which performs modifications that are **not safe** to share across different chain instances. Such as replacing `validate_seal` with an implementation that is stateful.

2. It also means that `validate_seal` on the VM had to become an instance method which also means that  `validate_chain` on the VM and  `validate_chain` on the `Chain` had to become instance methods. A fact that @carver had also pointed out in the linked Trintiy thread.

3. This also adds  a `PowConsensus` and a `NoProofConsensus` engine and refactors some test helpers.

4. There's a test that proves that stateful consensus engines do in fact not leak across different chain instances.

### To-Do

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/51/e6/6a/51e66a7cbd28936baf9f26b46548dfb0.jpg)
