### PR TITLE
Support more receipt fields

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -107,6 +107,24 @@ class ReceiptAPI(rlp.Serializable, ABC):
         ...
 
 
+class FullReceiptAPI:
+    """
+    A class representing a receipt with additional context information that is retrieved
+    via the transaction and block it belongs to.
+    """
+
+    block_hash: Hash32
+    block_number: BlockNumber
+    bloom: int
+    gas_used: int
+    logs: Sequence[LogAPI]
+    receipient: Address
+    sender: Address
+    state_root: bytes
+    transaction_hash: Hash32
+    transaction_index: int
+
+
 class BaseTransactionAPI(ABC):
     """
     A class to define all common methods of a transaction.
@@ -602,12 +620,22 @@ class ChainDatabaseAPI(HeaderDatabaseAPI):
         ...
 
     @abstractmethod
-    def get_receipt_by_index(self,
-                             block_number: BlockNumber,
-                             receipt_index: int) -> ReceiptAPI:
+    def get_receipt_by_number_and_index(self,
+                                        block_number: BlockNumber,
+                                        receipt_index: int) -> ReceiptAPI:
         """
         Return the receipt of the transaction at specified index
         for the block header obtained by the specified block number
+        """
+        ...
+
+    @abstractmethod
+    def get_receipt_by_header_and_index(self,
+                                        block_header: BlockHeaderAPI,
+                                        receipt_index: int) -> ReceiptAPI:
+        """
+        Return the receipt of the transaction at specified index
+        for the given block header.
         """
         ...
 
@@ -2998,7 +3026,7 @@ class ChainAPI(ConfigurableAPI):
         ...
 
     @abstractmethod
-    def get_transaction_receipt(self, transaction_hash: Hash32) -> ReceiptAPI:
+    def get_transaction_receipt(self, transaction_hash: Hash32) -> FullReceiptAPI:
         """
         Return the requested receipt for the transaction as specified by the ``transaction_hash``.
 

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -280,13 +280,19 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
         transaction_key = rlp.decode(encoded_key, sedes=TransactionKey)
         return (transaction_key.block_number, transaction_key.index)
 
-    def get_receipt_by_index(self,
-                             block_number: BlockNumber,
-                             receipt_index: int) -> ReceiptAPI:
+    def get_receipt_by_number_and_index(self,
+                                        block_number: BlockNumber,
+                                        receipt_index: int) -> ReceiptAPI:
         try:
             block_header = self.get_canonical_block_header_by_number(block_number)
         except HeaderNotFound:
             raise ReceiptNotFound(f"Block {block_number} is not in the canonical chain")
+
+        return self.get_receipt_by_header_and_index(block_header, receipt_index)
+
+    def get_receipt_by_header_and_index(self,
+                                        block_header: BlockHeader,
+                                        receipt_index: int) -> ReceiptAPI:
 
         receipt_db = HexaryTrie(db=self.db, root_hash=block_header.receipt_root)
         receipt_key = rlp.encode(receipt_index)

--- a/tests/database/test_eth1_chaindb.py
+++ b/tests/database/test_eth1_chaindb.py
@@ -149,7 +149,7 @@ def test_chaindb_get_canonical_block_hash(chaindb, block):
     assert block_hash == block.hash
 
 
-def test_chaindb_get_receipt_by_index(
+def test_chaindb_get_receipt_by_number_and_index(
         chain,
         funded_address,
         funded_address_private_key):
@@ -175,7 +175,7 @@ def test_chaindb_get_receipt_by_index(
         chain.mine_block()
 
     # Check that the receipt retrieved is indeed the actual one
-    chaindb_retrieved_receipt = chain.chaindb.get_receipt_by_index(
+    chaindb_retrieved_receipt = chain.chaindb.get_receipt_by_number_and_index(
         REQUIRED_BLOCK_NUMBER,
         REQUIRED_RECEIPT_INDEX,
     )
@@ -183,14 +183,14 @@ def test_chaindb_get_receipt_by_index(
 
     # Raise error if block number is not found
     with pytest.raises(ReceiptNotFound):
-        chain.chaindb.get_receipt_by_index(
+        chain.chaindb.get_receipt_by_number_and_index(
             NUMBER_BLOCKS_IN_CHAIN + 1,
             REQUIRED_RECEIPT_INDEX,
         )
 
     # Raise error if receipt index is out of range
     with pytest.raises(ReceiptNotFound):
-        chain.chaindb.get_receipt_by_index(
+        chain.chaindb.get_receipt_by_number_and_index(
             NUMBER_BLOCKS_IN_CHAIN,
             TRANSACTIONS_IN_BLOCK + 1,
         )


### PR DESCRIPTION
### What was wrong?

According to the specs and what geth does, this is what a response to `eth_getTransactionReceipt` should look like:

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "blockHash": "0xf64a12502afc36db3d29931a2148e5d6ddaa883a2a3c968ca2fb293fa9258c68",
    "blockNumber": "0x70839",
    "contractAddress": null,
    "cumulativeGasUsed": "0x75d5",
    "from": "0xc80fb22930b303b55df9b89901889126400add38",
    "gasUsed": "0x75d5",
    "logs": [
      {
        "address": "0x03fca6077d38dd99d0ce14ba32078bd2cda72d74",
        "topics": [
          "0x24bcf19562365f6510754002f8d7b818d275886315d29c7aa04785570b97a363"
        ],
        "data": "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000a4861636b65726e65777300000000000000000000000000000000000000000000",
        "blockNumber": "0x70839",
        "transactionHash": "0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1",
        "transactionIndex": "0x0",
        "blockHash": "0xf64a12502afc36db3d29931a2148e5d6ddaa883a2a3c968ca2fb293fa9258c68",
        "logIndex": "0x0",
        "removed": false
      }
    ],
    "logsBloom": "0x00000000000000000000000000000400000000020000000000000000400000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "root": "0xc659845f1ac4e899ff1b0666dbac5deeda33a4a5d85da71f617f352824146e40",
    "to": "0x03fca6077d38dd99d0ce14ba32078bd2cda72d74",
    "transactionHash": "0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1",
    "transactionIndex": "0x0"
  }
}
```

But the the receipt that I can fetch via `Chain.get_transaction_receipt` looks rather sparse.

```python
class ReceiptAPI(rlp.Serializable, ABC):
    """
    A class to define a receipt to capture the outcome of a transaction.
    """
    state_root: bytes
    gas_used: int
    bloom: int
    logs: Sequence[LogAPI]

    @property
    @abstractmethod
    def bloom_filter(self) -> BloomFilter:
        ...
```

I guess the fields on `ReceiptAPI` are all the bare fields that need to be persisted because we can not retrieve them from anywhere else. Which makes a lot of sense. We don't want to bloat the database with duplicate information. However, it's clear that I can't get all the information I need from that.

### How was it fixed?

I added a new `FullReceiptAPI` which is a superset of `ReceiptAPI`. We then fill in the gaps (mostly) at `Chain.get_transaction_receipt` which was changed to return a `FullReceiptAPI`.

### Open questions

1. Is this the general approach we wanna take? Any good alternatives?
2. Does it make sense to keep the old `Chain.get_transaction_receipt` which returns a `ReceiptAPI` and just add this other API as a new one? 
3. Do we want to give a proper `__init__ to not set all fields individually and if so, where would that live? (It is not an RLP but having actual implementations in `eth.abc` doesn't feel right either.
4. Or maybe, does the whole thing actually belong into Trinity? But that would mean we have to reach into `Chain.chaindb` from there which also doesn't feel *exactly* right.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
