### PR TITLE
Lock in storage changes before transaction starts

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -1574,6 +1574,16 @@ class AccountStorageDatabaseAPI(ABC):
         ...
 
     @abstractmethod
+    def lock_changes(self) -> None:
+        """
+        Locks in changes to storage, typically just as a transaction starts.
+
+        This is used, for example, to look up the storage value from the start
+        of the transaction, when calculating gas costs in EIP-2200: net gas metering.
+        """
+        ...
+
+    @abstractmethod
     def make_storage_root(self) -> None:
         """
         Force calculation of the storage root for this account
@@ -2150,6 +2160,16 @@ class StateAPI(ConfigurableAPI):
         """
         Commit the journal to the point where the snapshot was taken.  This
         merges in any changes that were recorded since the snapshot.
+        """
+        ...
+
+    @abstractmethod
+    def lock_changes(self) -> None:
+        """
+        Locks in all changes to state, typically just as a transaction starts.
+
+        This is used, for example, to look up the storage value from the start
+        of the transaction, when calculating gas costs in EIP-2200: net gas metering.
         """
         ...
 

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -370,6 +370,10 @@ class AccountDB(AccountDatabaseAPI):
         for _, store in self._dirty_account_stores():
             store.commit(checkpoint)
 
+    def lock_changes(self) -> None:
+        for _, store in self._dirty_account_stores():
+            store.lock_changes()
+
     def make_state_root(self) -> Hash32:
         for _, store in self._dirty_account_stores():
             store.make_storage_root()

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -148,6 +148,10 @@ class VM(Configurable, VirtualMachineAPI):
                           transaction: SignedTransactionAPI
                           ) -> Tuple[ReceiptAPI, ComputationAPI]:
         self.validate_transaction_against_header(header, transaction)
+
+        # Mark current state as un-revertable, since new transaction is starting...
+        self.state.lock_changes()
+
         computation = self.state.apply_transaction(transaction)
         receipt = self.make_receipt(header, transaction, computation, self.state)
         self.validate_receipt(receipt)

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -175,6 +175,9 @@ class BaseState(Configurable, StateAPI):
         _, account_snapshot = snapshot
         self._account_db.commit(account_snapshot)
 
+    def lock_changes(self) -> None:
+        self._account_db.lock_changes()
+
     def persist(self) -> None:
         self._account_db.persist()
 

--- a/newsfragments/1893.bugfix.rst
+++ b/newsfragments/1893.bugfix.rst
@@ -1,0 +1,3 @@
+Fix for net gas metering (EIP-2200) in Istanbul. The "original value" used to calculate gas
+costs was incorrectly accessing the value at the start of the block, instead of the start of the
+transaction.

--- a/tests/core/vm/test_vm_state.py
+++ b/tests/core/vm/test_vm_state.py
@@ -101,3 +101,13 @@ def test_revert_selfdestruct(state, read_storage_before_snapshot):
     #       "starting" storage root hash would always be the empty one, which causes
     #       it to not be able to recover from a revert
     assert state.get_storage(ADDRESS, 1) == 2
+
+
+def test_lock_state(state):
+    assert state.get_storage(ADDRESS, 1, from_journal=False) == 0
+
+    state.set_storage(ADDRESS, 1, 2)
+    assert state.get_storage(ADDRESS, 1, from_journal=False) == 0
+
+    state.lock_changes()
+    assert state.get_storage(ADDRESS, 1, from_journal=False) == 2


### PR DESCRIPTION
### What was wrong?

Currently, because we don't do this, there is a bug in EIP-2200, net gas
metering. When looking up the "original value", the EVM must get the
storage value at the beginning of the transaction, not the beginning of
the block.

Fixes #1893 

### How was it fixed?

So we lock in changes at the beginning of every transaction,
to make sure we don't read values from older transactions, when reading
the original value.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://files.brightside.me/files/news/part_63/637560/preview-7046060-1200x630-99-1540883964.jpg)
