### PR TITLE
Update hypothesis to unbreak CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ deps = {
     ],
     'test': [
         "factory-boy==2.11.1",
-        "hypothesis==3.69.5",
+        "hypothesis>=5,<6",
         "pexpect>=4.6, <5",
         "pytest>=5.1.3,<6",
         "pytest-asyncio>=0.10.0,<0.11",

--- a/tests/core/code-stream/test_code_stream.py
+++ b/tests/core/code-stream/test_code_stream.py
@@ -1,4 +1,5 @@
 import itertools
+import sys
 
 import pytest
 
@@ -203,7 +204,7 @@ def test_new_vs_reference_code_stream_iter(bytecode):
     assert latest.program_counter == reference.program_counter
 
 
-@given(read_len=st.integers(min_value=0), bytecode=st.binary(max_size=128))
+@given(read_len=st.integers(min_value=0, max_value=sys.maxsize), bytecode=st.binary(max_size=128))
 def test_new_vs_reference_code_stream_read(read_len, bytecode):
     reference = SlowCodeStream(bytecode)
     latest = CodeStream(bytecode)
@@ -217,7 +218,7 @@ def test_new_vs_reference_code_stream_read(read_len, bytecode):
 
 @given(
     read_idx=st.integers(min_value=0, max_value=10),
-    read_len=st.integers(min_value=0),
+    read_len=st.integers(min_value=0, max_value=sys.maxsize),
     bytecode=st.binary(max_size=128),
 )
 def test_new_vs_reference_code_stream_read_during_iter(read_idx, read_len, bytecode):


### PR DESCRIPTION
### What was wrong?

CI is currently broken due to some [hypothesis error](https://circleci.com/gh/ethereum/py-evm/140594?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

### How was it fixed?

1.  Upgraded hypothesis to latest version which resulted in [another error](https://circleci.com/gh/ethereum/py-evm/140612?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)
2. Bound some `max_value` in hypothesis tests to `sys.maxsize`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/c4/82/99/c482993ecccd7fd1ae2918af7b27f0f5.jpg)
