### PR TITLE
Add Istanbul fork to GOERLI_VM_CONFIGURATION

### DIFF
--- a/eth/chains/goerli/__init__.py
+++ b/eth/chains/goerli/__init__.py
@@ -1,6 +1,7 @@
 from eth_utils import decode_hex
 
 from .constants import (
+    ISTANBUL_GOERLI_BLOCK,
     PETERSBURG_GOERLI_BLOCK,
 )
 
@@ -8,11 +9,13 @@ from eth import constants
 
 from eth.rlp.headers import BlockHeader
 from eth.vm.forks import (
+    IstanbulVM,
     PetersburgVM,
 )
 
 GOERLI_VM_CONFIGURATION = (
     (PETERSBURG_GOERLI_BLOCK, PetersburgVM),
+    (ISTANBUL_GOERLI_BLOCK, IstanbulVM),
 )
 
 

--- a/newsfragments/1904.feature.rst
+++ b/newsfragments/1904.feature.rst
@@ -1,0 +1,1 @@
+Support Istanbul fork in ``GOERLI_VM_CONFIGURATION``


### PR DESCRIPTION
### What was wrong?

The `GOERLI_VM_CONFIGURATION` was missing Istanbul support.

### How was it fixed?

Added Istanbul support to `GOERLI_VM_CONFIGURATION`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://p0.pxfuel.com/preview/677/276/833/raccoon-wild-animal-furry-mammal.jpg)
