### PR TITLE
Remove ice age delay from Istanbul

### DIFF
--- a/eth/vm/forks/istanbul/headers.py
+++ b/eth/vm/forks/istanbul/headers.py
@@ -1,11 +1,11 @@
 from eth.vm.forks.petersburg.headers import (
     configure_header,
     create_header_from_parent,
-    compute_difficulty,
+    compute_petersburg_difficulty,
 )
 
 
-compute_istanbul_difficulty = compute_difficulty(7000000)  # TODO
+compute_istanbul_difficulty = compute_petersburg_difficulty
 
 create_istanbul_header_from_parent = create_header_from_parent(
     compute_istanbul_difficulty

--- a/newsfragments/1877.bugfix.rst
+++ b/newsfragments/1877.bugfix.rst
@@ -1,0 +1,1 @@
+Remove the ice age delay that was accidentally left in Istanbul (which should not delay ice age)


### PR DESCRIPTION
### What was wrong?

Fixes #1877 

### How was it fixed?

Remove the delay, use the exact same difficulty definition as Constantinople (er, Petersburg).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.sfu.ca/content/sfu/archaeology/museum/exhibits/virtual-exhibits/glacial-and-post-glacial-archaeology-of-north-america/ice-age-animals/jcr:content/main_content/image.img.640.medium.jpg/1465950332205.jpg)
