### PR TITLE
Tighten type support and fix typing issues

### DIFF
--- a/eth/_utils/datatypes.py
+++ b/eth/_utils/datatypes.py
@@ -116,7 +116,7 @@ class Configurable(ConfigurableAPI):
                     f"instance: {sub_cls!r}"
                 )
 
-            configured_sub_cls = sub_cls.configure(**sub_overrides)
+            configured_sub_cls = sub_cls.configure(**sub_overrides)  # type: ignore
             local_overrides = assoc(local_overrides, key, configured_sub_cls)
 
         return type(__name__, (cls,), local_overrides)

--- a/eth/_utils/headers.py
+++ b/eth/_utils/headers.py
@@ -4,6 +4,8 @@ from typing import Callable, Tuple, Optional
 from eth_typing import (
     Address
 )
+
+from eth.abc import BlockHeaderAPI
 from eth.constants import (
     GENESIS_GAS_LIMIT,
     GAS_LIMIT_EMA_DENOMINATOR,
@@ -17,7 +19,7 @@ from eth.rlp.headers import (
 )
 
 
-def compute_gas_limit_bounds(parent: BlockHeader) -> Tuple[int, int]:
+def compute_gas_limit_bounds(parent: BlockHeaderAPI) -> Tuple[int, int]:
     """
     Compute the boundaries for the block gas limit based on the parent block.
     """
@@ -27,7 +29,7 @@ def compute_gas_limit_bounds(parent: BlockHeader) -> Tuple[int, int]:
     return lower_bound, upper_bound
 
 
-def compute_gas_limit(parent_header: BlockHeader, gas_limit_floor: int) -> int:
+def compute_gas_limit(parent_header: BlockHeaderAPI, gas_limit_floor: int) -> int:
     """
     A simple strategy for adjusting the gas limit.
 
@@ -78,8 +80,8 @@ def compute_gas_limit(parent_header: BlockHeader, gas_limit_floor: int) -> int:
 
 
 def generate_header_from_parent_header(
-        compute_difficulty_fn: Callable[[BlockHeader, int], int],
-        parent_header: BlockHeader,
+        compute_difficulty_fn: Callable[[BlockHeaderAPI, int], int],
+        parent_header: BlockHeaderAPI,
         coinbase: Address,
         timestamp: Optional[int] = None,
         extra_data: bytes = b'') -> BlockHeader:

--- a/eth/_utils/transactions.py
+++ b/eth/_utils/transactions.py
@@ -13,6 +13,7 @@ from eth_utils import (
     ValidationError,
 )
 
+from eth.abc import UnsignedTransactionAPI
 from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
 )
@@ -53,7 +54,7 @@ def extract_signature_v(v: int) -> int:
         return V_OFFSET
 
 
-def create_transaction_signature(unsigned_txn: BaseTransaction,
+def create_transaction_signature(unsigned_txn: UnsignedTransactionAPI,
                                  private_key: datatypes.PrivateKey,
                                  chain_id: int=None) -> VRS:
 

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -317,7 +317,7 @@ class Chain(BaseChain):
         # We construct a temporary block object
         vm_class = self.get_vm_class_for_block_number(header.block_number)
         block_class = vm_class.get_block_class()
-        block = block_class(header=header, uncles=[])
+        block = block_class(header=header, uncles=[], transactions=[])
 
         ancestor_generator = iterate(compose(
             self.get_block_by_hash,
@@ -611,7 +611,7 @@ class Chain(BaseChain):
                 uncle_parent = self.get_block_header_by_hash(uncle.parent_hash)
             except HeaderNotFound:
                 raise ValidationError(
-                    f"Uncle ancestor not found: {uncle.parent_hash}"
+                    f"Uncle ancestor not found: {uncle.parent_hash!r}"
                 )
 
             uncle_vm_class = self.get_vm_class_for_block_number(uncle.block_number)
@@ -643,7 +643,7 @@ class MiningChain(Chain, MiningChainAPI):
 
         # since we are building the block locally, we have to persist all the incremental state
         vm.state.persist()
-        new_header = header_with_receipt.copy(state_root=vm.state.state_root)
+        new_header: BlockHeaderAPI = header_with_receipt.copy(state_root=vm.state.state_root)
 
         transactions = base_block.transactions + (transaction, )
         receipts = base_block.get_receipts(self.chaindb) + (receipt, )

--- a/eth/chains/tester/__init__.py
+++ b/eth/chains/tester/__init__.py
@@ -21,7 +21,6 @@ from eth_utils import (
 )
 
 from eth.abc import (
-    BlockAPI,
     BlockHeaderAPI,
     VirtualMachineAPI,
 )
@@ -147,7 +146,7 @@ class MainnetTesterChain(BaseMainnetTesterChain):
     configuration of fork rules.
     """
 
-    def validate_seal(self, block: BlockAPI) -> None:
+    def validate_seal(self, header: BlockHeaderAPI) -> None:
         """
         We don't validate the proof of work seal on the tester chain.
         """

--- a/eth/consensus/clique/_utils.py
+++ b/eth/consensus/clique/_utils.py
@@ -68,7 +68,7 @@ def get_signature_hash(header: BlockHeaderAPI) -> Hash32:
     if len(header.extra_data) < SIGNATURE_LENGTH:
         raise ValueError("header.extra_data too short to contain signature")
 
-    signature_header = header.copy(
+    signature_header: BlockHeaderAPI = header.copy(
         extra_data=header.extra_data[:len(header.extra_data) - SIGNATURE_LENGTH]
     )
     return signature_header.hash
@@ -162,7 +162,7 @@ def validate_header_integrity(header: BlockHeaderAPI, epoch_length: int) -> None
         raise ValidationError(f"Invalid mix hash: {header.mix_hash!r}")
 
     if header.uncles_hash != EMPTY_UNCLE_HASH:
-        raise ValidationError(f"Invalid uncle hash: {header.uncle_hash}")
+        raise ValidationError(f"Invalid uncle hash: {header.uncles_hash!r}")
 
     if header.difficulty not in ALLOWED_CLIQUE_DIFFICULTIES:
         raise ValidationError(f"Invalid difficulty: {header.difficulty}")

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -280,7 +280,7 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
         return self._persist_uncles(self.db, uncles)
 
     @staticmethod
-    def _persist_uncles(db: DatabaseAPI, uncles: Tuple[BlockHeaderAPI]) -> Hash32:
+    def _persist_uncles(db: DatabaseAPI, uncles: Tuple[BlockHeaderAPI, ...]) -> Hash32:
         uncles_hash = keccak(rlp.encode(uncles))
         db.set(
             uncles_hash,

--- a/eth/rlp/accounts.py
+++ b/eth/rlp/accounts.py
@@ -3,6 +3,7 @@ from rlp.sedes import (
     big_endian_int,
 )
 
+from eth.abc import AccountAPI
 from eth.constants import (
     EMPTY_SHA3,
     BLANK_ROOT_HASH,
@@ -16,7 +17,7 @@ from .sedes import (
 from typing import Any
 
 
-class Account(rlp.Serializable):
+class Account(rlp.Serializable, AccountAPI):
     """
     RLP object for accounts.
     """

--- a/eth/rlp/blocks.py
+++ b/eth/rlp/blocks.py
@@ -1,10 +1,11 @@
 from typing import (
-    Type
+    Type,
 )
 
 from eth_utils import (
     humanize_hash,
 )
+import rlp
 
 from eth._utils.datatypes import (
     Configurable,
@@ -15,7 +16,7 @@ from eth.abc import (
 )
 
 
-class BaseBlock(Configurable, BlockAPI):
+class BaseBlock(Configurable, rlp.Serializable, BlockAPI):
     transaction_class: Type[SignedTransactionAPI] = None
 
     @classmethod

--- a/eth/rlp/headers.py
+++ b/eth/rlp/headers.py
@@ -45,7 +45,7 @@ from .sedes import (
 )
 
 
-class MiningHeader(MiningHeaderAPI):
+class MiningHeader(rlp.Serializable, MiningHeaderAPI):
     fields = [
         ('parent_hash', hash32),
         ('uncles_hash', hash32),
@@ -63,7 +63,7 @@ class MiningHeader(MiningHeaderAPI):
     ]
 
 
-class BlockHeader(BlockHeaderAPI):
+class BlockHeader(rlp.Serializable, BlockHeaderAPI):
     fields = [
         ('parent_hash', hash32),
         ('uncles_hash', hash32),
@@ -170,7 +170,7 @@ class BlockHeader(BlockHeaderAPI):
                     nonce: bytes=None,
                     extra_data: bytes=None,
                     transaction_root: bytes=None,
-                    receipt_root: bytes=None) -> BlockHeaderAPI:
+                    receipt_root: bytes=None) -> 'BlockHeader':
         """
         Initialize a new block header with the `parent` header as the block's
         parent hash.

--- a/eth/rlp/logs.py
+++ b/eth/rlp/logs.py
@@ -7,6 +7,8 @@ from typing import (
     Tuple,
 )
 
+import rlp
+
 from eth.abc import LogAPI
 
 from .sedes import (
@@ -15,7 +17,7 @@ from .sedes import (
 )
 
 
-class Log(LogAPI):
+class Log(rlp.Serializable, LogAPI):
     fields = [
         ('address', address),
         ('topics', CountableList(uint32)),

--- a/eth/rlp/receipts.py
+++ b/eth/rlp/receipts.py
@@ -1,5 +1,6 @@
 import itertools
 
+import rlp
 from rlp.sedes import (
     big_endian_int,
     CountableList,
@@ -19,7 +20,7 @@ from .sedes import (
 from .logs import Log
 
 
-class Receipt(ReceiptAPI):
+class Receipt(rlp.Serializable, ReceiptAPI):
 
     fields = [
         ('state_root', binary),

--- a/eth/rlp/transactions.py
+++ b/eth/rlp/transactions.py
@@ -6,7 +6,8 @@ from rlp.sedes import (
 )
 
 from eth_typing import (
-    Address
+    Address,
+    Hash32,
 )
 
 from eth_hash.auto import keccak
@@ -26,6 +27,7 @@ from .sedes import address
 
 
 class BaseTransactionMethods(BaseTransactionAPI):
+
     def validate(self) -> None:
         pass
 
@@ -54,7 +56,7 @@ class BaseTransactionFields(rlp.Serializable, TransactionFieldsAPI):
     fields = BASE_TRANSACTION_FIELDS
 
     @property
-    def hash(self) -> bytes:
+    def hash(self) -> Hash32:
         return keccak(rlp.encode(self))
 
 
@@ -97,7 +99,7 @@ class BaseTransaction(BaseTransactionFields, BaseTransactionMethods, SignedTrans
             return True
 
 
-class BaseUnsignedTransaction(BaseTransactionMethods, UnsignedTransactionAPI):
+class BaseUnsignedTransaction(BaseTransactionMethods, rlp.Serializable, UnsignedTransactionAPI):
     fields = [
         ('nonce', big_endian_int),
         ('gas_price', big_endian_int),

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -204,7 +204,7 @@ def new_chain_from_fixture(fixture: Dict[str, Any],
 def apply_fixture_block_to_chain(
         block_fixture: Dict[str, Any],
         chain: ChainAPI,
-        perform_validation: bool=True) -> Tuple[BlockAPI, BlockAPI, BlockAPI]:
+        perform_validation: bool=True) -> Tuple[BlockAPI, BlockAPI, bytes]:
     """
     :return: (premined_block, mined_block, rlp_encoded_mined_block)
     """

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -409,7 +409,7 @@ class VM(Configurable, VirtualMachineAPI):
                 f"Received the following unexpected fields: {', '.join(unknown_fields)}."
             )
 
-        header = block.header.copy(**kwargs)
+        header: BlockHeaderAPI = block.header.copy(**kwargs)
         packed_block = block.copy(uncles=uncles, header=header)
 
         return packed_block
@@ -536,7 +536,7 @@ class VM(Configurable, VirtualMachineAPI):
         tx_root_hash, _ = make_trie_root_and_nodes(block.transactions)
         if tx_root_hash != block.header.transaction_root:
             raise ValidationError(
-                f"Block's transaction_root ({block.header.transaction_root}) "
+                f"Block's transaction_root ({block.header.transaction_root!r}) "
                 f"does not match expected value: {tx_root_hash!r}"
             )
 
@@ -549,15 +549,15 @@ class VM(Configurable, VirtualMachineAPI):
         if not self.chaindb.exists(block.header.state_root):
             raise ValidationError(
                 "`state_root` was not found in the db.\n"
-                f"- state_root: {block.header.state_root}"
+                f"- state_root: {block.header.state_root!r}"
             )
         local_uncle_hash = keccak(rlp.encode(block.uncles))
         if local_uncle_hash != block.header.uncles_hash:
             raise ValidationError(
                 "`uncles_hash` and block `uncles` do not match.\n"
                 f" - num_uncles       : {len(block.uncles)}\n"
-                f" - block uncle_hash : {local_uncle_hash}\n"
-                f" - header uncle_hash: {block.header.uncles_hash}"
+                f" - block uncle_hash : {local_uncle_hash!r}\n"
+                f" - header uncle_hash: {block.header.uncles_hash!r}"
             )
 
     @classmethod
@@ -607,7 +607,11 @@ class VM(Configurable, VirtualMachineAPI):
         self._consensus.validate_seal_extension(header, parents)
 
     @classmethod
-    def validate_uncle(cls, block: BlockAPI, uncle: BlockAPI, uncle_parent: BlockAPI) -> None:
+    def validate_uncle(cls,
+                       block: BlockAPI,
+                       uncle: BlockHeaderAPI,
+                       uncle_parent: BlockHeaderAPI) -> None:
+
         if uncle.block_number >= block.number:
             raise ValidationError(
                 f"Uncle number ({uncle.block_number}) is higher than "

--- a/eth/vm/forks/byzantium/__init__.py
+++ b/eth/vm/forks/byzantium/__init__.py
@@ -45,7 +45,7 @@ from .state import ByzantiumState
 
 
 @curry
-def get_uncle_reward(block_reward: int, block_number: int, uncle: BlockAPI) -> int:
+def get_uncle_reward(block_reward: int, block_number: int, uncle: BlockHeaderAPI) -> int:
     block_number_delta = block_number - uncle.block_number
     validate_lte(block_number_delta, MAX_UNCLE_DEPTH)
     return (8 - block_number_delta) * block_reward // 8

--- a/eth/vm/forks/frontier/__init__.py
+++ b/eth/vm/forks/frontier/__init__.py
@@ -83,7 +83,7 @@ class FrontierVM(VM):
         return BLOCK_REWARD
 
     @staticmethod
-    def get_uncle_reward(block_number: int, uncle: BlockAPI) -> int:
+    def get_uncle_reward(block_number: int, uncle: BlockHeaderAPI) -> int:
         return BLOCK_REWARD * (
             UNCLE_DEPTH_PENALTY_FACTOR + uncle.block_number - block_number
         ) // UNCLE_DEPTH_PENALTY_FACTOR

--- a/eth/vm/forks/frontier/blocks.py
+++ b/eth/vm/forks/frontier/blocks.py
@@ -114,7 +114,7 @@ class FrontierBlock(BaseBlock):
         :raise eth.exceptions.BlockNotFound: if transactions or uncle headers are missing
         """
         if header.uncles_hash == EMPTY_UNCLE_HASH:
-            uncles: Tuple[BlockHeader, ...] = ()
+            uncles: Tuple[BlockHeaderAPI, ...] = ()
         else:
             try:
                 uncles = chaindb.get_block_uncles(header.uncles_hash)
@@ -136,6 +136,6 @@ class FrontierBlock(BaseBlock):
     # Execution API
     #
     def add_uncle(self, uncle: BlockHeaderAPI) -> "FrontierBlock":
-        self.uncles.append(uncle)
+        self.uncles += (uncle,)
         self.header.uncles_hash = keccak(rlp.encode(self.uncles))
         return self

--- a/eth/vm/forks/frontier/headers.py
+++ b/eth/vm/forks/frontier/headers.py
@@ -3,6 +3,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from eth.abc import BlockHeaderAPI
 from eth.validation import (
     validate_gt,
     validate_header_params_for_configuration,
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
     from eth.vm.forks.frontier import FrontierVM    # noqa: F401
 
 
-def compute_frontier_difficulty(parent_header: BlockHeader, timestamp: int) -> int:
+def compute_frontier_difficulty(parent_header: BlockHeaderAPI, timestamp: int) -> int:
     """
     Computes the difficulty for a frontier block based on the parent block.
     """
@@ -71,7 +72,7 @@ def compute_frontier_difficulty(parent_header: BlockHeader, timestamp: int) -> i
     return difficulty
 
 
-def create_frontier_header_from_parent(parent_header: BlockHeader,
+def create_frontier_header_from_parent(parent_header: BlockHeaderAPI,
                                        **header_params: Any) -> BlockHeader:
     if 'difficulty' not in header_params:
         # Use setdefault to ensure the new header has the same timestamp we use to calculate its

--- a/eth/vm/forks/homestead/headers.py
+++ b/eth/vm/forks/homestead/headers.py
@@ -10,6 +10,7 @@ from eth_utils import (
     decode_hex,
 )
 
+from eth.abc import BlockHeaderAPI
 from eth.constants import (
     DIFFICULTY_ADJUSTMENT_DENOMINATOR,
     DIFFICULTY_MINIMUM,
@@ -36,7 +37,7 @@ if TYPE_CHECKING:
     from eth.vm.forks.homestead import HomesteadVM      # noqa: F401
 
 
-def compute_homestead_difficulty(parent_header: BlockHeader, timestamp: int) -> int:
+def compute_homestead_difficulty(parent_header: BlockHeaderAPI, timestamp: int) -> int:
     """
     Computes the difficulty for a homestead block based on the parent block.
     """
@@ -58,7 +59,7 @@ def compute_homestead_difficulty(parent_header: BlockHeader, timestamp: int) -> 
         return difficulty
 
 
-def create_homestead_header_from_parent(parent_header: BlockHeader,
+def create_homestead_header_from_parent(parent_header: BlockHeaderAPI,
                                         **header_params: Any) -> BlockHeader:
     if 'difficulty' not in header_params:
         # Use setdefault to ensure the new header has the same timestamp we use to calculate its

--- a/newsfragments/1948.internal.rst
+++ b/newsfragments/1948.internal.rst
@@ -1,0 +1,2 @@
+Improve type safety by ensuring abc types do not inherit from ``rlp.Serializable``
+which implicitly has type ``Any``.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ deps = {
     'lint': [
         "flake8==3.8.2",
         "flake8-bugbear==20.1.4",
-        "mypy==0.750",
+        "mypy==0.782",
     ],
     'benchmark': [
         "termcolor>=1.1.0,<2.0.0",


### PR DESCRIPTION
### What was wrong?

Currently, any method that expects any of `BaseHeaderAPI`, `BaseBlockAPI`, `UnsignedTransactionAPI`, `ReceiptAPI` does not properly enforce type safe. In practice that means that a method such as:

```python

def do_something_with_block(block: BlockAPI):`
   ...
```

Can be called as `do_something_with_block(accidential_is_transaction)` or `do_something_with_block(accidential_is_header)` and mypy does not complain about it.

This has allowed serious bugs to fly under the radar: https://github.com/ethereum/trinity/pull/1830 

The root cause for this is that anything derived from `rlp.Serializable` will be seen as `Any` by mypy. We currently do not enforce this to be invalid but if so, mypy would rightfully reject a series of types:

```
$ mypy -p eth --config-file mypy.ini 
eth/vm/interrupt.py:28: error: Class cannot subclass 'MissingTrieNode' (has type 'Any')
eth/vm/interrupt.py:54: error: Class cannot subclass 'MissingTrieNode' (has type 'Any')
eth/rlp/transactions.py:55: error: Class cannot subclass 'Serializable' (has type 'Any')
eth/rlp/transactions.py:102: error: Class cannot subclass 'Serializable' (has type 'Any')
eth/rlp/logs.py:20: error: Class cannot subclass 'Serializable' (has type 'Any')
eth/rlp/headers.py:48: error: Class cannot subclass 'Serializable' (has type 'Any')
eth/rlp/headers.py:66: error: Class cannot subclass 'Serializable' (has type 'Any')
eth/rlp/accounts.py:20: error: Class cannot subclass 'Serializable' (has type 'Any')
eth/rlp/receipts.py:23: error: Class cannot subclass 'Serializable' (has type 'Any')
eth/rlp/blocks.py:19: error: Class cannot subclass 'Serializable' (has type 'Any')
eth/db/chain.py:77: error: Class cannot subclass 'Serializable' (has type 'Any')
Found 11 errors in 8 files (checked 228 source files)

```

### How was it fixed?

I believe the best fix would be to do a serious overhaul of py-rlp to enforce strong type support. As I tried to add type support to py-rlp in a minimalistic fashion I noticed another way of approaching this which gets us halfway there without even touching py-rlp (and hence being faster to deliver).

Basically, what this does is rewrite all `eth.abc` types to not derive from `rlp.Serializable` and move the `rlp.Serializable` a level deeper. That means that things such as `BaseBlock` will still be seen as `Any` (just like before)  but at least we have full type safety at the top level e.g. `BlockAPI`.

This does already a great job at exposing tons of bugs without opening a huge time sink such as refactoring py-rlp.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/EJFMVWOy_ws/maxresdefault.jpg)
