### PR TITLE
Improve header chain extension performance

### DIFF
--- a/eth/tools/_utils/normalization.py
+++ b/eth/tools/_utils/normalization.py
@@ -128,7 +128,7 @@ def normalize_to_address(value: AnyStr) -> Address:
         return CREATE_CONTRACT_ADDRESS
 
 
-robust_decode_hex = eth_utils.curried.hexstr_if_str(to_bytes)  # type: ignore  # https://github.com/ethereum/eth-utils/issues/156  # noqa: E501
+robust_decode_hex = eth_utils.curried.hexstr_if_str(to_bytes)
 
 
 #
@@ -247,7 +247,7 @@ normalize_state = compose(
         "nonce": normalize_int,
         "storage": normalize_storage
     }, required=[])),
-    eth_utils.curried.apply_formatter_if(  # type: ignore  # https://github.com/ethereum/eth-utils/issues/156  # noqa: E501
+    eth_utils.curried.apply_formatter_if(
         lambda s: isinstance(s, Iterable) and not isinstance(s, Mapping),
         state_definition_to_dict
     ),

--- a/newsfragments/1891.performance.rst
+++ b/newsfragments/1891.performance.rst
@@ -1,0 +1,2 @@
+Improve performance when importing a header which is a child of the current canonical
+chain tip.


### PR DESCRIPTION
### What was wrong? / How was it fixed?

Breaking this out from #1888, improves performance if the parent of the header being imported is the canonical chain tip. `_find_new_ancestors` is relatively expensive; if I remember right a lot of time is spent fetching and de-serializing the header which was just imported, when all that's wanted is its hash.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![panda-tree](https://user-images.githubusercontent.com/466333/70288465-a173d180-1786-11ea-8a43-7002e88a2833.jpg)
