### PR TITLE
More informative nonce error

### DIFF
--- a/eth/vm/forks/frontier/validation.py
+++ b/eth/vm/forks/frontier/validation.py
@@ -26,8 +26,11 @@ def validate_frontier_transaction(state: StateAPI,
     if sender_balance < total_cost:
         raise ValidationError("Sender account balance cannot afford txn")
 
-    if state.get_nonce(transaction.sender) != transaction.nonce:
-        raise ValidationError("Invalid transaction nonce")
+    sender_nonce = state.get_nonce(transaction.sender)
+    if sender_nonce != transaction.nonce:
+        raise ValidationError(
+            f"Invalid transaction nonce: Expected {sender_nonce}, but got {transaction.nonce}"
+        )
 
 
 def validate_frontier_transaction_against_header(_vm: VirtualMachineAPI,


### PR DESCRIPTION
### What was wrong?

When verifying a transaction with a bad nonce, the error was uninformative.

### How was it fixed?

Include the expected and actual nonce in the exception.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/4262541056/h8239AD97/counting-sheep)
