### PR TITLE
Add generate_contract_address to transaction methods API

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -111,6 +111,15 @@ class BaseTransactionAPI(ABC):
     """
     A class to define all common methods of a transaction.
     """
+
+    @staticmethod
+    @abstractmethod
+    def generate_contract_address(sender: Address, nonce: int) -> Address:
+        """
+        Generate an address for a contract that is created by a *Contract Creation Transaction*,
+        that is, a transaction where the ``to`` field is empty.
+        """
+
     @abstractmethod
     def validate(self) -> None:
         """

--- a/eth/rlp/transactions.py
+++ b/eth/rlp/transactions.py
@@ -22,6 +22,10 @@ from eth.abc import (
     UnsignedTransactionAPI,
 )
 
+from eth._utils.address import (
+    generate_contract_address,
+)
+
 from .sedes import address
 
 
@@ -35,6 +39,10 @@ class BaseTransactionMethods(BaseTransactionAPI):
 
     def gas_used_by(self, computation: ComputationAPI) -> int:
         return self.get_intrinsic_gas() + computation.get_gas_used()
+
+    @staticmethod
+    def generate_contract_address(sender: Address, nonce: int) -> Address:
+        return generate_contract_address(sender, nonce)
 
 
 BASE_TRANSACTION_FIELDS = [

--- a/eth/vm/forks/frontier/state.py
+++ b/eth/vm/forks/frontier/state.py
@@ -21,10 +21,6 @@ from eth.exceptions import (
     ContractCreationCollision,
 )
 
-from eth._utils.address import (
-    generate_contract_address,
-)
-
 from eth.vm.message import (
     Message,
 )
@@ -63,7 +59,7 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
         message_gas = transaction.gas - transaction.intrinsic_gas
 
         if transaction.to == CREATE_CONTRACT_ADDRESS:
-            contract_address = generate_contract_address(
+            contract_address = transaction.generate_contract_address(
                 transaction.sender,
                 self.vm_state.get_nonce(transaction.sender) - 1,
             )


### PR DESCRIPTION
### What was wrong?

1. In theory the way a contract address is derived for a *Contract Creation Transaction*  could change between forks. Our architecture does currently not reflect that.

2. We would like to reuse the `generate_contract_address` logic to compute contract addresses when we serve receipts in Trinity. (See https://github.com/ethereum/trinity/pull/1380)

### How was it fixed?

1. Added `generate_contract_addess` to the `BaseTransactionAPI`

2. Call `transaction.generate_contract_address` instead of the hardcoded utility method in `FrontierTransactionExecutor`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
