### PR TITLE
Add tests for validate_header

### DIFF
--- a/newsfragments/1911.internal.rst
+++ b/newsfragments/1911.internal.rst
@@ -1,0 +1,1 @@
+Add explicit tests for ``validate_header``

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -1,14 +1,38 @@
 import pytest
 
-from eth_utils import decode_hex
+from eth_utils import (
+    decode_hex,
+    ValidationError,
+)
 
 from eth import constants
 from eth.chains.base import (
     MiningChain,
 )
+from eth.chains.mainnet import MAINNET_VMS
+from eth.tools.builder.chain import api
 from eth.tools.factories.transaction import (
     new_transaction
 )
+
+
+@pytest.fixture(params=MAINNET_VMS)
+def pow_consensus_chain(request):
+    return api.build(
+        MiningChain,
+        api.fork_at(request.param, 0),
+        api.genesis(),
+    )
+
+
+@pytest.fixture(params=MAINNET_VMS)
+def noproof_consensus_chain(request):
+    return api.build(
+        MiningChain,
+        api.fork_at(request.param, 0),
+        api.disable_pow_check(),
+        api.genesis(),
+    )
 
 
 @pytest.fixture
@@ -73,3 +97,28 @@ def test_import_block(chain, funded_address, funded_address_private_key):
     validation_vm = chain.get_vm(pending_header)
     block = validation_vm.import_block(new_block)
     assert block.transactions == (tx, )
+
+
+def test_validate_header_succeeds_but_pow_fails(pow_consensus_chain, noproof_consensus_chain):
+    # Create to "structurally valid" blocks that are not backed by PoW
+    block1 = noproof_consensus_chain.mine_block()
+    block2 = noproof_consensus_chain.mine_block()
+
+    vm = pow_consensus_chain.get_vm(block2.header)
+
+    # The `validate_header` check is expected to succeed as it does not perform seal validation
+    vm.validate_header(block2.header, block1.header)
+
+    with pytest.raises(ValidationError, match="mix hash mismatch"):
+        vm.validate_seal(block2.header)
+
+
+def test_validate_header_fails_on_invalid_parent(noproof_consensus_chain):
+    block1 = noproof_consensus_chain.mine_block()
+    noproof_consensus_chain.mine_block()
+    block3 = noproof_consensus_chain.mine_block()
+
+    vm = noproof_consensus_chain.get_vm(block3.header)
+
+    with pytest.raises(ValidationError, match="Blocks must be numbered consecutively"):
+        vm.validate_header(block3.header, block1.header)


### PR DESCRIPTION
### What was wrong?

We don't have tests that cover `validate_header` directly. ([Related discussion](https://github.com/ethereum/trinity/pull/1196#discussion_r366641218))

### How was it fixed?

1. Added one test that demonstrates that `validate_header` will succeed given that the header is structurally correct even if `validate_seal` will fail on that header.

2. Added one test that demonstrates that `validate_header` will fail if the parent is invalid.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://1877003920.rsc.cdn77.org/wp-content/uploads/2019/01/sa-04_kangaroo_island-017-900x600-700x467.jpg)
