### PR TITLE
Only delete (account) storage values if they are present

### DIFF
--- a/eth/db/storage.py
+++ b/eth/db/storage.py
@@ -210,7 +210,15 @@ class AccountStorageDB(AccountStorageDatabaseAPI):
         if value:
             self._journal_storage[key] = rlp.encode(value)
         else:
-            del self._journal_storage[key]
+            try:
+                current_val = self._journal_storage[key]
+            except KeyError:
+                # deleting an empty key has no effect
+                return
+            else:
+                if current_val != b'':
+                    # only try to delete the value if it's present
+                    del self._journal_storage[key]
 
     def delete(self) -> None:
         self.logger.debug2(

--- a/newsfragments/1898.bugfix.rst
+++ b/newsfragments/1898.bugfix.rst
@@ -1,0 +1,3 @@
+When double-deleting a storage slot, got ``KeyError: (b'\x03', 'key could not be deleted in
+JournalDB, because it was missing')``. This was fallout from `#1893
+  <https://github.com/ethereum/py-evm/pull/1893>`_


### PR DESCRIPTION
### What was wrong?

Fixes: https://github.com/ethereum/trinity/issues/1376

### How was it fixed?

Was trying to delete a storage value that was missing. Other changes made this problem more apparent.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/57/26/fa/5726faab496635e6546866e6b5694094.jpg)
