### PR TITLE
Bugfix: don't resume apply_all_transactions if EVM is missing data

### DIFF
--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -231,6 +231,7 @@ class VM(Configurable, VirtualMachineAPI):
                 )
             except EVMMissingData as exc:
                 self.state.revert(snapshot)
+                raise
 
             result_header = self.add_receipt_to_header(previous_header, receipt)
             previous_header = result_header

--- a/newsfragments/1889.bugfix.rst
+++ b/newsfragments/1889.bugfix.rst
@@ -1,0 +1,3 @@
+Bug: if data was missing during a call to :meth:`~eth.vm.base.VM.apply_all_transactions`,
+then the call would revert and continue processing transactions. Fix: we re-raise
+the :class:`~eth.exceptions.EVMMissingData` and do not continue processing transactions.


### PR DESCRIPTION

### What was wrong?

Fix #1889 

### How was it fixed?

If apply_all_transactions is missing data, reraise

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cache.desktopnexus.com/thumbseg/783/783745-bigthumbnail.jpg)
