### PR TITLE
Raise BlockNotFound on missing txns or uncles

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -3197,6 +3197,9 @@ class ChainAPI(ConfigurableAPI):
     def get_block_by_hash(self, block_hash: Hash32) -> BlockAPI:
         """
         Return the requested block as specified by ``block_hash``.
+
+        :raise eth.exceptions.HeaderNotFound: if the header is missing
+        :raise eth.exceptions.BlockNotFound: if any part of the block body is missing
         """
         ...
 
@@ -3204,6 +3207,8 @@ class ChainAPI(ConfigurableAPI):
     def get_block_by_header(self, block_header: BlockHeaderAPI) -> BlockAPI:
         """
         Return the requested block as specified by the ``block_header``.
+
+        :raise eth.exceptions.BlockNotFound: if any part of the block body is missing
         """
         ...
 

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -84,10 +84,10 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
             return ()
         try:
             encoded_uncles = self.db[uncles_hash]
-        except KeyError:
+        except KeyError as exc:
             raise HeaderNotFound(
                 f"No uncles found for hash {uncles_hash!r}"
-            )
+            ) from exc
         else:
             return tuple(rlp.decode(encoded_uncles, sedes=rlp.sedes.CountableList(BlockHeader)))
 

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -377,7 +377,8 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
         return self.db[key]
 
     def persist_trie_data_dict(self, trie_data_dict: Dict[Hash32, bytes]) -> None:
-        self._persist_trie_data_dict(self.db, trie_data_dict)
+        with self.db.atomic_batch() as db:
+            self._persist_trie_data_dict(db, trie_data_dict)
 
     @classmethod
     def _persist_trie_data_dict(cls, db: DatabaseAPI, trie_data_dict: Dict[Hash32, bytes]) -> None:

--- a/eth/exceptions.py
+++ b/eth/exceptions.py
@@ -33,6 +33,8 @@ class HeaderNotFound(PyEVMError):
 class BlockNotFound(PyEVMError):
     """
     Raised when the block with the given number/hash does not exist.
+    This will happen, for example, if the transactions or uncles are not
+    saved in the database.
     """
     pass
 

--- a/newsfragments/1943.feature.rst
+++ b/newsfragments/1943.feature.rst
@@ -1,0 +1,8 @@
+Methods now raise :class:`~eth.exceptions.BlockNotFound` when retrieving a block, and some part
+of the block is missing. These methods used to raise a KeyError if transactions were missing, or a
+``HeaderNotFound`` if uncles were missing:
+
+  - :meth:`eth.db.chain.ChainDB.get_block_by_header`
+  - :meth:`eth.db.chain.ChainDB.get_block_by_hash` (it still raises a HeaderNotFound if there is no
+    header matching the given hash)
+  - :meth:`~eth.abc.BlockHeaderAPI`

--- a/tests/database/test_eth1_chaindb.py
+++ b/tests/database/test_eth1_chaindb.py
@@ -21,6 +21,7 @@ from eth.db.chain import (
 )
 from eth.db.schema import SchemaV1
 from eth.exceptions import (
+    BlockNotFound,
     HeaderNotFound,
     ParentNotFound,
     ReceiptNotFound,
@@ -291,3 +292,19 @@ def test_chaindb_persist_unexecuted_block(chain,
             NUMBER_BLOCKS_IN_CHAIN,
             TRANSACTIONS_IN_BLOCK + 1,
         )
+
+
+def test_chaindb_raises_blocknotfound_on_missing_uncles(VM, chaindb, header):
+    bad_header = header.copy(uncles_hash=b'unicorns' * 4)
+    chaindb.persist_header(bad_header)
+
+    with pytest.raises(BlockNotFound):
+        VM.get_block_class().from_header(bad_header, chaindb)
+
+
+def test_chaindb_raises_blocknotfound_on_missing_transactions(VM, chaindb, header):
+    bad_header = header.copy(transaction_root=b'unicorns' * 4)
+    chaindb.persist_header(bad_header)
+
+    with pytest.raises(BlockNotFound):
+        VM.get_block_class().from_header(bad_header, chaindb)


### PR DESCRIPTION
### What was wrong?

Having py-trie make `MissingTrieNode` stop subclassing `KeyError` exposed an awkwardness mentioned here in trinity:
https://github.com/ethereum/trinity/blob/e40aac0ab2a9a2e7a703af0b94fafd1047ce6e55/trinity/sync/beam/chain.py#L330-L331

The exception story for loading a block body was pretty messy.

To be clear, Trinity breaks if you upgrade to py-trie v2a1 without this change (although it still requires a change to catch the `BlockNotFound`, but that's an improvement).

### How was it fixed?

Raise a `BlockNotFound` if the transactions or uncles are missing.

Bonus change: bring back a performance boost when persisting a trie (using a batch write).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/60/8c/3e/608c3e697842e87a5f258f4b750afabd.jpg)