### PR TITLE
Upgrade to latest pytest-xdist

### DIFF
--- a/newsfragments/1919.internal.rst
+++ b/newsfragments/1919.internal.rst
@@ -1,0 +1,1 @@
+Upgrade pytest-xdist from 1.18.1 to 1.31.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ deps = {
         "pytest-asyncio>=0.10.0,<0.11",
         "pytest-cov==2.5.1",
         "pytest-watch>=4.1.0,<5",
-        "pytest-xdist==1.18.1",
+        "pytest-xdist==1.31.0",
     ],
     'lint': [
         "flake8==3.5.0",


### PR DESCRIPTION
### What was wrong?

Old xdist, maybe crashes more. For example: https://circleci.com/gh/ethereum/py-evm/141979?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

### How was it fixed?

Upgrade from 1.18.1 to 1.31.0

### To-Do
[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)