### PR TITLE
WIP: make sure validate_header also validates seal on parent

### DIFF
--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -642,10 +642,18 @@ class VM(Configurable, VirtualMachineAPI):
 
             if check_seal:
                 try:
+                    cls.validate_seal(parent_header)
+                except ValidationError:
+                    cls.cls_logger.warning(
+                        "Failed to validate seal on parent header: %r",
+                        header.as_dict()
+                    )
+                    raise
+                try:
                     cls.validate_seal(header)
                 except ValidationError:
                     cls.cls_logger.warning(
-                        "Failed to validate header proof of work on header: %r",
+                        "Failed to validate seal on header: %r",
                         header.as_dict()
                     )
                     raise


### PR DESCRIPTION
### What was wrong?

In CliqueConsensus we can not validate a seal on a header if we haven't validated the seal of the parent. But that's exactly what can happen when using `validate_header`. This was causing a bug during Görli sync that I just had ignored so far.

### How was it fixed?

**THE IMPLEMENTATION IS JUST AN EXAMPLE**

We probably want to fix that on the Clique level to not waste cpu cycles when it's not needed.

I'm going to wait until the dust around #1874 / #1875 has settled before I attempt to send a proper fix.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
