### PR TITLE
Add new APIs to allow efficient retrieval of receipts

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -440,7 +440,7 @@ class HeaderDatabaseAPI(ABC):
         """
         Return the block header with the given number in the canonical chain.
 
-        Raise ``BlockNotFound`` if there's no block header with the given number in the
+        Raise ``HeaderNotFound`` if there's no block header with the given number in the
         canonical chain.
         """
         ...
@@ -2877,6 +2877,16 @@ class ChainAPI(ConfigurableAPI):
         ...
 
     @abstractmethod
+    def get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeaderAPI:
+        """
+        Return the block header with the given number in the canonical chain.
+
+        Raise ``HeaderNotFound`` if there's no block header with the given number in the
+        canonical chain.
+        """
+        ...
+
+    @abstractmethod
     def get_canonical_head(self) -> BlockHeaderAPI:
         """
         Return the block header at the canonical chain head.
@@ -2987,6 +2997,17 @@ class ChainAPI(ConfigurableAPI):
         ...
 
     @abstractmethod
+    def get_canonical_transaction_index(self, transaction_hash: Hash32) -> Tuple[BlockNumber, int]:
+        """
+        Return a 2-tuple of (block_number, transaction_index) indicating which
+        block the given transaction can be found in and at what index in the
+        block transactions.
+
+        Raise ``TransactionNotFound`` if the transaction does not exist in the canoncial
+        chain.
+        """
+
+    @abstractmethod
     def get_canonical_transaction(self, transaction_hash: Hash32) -> SignedTransactionAPI:
         """
         Return the requested transaction as specified by the ``transaction_hash``
@@ -2998,12 +3019,36 @@ class ChainAPI(ConfigurableAPI):
         ...
 
     @abstractmethod
+    def get_canonical_transaction_by_index(self,
+                                           block_number: BlockNumber,
+                                           index: int) -> SignedTransactionAPI:
+        """
+        Return the requested transaction as specified by the ``block_number``
+        and ``index`` from the canonical chain.
+
+        Raise ``TransactionNotFound`` if no transaction exists at ``index`` at ``block_number`` in
+        the canonical chain.
+        """
+        ...
+
+    @abstractmethod
     def get_transaction_receipt(self, transaction_hash: Hash32) -> ReceiptAPI:
         """
         Return the requested receipt for the transaction as specified by the ``transaction_hash``.
 
         Raise ``ReceiptNotFound`` if not receipt for the specified ``transaction_hash`` is found
         in the canonical chain.
+        """
+        ...
+
+    @abstractmethod
+    def get_transaction_receipt_by_index(self, block_number: BlockNumber, index: int) -> ReceiptAPI:
+        """
+        Return the requested receipt for the transaction as specified by the ``block_number``
+        and ``index``.
+
+        Raise ``ReceiptNotFound`` if not receipt for the specified ``block_number`` and ``index`` is
+        found in the canonical chain.
         """
         ...
 

--- a/newsfragments/1887.feature.rst
+++ b/newsfragments/1887.feature.rst
@@ -1,0 +1,6 @@
+Add new Chain APIs:
+
+- `get_canonical_block_header_by_number`
+- `get_canonical_transaction_index`
+- `get_canonical_transaction_by_index`
+- `get_transaction_receipt_by_index`


### PR DESCRIPTION
### What was wrong?

Our current APIs do not allow to implement `getTransactionReceipt` in Trinity (without reaching into Py-EVM internals).

That's because the expected response includes information that we can not retrieve if the APIs aren't changed or new APIs are added.

**Exampe response**
```
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "blockHash": "0xf64a12502afc36db3d29931a2148e5d6ddaa883a2a3c968ca2fb293fa9258c68",
    "blockNumber": "0x70839",
    "contractAddress": null,
    "cumulativeGasUsed": "0x75d5",
    "from": "0xc80fb22930b303b55df9b89901889126400add38",
    "gasUsed": "0x75d5",
    "logs": [
      {
        "address": "0x03fca6077d38dd99d0ce14ba32078bd2cda72d74",
        "topics": [
          "0x24bcf19562365f6510754002f8d7b818d275886315d29c7aa04785570b97a363"
        ],
        "data": "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000a4861636b65726e65777300000000000000000000000000000000000000000000",
        "blockNumber": "0x70839",
        "transactionHash": "0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1",
        "transactionIndex": "0x0",
        "blockHash": "0xf64a12502afc36db3d29931a2148e5d6ddaa883a2a3c968ca2fb293fa9258c68",
        "logIndex": "0x0",
        "removed": false
      }
    ],
    "logsBloom": "0x00000000000000000000000000000400000000020000000000000000400000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "root": "0xc659845f1ac4e899ff1b0666dbac5deeda33a4a5d85da71f617f352824146e40",
    "to": "0x03fca6077d38dd99d0ce14ba32078bd2cda72d74",
    "transactionHash": "0x1e2910a262b1008d0616a0beb24c1a491d78771baa54a33e66065e03b1f46bc1",
    "transactionIndex": "0x0"
  }
}
```

With only a `transaction_hash` we have no way of telling the block or the index of the transaction within that block which we need to give a qualified response.

### How was it fixed?

I tried to change the APIs in a way that would prevent us from unnecessary database access as much as possible (I think).

Therefore I've added the following new APIs to `Chain`:

```python
def get_canonical_transaction_index(self, transaction_hash: Hash32) -> Tuple[BlockNumber, int]:
```

:point_up: Allows to make subsequent requests that would not re-read the same information again.

```python
def get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeaderAPI
```

:point_up: We have a similar API for full blocks but it seems wasteful to call that when retrieving a block header by number would do it.

```python
def get_canonical_transaction_by_index(self, block_number: BlockNumber, index: int) -> SignedTransactionAPI:
```
This API is to bypass `get_canonical_transaction` which would involve another db lookup that for the block number and index that we already know at this point.

```python
def get_transaction_receipt_by_index(self, block_number: BlockNumber, index: int) -> ReceiptAPI:
```

This API is to bypass `get_canonical_transaction` which would involve another db lookup that for the block number and index that we already know at this point.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cutebabypets.files.wordpress.com/2016/11/image5.jpg)
