### PR TITLE
Add missing docstrings

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -827,7 +827,10 @@ class StackAPI(ABC):
 
 
 class CodeStreamAPI(ABC):
-    pc: int
+    """
+    A class representing a stream of EVM code.
+    """
+    program_counter: int
 
     @abstractmethod
     def read(self, size: int) -> bytes:
@@ -850,7 +853,11 @@ class CodeStreamAPI(ABC):
         ...
 
     @abstractmethod
-    def seek(self, pc: int) -> ContextManager['CodeStreamAPI']:
+    def seek(self, program_counter: int) -> ContextManager['CodeStreamAPI']:
+        """
+        Return a :class:`~typing.ContextManager` with the program counter
+        set to ``program_counter``.
+        """
         ...
 
     @abstractmethod

--- a/eth/db/journal.py
+++ b/eth/db/journal.py
@@ -180,11 +180,11 @@ class Journal(BaseDB):
         We build a special empty reversion changeset just for marking that all previous data should
         be ignored.
         """
-        checkpooint = get_next_checkpoint()
-        self._journal_data[checkpooint] = self._current_values
+        checkpoint = get_next_checkpoint()
+        self._journal_data[checkpoint] = self._current_values
         self._current_values = {}
         self._ignore_wrapped_db = True
-        self._clears_at.add(checkpooint)
+        self._clears_at.add(checkpoint)
 
     def has_clear(self, at_checkpoint: JournalDBCheckpoint) -> bool:
         for reversion_changeset_id in reversed(self._journal_data.keys()):

--- a/eth/tools/_utils/slow_code_stream.py
+++ b/eth/tools/_utils/slow_code_stream.py
@@ -65,27 +65,27 @@ class SlowCodeStream:
             return STOP
 
     def peek(self) -> int:
-        current_pc = self.pc
+        current_pc = self.program_counter
         next_opcode = next(self)
-        self.pc = current_pc
+        self.program_counter = current_pc
         return next_opcode
 
     @property
-    def pc(self) -> int:
+    def program_counter(self) -> int:
         return self.stream.tell()
 
-    @pc.setter
-    def pc(self, value: int) -> None:
+    @program_counter.setter
+    def program_counter(self, value: int) -> None:
         self.stream.seek(min(value, len(self)))
 
     @contextlib.contextmanager
     def seek(self, pc: int) -> Iterator['SlowCodeStream']:
-        anchor_pc = self.pc
-        self.pc = pc
+        anchor_pc = self.program_counter
+        self.program_counter = pc
         try:
             yield self
         finally:
-            self.pc = anchor_pc
+            self.program_counter = anchor_pc
 
     def _potentially_disqualifying_opcode_positions(self, position: int) -> Iterator[int]:
         # Look at the last 32 positions (from 1 byte back to 32 bytes back).

--- a/eth/validation.py
+++ b/eth/validation.py
@@ -174,8 +174,7 @@ def validate_stack_int(value: int) -> None:
     if 0 <= value <= UINT_256_MAX:
         return
     raise ValidationError(
-        "Invalid Stack Item: Must be either a length 32 byte "
-        f"string or a 256 bit integer. Got {value!r}"
+        "Invalid Stack Item: Must be a 256 bit integer. Got {value!r}"
     )
 
 
@@ -183,8 +182,7 @@ def validate_stack_bytes(value: bytes) -> None:
     if len(value) <= 32:
         return
     raise ValidationError(
-        "Invalid Stack Item: Must be either a length 32 byte "
-        f"string or a 256 bit integer. Got {value!r}"
+        "Invalid Stack Item: Must be either a length 32 byte string. Got {value!r}"
     )
 
 

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -547,7 +547,7 @@ class BaseComputation(Configurable, ComputationAPI):
                         "OPCODE: 0x%x (%s) | pc: %s",
                         opcode,
                         opcode_fn.mnemonic,
-                        max(0, computation.code.pc - 1),
+                        max(0, computation.code.program_counter - 1),
                     )
 
                 try:

--- a/eth/vm/forks/frontier/opcodes.py
+++ b/eth/vm/forks/frontier/opcodes.py
@@ -301,7 +301,7 @@ FRONTIER_OPCODES: Dict[int, OpcodeAPI] = {
         gas_cost=constants.GAS_HIGH,
     ),
     opcode_values.PC: as_opcode(
-        logic_fn=flow.pc,
+        logic_fn=flow.program_counter,
         mnemonic=mnemonics.PC,
         gas_cost=constants.GAS_BASE,
     ),

--- a/eth/vm/logic/flow.py
+++ b/eth/vm/logic/flow.py
@@ -17,7 +17,7 @@ def stop(computation: BaseComputation) -> None:
 def jump(computation: BaseComputation) -> None:
     jump_dest = computation.stack_pop1_int()
 
-    computation.code.pc = jump_dest
+    computation.code.program_counter = jump_dest
 
     next_opcode = computation.code.peek()
 
@@ -32,7 +32,7 @@ def jumpi(computation: BaseComputation) -> None:
     jump_dest, check_value = computation.stack_pop_ints(2)
 
     if check_value:
-        computation.code.pc = jump_dest
+        computation.code.program_counter = jump_dest
 
         next_opcode = computation.code.peek()
 
@@ -47,8 +47,8 @@ def jumpdest(computation: BaseComputation) -> None:
     pass
 
 
-def pc(computation: BaseComputation) -> None:
-    pc = max(computation.code.pc - 1, 0)
+def program_counter(computation: BaseComputation) -> None:
+    pc = max(computation.code.program_counter - 1, 0)
 
     computation.stack_push_int(pc)
 

--- a/eth/vm/logic/invalid.py
+++ b/eth/vm/logic/invalid.py
@@ -13,5 +13,5 @@ class InvalidOpcode(Opcode):
 
     def __call__(self, computation: ComputationAPI) -> None:
         raise InvalidInstruction(
-            f"Invalid opcode 0x{self.value:x} @ {computation.code.pc - 1}"
+            f"Invalid opcode 0x{self.value:x} @ {computation.code.program_counter - 1}"
         )

--- a/newsfragments/1882.doc.rst
+++ b/newsfragments/1882.doc.rst
@@ -1,0 +1,1 @@
+Add docstrings to all public APIs that were still lacking one.

--- a/tests/core/code-stream/test_code_stream.py
+++ b/tests/core/code-stream/test_code_stream.py
@@ -39,13 +39,13 @@ def test_next_returns_the_correct_next_opcode():
 def test_peek_returns_next_opcode_without_changing_code_stream_location():
     code_stream = CodeStream(b'\x01\x02\x30')
     code_iter = iter(code_stream)
-    assert code_stream.pc == 0
+    assert code_stream.program_counter == 0
     assert code_stream.peek() == opcode_values.ADD
-    assert code_stream.pc == 0
+    assert code_stream.program_counter == 0
     assert next(code_iter) == opcode_values.ADD
-    assert code_stream.pc == 1
+    assert code_stream.program_counter == 1
     assert code_stream.peek() == opcode_values.MUL
-    assert code_stream.pc == 1
+    assert code_stream.program_counter == 1
 
 
 def test_STOP_opcode_is_returned_when_bytecode_end_is_reached():
@@ -59,11 +59,11 @@ def test_STOP_opcode_is_returned_when_bytecode_end_is_reached():
 def test_seek_reverts_to_original_stream_position_when_context_exits():
     code_stream = CodeStream(b'\x01\x02\x30')
     code_iter = iter(code_stream)
-    assert code_stream.pc == 0
+    assert code_stream.program_counter == 0
     with code_stream.seek(1):
-        assert code_stream.pc == 1
+        assert code_stream.program_counter == 1
         assert next(code_iter) == opcode_values.MUL
-    assert code_stream.pc == 0
+    assert code_stream.program_counter == 0
     assert code_stream.peek() == opcode_values.ADD
 
 
@@ -198,9 +198,9 @@ def test_new_vs_reference_code_stream_iter(bytecode):
     latest = CodeStream(bytecode)
     for expected_op, actual_op in zip(reference, latest):
         assert expected_op == actual_op
-        assert reference.pc == latest.pc
+        assert reference.program_counter == latest.program_counter
 
-    assert latest.pc == reference.pc
+    assert latest.program_counter == reference.program_counter
 
 
 @given(read_len=st.integers(min_value=0), bytecode=st.binary(max_size=128))
@@ -211,7 +211,7 @@ def test_new_vs_reference_code_stream_read(read_len, bytecode):
     readout_actual = latest.read(read_len)
     assert readout_expected == readout_actual
     if read_len <= len(bytecode):
-        assert latest.pc == reference.pc
+        assert latest.program_counter == reference.program_counter
     assert latest.read(1) == reference.read(1)
 
 
@@ -229,7 +229,7 @@ def test_new_vs_reference_code_stream_read_during_iter(read_idx, read_len, bytec
             readout_actual = latest.read(read_len)
             readout_expected = reference.read(read_len)
             assert readout_expected == readout_actual
-        if reference.pc >= len(reference):
-            assert latest.pc >= len(reference)
+        if reference.program_counter >= len(reference):
+            assert latest.program_counter >= len(reference)
         else:
-            assert latest.pc == reference.pc
+            assert latest.program_counter == reference.program_counter


### PR DESCRIPTION
### What was wrong?

We have a bunch of types in our docs that are lacking docstrings. I believe having at least *some* docstring per public API is the lowest bar of requirement before we can cut a beta.

### How was it fixed?

Added at least **some** docstring for every single public API.

Imperative present tense is being used for the docstrings.

For methods, it should rhyme with **IT WILL:**
Example:

```python
def get_block:
    """
    Return the block at the tip of the chain
    """
```

For methods, it should rhyme with **IT IS:**
Example:

```python
class SchemaAPI(ABC):
    """
    A class representing a database schema that maps values to lookup keys.
    """
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.petfoodindustry.com/ext/resources/Images-by-month-year/16_11/dog-reading-book-web.jpg)
