### PR TITLE
Upgrade py-trie to v2 alpha 1

### DIFF
--- a/eth/db/storage.py
+++ b/eth/db/storage.py
@@ -129,6 +129,7 @@ class StorageLookup(BaseDB):
                 exc.missing_node_hash,
                 self._starting_root_hash,
                 exc.requested_key,
+                exc.prefix,
                 self._address,
             ) from exc
 
@@ -153,6 +154,7 @@ class StorageLookup(BaseDB):
                 exc.missing_node_hash,
                 self._starting_root_hash,
                 exc.requested_key,
+                exc.prefix,
                 self._address,
             ) from exc
 

--- a/eth/vm/interrupt.py
+++ b/eth/vm/interrupt.py
@@ -1,3 +1,7 @@
+from typing import (
+    Optional,
+)
+
 from eth_typing import (
     Address,
     Hash32,
@@ -7,6 +11,9 @@ from eth_utils import (
 )
 from trie.exceptions import (
     MissingTrieNode,
+)
+from trie.typing import (
+    Nibbles,
 )
 
 from eth.exceptions import (
@@ -53,6 +60,7 @@ class MissingStorageTrieNode(EVMMissingData, MissingTrieNode):
             missing_node_hash: Hash32,
             storage_root_hash: Hash32,
             requested_key: Hash32,
+            prefix: Optional[Nibbles],
             account_address: Address,
             *args: bytes) -> None:
         if not isinstance(account_address, bytes):
@@ -62,6 +70,7 @@ class MissingStorageTrieNode(EVMMissingData, MissingTrieNode):
             missing_node_hash,
             storage_root_hash,
             requested_key,
+            prefix,
             account_address,
             *args,
         )
@@ -72,7 +81,7 @@ class MissingStorageTrieNode(EVMMissingData, MissingTrieNode):
 
     @property
     def account_address(self) -> Address:
-        return self.args[3]
+        return self.args[4]
 
     def __repr__(self) -> str:
         return f"MissingStorageTrieNode: {self}"

--- a/newsfragments/1935.internal.rst
+++ b/newsfragments/1935.internal.rst
@@ -1,0 +1,1 @@
+Upgrade py-trie to the new v2.0.0-alpha.1, and pin it for stability.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ deps = {
         "py-ecc>=1.4.7,<5.0.0",
         "pyethash>=0.1.27,<1.0.0",
         "rlp>=1.1.0,<2.0.0",
-        "trie>=1.4.0,<2.0.0",
+        "trie==2.0.0-alpha.1",
     ],
     # The eth-extra sections is for libraries that the evm does not
     # explicitly need to function and hence should not depend on.


### PR DESCRIPTION
### What was wrong?

Need to support new py-trie API to eventually use trie tools to help with state backfill in trinity.

### How was it fixed?

Upgrade and see what's what.

Looks like only exceptions are affected. So upgrading should be pretty smooth.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/8348644352/h293DE3F7/)
