### PR TITLE
Remove unused add_uncle API

### DIFF
--- a/eth/vm/forks/frontier/blocks.py
+++ b/eth/vm/forks/frontier/blocks.py
@@ -4,7 +4,6 @@ from typing import (
     Type,
 )
 
-import rlp
 from rlp.sedes import (
     CountableList,
 )
@@ -18,7 +17,6 @@ from eth_typing import (
     Hash32,
 )
 
-from eth_hash.auto import keccak
 from trie.exceptions import (
     MissingTrieNode,
 )
@@ -131,11 +129,3 @@ class FrontierBlock(BaseBlock):
             transactions=transactions,
             uncles=uncles,
         )
-
-    #
-    # Execution API
-    #
-    def add_uncle(self, uncle: BlockHeaderAPI) -> "FrontierBlock":
-        self.uncles += (uncle,)
-        self.header.uncles_hash = keccak(rlp.encode(self.uncles))
-        return self

--- a/newsfragments/1949.removal.rst
+++ b/newsfragments/1949.removal.rst
@@ -1,0 +1,2 @@
+Removed unused and broken ``add_uncle` API on ``FrontierBlock`` and
+consequentially on all other derived block classes.


### PR DESCRIPTION
### What was wrong?

Looks like the `add_uncle` API on blocks is not used anywhere.

### How was it fixed?

Removed dead API.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/d8/d5/40/d8d540fda612b227cf30192dcdfc3613.jpg)
