### PR TITLE
Drop check_seal support from validate_header

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -2696,12 +2696,11 @@ class VirtualMachineAPI(ConfigurableAPI):
         """
         ...
 
+    @classmethod
     @abstractmethod
     def validate_header(self,
                         header: BlockHeaderAPI,
-                        parent_header: BlockHeaderAPI,
-                        check_seal: bool = True
-                        ) -> None:
+                        parent_header: BlockHeaderAPI) -> None:
         """
         :raise eth.exceptions.ValidationError: if the header is not valid
         """

--- a/eth/chains/mainnet/__init__.py
+++ b/eth/chains/mainnet/__init__.py
@@ -68,15 +68,15 @@ def validate_header_is_on_intended_dao_fork(support_dao_fork: bool,
 class MainnetDAOValidatorVM(HomesteadVM):
     """Only on mainnet, TheDAO fork is accompanied by special extra data. Validate those headers"""
 
-    def validate_header(self,
+    @classmethod
+    def validate_header(cls,
                         header: BlockHeaderAPI,
-                        previous_header: BlockHeaderAPI,
-                        check_seal: bool=True) -> None:
+                        previous_header: BlockHeaderAPI) -> None:
 
-        super().validate_header(header, previous_header, check_seal)
+        super().validate_header(header, previous_header)
         validate_header_is_on_intended_dao_fork(
-            self.support_dao_fork,
-            self.get_dao_fork_block_number(),
+            cls.support_dao_fork,
+            cls.get_dao_fork_block_number(),
             header
         )
 

--- a/newsfragments/1909.removal.rst
+++ b/newsfragments/1909.removal.rst
@@ -1,0 +1,3 @@
+Drop optional ``check_seal`` param from ``VM.validate_header`` and turn it into a ``classmethod``.
+Seal checks now need to be made explicitly via ``VM.check_seal`` which is also aligned
+with ``VM.check_seal_extension``.

--- a/tests/core/vm/test_mainnet_dao_fork.py
+++ b/tests/core/vm/test_mainnet_dao_fork.py
@@ -10,9 +10,7 @@ from eth_utils.toolz import sliding_window
 from eth.chains.mainnet import (
     MainnetHomesteadVM,
 )
-from eth.consensus import ConsensusContext
 from eth.rlp.headers import BlockHeader
-from eth.vm.chain_context import ChainContext
 
 
 class ETC_VM(MainnetHomesteadVM):
@@ -269,11 +267,6 @@ def header_pairs(VM, headers, valid):
         yield VM, pair[1], pair[0], valid
 
 
-class FakeChainDB:
-    def __init__(self, db):
-        self.db = db
-
-
 @pytest.mark.parametrize(
     'VM, header, previous_header, valid',
     header_pairs(MainnetHomesteadVM, ETH_HEADERS_NEAR_FORK, valid=True) + (
@@ -287,19 +280,12 @@ class FakeChainDB:
     ),
 )
 def test_mainnet_dao_fork_header_validation(VM, header, previous_header, valid):
-    chain_db = FakeChainDB({})
-    consensus_context = ConsensusContext(chain_db.db)
-    vm = VM(
-        header=previous_header,
-        chaindb=chain_db,
-        chain_context=ChainContext(1),
-        consensus_context=consensus_context
-    )
+
     if valid:
-        vm.validate_header(header, previous_header, check_seal=True)
+        VM.validate_header(header, previous_header)
     else:
         try:
-            vm.validate_header(header, previous_header, check_seal=True)
+            VM.validate_header(header, previous_header)
         except ValidationError:
             pass
         else:


### PR DESCRIPTION
### What was wrong?

`VM.validate_header` recently became an instance method (was a `classmethod` before). The only reason why it became an instance method is because it has an optional seal check and seal checks can only be performed on VM instances.

### How was it fixed?

@carver [suggested](https://github.com/ethereum/trinity/pull/1196#discussion_r364957121) to take the seal check out of this method. I initially was a bit skeptical about that as it comes with the risk of simply forgetting about the check. But in practice, there are few places where we explicitly need to call this and higher level code usually deals with APIs such as `validate_chain` that cover the seal check internally.
 
So yeah, this PR drops `check_seal` from `validate_header`, makes it a `classmethod` and changes all call sites accordingly.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.farandwide.com/12/6a/126a58159c9f45e19e0e4b02e9961dae.jpg)
