### PR TITLE
Generate Witness Index while executing a block

### DIFF
--- a/docs/guides/understanding_the_mining_process.rst
+++ b/docs/guides/understanding_the_mining_process.rst
@@ -186,7 +186,8 @@ Now that we have the building blocks available, let's put it all together and mi
 
     # We have to finalize the block first in order to be able read the
     # attributes that are important for the PoW algorithm
-    block = chain.get_vm().finalize_block(chain.get_block())
+    block_result = chain.get_vm().finalize_block(chain.get_block())
+    block = block_result.block
 
     # based on mining_hash, block number and difficulty we can perform
     # the actual Proof of Work (PoW) mechanism to mine the correct
@@ -373,7 +374,8 @@ zero value transfer transaction.
   (<ByzantiumBlock(#Block #1...)
   >>> # We have to finalize the block first in order to be able read the
   >>> # attributes that are important for the PoW algorithm
-  >>> block = chain.get_vm().finalize_block(chain.get_block())
+  >>> block_result = chain.get_vm().finalize_block(chain.get_block())
+  >>> block = block_result.block
 
   >>> # based on mining_hash, block number and difficulty we can perform
   >>> # the actual Proof of Work (PoW) mechanism to mine the correct

--- a/eth/db/witness.py
+++ b/eth/db/witness.py
@@ -1,0 +1,64 @@
+from typing import (
+    Dict,
+    FrozenSet,
+    NamedTuple,
+    Set,
+)
+
+from eth_typing import (
+    Address,
+    Hash32,
+)
+
+from eth.abc import (
+    MetaWitnessAPI,
+)
+
+
+class AccountQueryTracker(NamedTuple):
+    did_query_bytecode: bool
+    slots_queried: FrozenSet[int]
+
+
+class MetaWitness(MetaWitnessAPI):
+    def __init__(
+            self,
+            witness_hashes: Set[Hash32],
+            accounts_metadata_queried: Dict[Address, AccountQueryTracker]) -> None:
+
+        self._trie_node_hashes = frozenset(witness_hashes)
+        self._accounts_metadata_queried = accounts_metadata_queried
+
+    @property
+    def hashes(self) -> FrozenSet[Hash32]:
+        return self._trie_node_hashes
+
+    @property
+    def accounts_queried(self) -> FrozenSet[Address]:
+        return frozenset(self._accounts_metadata_queried.keys())
+
+    @property
+    def account_bytecodes_queried(self) -> FrozenSet[Address]:
+        return frozenset(
+            address
+            for address, query_tracker in self._accounts_metadata_queried.items()
+            if query_tracker.did_query_bytecode
+        )
+
+    def get_slots_queried(self, address: Address) -> FrozenSet[int]:
+        try:
+            query_tracker = self._accounts_metadata_queried[address]
+        except KeyError:
+            return frozenset()
+        else:
+            return query_tracker.slots_queried
+
+    @property
+    def total_slots_queried(self) -> int:
+        """
+        Summed across all accounts, how many storage slots were queried?
+        """
+        return sum(
+            len(query_tracker.slots_queried)
+            for query_tracker in self._accounts_metadata_queried.values()
+        )

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -219,7 +219,8 @@ def apply_fixture_block_to_chain(
 
     block = rlp.decode(block_fixture['rlp'], sedes=block_class)
 
-    mined_block, _, _ = chain.import_block(block, perform_validation=perform_validation)
+    import_result = chain.import_block(block, perform_validation=perform_validation)
+    mined_block = import_result.imported_block
 
     rlp_encoded_mined_block = rlp.encode(mined_block, sedes=block_class)
 

--- a/eth/tools/mining.py
+++ b/eth/tools/mining.py
@@ -1,5 +1,6 @@
 from eth.abc import (
     BlockAPI,
+    BlockAndMetaWitness,
     VirtualMachineAPI,
 )
 from eth.consensus import (
@@ -12,8 +13,13 @@ class POWMiningMixin(VirtualMachineAPI):
     A VM that does POW mining as well. Should be used only in tests, when we
     need to programatically populate a ChainDB.
     """
-    def finalize_block(self, block: BlockAPI) -> BlockAPI:
-        block = super().finalize_block(block)
+    def finalize_block(self, block: BlockAPI) -> BlockAndMetaWitness:
+        block_result = super().finalize_block(block)
+        block = block_result.block
+
         nonce, mix_hash = pow.mine_pow_nonce(
             block.number, block.header.mining_hash, block.header.difficulty)
-        return block.copy(header=block.header.copy(nonce=nonce, mix_hash=mix_hash))
+
+        mined_block = block.copy(header=block.header.copy(nonce=nonce, mix_hash=mix_hash))
+
+        return BlockAndMetaWitness(mined_block, block_result.meta_witness)

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -27,6 +27,7 @@ from eth.abc import (
     StateAPI,
     TransactionContextAPI,
     TransactionExecutorAPI,
+    MetaWitnessAPI,
 )
 from eth.constants import (
     MAX_PREV_HEADER_DEPTH,
@@ -178,8 +179,8 @@ class BaseState(Configurable, StateAPI):
     def lock_changes(self) -> None:
         self._account_db.lock_changes()
 
-    def persist(self) -> None:
-        self._account_db.persist()
+    def persist(self) -> MetaWitnessAPI:
+        return self._account_db.persist()
 
     #
     # Access self.prev_hashes (Read-only)

--- a/newsfragments/1917.feature.rst
+++ b/newsfragments/1917.feature.rst
@@ -1,0 +1,3 @@
+Chain.import_block() now returns some meta-information about the witness. You can get a list of trie
+node hashes needed to build the witness, as well as the accesses of accounts, storage slots, and
+bytecodes.

--- a/newsfragments/1917.internal.rst
+++ b/newsfragments/1917.internal.rst
@@ -1,0 +1,1 @@
+Upgrade pytest-xdist from 1.18.1 to 1.31.0, to fix a CI crash.

--- a/newsfragments/1918.internal.rst
+++ b/newsfragments/1918.internal.rst
@@ -1,3 +1,3 @@
 Added :class:`~eth.db.accesslog.KeyAccessLoggerDB` and its atomic twin; faster ``make
 validate-docs`` (but you have to remember to ``pip install -e .[doc]`` yourself); ``str(block)`` now
-includes the first 3 bytes of the block hash.
+includes some bytes of the block hash.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ deps = {
         "pytest-asyncio>=0.10.0,<0.11",
         "pytest-cov==2.5.1",
         "pytest-watch>=4.1.0,<5",
-        "pytest-xdist==1.18.1",
+        "pytest-xdist==1.31.0",
     ],
     'lint': [
         "flake8==3.5.0",

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -65,7 +65,8 @@ def test_import_block(chain, tx):
         new_block, receipts, computations = chain.build_block_with_transactions([tx])
         computations[0].raise_if_error()
 
-    block, _, _ = chain.import_block(new_block)
+    block_import_result = chain.import_block(new_block)
+    block = block_import_result.imported_block
 
     assert block.transactions == (tx,)
     assert chain.get_block_by_hash(block.hash) == block

--- a/tests/core/chain-object/test_chain_get_ancestors.py
+++ b/tests/core/chain-object/test_chain_get_ancestors.py
@@ -101,9 +101,12 @@ def test_chain_get_ancestors_for_fork_chains(chain, fork_chain):
     ) = [fork_chain.mine_block() for _ in range(3)]
 
     # import the fork blocks into the main chain (ensuring they don't cause a reorg)
-    _, new_chain, _ = chain.import_block(f_block_4)
+    block_import_result = chain.import_block(f_block_4)
+    new_chain = block_import_result.new_canonical_blocks
     assert new_chain == tuple()
-    _, new_chain, _ = chain.import_block(f_block_5)
+
+    block_import_result = chain.import_block(f_block_5)
+    new_chain = block_import_result.new_canonical_blocks
     assert new_chain == tuple()
 
     # check with a block that has been imported

--- a/tests/core/chain-object/test_chain_reorganization.py
+++ b/tests/core/chain-object/test_chain_reorganization.py
@@ -66,16 +66,16 @@ def test_import_block_with_reorg(chain, funded_address_private_key):
     # now we proceed to import the blocks from the fork chain into the main
     # chain.  Blocks 4 and 5 should import resulting in no re-organization.
     for block in (f_block_4, f_block_5):
-        _, new_canonical_blocks, old_canonical_blocks = main_chain.import_block(block)
-        assert not new_canonical_blocks
-        assert not old_canonical_blocks
+        block_import_result = main_chain.import_block(block)
+        assert not block_import_result.new_canonical_blocks
+        assert not block_import_result.old_canonical_blocks
         # ensure that the main chain head has not changed.
         assert main_chain.header == pre_reorg_chain_head
 
     # now we import block 6 from the fork chain.  This should cause a re-org.
-    _, new_canonical_blocks, old_canonical_blocks = main_chain.import_block(f_block_6)
-    assert new_canonical_blocks == (f_block_4, f_block_5, f_block_6)
-    assert old_canonical_blocks == (block_4, block_5)
+    block_import_result = main_chain.import_block(f_block_6)
+    assert block_import_result.new_canonical_blocks == (f_block_4, f_block_5, f_block_6)
+    assert block_import_result.old_canonical_blocks == (block_4, block_5)
 
     assert main_chain.get_canonical_head() == f_block_6.header
 

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -95,7 +95,7 @@ def test_import_block(chain, funded_address, funded_address_private_key):
 
     # import the built block
     validation_vm = chain.get_vm(pending_header)
-    block = validation_vm.import_block(new_block)
+    block, _ = validation_vm.import_block(new_block)
     assert block.transactions == (tx, )
 
 

--- a/tests/core/vm/test_vm_state.py
+++ b/tests/core/vm/test_vm_state.py
@@ -21,7 +21,9 @@ def state(chain_without_block_validation):
 def test_block_properties(chain_without_block_validation):
     chain = chain_without_block_validation
     vm = chain.get_vm()
-    block, _, _ = chain.import_block(vm.mine_block())
+    mined_block = vm.mine_block().block
+    block_import_result = chain.import_block(mined_block)
+    block = block_import_result.imported_block
 
     assert vm.state.coinbase == block.header.coinbase
     assert vm.state.timestamp == block.header.timestamp


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/trinity/issues/1225 requires a way to generate information about a witness.

### How was it fixed?

(Note that this is based on #1918 -- I will rebase on master when that gets merged)

Modified `Chain.import_block()` to include another result in `BlockImportResult`, called a `WitnessIndex`.

The `WitnessIndex` includes important information like:
- the hashes of the trie nodes which are accessed while executing a block
- the list of accounts that were accessed while executing a block
- the list of storage slots, for each account, that were accessed while executing a block
- the list of accounts for which we loaded contract bytecode

Note that a `WitnessIndex` is not **the** witness. It doesn't include required information like:
- the bodies of the trie nodes which are accessed while executing a block
- the rlp's accounts that were accessed while executing a block
- the values of storage slots, for each account, that were accessed while executing a block
- the bytecode for each account that had it's bytecode accessed

(note that the witness can be fully generated from the first item, or partially generated by the rest, but need some extra bits of data to prove inclusion in the state root).

The first practical use case will focus entirely on the trie node hashes and trie node bodies for witnesses.

### To-Do

- [x] move new key logger db to fresh PR: #
- [x] move minor stuff to ^ PR (makefile, block `__str__` upgrade)
- [x] switch `mine_block()` etc to use NamedTuple result
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/1cP-AYRpcUk/maxresdefault.jpg)
