### PR TITLE
Enable PoW consensus for fully validating chain in test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from eth.chains.base import (
     Chain,
     MiningChain,
 )
+from eth.consensus import PowConsensus
 from eth.consensus.noproof import NoProofConsensus
 from eth.db.atomic import AtomicDB
 from eth.rlp.headers import BlockHeader
@@ -147,7 +148,7 @@ def _chain_with_block_validation(VM, base_db, genesis_state, chain_cls=Chain):
     klass = chain_cls.configure(
         __name__='TestChain',
         vm_configuration=(
-            (constants.GENESIS_BLOCK_NUMBER, VM.configure(consensus_class=NoProofConsensus)),
+            (constants.GENESIS_BLOCK_NUMBER, VM.configure(consensus_class=PowConsensus)),
         ),
         chain_id=1337,
     )


### PR DESCRIPTION
### What was wrong?

The `chain_with_block_validation` fixture was set to `NoProofConsensus`. I believe the idea of the fixture is to operate under `PowConsensus`.

### How was it fixed?

Change consensus engine to `PowConsensus`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/4a/65/17/4a651791857e8e91ee0479f8e3778cfd.jpg)
