### PR TITLE
Bugfix duplicate pytest requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ deps = {
         "py-evm>=0.2.0-alpha.14",
         # We need to have pysha for autodoc to be able to extract API docs
         "pysha3>=1.0.0,<2.0.0",
-        "pytest~=3.2",
         # Sphinx pined to `<1.8.0`: https://github.com/sphinx-doc/sphinx/issues/3494
         "Sphinx>=1.5.5,<1.8.0",
         "sphinx_rtd_theme>=0.1.9",


### PR DESCRIPTION
### What was wrong?

pytest-xdist requires a certain pytest version.

### How was it fixed?

remove a duplicate pytest requirement that was the wrong version