### PR TITLE
Updates on subgroup check

### DIFF
--- a/eth/_utils/bn128.py
+++ b/eth/_utils/bn128.py
@@ -25,6 +25,8 @@ def validate_point(x: int, y: int) -> Tuple[bn128.FQ, bn128.FQ, bn128.FQ]:
         p1 = (FQ(x), FQ(y), FQ(1))
         if not bn128.is_on_curve(p1, bn128.b):
             raise ValidationError("Point is not on the curve")
+        if bn128.multiply(p1, bn128.curve_order)[-1] != FQ.zero():
+            raise ValidationError("Point is not in correct subgroup")
     else:
         p1 = (FQ(1), FQ(1), FQ(0))
 

--- a/eth/precompiles/ecpairing.py
+++ b/eth/precompiles/ecpairing.py
@@ -101,7 +101,7 @@ def _process_point(data_buffer: bytes, exponent: int) -> bn128.FQP:
             raise ValidationError("point is not on curve")
 
     if bn128.multiply(p2, bn128.curve_order)[-1] != bn128.FQ2.zero():
-        raise ValidationError("TODO: what case is this?????")
+        raise ValidationError("Point is not in correct subgroup")
 
     return exponent * bn128.pairing(FQP_point_to_FQ2_point(p2), p1, final_exponentiate=False)
 


### PR DESCRIPTION
### What was wrong?

Come across the pairing precompile and find these 2 issues.

1.  TODO error message on pairing.
2. Observed that the p1 subgroup check is missing.

I'm actually uncertain about the second issue and just keeping the diff there for better discussion.
I'm seeing conflict signs of whether to do that check.
- The fixture tests have [no case](https://github.com/ethereum/tests/pull/328) for the invalid p1 that's not in a subgroup.
- Go-ethereum [checks](https://github.com/ethereum/go-ethereum/blob/295693759e5ded05fec0b2fb39359965b60da785/core/vm/contracts.go#L848) the p1 in subgroup 

### How was it fixed?

1. Fix the wording of the error message.
2. Add a subgroup check for the p1.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3391420/90786560-4abf1f80-e336-11ea-8e52-784026350798.png)

