### PR TITLE
import_block return refactor

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -17,7 +17,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
-)
+    NamedTuple)
 from uuid import UUID
 
 import rlp
@@ -332,6 +332,12 @@ class BlockAPI(rlp.Serializable, ABC):
         otherwise ``False``.
         """
         ...
+
+
+class BlockImportResult(NamedTuple):
+    imported_block: BlockAPI
+    new_canonical_blocks: Tuple[BlockAPI, ...]
+    old_canonical_blocks: Tuple[BlockAPI, ...]
 
 
 class SchemaAPI(ABC):
@@ -3183,7 +3189,7 @@ class ChainAPI(ConfigurableAPI):
     def import_block(self,
                      block: BlockAPI,
                      perform_validation: bool=True,
-                     ) -> Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]:
+                     ) -> BlockImportResult:
         """
         Import the given ``block`` and return a 3-tuple
 

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -51,6 +51,7 @@ from eth.abc import (
     StateAPI,
     SignedTransactionAPI,
     UnsignedTransactionAPI,
+    BlockImportResult
 )
 from eth.consensus import (
     ConsensusContext,
@@ -451,7 +452,7 @@ class Chain(BaseChain):
     def import_block(self,
                      block: BlockAPI,
                      perform_validation: bool=True
-                     ) -> Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]:
+                     ) -> BlockImportResult:
 
         try:
             parent_header = self.get_block_header_by_hash(block.header.parent_hash)
@@ -492,7 +493,11 @@ class Chain(BaseChain):
             in old_canonical_hashes
         )
 
-        return imported_block, new_canonical_blocks, old_canonical_blocks
+        return BlockImportResult(
+            imported_block=imported_block,
+            new_canonical_blocks=new_canonical_blocks,
+            old_canonical_blocks=old_canonical_blocks
+        )
 
     #
     # Validation API
@@ -641,12 +646,12 @@ class MiningChain(Chain, MiningChainAPI):
     def import_block(self,
                      block: BlockAPI,
                      perform_validation: bool=True
-                     ) -> Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]:
-        imported_block, new_canonical_blocks, old_canonical_blocks = super().import_block(
+                     ) -> BlockImportResult:
+        result = super().import_block(
             block, perform_validation)
 
         self.header = self.ensure_header()
-        return imported_block, new_canonical_blocks, old_canonical_blocks
+        return result
 
     def mine_block(self, *args: Any, **kwargs: Any) -> BlockAPI:
         mined_block = self.get_vm(self.header).mine_block(*args, **kwargs)

--- a/newsfragments/1910.feature.rst
+++ b/newsfragments/1910.feature.rst
@@ -1,0 +1,1 @@
+Change return type for import_block from Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]] to BlockImportResult (NamedTuple).

--- a/newsfragments/1910.feature.rst
+++ b/newsfragments/1910.feature.rst
@@ -1,1 +1,1 @@
-Change return type for import_block from Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]] to BlockImportResult (NamedTuple).
+Change return type for ``import_block`` from ``Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]`` to ``BlockImportResult`` (NamedTuple).

--- a/scripts/benchmark/checks/import_empty_blocks.py
+++ b/scripts/benchmark/checks/import_empty_blocks.py
@@ -47,7 +47,7 @@ class ImportEmptyBlocksBenchmark(BaseBenchmark):
 
         total_gas_used = 0
         for _ in range(1, number_blocks + 1):
-            block, _, _ = chain.import_block(chain.get_vm().get_block(), False)
+            block = chain.import_block(chain.get_vm().get_block(), False).imported_block
 
             total_gas_used = total_gas_used + block.header.gas_used
             logging.debug(format_block(block))


### PR DESCRIPTION
### What was wrong?
See #1881 

### How was it fixed?
Created the named tuple and used it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/0InjL3o.jpg)
