### PR TITLE
Ensure persist_block persists tx and receipts

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -631,9 +631,34 @@ class ChainDatabaseAPI(HeaderDatabaseAPI):
             as genesis. Providing a ``genesis_parent_hash`` allows storage of blocks that
             aren't (yet) connected back to the true genesis header.
 
-        Assumes all block transactions have been persisted already.
+        .. warning::
+            This API assumes all block transactions have been persisted already. Use
+            :meth:`eth.abc.ChainDatabaseAPI.persist_unexecuted_block` to persist blocks that were
+            not executed.
         """
         ...
+
+    @abstractmethod
+    def persist_unexecuted_block(self,
+                                 block: BlockAPI,
+                                 receipts: Tuple[ReceiptAPI, ...],
+                                 genesis_parent_hash: Hash32 = None
+                                 ) -> Tuple[Tuple[Hash32, ...], Tuple[Hash32, ...]]:
+        """
+        Persist the given block's header, uncles, transactions, and receipts. Does
+        **not** validate if state transitions are valid.
+
+        :param block: the block that gets persisted
+        :param receipts: the receipts for the given block
+        :param genesis_parent_hash: *optional* parent hash of the header that is treated
+            as genesis. Providing a ``genesis_parent_hash`` allows storage of blocks that
+            aren't (yet) connected back to the true genesis header.
+
+        This API should be used to persist blocks that the EVM does not execute but which it
+        stores to make them available. It ensures to persist receipts and transactions which
+        :meth:`eth.abc.ChainDatabaseAPI.persist_block` in contrast assumes to be persisted
+        separately.
+        """
 
     @abstractmethod
     def persist_uncles(self, uncles: Tuple[BlockHeaderAPI]) -> Hash32:

--- a/newsfragments/1925.feature.rst
+++ b/newsfragments/1925.feature.rst
@@ -1,0 +1,4 @@
+Add a new ``persist_unexecuted_block`` API to ``ChainDB``. This API should be used to persist
+a block without executing the EVM on it. The API is used by
+syncing strategies that do not execute all blocks but fill old blocks
+back in (e.g. ``beam`` or ``fast`` sync)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,6 +243,11 @@ def chain_without_block_validation(
 
 
 @pytest.fixture(params=[Chain, MiningChain])
+def chain_without_block_validation_factory(request, VM, genesis_state):
+    return lambda db: _chain_without_block_validation(request, VM, db, genesis_state)
+
+
+@pytest.fixture(params=[Chain, MiningChain])
 def chain_without_block_validation_from_vm(request, base_db, genesis_state):
     """
     This fixture is to be used only when the properties of the


### PR DESCRIPTION
### What was wrong?

As noted in #1925, currently `persist_block` does not actually persist the transactions and receipts. It relies on the side effect of block *execution*  to save these.

### How was it fixed?

- Added a new API `persist_unexecuted_block` which takes in an additional `receipts` parameter
- Improved docs to better distinguish when to use which API  
- Added tests that prove `persist_block` does not properly persist transactions and receipts whereas `persist_unexecuted_block` does.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/53/d6/e9/53d6e9af7cdb9c882dfb359dbdc3f5fb.jpg)
