### PR TITLE
Upgrade py-trie for v2 rlp support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ deps = {
         "py-ecc>=1.4.7,<5.0.0",
         "pyethash>=0.1.27,<1.0.0",
         "rlp==2.0.0-alpha.1",
-        "trie==2.0.0-alpha.3",
+        "trie==2.0.0-alpha.4",
     ],
     # The eth-extra sections is for libraries that the evm does not
     # explicitly need to function and hence should not depend on.


### PR DESCRIPTION
### What was wrong?

The current py-trie doesn't support the latest py-rlp that py-evm was upgraded to. Not sure why #1951 looked fine pre-merge. :/

### How was it fixed?

Released a py-trie that supports the latest py-rlp.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/8348644352/h293DE3F7/just-a-couple-of-cubs-climbing-a-tree)
