### PR TITLE
Upgrade Py-RLP to see if anything breaks.

### DIFF
--- a/newsfragments/1951.performance.rst
+++ b/newsfragments/1951.performance.rst
@@ -1,0 +1,1 @@
+Upgrade rlp library to ``v2.0.0-a1`` which uses faster rust based encoding/decoding.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ deps = {
         "mypy_extensions>=0.4.1,<1.0.0",
         "py-ecc>=1.4.7,<5.0.0",
         "pyethash>=0.1.27,<1.0.0",
-        "rlp>=1.1.0,<2.0.0",
+        "rlp==2.0.0-alpha.1",
         "trie==2.0.0-alpha.3",
     ],
     # The eth-extra sections is for libraries that the evm does not


### PR DESCRIPTION
### What was wrong?

Nothing wrong but Py-RLP shipped a new version that uses a rust based backend to speed up decoding/encoding. 

We can clearly observe the performance gains for Py-EVM.

Current:

```
Starting benchmark: Simple value transfer

Sending to existing address

------------------------------------------------------------------------------------------------------------------------------------------------
|        VM         | total seconds  |    total tx    |  tx / second   |  total blocks  |  blocks / second   |   total gas    |  gas / second  |
------------------------------------------------------------------------------------------------------------------------------------------------
|     frontier      |     5.738      |      142       |     24.749     |       1        |       0.174        |   2,982,000    |  519,731.556   |
|     homestead     |     6.308      |      142       |     22.512     |       1        |       0.159        |   2,982,000    |  472,756.675   |
| tangerine-whistle |     6.299      |      142       |     22.543     |       1        |       0.159        |   2,982,000    |  473,398.113   |
|  spurious-dragon  |     6.290      |      142       |     22.577     |       1        |       0.159        |   2,982,000    |  474,118.907   |
|     byzantium     |     6.300      |      142       |     22.540     |       1        |       0.159        |   2,982,000    |  473,336.865   |
|    petersburg     |     6.282      |      142       |     22.604     |       1        |       0.159        |   2,982,000    |  474,682.378   |
|     istanbul      |     6.362      |      142       |     22.319     |       1        |       0.157        |   2,982,000    |  468,700.784   |
|   muir-glacier    |     6.299      |      142       |     22.544     |       1        |       0.159        |   2,982,000    |  473,430.261   |
------------------------------------------------------------------------------------------------------------------------------------------------
|       Total       |     49.877     |      1136      |       -        |       8        |         -          |   23,856,000   |       -        |
|        Avg        |     6.235      |      142       |     22.776     |       1        |       0.160        |   2,982,000    |  478,296.726   |
================================================================================================================================================

```

New:

```
Starting benchmark: Simple value transfer

Sending to existing address

------------------------------------------------------------------------------------------------------------------------------------------------
|        VM         | total seconds  |    total tx    |  tx / second   |  total blocks  |  blocks / second   |   total gas    |  gas / second  |
------------------------------------------------------------------------------------------------------------------------------------------------
|     frontier      |     4.398      |      142       |     32.290     |       1        |       0.227        |   2,982,000    |  678,089.862   |
|     homestead     |     4.400      |      142       |     32.273     |       1        |       0.227        |   2,982,000    |  677,736.711   |
| tangerine-whistle |     4.400      |      142       |     32.276     |       1        |       0.227        |   2,982,000    |  677,793.365   |
|  spurious-dragon  |     4.400      |      142       |     32.273     |       1        |       0.227        |   2,982,000    |  677,732.111   |
|     byzantium     |     4.441      |      142       |     31.971     |       1        |       0.225        |   2,982,000    |  671,399.438   |
|    petersburg     |     4.864      |      142       |     29.191     |       1        |       0.206        |   2,982,000    |  613,017.025   |
|     istanbul      |     4.861      |      142       |     29.215     |       1        |       0.206        |   2,982,000    |  613,515.807   |
|   muir-glacier    |     4.846      |      142       |     29.302     |       1        |       0.206        |   2,982,000    |  615,338.591   |
------------------------------------------------------------------------------------------------------------------------------------------------
|       Total       |     36.610     |      1136      |       -        |       8        |         -          |   23,856,000   |       -        |
|        Avg        |     4.576      |      142       |     31.030     |       1        |       0.219        |   2,982,000    |  651,630.883   |
================================================================================================================================================

```

Notice the higher throughput (tx / second and gas / second) that shows an increase of `1.36x`.

### How was it fixed?

This PR updates the rlp dependency to use it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.fastcompany.net/image/upload/w_1280,f_auto,q_auto,fl_lossy/fc/3040131-poster-p-1-the-fastest-animal-on-earth-is-not-a-cheetah.jpg)
