### PR TITLE
Handle a lot more scenarios of filling header gaps, created by checkpoints

### DIFF
--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -4,6 +4,7 @@ import itertools
 from typing import (
     Dict,
     Iterable,
+    Sequence,
     Tuple,
     Type,
 )
@@ -94,14 +95,14 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
     def _decanonicalize_old_headers(
         cls,
         db: DatabaseAPI,
-        new_canonical_headers: Tuple[BlockHeaderAPI, ...]
+        numbers_to_decanonicalize: Sequence[BlockNumber],
     ) -> Tuple[BlockHeaderAPI, ...]:
         old_canonical_headers = []
 
         # remove transaction lookups for blocks that are no longer canonical
-        for h in new_canonical_headers:
+        for block_number in numbers_to_decanonicalize:
             try:
-                old_hash = cls._get_canonical_block_hash(db, h.block_number)
+                old_hash = cls._get_canonical_block_hash(db, block_number)
             except HeaderNotFound:
                 # no old block, and no more possible
                 break

--- a/eth/db/schema.py
+++ b/eth/db/schema.py
@@ -25,5 +25,12 @@ class SchemaV1(SchemaAPI):
         return b'v1:header_chain_gaps'
 
     @staticmethod
+    def make_checkpoint_headers_key() -> bytes:
+        """
+        Checkpoint header hashes stored as concatenated 32 byte values
+        """
+        return b'v1:checkpoint-header-hashes-list'
+
+    @staticmethod
     def make_transaction_hash_to_block_lookup_key(transaction_hash: Hash32) -> bytes:
         return b'transaction-hash-to-block:%s' % transaction_hash

--- a/eth/exceptions.py
+++ b/eth/exceptions.py
@@ -72,6 +72,13 @@ class GapTrackingCorrupted(PyEVMError):
     pass
 
 
+class CheckpointsMustBeCanonical(PyEVMError):
+    """
+    Raised when a persisted header attempts to de-canonicalize a checkpoint
+    """
+    pass
+
+
 class Halt(PyEVMError):
     """
     Raised when an opcode function halts vm execution.

--- a/newsfragments/1929.bugfix.rst
+++ b/newsfragments/1929.bugfix.rst
@@ -1,0 +1,14 @@
+A number of fixes related to checkpoints and persisting old headers, especially handling
+when we try to persist headers that don't match the checkpoints.
+
+  - A new exception :class:`~eth.exceptions.CheckpointsMustBeCanonical` raised when persisting a
+    header that is not linked to a previously-saved checkpoint.
+    (note: we now explicitly save checkpoints)
+  - More broadly, any block persist that would cause the checkpoint to be decanonicalized will
+    raise the :class:`~eth.exceptions.CheckpointsMustBeCanonical`.
+  - Re-insert gaps in the chain when a checkpoint and (parent or child) header do not link
+  - De-canonicalize all children of orphans. (Previously, only decanonicalized headers with block
+    numbers that matched the new canonical headers)
+  - Added some new hypothesis tests to get more confidence that we covered most cases
+  - When filling a gap, if there's an existing child that is not a checkpoint and doesn't link to
+    the parent, then the parent block wins, and the child block is de-canonicalized (and gap added).

--- a/tests/database/test_header_db.py
+++ b/tests/database/test_header_db.py
@@ -6,6 +6,7 @@ import random
 from hypothesis import (
     example,
     given,
+    settings,
     strategies as st,
 )
 import pytest
@@ -28,6 +29,7 @@ from eth.constants import (
     GENESIS_DIFFICULTY,
     GENESIS_GAS_LIMIT,
 )
+from eth.db.atomic import AtomicDB
 from eth.db.chain_gaps import (
     GapChange,
     GENESIS_CHAIN_GAPS,
@@ -37,6 +39,7 @@ from eth.db.chain_gaps import (
 )
 from eth.exceptions import (
     CanonicalHeadNotFound,
+    CheckpointsMustBeCanonical,
     GapTrackingCorrupted,
     HeaderNotFound,
     ParentNotFound,
@@ -165,6 +168,27 @@ def _all_gap_numbers(chain_gaps, highest_block_number):
     yield from range(tail, highest_block_number + 1)
 
 
+def _validate_consecutive_canonical_links(headerdb, through_block_number):
+    # Validate at every step that there are no two contiguous headers which are both:
+    #   - canonical
+    #   - mismatched parent/child
+    for parent_num, child_num in sliding_window(2, range(0, through_block_number + 1)):
+        try:
+            parent = headerdb.get_canonical_block_header_by_number(parent_num)
+        except HeaderNotFound:
+            # no canonical parent, move on...
+            continue
+        else:
+            try:
+                child = headerdb.get_canonical_block_header_by_number(child_num)
+            except HeaderNotFound:
+                # no canonical child, move on...
+                continue
+            else:
+                # Both parent and child are canonical, so they must be parent/child
+                assert child.parent_hash == parent.hash
+
+
 def _validate_gap_invariants(gaps):
     # 1. gaps are sorted
     for low, high in gaps[0]:
@@ -184,6 +208,79 @@ def _validate_gap_invariants(gaps):
 @pytest.mark.parametrize(
     'steps',
     (
+        # Make sure children of old canonical headers also get de-canonicalized
+        (
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:4])),
+            (StepAction.VERIFY_GAPS, ((), 5)),
+            # If a header has enough difficulty, be sure to de-canonicalize the old children
+            # In an old implementation, only headers at the same block number were de-canonicalized
+            (StepAction.PERSIST_HEADERS, (
+                'a',
+                # Insert a huge-difficulty header, enough to make sure all of b gets over-taken
+                lambda headers: [headers[0].copy(difficulty=headers[0].difficulty * 10)],
+            )),
+            (StepAction.VERIFY_GAPS, ((), 2)),
+        ),
+        # If trying to de-canonicalize children of old canonical headers, and the first child
+        #   is a checkpoint, then raise an exception.
+        (
+            (StepAction.PERSIST_HEADERS, ('a', lambda headers: headers[:1])),
+            (StepAction.PERSIST_CHECKPOINT, 2),
+            (StepAction.VERIFY_GAPS, ((), 3)),
+            # If a header has enough difficulty, be sure to de-canonicalize the old children
+            # In an old implementation, only headers at the same block number were de-canonicalized
+            # BUT, if one of those children is a checkpoint, then fail hard
+            (StepAction.VERIFY_PERSIST_RAISES, (
+                'b',
+                CheckpointsMustBeCanonical,
+                # Insert a huge-difficulty header, enough to make sure all of a gets over-taken
+                lambda headers: [headers[0].copy(difficulty=headers[0].difficulty * 10)],
+            )),
+        ),
+        # If trying to de-canonicalize children of old canonical headers, and a grandchild
+        #   is a checkpoint, then raise an exception.
+        (
+            (StepAction.PERSIST_HEADERS, ('a', lambda headers: headers[:2])),
+            (StepAction.PERSIST_CHECKPOINT, 3),
+            (StepAction.VERIFY_GAPS, ((), 4)),
+            # If a header has enough difficulty, be sure to de-canonicalize the old children
+            # In an old implementation, only headers at the same block number were de-canonicalized
+            # BUT, if one of those children is a checkpoint, then fail hard
+            (StepAction.VERIFY_PERSIST_RAISES, (
+                'b',
+                CheckpointsMustBeCanonical,
+                # Insert a huge-difficulty header, enough to make sure all of a gets over-taken
+                lambda headers: [headers[0].copy(difficulty=headers[0].difficulty * 10)],
+            )),
+        ),
+        # If a gap gets filled with a checkpoint, make sure that the checkpoint's parent
+        # is valid. Otherwise, decanonicalize and re-insert a gap.
+        (
+            (StepAction.PERSIST_CHECKPOINT, 4),
+            (StepAction.VERIFY_GAPS, (((1, 3),), 5)),
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:2])),
+            (StepAction.VERIFY_GAPS, (((3, 3),), 5)),
+            (StepAction.PERSIST_CHECKPOINT, 3),
+            (StepAction.VERIFY_GAPS, (((2, 2),), 5)),
+            (StepAction.PERSIST_CHECKPOINT, 2),
+            (StepAction.VERIFY_GAPS, (((1, 1),), 5)),
+            (StepAction.PERSIST_CHECKPOINT, 1),
+            (StepAction.VERIFY_GAPS, ((), 5)),
+        ),
+        # Make sure that b can't sneak it's way to canonical
+        (
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:5])),
+            (StepAction.PERSIST_CHECKPOINT, 9),
+            (StepAction.PERSIST_CHECKPOINT, 6),
+            (StepAction.PERSIST_CHECKPOINT, 1),
+            (StepAction.PERSIST_CHECKPOINT, 4),
+            (StepAction.VERIFY_GAPS, (((2, 3), (5, 5), (7, 8)), 10)),
+            (StepAction.VERIFY_PERSIST_RAISES, (
+                'b',
+                CheckpointsMustBeCanonical,
+                lambda headers: headers[5:7]
+            )),
+        ),
         # Start patching gap with uncles, later overwrite with true chain
         (
             (StepAction.PERSIST_CHECKPOINT, 8),
@@ -201,12 +298,117 @@ def _validate_gap_invariants(gaps):
             (StepAction.VERIFY_CANONICAL_HEADERS, ('a', lambda headers: headers)),
             (StepAction.VERIFY_GAPS, ((), 11)),
         ),
+        # Writing to the tail end of a gap, when its child would not have a matching parent_hash
+        #   should raise a validation error
+        (
+            (StepAction.PERSIST_CHECKPOINT, 4),
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:2])),
+            (StepAction.VERIFY_GAPS, (((3, 3),), 5)),
+            (StepAction.PERSIST_CHECKPOINT, 1),
+            (StepAction.VERIFY_GAPS, (((2, 3),), 5)),
+            # Cannot fill the end of the (2, 3) gap because it doesn't match the checkpoint at 4
+            (StepAction.VERIFY_PERSIST_RAISES, ('b', CheckpointsMustBeCanonical, lambda h: h[2:3])),
+        ),
+        # Make sure b can't sneak into canonical, overwriting a checkpoint
+        (
+            (StepAction.PERSIST_CHECKPOINT, 5),
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:2])),
+            (StepAction.VERIFY_GAPS, (((3, 4),), 6)),
+            (StepAction.PERSIST_CHECKPOINT, 1),
+            (StepAction.VERIFY_GAPS, (((2, 4),), 6)),
+            (StepAction.VERIFY_PERSIST_RAISES, (
+                'b',
+                CheckpointsMustBeCanonical,
+                lambda headers: headers[2:3]
+            )),
+            (StepAction.VERIFY_GAPS, (((2, 4),), 6)),
+        ),
+        # A couple cases of invalid checkpoint descendents getting de-canonicalized
+        (
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:4])),
+            (StepAction.PERSIST_CHECKPOINT, 4),
+            (StepAction.PERSIST_HEADERS, ('a', lambda headers: headers[4:5])),
+            (StepAction.PERSIST_CHECKPOINT, 1),
+            (StepAction.VERIFY_GAPS, (((2, 3),), 6)),
+        ),
+        (
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:4])),
+            (StepAction.PERSIST_CHECKPOINT, 2),
+            (StepAction.VERIFY_GAPS, (((1, 1), ), 3)),
+            (StepAction.PERSIST_HEADERS, ('a', lambda headers: headers[2:3])),
+            (StepAction.VERIFY_GAPS, (((1, 1), ), 4)),
+        ),
+        # Disallow checkpoints being made non-canonical
+        (
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:4])),
+            (StepAction.PERSIST_CHECKPOINT, 4),
+            (StepAction.PERSIST_HEADERS, ('a', lambda headers: headers[4:5])),
+            (StepAction.PERSIST_CHECKPOINT, 1),
+            (StepAction.VERIFY_PERSIST_RAISES, (
+                'b',
+                CheckpointsMustBeCanonical,
+                lambda headers: headers[4:6],
+            )),
+            (
+                StepAction.VERIFY_CANONICAL_HEADERS,
+                ('a', lambda headers: headers[0:1] + headers[3:5]),
+            ),
+            (StepAction.VERIFY_GAPS, (((2, 3),), 6)),
+        ),
+        # Another of ^
+        (
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:1])),
+            (StepAction.PERSIST_CHECKPOINT, 2),
+            (StepAction.VERIFY_GAPS, (((1, 1),), 3)),
+            (StepAction.VERIFY_PERSIST_RAISES, (
+                'b',
+                CheckpointsMustBeCanonical,
+                lambda headers: headers[1:3],
+            )),
+            (StepAction.PERSIST_HEADERS, ('a', lambda headers: headers[:1])),
+            (StepAction.VERIFY_GAPS, ((), 3)),
+            (StepAction.VERIFY_CANONICAL_HEADERS, ('a', lambda headers: headers[:2])),
+        ),
+        # Checkpoint a child of an uncle
+        (
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:1])),
+            (StepAction.VERIFY_GAPS, ((), 2)),
+            (StepAction.PERSIST_CHECKPOINT, 2),
+            # Persisting a checkpoint where the parent is not a match should cause the
+            # parent to become non-canonical.
+            (StepAction.VERIFY_GAPS, (((1, 1), ), 3)),
+            (StepAction.VERIFY_CANONICAL_HEAD, 2),
+            # Fill the uncled gap, the checkpoint (no-op) and the tail
+            (StepAction.PERSIST_HEADERS, ('a', lambda headers: headers)),
+            # Verify that block 1 gets canonicalized as A
+            (StepAction.VERIFY_CANONICAL_HEADERS, ('a', lambda headers: headers)),
+            (StepAction.VERIFY_GAPS, ((), 11)),
+        ),
+        # Don't override a checkpoint by persisting a chain that's a child of a gap
+        (
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:1])),
+            (StepAction.PERSIST_CHECKPOINT, 2),
+            (StepAction.VERIFY_GAPS, (((1, 1), ), 3)),
+            (StepAction.VERIFY_PERSIST_RAISES, (
+                'b',
+                CheckpointsMustBeCanonical,
+                lambda headers: headers[1:3]
+            )),
+        ),
+        # checkpointing should canonicalize matching parent header chain
+        (
+            (StepAction.PERSIST_HEADERS, ('a', lambda headers: headers[:2])),
+            (StepAction.PERSIST_HEADERS, ('b', lambda headers: headers[:3])),
+            (StepAction.PERSIST_CHECKPOINT, 3),
+            (StepAction.VERIFY_GAPS, ((), 4)),
+            (StepAction.VERIFY_CANONICAL_HEADERS, ('a', lambda headers: headers[:3])),
+        ),
         # Can not close gap with uncle chain
         (
             (StepAction.PERSIST_CHECKPOINT, 8),
             (StepAction.VERIFY_GAPS, (((1, 7),), 9)),
             (StepAction.VERIFY_CANONICAL_HEAD, 8),
-            (StepAction.VERIFY_PERSIST_RAISES, ('b', ValidationError, lambda h: h[:7])),
+            (StepAction.VERIFY_PERSIST_RAISES, ('b', CheckpointsMustBeCanonical, lambda h: h[:7])),
             (StepAction.VERIFY_GAPS, (((1, 7),), 9)),
         ),
         # Can not fill gaps non-sequentially (backwards from checkpoint)
@@ -260,8 +462,9 @@ def _validate_gap_invariants(gaps):
 )
 def test_different_cases_of_patching_gaps(headerdb, genesis_header, steps):
     headerdb.persist_header(genesis_header)
-    chain_a = mk_header_chain(genesis_header, length=10)
-    chain_b = mk_header_chain(genesis_header, length=10)
+    new_chain_length = 10
+    chain_a = mk_header_chain(genesis_header, length=new_chain_length)
+    chain_b = mk_header_chain(genesis_header, length=new_chain_length)
 
     def _get_chain(id):
         if chain_id == 'a':
@@ -273,7 +476,7 @@ def test_different_cases_of_patching_gaps(headerdb, genesis_header, steps):
 
     assert headerdb.get_header_chain_gaps() == GENESIS_CHAIN_GAPS
 
-    for step in steps:
+    for step_index, step in enumerate(steps):  # noqa: B007  # step_index only present for debugging
         step_action, step_data = step
         if step_action is StepAction.PERSIST_CHECKPOINT:
             pseudo_genesis = chain_a[step_data - 1]
@@ -281,21 +484,34 @@ def test_different_cases_of_patching_gaps(headerdb, genesis_header, steps):
             headerdb.persist_checkpoint_header(pseudo_genesis, pseudo_genesis_score)
         elif step_action is StepAction.PERSIST_HEADERS:
             chain_id, selector_fn = step_data
-            headerdb.persist_header_chain(selector_fn(_get_chain(chain_id)))
+            headers = selector_fn(_get_chain(chain_id))
+            headerdb.persist_header_chain(headers)
         elif step_action is StepAction.VERIFY_GAPS:
-            assert headerdb.get_header_chain_gaps() == step_data
+            gaps = headerdb.get_header_chain_gaps()
+            assert gaps == step_data
+            all_gap_numbers = _all_gap_numbers(gaps, highest_block_number=new_chain_length + 1)
+            for missing_block_number in all_gap_numbers:
+                with pytest.raises(HeaderNotFound):
+                    headerdb.get_canonical_block_header_by_number(missing_block_number)
         elif step_action is StepAction.VERIFY_PERSIST_RAISES:
             chain_id, error, selector_fn = step_data
+            headers = selector_fn(_get_chain(chain_id))
             with pytest.raises(error):
-                headerdb.persist_header_chain(selector_fn(_get_chain(chain_id)))
+                headerdb.persist_header_chain(headers)
         elif step_action is StepAction.VERIFY_CANONICAL_HEAD:
-            assert_headers_eq(headerdb.get_canonical_head(), chain_a[step_data - 1])
+            # save actual and expected for easy reading on a failed test
+            actual_canonical = headerdb.get_canonical_head()
+            expected_canonical = chain_a[step_data - 1]
+            assert_headers_eq(actual_canonical, expected_canonical)
         elif step_action is StepAction.VERIFY_CANONICAL_HEADERS:
             chain_id, selector_fn = step_data
             for header in selector_fn(_get_chain(chain_id)):
                 assert headerdb.get_canonical_block_header_by_number(header.block_number) == header
         else:
             raise Exception("Unknown step action")
+
+        _validate_gap_invariants(headerdb.get_header_chain_gaps())
+        _validate_consecutive_canonical_links(headerdb, new_chain_length + 1)
 
 
 @pytest.mark.parametrize(
@@ -443,6 +659,107 @@ def test_gap_continuity(changes):
         _validate_gap_invariants(chain_gaps)
 
 
+@given(st.data())
+@settings(max_examples=1)
+def test_true_chain_canonicalized_regardless_of_order(genesis_header, data):
+    class ActionEnum(enum.Enum):
+        PERSIST_CHAIN = enum.auto()
+        CHECKPOINT = enum.auto()
+
+    # Setup
+    headerdb = HeaderDB(AtomicDB())
+    CHAIN_A, CHAIN_B = 0, 1
+    chain_length = data.draw(st.integers(min_value=2, max_value=20))
+    headerdb.persist_header(genesis_header)
+    chain_a_headers = mk_header_chain(genesis_header, length=chain_length)
+    headers = [
+        # chain A: eventually canonical; the only source for checkpoints
+        chain_a_headers,
+        # chain B: non-canonical
+        mk_header_chain(genesis_header, length=chain_length),
+    ]
+    missing_indices = [
+        set(range(chain_length)),  # chain A
+        set(range(chain_length)),  # chain B
+    ]
+
+    @to_tuple
+    def _get_valid_extensions(of_missing_indices):
+        """
+        Find the headers that have available parents, and so are valid to persist
+        """
+        # For each chain
+        for chain_index, header_indices in enumerate(of_missing_indices):
+            # yield each header number that has a parent that's not missing
+            # Sorting header_indices is important for hypothesis consistency
+            for header_index in sorted(header_indices):
+                if header_index == 0 or header_index - 1 not in header_indices:
+                    yield (chain_index, header_index)
+
+    last_checkpoint = None
+
+    while len(missing_indices[CHAIN_A]):
+        _validate_consecutive_canonical_links(headerdb, chain_length)
+        _validate_gap_invariants(headerdb.get_header_chain_gaps())
+
+        action = data.draw(st.sampled_from(ActionEnum))
+        if action == ActionEnum.CHECKPOINT:
+            checkpoint_index = data.draw(st.sampled_from(list(sorted(missing_indices[CHAIN_A]))))
+            checkpoint = chain_a_headers[checkpoint_index]
+            checkpoint_score = get_score(genesis_header, chain_a_headers[:checkpoint_index + 1])
+            headerdb.persist_checkpoint_header(checkpoint, checkpoint_score)
+
+            # keep track of whether any checkpoints were added, so we eventually
+            # guarantee A as canonical
+            last_checkpoint = checkpoint_index
+
+            missing_indices[CHAIN_A].discard(checkpoint_index)
+
+        elif action == ActionEnum.PERSIST_CHAIN:
+            # choose the series of headers to add
+            valid_extensions = _get_valid_extensions(missing_indices)
+            chain_idx, next_chain_start = data.draw(st.sampled_from(valid_extensions))
+            next_chain_len = data.draw(st.integers(min_value=1, max_value=chain_length))
+            chain_range_end = next_chain_start + next_chain_len
+            next_headers = headers[chain_idx][next_chain_start:chain_range_end]
+
+            # persist them to chain
+            try:
+                headerdb.persist_header_chain(next_headers)
+            except CheckpointsMustBeCanonical:
+                assert chain_idx == CHAIN_B, "Only chain B should fail to decanonize checkpoint"
+                # Persist failed, so retry different action
+                continue
+
+            # mark persisted headers as not missing
+            for inserted_index in range(next_chain_start, chain_range_end):
+                missing_indices[chain_idx].discard(inserted_index)
+
+    _validate_consecutive_canonical_links(headerdb, chain_length)
+    _validate_gap_invariants(headerdb.get_header_chain_gaps())
+
+    if last_checkpoint is None:
+        # Force canonicalization of chain a by adding a bonus header at the end of
+        #   all the chain A headers.
+        (subsequent_header, ) = mk_header_chain(chain_a_headers[-1], length=1)
+        headerdb.persist_checkpoint_header(
+            subsequent_header,
+            get_score(genesis_header, chain_a_headers + (subsequent_header,)),
+        )
+
+        assert_is_canonical_chain(headerdb, chain_a_headers + (subsequent_header, ))
+    else:
+        if headerdb.get_canonical_head() != chain_a_headers[-1]:
+            child_headers = mk_header_chain(chain_a_headers[-1], length=1)
+            headerdb.persist_header_chain(child_headers)
+            assert_is_canonical_chain(headerdb, chain_a_headers + child_headers)
+        else:
+            assert_is_canonical_chain(headerdb, chain_a_headers)
+
+    _validate_consecutive_canonical_links(headerdb, chain_length)
+    _validate_gap_invariants(headerdb.get_header_chain_gaps())
+
+
 @pytest.mark.parametrize(
     'chain_length',
     (0, 1, 2, 3),
@@ -550,8 +867,8 @@ def assert_is_canonical_chain(headerdb, headers):
 
     # verify that each header is set as the canonical block.
     for header in headers:
-        canonical_hash = headerdb.get_canonical_block_hash(header.block_number)
-        assert canonical_hash == header.hash
+        canonical = headerdb.get_canonical_block_header_by_number(header.block_number)
+        assert canonical == header
 
     # verify difficulties are correctly set.
     base_header = headerdb.get_block_header_by_hash(headers[0].parent_hash)


### PR DESCRIPTION
### What was wrong?

Fix #1928
Fix #1929 

### How was it fixed?

Use hypothesis data draws to make aggressive assertions about headers becoming canonical, no matter what order they are inserted. I think Piper is interested in the state machine approach, which may be superior. _(maybe so, but this one is done, and worked pretty well!)_

There was a lot more hiding under the hood here than I expected. Looks like it's all working now. I'm not 100% confident because I had to manually deal with changing header difficulty, but it's certainly an improvement!

I had to explicitly mark which headers are canonical (we could no longer assume that the end of a gap is the beginning of a checkpoint, because of the way we de-canonicalize headers, and insert a gap, if a header doesn't match an adjacent checkpoint).


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] Make sure #1928 test is explicitly included
- [x] ~maybe~ _open issue to_ get rid of all the `genesis_parent_hash` passing around, since it's not used when persisting a checkpoint anymore IIRC

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://boyslifeorg.files.wordpress.com/2017/03/dentist-1.jpg)