### PR TITLE
Improve logging message for failed seal check

### DIFF
--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -580,10 +580,11 @@ class VM(Configurable, VirtualMachineAPI):
             if check_seal:
                 try:
                     self.validate_seal(header)
-                except ValidationError:
+                except ValidationError as exc:
                     self.cls_logger.warning(
-                        "Failed to validate header proof of work on header: %r",
-                        header.as_dict()
+                        "Failed to validate seal on header: %r. Error: %s",
+                        header.as_dict(),
+                        exc,
                     )
                     raise
 

--- a/newsfragments/1907.bugfix.rst
+++ b/newsfragments/1907.bugfix.rst
@@ -1,0 +1,2 @@
+Do not mention PoW in the logging message that we log when `validate_seal` fails.
+The VM could also be running under a non-PoW consensus mechanism.


### PR DESCRIPTION
### What was wrong?

There's a logging message printed when the seal check fails that mentions PoW even though that code path could also be running under a different consensus mechanism.

### How was it fixed?

Changed the logging message to be more generic (failed seal check

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/b7/44/ba/b744ba6b4d4300210068e0c87a828793.jpg)
