### PR TITLE
Track gaps in the chain of blocks

### DIFF
--- a/eth/db/schema.py
+++ b/eth/db/schema.py
@@ -25,6 +25,10 @@ class SchemaV1(SchemaAPI):
         return b'v1:header_chain_gaps'
 
     @staticmethod
+    def make_chain_gaps_lookup_key() -> bytes:
+        return b'v1:chain_gaps'
+
+    @staticmethod
     def make_checkpoint_headers_key() -> bytes:
         """
         Checkpoint header hashes stored as concatenated 32 byte values

--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -361,8 +361,14 @@ def mine_block(chain: MiningChainAPI, **kwargs: Any) -> MiningChainAPI:
     overridden using keyword arguments.
 
     """
+
     if not isinstance(chain, MiningChainAPI):
         raise ValidationError('`mine_block` may only be used on MiningChain instances')
+
+    transactions = kwargs.pop('transactions', ())
+    for tx in transactions:
+        chain.apply_transaction(tx)
+
     chain.mine_block(**kwargs)
     return chain
 

--- a/newsfragments/1947.feature.rst
+++ b/newsfragments/1947.feature.rst
@@ -1,0 +1,1 @@
+Expose ``get_chain_gaps()`` on ``ChainDB`` to track gaps in the chain of blocks.

--- a/newsfragments/1947.internal.rst
+++ b/newsfragments/1947.internal.rst
@@ -1,0 +1,3 @@
+Allow `mine_block` of chain builder tools to take a ``transactions`` parameter.
+This makes it easier to model test scenarios that depend on creating blocks
+with transactions.


### PR DESCRIPTION
### What was wrong?

Similar to how we track gaps in the chain of headers, we also need to track gaps in the chain of blocks.

### How was it fixed?

1. Taught `mine_blocks` of chain builer tools to accept a `transactions` argument to make it easier to write tests where blocks are mined with transactions

2. Track gaps in `persist_block` (similar but simpler to header gap tracking)

3. Overwrite `_update_header_chain_gaps` in `ChainDB` to hook into the `HeaderDB` gap tracking to react to cases where an uncle header gets replaced and should trigger an update to the block gap tracking.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Squash changes into two commits

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/ef/ad/9a/efad9a69e15694ac91c647807d391151.jpg)
