### PR TITLE
Upgrade py-trie, which has a fixed TraversedPartialPath

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ deps = {
         "py-ecc>=1.4.7,<5.0.0",
         "pyethash>=0.1.27,<1.0.0",
         "rlp>=1.1.0,<2.0.0",
-        "trie==2.0.0-alpha.1",
+        "trie==2.0.0-alpha.2",
     ],
     # The eth-extra sections is for libraries that the evm does not
     # explicitly need to function and hence should not depend on.


### PR DESCRIPTION
### What was wrong?

`TraversedPartialPath` was incorrectly raised on leaf nodes that didn't match. Also, the "recovery" mechanism for traversing from sub_segments of the partially traversed node was broken.

### How was it fixed?

Upgrade to new py-trie:
https://github.com/ethereum/py-trie/blob/e3889c54013125d0f664fbfa6a4dea4bc85e67a6/CHANGELOG#L6-L45

Plan to use the new `TraversedPartialPath.simulated_node` feature. (Although I think it doesn't really come into play directly in py-evm, just trinity).

I hope this upgrade is entirely uneventful... :crossed_fingers: 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- ~Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.fodors.com/wp-content/uploads/2020/03/CutestBabyAnimals__HERO_shutterstock_115739671.jpg)
