### PR TITLE
Call a new hook when a transaction is applied

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -2667,6 +2667,25 @@ class VirtualMachineAPI(ConfigurableAPI):
         ...
 
     #
+    # Hooks
+    #
+
+    def transaction_applied_hook(
+            self,
+            transaction_index: int,
+            transactions: Sequence[SignedTransactionAPI],
+            base_header: BlockHeaderAPI,
+            partial_header: BlockHeaderAPI,
+            computation: ComputationAPI,
+            receipt: ReceiptAPI) -> None:
+        """
+        A hook for a subclass to use as a way to note that a transaction was applied.
+        This only gets triggered as part of `apply_all_transactions`, which is called
+        by `block_import`.
+        """
+        pass
+
+    #
     # Execution
     #
     @abstractmethod

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -468,7 +468,10 @@ class Chain(BaseChain):
             )
 
         base_header_for_import = self.create_header_from_parent(parent_header)
-        block_result = self.get_vm(base_header_for_import).import_block(block)
+        # Make a copy of the empty header, adding in the expected amount of gas used. This
+        #   allows for richer logging in the VM.
+        annotated_header = base_header_for_import.copy(gas_used=block.header.gas_used)
+        block_result = self.get_vm(annotated_header).import_block(block)
         imported_block = block_result.block
 
         # Validate the imported block.

--- a/newsfragments/1950.feature.rst
+++ b/newsfragments/1950.feature.rst
@@ -1,0 +1,3 @@
+Add a new hook :meth:`eth.abc.VirtualMachineAPI.transaction_applied_hook` which is triggered after
+each transaction in ``apply_all_transactions``, which is called by ``import_block``. The first use
+case is reporting progress in the middle of Beam Sync.


### PR DESCRIPTION


### What was wrong?

No convenient way to report progress in the middle of `apply_all_transactions` (the longest step of `import_block`).

See https://github.com/ethereum/trinity/pull/1916/files#r458190667

### How was it fixed?

- Added a new `VirtualMachineAPI.transaction_applied_hook()`
- In the hook, supply a header that includes the expected amount of gas to be used by the full block. This allows for things like monitoring the progress of the block in between transactions if they are slow. Executing transactions can be very slow in Beam Sync, for example.

We have to explicitly annotate the header used to generate the VM with the gas used by the final header in order to do that last step.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/8252341248/h9329DC93/)
