### PR TITLE
Convert apply_message to a classmethod

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -1542,17 +1542,27 @@ class ComputationAPI(ContextManager['ComputationAPI'], StackManipulationAPI):
     #
     # State Transition
     #
+    @classmethod
     @abstractmethod
-    def apply_message(self) -> 'ComputationAPI':
+    def apply_message(
+            cls,
+            state: 'StateAPI',
+            message: MessageAPI,
+            transaction_context: TransactionContextAPI) -> 'ComputationAPI':
         """
-        Execution of a VM message.
+        Execution of a VM message. Typically used for sub-calls.
         """
         ...
 
+    @classmethod
     @abstractmethod
-    def apply_create_message(self) -> 'ComputationAPI':
+    def apply_create_message(
+            cls,
+            state: 'StateAPI',
+            message: MessageAPI,
+            transaction_context: TransactionContextAPI) -> 'ComputationAPI':
         """
-        Execution of a VM message to create a new contract.
+        Execution of a VM message to create a new contract. Typically used for sub-calls.
         """
         ...
 

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -216,7 +216,7 @@ class VM(Configurable, VirtualMachineAPI):
         )
 
         # Execute it in the VM
-        return self.state.get_computation(message, transaction_context).apply_computation(
+        return self.state.computation_class.apply_computation(
             self.state,
             message,
             transaction_context,

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -1,6 +1,3 @@
-from abc import (
-    abstractmethod,
-)
 import itertools
 from types import TracebackType
 from typing import (
@@ -369,17 +366,17 @@ class BaseComputation(Configurable, ComputationAPI):
 
     def generate_child_computation(self, child_msg: MessageAPI) -> ComputationAPI:
         if child_msg.is_create:
-            child_computation = self.__class__(
+            child_computation = self.apply_create_message(
                 self.state,
                 child_msg,
                 self.transaction_context,
-            ).apply_create_message()
+            )
         else:
-            child_computation = self.__class__(
+            child_computation = self.apply_message(
                 self.state,
                 child_msg,
                 self.transaction_context,
-            ).apply_message()
+            )
         return child_computation
 
     def add_child_computation(self, child_computation: ComputationAPI) -> None:
@@ -513,14 +510,6 @@ class BaseComputation(Configurable, ComputationAPI):
     #
     # State Transition
     #
-    @abstractmethod
-    def apply_message(self) -> ComputationAPI:
-        raise NotImplementedError("Must be implemented by subclasses")
-
-    @abstractmethod
-    def apply_create_message(self) -> ComputationAPI:
-        raise NotImplementedError("Must be implemented by subclasses")
-
     @classmethod
     def apply_computation(cls,
                           state: StateAPI,

--- a/eth/vm/forks/frontier/state.py
+++ b/eth/vm/forks/frontier/state.py
@@ -123,14 +123,17 @@ class FrontierTransactionExecutor(BaseTransactionExecutor):
                     encode_hex(message.storage_address),
                 )
             else:
-                computation = self.vm_state.get_computation(
+                computation = self.vm_state.computation_class.apply_create_message(
+                    self.vm_state,
                     message,
                     transaction_context,
-                ).apply_create_message()
+                )
         else:
-            computation = self.vm_state.get_computation(
+            computation = self.vm_state.computation_class.apply_message(
+                self.vm_state,
                 message,
-                transaction_context).apply_message()
+                transaction_context,
+            )
 
         return computation
 

--- a/newsfragments/1921.internal.rst
+++ b/newsfragments/1921.internal.rst
@@ -1,0 +1,5 @@
+Fix for creating a duplicate "ghost" Computation that was never used. It didn't
+break anything, but was ineligant and surprising to get extra objects created
+that were mostly useless. This was achieved by changing
+:meth:`ComputationAPI.apply_message` and
+:meth:`ComputationAPI.apply_create_message` to be class methods.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,9 @@
 [pytest]
-addopts= --showlocals
+addopts= --showlocals --durations 10
 python_paths= .
 xfail_strict=true
 log_format = %(levelname)8s  %(asctime)s  %(filename)20s  %(message)s
 log_date_format = %m-%d %H:%M:%S
+
+[pytest-watch]
+runner= pytest --failed-first --maxfail=1

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -828,7 +828,11 @@ def test_sstore(vm_class, code, gas_used, refund, original):
     assert computation.state.get_storage(CANONICAL_ADDRESS_B, 0, from_journal=True) == original
     assert computation.state.get_storage(CANONICAL_ADDRESS_B, 0, from_journal=False) == original
 
-    comp = computation.apply_message()
+    comp = computation.apply_message(
+        computation.state,
+        computation.msg,
+        computation.transaction_context,
+    )
     assert comp.get_gas_refund() == refund
     assert comp.get_gas_used() == gas_used
 
@@ -858,7 +862,11 @@ def test_sstore_limit_2300(gas_supplied, success, gas_used, refund):
     assert computation.state.get_storage(CANONICAL_ADDRESS_B, 0) == original
     computation.state.persist()
 
-    comp = computation.apply_message()
+    comp = computation.apply_message(
+        computation.state,
+        computation.msg,
+        computation.transaction_context,
+    )
     if success and not comp.is_success:
         raise comp._error
     else:
@@ -963,7 +971,11 @@ def test_balance(vm_class, code, expect_exception, expect_gas_used):
     computation.state.set_balance(CANONICAL_ADDRESS_B, sender_balance)
     computation.state.persist()
 
-    comp = computation.apply_message()
+    comp = computation.apply_message(
+        computation.state,
+        computation.msg,
+        computation.transaction_context,
+    )
     if expect_exception:
         assert isinstance(comp.error, expect_exception)
     else:
@@ -1017,7 +1029,11 @@ def test_balance(vm_class, code, expect_exception, expect_gas_used):
 )
 def test_gas_costs(vm_class, code, expect_gas_used):
     computation = setup_computation(vm_class, CANONICAL_ADDRESS_B, code)
-    comp = computation.apply_message()
+    comp = computation.apply_message(
+        computation.state,
+        computation.msg,
+        computation.transaction_context,
+    )
     assert comp.is_success
     assert comp.get_gas_used() == expect_gas_used
 
@@ -1098,7 +1114,11 @@ def test_blake2b_f_compression(vm_class, input_hex, output_hex, expect_exception
         data=to_bytes(hexstr=input_hex),
     )
 
-    comp = computation.apply_message()
+    comp = computation.apply_message(
+        computation.state,
+        computation.msg,
+        computation.transaction_context,
+    )
     if expect_exception:
         assert isinstance(comp.error, expect_exception)
     else:

--- a/tests/core/vm/test_base_computation.py
+++ b/tests/core/vm/test_base_computation.py
@@ -27,11 +27,13 @@ CANONICAL_ADDRESS_B = to_canonical_address("0xcd1722f3947def4cf144679da39c4c32bd
 
 
 class DummyComputation(BaseComputation):
-    def apply_message(self):
-        return self
+    @classmethod
+    def apply_message(cls, *args):
+        return cls(*args)
 
-    def apply_create_message(self):
-        return self
+    @classmethod
+    def apply_create_message(cls, *args):
+        return cls(*args)
 
 
 class DummyTransactionContext(BaseTransactionContext):

--- a/tests/json-fixtures/test_virtual_machine.py
+++ b/tests/json-fixtures/test_virtual_machine.py
@@ -87,18 +87,18 @@ def fixture(fixture_data):
 #
 # Testing Overrides
 #
-def apply_message_for_testing(self):
+def apply_message_for_testing(cls, *args):
     """
     For VM tests, we don't actually apply messages.
     """
-    return self
+    return cls(*args)
 
 
-def apply_create_message_for_testing(self):
+def apply_create_message_for_testing(cls, *args):
     """
     For VM tests, we don't actually apply messages.
     """
-    return self
+    return cls(*args)
 
 
 def get_block_hash_for_testing(self, block_number):


### PR DESCRIPTION
### What was wrong?

Computations are unnecessarily getting created and then thrown away. See:

```
Peteris Erins @Pet3ris Apr 07 08:58
Hi There! I'm noticing that when a contract CALL is issued by py-evm (internal CALL), two new computations are created immediately. Anyone know why is that the case?
49
Op: GAS
[384, 2, 672, 33, 33, 768, 33, 672, 0, 4]
49
Op: CALL
[384, 2, 672, 33, 33, 768, 33, 672, 0, 4, 113796]
New computation started
<eth.vm.forks.constantinople.computation.ConstantinopleComputation object at 0x10d237bd0>
New computation started
<eth.vm.forks.constantinople.computation.ConstantinopleComputation object at 0x10d32c2d0>
50
Op: PUSH2
[]

Peteris Erins @Pet3ris Apr 07 09:07
moreover they both seem to be using the same message computation.msg

Peteris Erins @Pet3ris Apr 07 09:22
one of the computations terminates immediately which suggests to me that it's calling a pre-compiled contract, but the other one is not terminated. By termination I mean that it's apply_computation function returns

Eth-Gitter-Bridge @Eth-Gitter-Bridge Apr 07 12:30
<carver> > I've tried to deploy contract without EthereumTester and web3.py. Is this possible (with only py-evm)?

It's easy to add a transaction in py-evm, but it's not easy to build that transaction to invoke a contract. Those transaction-building tools are mostly in web3.py. They help you build the data that goes into a transaction and then sign it. @ArtObr

<carver> @Pet3ris Hm, the double-computation thing doesn't sound familiar. Calling into a precompile doesn't sound right, I don't think computations are created at all for them: https://github.com/ethereum/py-evm/blob/086e0704a8d2da5f8f0a64d708d8830d1015895d/eth/vm/computation.py#L531-L534

Peteris Erins @Pet3ris 00:31
@Eth-Gitter-Bridge that's very helfpul re: precomputed contracts. Maybe this is just an internal call. Effectively what I'm trying to do is to keep track of the current computation by maintaining a stack of computations. When BaseComputation.__init__ is called, I add to the stack and when a BaseComputation.apply_computation is finished, I remove the top computation from the stack.

But I'm observing the following:

BaseComputation.__init__ called twice if the current Opcode is a CALL (and both times with the same message), only one of those computations then has a state that updates (_stack, etc.)
over time, there are more __init__ calls than there are apply_computation calls (does this mean __init__ is called twice for some subclasses of BaseComputation?
Any thoughts why that could be happening? Am I still monkey patching the right functions to track computations?


Peteris Erins @Pet3ris 01:50
Yeah, I can see how the logger would be an appealing place to hook into apply_computation, because the opcodes are dispersed, there's not a common path to inject in a single place. So yeah, I guess my next approach would be to patch Computationwith a custom apply_computation.

Just for context - I'm following your suggestion in terms of managing computations (and it is working well in general) but I couldn't use apply_computation for adds because it kicked in too early so needed to go exactly to the point where computation is constructed.


Eth-Gitter-Bridge @Eth-Gitter-Bridge 12:07
<carver> Hm, not sure why. It's plausible the double-init is some kind of bug (in the form of extra useless work that's happening). My next step would probably be a breakpoint, or a logger with the calling stack's info, like a self.logger.debug("BaseComputation.__init__ was called", stack_info=True)

Peteris Erins @Pet3ris 12:37
gotcha - will try that!

Peteris Erins @Pet3ris 14:25
interestingly both originate from the CALL opcode
the stack traces look absolutely identical
File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/chains/base.py", line 899, in apply_transaction
    receipt, computation = vm.apply_transaction(base_block.header, transaction)
  File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/vm/base.py", line 468, in apply_transaction
    computation = self.state.apply_transaction(transaction)
  File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/vm/state.py", line 323, in apply_transaction
    return self.execute_transaction(transaction)
  File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/vm/forks/frontier/state.py", line 200, in execute_transaction
    return executor(transaction)
  File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/vm/state.py", line 372, in __call__
    computation = self.build_computation(message, valid_transaction)
  File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/vm/forks/frontier/state.py", line 138, in build_computation
    transaction_context).apply_message()
  File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/vm/forks/frontier/computation.py", line 76, in apply_message
    self.transaction_context,
  File "/Users/p/Dev/auditless/auditless-debugger/api/src/endpoints.py", line 399, in apply_computation
    computation = old_apply_computation(cls, state, message, transaction_context)
  File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/vm/computation.py", line 703, in apply_computation
    opcode_fn(computation=computation)
  File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/vm/logic/call.py", line 137, in __call__
    child_computation = computation.apply_child_computation(child_msg)
  File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/vm/computation.py", line 505, in apply_child_computation
    child_computation = self.generate_child_computation(child_msg)
  File "/Users/p/.local/share/virtualenvs/api-QuiCHkzb/lib/python3.7/site-packages/eth/vm/computation.py", line 520, in generate_child_computation
    self.transaction_context,
  File "/Users/p/Dev/auditless/auditless-debugger/api/src/endpoints.py", line 418, in new__init__
    logging.warning("Base Computation init was called.", stack_info=True)

Eth-Gitter-Bridge @Eth-Gitter-Bridge 17:10
<carver> Huh, interesting. So that maybe/probably means it's not a "extra useless work" bug. Any more information about the types of computations that are never updating their _stack and other variables that you're expecting? Is it the first of two sub-calls made by contracts? Is it contract creation calls? I guess I would move forward assuming that these are real calls, unless it becomes more obvious that something is broken.

Peteris Erins @Pet3ris 01:29
weirdly there is only one CALL
statement after which 2 computations are created, nearly identical, and only one of them goes on to update their state
the reason I suspect something is broken is that the computations don't end up being "closed", e.g., I have more computations open than closed even for terminated transactions so clearly the number of BaseComputation.init statements exceeds the number of apply_computation statements

Peteris Erins @Pet3ris 08:25
I've done some in-depth debugging and I think I know why there are 2 computations originating during the CALL:

1) one is the child computation that is immediately triggered by the call and generate_child_computation

https://github.com/ethereum/py-evm/blob/bc476b21928b5f732ce980da9cc8fb9e4fbd9f3a/eth/vm/computation.py#L366

2) this child computation then calls apply_message on itself

3) apply_message calls apply_computation

4) apply_computation then creates another new computation with the same parameters.

This bit is probably the confusing bit for me. We create a computation only to call apply_computation on it which then recreates the computation and runs it again? It does seem like this is not a bug, but intentional and I can definitely work around it :).


Peteris Erins @Pet3ris 09:55
managed to make a workaround and it's all good :)
thanks for the debugging tips!
```

### How was it fixed?

A computation was being created here:
https://github.com/ethereum/py-evm/blob/086e0704a8d2da5f8f0a64d708d8830d1015895d/eth/vm/computation.py#L372-L376

It's only purpose, as far as I can tell, was to carry the state, message, and transaction context to be used when later creating the actual computation that will be returned.

Instead, this PR makes `apply_message()` and `apply_create_message()` into class methods, and passes in the couple of variables they need to create the computation within.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://thumbs-prod.si-cdn.com/l5gd6NPWlwpnap8DB7gVOGI7QpQ=/1072x720/filters:no_upscale()/https://public-media.si-cdn.com/filer/two-male-lions-Kenya-631.jpg)
