### PR TITLE
Issue #1942 remove linting error ignores

### DIFF
--- a/eth/_utils/datatypes.py
+++ b/eth/_utils/datatypes.py
@@ -72,7 +72,7 @@ class Configurable(ConfigurableAPI):
     """
     @classmethod
     def configure(cls: Type[T],
-                  __name__: str=None,
+                  __name__: str = None,
                   **overrides: Any) -> Type[T]:
 
         if __name__ is None:

--- a/eth/_utils/env.py
+++ b/eth/_utils/env.py
@@ -33,7 +33,7 @@ class empty:
     pass
 
 
-def get_env_value(name: str, required: bool=False, default: Any=empty) -> str:
+def get_env_value(name: str, required: bool = False, default: Any = empty) -> str:
     """
     Core function for extracting the environment variable.
 
@@ -56,7 +56,7 @@ def get_env_value(name: str, required: bool=False, default: Any=empty) -> str:
     return value
 
 
-def env_int(name: str, required: bool=False, default: Union[Type[empty], int]=empty) -> int:
+def env_int(name: str, required: bool = False, default: Union[Type[empty], int] = empty) -> int:
     """Pulls an environment variable out of the environment and casts it to an
     integer. If the name is not present in the environment and no default is
     specified then a ``ValueError`` will be raised. Similarly, if the
@@ -84,7 +84,9 @@ def env_int(name: str, required: bool=False, default: Union[Type[empty], int]=em
     return int(value)
 
 
-def env_float(name: str, required: bool=False, default: Union[Type[empty], float]=empty) -> float:
+def env_float(name: str,
+              required: bool = False,
+              default: Union[Type[empty], float] = empty) -> float:
     """Pulls an environment variable out of the environment and casts it to an
     float. If the name is not present in the environment and no default is
     specified then a ``ValueError`` will be raised. Similarly, if the
@@ -113,9 +115,9 @@ def env_float(name: str, required: bool=False, default: Union[Type[empty], float
 
 
 def env_bool(name: str,
-             truthy_values: Iterable[Any]=TRUE_VALUES,
-             required: bool=False,
-             default: Union[Type[empty], bool]=empty) -> bool:
+             truthy_values: Iterable[Any] = TRUE_VALUES,
+             required: bool = False,
+             default: Union[Type[empty], bool] = empty) -> bool:
     """Pulls an environment variable out of the environment returning it as a
     boolean. The strings ``'True'`` and ``'true'`` are the default *truthy*
     values. If not present in the environment and no default is specified,
@@ -143,7 +145,7 @@ def env_bool(name: str,
     return value in TRUE_VALUES
 
 
-def env_string(name: str, required: bool=False, default: Union[Type[empty], str]=empty) -> str:
+def env_string(name: str, required: bool = False, default: Union[Type[empty], str] = empty) -> str:
     """Pulls an environment variable out of the environment returning it as a
     string. If not present in the environment and no default is specified, an
     empty string is returned.
@@ -167,9 +169,9 @@ def env_string(name: str, required: bool=False, default: Union[Type[empty], str]
 
 
 def env_list(name: str,
-             separator: str =',',
-             required: bool=False,
-             default: Union[Type[empty], List[Any]]=empty) -> List[Any]:
+             separator: str = ',',
+             required: bool = False,
+             default: Union[Type[empty], List[Any]] = empty) -> List[Any]:
     """Pulls an environment variable out of the environment, splitting it on a
     separator, and returning it as a list. Extra whitespace on the list values
     is stripped. List values that evaluate as falsy are removed. If not present
@@ -201,9 +203,9 @@ T = TypeVar('T')
 
 
 def get(name: str,
-        required: bool=False,
-        default: Union[Type[empty], T]=empty,
-        type: Type[T]=None) -> T:
+        required: bool = False,
+        default: Union[Type[empty], T] = empty,
+        type: Type[T] = None) -> T:
     """Generic getter for environment variables. Handles defaults,
     required-ness, and what type to expect.
 

--- a/eth/_utils/rlp.py
+++ b/eth/_utils/rlp.py
@@ -56,8 +56,8 @@ def diff_rlp_object(left: BaseBlock,
 @curry
 def validate_rlp_equal(obj_a: BaseBlock,
                        obj_b: BaseBlock,
-                       obj_a_name: str=None,
-                       obj_b_name: str=None) -> None:
+                       obj_a_name: str = None,
+                       obj_b_name: str = None) -> None:
     if obj_a == obj_b:
         return
 

--- a/eth/_utils/transactions.py
+++ b/eth/_utils/transactions.py
@@ -56,7 +56,7 @@ def extract_signature_v(v: int) -> int:
 
 def create_transaction_signature(unsigned_txn: UnsignedTransactionAPI,
                                  private_key: datatypes.PrivateKey,
-                                 chain_id: int=None) -> VRS:
+                                 chain_id: int = None) -> VRS:
 
     transaction_parts = rlp.decode(rlp.encode(unsigned_txn))
 

--- a/eth/abc.py
+++ b/eth/abc.py
@@ -1764,7 +1764,7 @@ class AccountStorageDatabaseAPI(ABC):
     merklized until :meth:`make_storage_root` is called.
     """
     @abstractmethod
-    def get(self, slot: int, from_journal: bool=True) -> int:
+    def get(self, slot: int, from_journal: bool = True) -> int:
         """
         Return the value at ``slot``. Lookups take the journal into consideration unless
         ``from_journal`` is explicitly set to ``False``.
@@ -1904,7 +1904,7 @@ class AccountDatabaseAPI(ABC):
     # Storage
     #
     @abstractmethod
-    def get_storage(self, address: Address, slot: int, from_journal: bool=True) -> int:
+    def get_storage(self, address: Address, slot: int, from_journal: bool = True) -> int:
         """
         Return the value stored at ``slot`` for the given ``address``. Take the journal
         into consideration unless ``from_journal`` is set to ``False``.
@@ -2165,7 +2165,7 @@ class ConfigurableAPI(ABC):
     @classmethod
     @abstractmethod
     def configure(cls: Type[T],
-                  __name__: str=None,
+                  __name__: str = None,
                   **overrides: Any) -> Type[T]:
         ...
 
@@ -2286,7 +2286,7 @@ class StateAPI(ConfigurableAPI):
         ...
 
     @abstractmethod
-    def get_storage(self, address: Address, slot: int, from_journal: bool=True) -> int:
+    def get_storage(self, address: Address, slot: int, from_journal: bool = True) -> int:
         """
         Return the storage at ``slot`` for ``address``.
         """
@@ -3220,7 +3220,7 @@ class ChainAPI(ConfigurableAPI):
     def from_genesis(cls,
                      base_db: AtomicDatabaseAPI,
                      genesis_params: Dict[str, HeaderParams],
-                     genesis_state: AccountState=None) -> 'ChainAPI':
+                     genesis_state: AccountState = None) -> 'ChainAPI':
         """
         Initialize the Chain from a genesis state.
         """
@@ -3491,7 +3491,7 @@ class ChainAPI(ConfigurableAPI):
     @abstractmethod
     def import_block(self,
                      block: BlockAPI,
-                     perform_validation: bool=True,
+                     perform_validation: bool = True,
                      ) -> BlockImportResult:
         """
         Import the given ``block`` and return a 3-tuple

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -221,7 +221,7 @@ class Chain(BaseChain):
     def from_genesis(cls,
                      base_db: AtomicDatabaseAPI,
                      genesis_params: Dict[str, HeaderParams],
-                     genesis_state: AccountState=None) -> 'BaseChain':
+                     genesis_state: AccountState = None) -> 'BaseChain':
         genesis_vm_class = cls.get_vm_class_for_block_number(BlockNumber(0))
 
         pre_genesis_header = BlockHeader(difficulty=0, block_number=-1, gas_limit=0)
@@ -455,7 +455,7 @@ class Chain(BaseChain):
 
     def import_block(self,
                      block: BlockAPI,
-                     perform_validation: bool=True
+                     perform_validation: bool = True
                      ) -> BlockImportResult:
 
         try:
@@ -659,7 +659,7 @@ class MiningChain(Chain, MiningChainAPI):
 
     def import_block(self,
                      block: BlockAPI,
-                     perform_validation: bool=True
+                     perform_validation: bool = True
                      ) -> BlockImportResult:
         result = super().import_block(
             block, perform_validation)

--- a/eth/chains/tester/__init__.py
+++ b/eth/chains/tester/__init__.py
@@ -60,7 +60,7 @@ VMStartBlock = Tuple[BlockNumber, Type[VirtualMachineAPI]]
 
 @to_tuple
 def _generate_vm_configuration(*fork_start_blocks: ForkStartBlocks,
-                               dao_start_block: Union[int, bool]=None) -> Generator[VMStartBlock, None, None]:  # noqa: E501
+                               dao_start_block: Union[int, bool] = None) -> Generator[VMStartBlock, None, None]:  # noqa: E501
     """
     fork_start_blocks should be 2-tuples of (start_block, fork_name_or_vm_class)
 
@@ -154,7 +154,7 @@ class MainnetTesterChain(BaseMainnetTesterChain):
 
     def configure_forks(self,
                         *fork_start_blocks: ForkStartBlocks,
-                        dao_start_block: Union[int, bool]=None) -> None:
+                        dao_start_block: Union[int, bool] = None) -> None:
         """
         On demand configuration of fork rules.  This is a foot gun that if used
         incorrectly could cause weird VM errors.

--- a/eth/db/accesslog.py
+++ b/eth/db/accesslog.py
@@ -26,7 +26,7 @@ class KeyAccessLoggerDB(BaseDB):
 
     logger = logging.getLogger("eth.db.KeyAccessLoggerDB")
 
-    def __init__(self, wrapped_db: DatabaseAPI, log_missing_keys: bool=True) -> None:
+    def __init__(self, wrapped_db: DatabaseAPI, log_missing_keys: bool = True) -> None:
         """
         :param log_missing_keys: True if a key is added to :attr:`keys_read` even if the
             key/value does not exist in the database.
@@ -70,7 +70,7 @@ class KeyAccessLoggerAtomicDB(BaseAtomicDB):
     """
     logger = logging.getLogger("eth.db.KeyAccessLoggerAtomicDB")
 
-    def __init__(self, wrapped_db: AtomicDatabaseAPI, log_missing_keys: bool=True) -> None:
+    def __init__(self, wrapped_db: AtomicDatabaseAPI, log_missing_keys: bool = True) -> None:
         """
         :param log_missing_keys: True if a key is added to :attr:`keys_read` even if the
             key/value does not exist in the database.

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -83,7 +83,7 @@ from .hash_trie import HashTrie
 class AccountDB(AccountDatabaseAPI):
     logger = get_extended_debug_logger('eth.db.account.AccountDB')
 
-    def __init__(self, db: AtomicDatabaseAPI, state_root: Hash32=BLANK_ROOT_HASH) -> None:
+    def __init__(self, db: AtomicDatabaseAPI, state_root: Hash32 = BLANK_ROOT_HASH) -> None:
         r"""
         Internal implementation details (subject to rapid change):
         Database entries go through several pipes, like so...
@@ -152,7 +152,7 @@ class AccountDB(AccountDatabaseAPI):
     #
     # Storage
     #
-    def get_storage(self, address: Address, slot: int, from_journal: bool=True) -> int:
+    def get_storage(self, address: Address, slot: int, from_journal: bool = True) -> int:
         validate_canonical_address(address, title="Storage Address")
         validate_uint256(slot, title="Storage Slot")
 
@@ -333,7 +333,7 @@ class AccountDB(AccountDatabaseAPI):
     #
     # Internal
     #
-    def _get_encoded_account(self, address: Address, from_journal: bool=True) -> bytes:
+    def _get_encoded_account(self, address: Address, from_journal: bool = True) -> bytes:
         self._accessed_accounts.add(address)
         lookup_trie = self._journaltrie if from_journal else self._trie_cache
 
@@ -345,7 +345,7 @@ class AccountDB(AccountDatabaseAPI):
             # In case the account is deleted in the JournalDB
             return b''
 
-    def _get_account(self, address: Address, from_journal: bool=True) -> Account:
+    def _get_account(self, address: Address, from_journal: bool = True) -> Account:
         if from_journal and address in self._account_cache:
             return self._account_cache[address]
 

--- a/eth/db/backends/level.py
+++ b/eth/db/backends/level.py
@@ -33,8 +33,8 @@ class LevelDB(BaseAtomicDB):
 
     # Creates db as a class variable to avoid level db lock error
     def __init__(self,
-                 db_path: Path=None,
-                 max_open_files: int=None) -> None:
+                 db_path: Path = None,
+                 max_open_files: int = None) -> None:
         if not db_path:
             raise TypeError("Please specifiy a valid path for your database.")
         try:

--- a/eth/db/cache.py
+++ b/eth/db/cache.py
@@ -9,7 +9,7 @@ class CacheDB(BaseDB):
     Set and get decoded RLP objects, where the underlying db stores
     encoded objects.
     """
-    def __init__(self, db: DatabaseAPI, cache_size: int=2048) -> None:
+    def __init__(self, db: DatabaseAPI, cache_size: int = 2048) -> None:
         self._db = db
         self._cache_size = cache_size
         self.reset_cache()

--- a/eth/db/storage.py
+++ b/eth/db/storage.py
@@ -297,7 +297,7 @@ class AccountStorageDB(AccountStorageDatabaseAPI):
         # as an index to find the base trie from before the revert.
         self._clear_count = JournalDB(MemoryDB({CLEAR_COUNT_KEY_NAME: to_bytes(0)}))
 
-    def get(self, slot: int, from_journal: bool=True) -> int:
+    def get(self, slot: int, from_journal: bool = True) -> int:
         self._accessed_slots.add(slot)
         key = int_to_big_endian(slot)
         lookup_db = self._journal_storage if from_journal else self._locked_changes

--- a/eth/estimators/gas.py
+++ b/eth/estimators/gas.py
@@ -27,7 +27,9 @@ def _get_computation_error(state: StateAPI, transaction: SignedTransactionAPI) -
 
 
 @curry
-def binary_gas_search(state: StateAPI, transaction: SignedTransactionAPI, tolerance: int=1) -> int:
+def binary_gas_search(state: StateAPI,
+                      transaction: SignedTransactionAPI,
+                      tolerance: int = 1) -> int:
     """
     Run the transaction with various gas limits, progressively
     approaching the minimum needed to succeed without an OutOfGas exception.

--- a/eth/rlp/accounts.py
+++ b/eth/rlp/accounts.py
@@ -29,10 +29,10 @@ class Account(rlp.Serializable, AccountAPI):
     ]
 
     def __init__(self,
-                 nonce: int=0,
-                 balance: int=0,
-                 storage_root: bytes=BLANK_ROOT_HASH,
-                 code_hash: bytes=EMPTY_SHA3,
+                 nonce: int = 0,
+                 balance: int = 0,
+                 storage_root: bytes = BLANK_ROOT_HASH,
+                 code_hash: bytes = EMPTY_SHA3,
                  **kwargs: Any) -> None:
         super().__init__(nonce, balance, storage_root, code_hash, **kwargs)
 

--- a/eth/rlp/headers.py
+++ b/eth/rlp/headers.py
@@ -91,36 +91,36 @@ class BlockHeader(rlp.Serializable, BlockHeaderAPI):
                  difficulty: int,
                  block_number: BlockNumber,
                  gas_limit: int,
-                 timestamp: int=None,
-                 coinbase: Address=ZERO_ADDRESS,
-                 parent_hash: Hash32=ZERO_HASH32,
-                 uncles_hash: Hash32=EMPTY_UNCLE_HASH,
-                 state_root: Hash32=BLANK_ROOT_HASH,
-                 transaction_root: Hash32=BLANK_ROOT_HASH,
-                 receipt_root: Hash32=BLANK_ROOT_HASH,
-                 bloom: int=0,
-                 gas_used: int=0,
-                 extra_data: bytes=b'',
-                 mix_hash: Hash32=ZERO_HASH32,
-                 nonce: bytes=GENESIS_NONCE) -> None:
+                 timestamp: int = None,
+                 coinbase: Address = ZERO_ADDRESS,
+                 parent_hash: Hash32 = ZERO_HASH32,
+                 uncles_hash: Hash32 = EMPTY_UNCLE_HASH,
+                 state_root: Hash32 = BLANK_ROOT_HASH,
+                 transaction_root: Hash32 = BLANK_ROOT_HASH,
+                 receipt_root: Hash32 = BLANK_ROOT_HASH,
+                 bloom: int = 0,
+                 gas_used: int = 0,
+                 extra_data: bytes = b'',
+                 mix_hash: Hash32 = ZERO_HASH32,
+                 nonce: bytes = GENESIS_NONCE) -> None:
         ...
 
     def __init__(self,              # type: ignore  # noqa: F811
                  difficulty: int,
                  block_number: BlockNumber,
                  gas_limit: int,
-                 timestamp: int=None,
-                 coinbase: Address=ZERO_ADDRESS,
-                 parent_hash: Hash32=ZERO_HASH32,
-                 uncles_hash: Hash32=EMPTY_UNCLE_HASH,
-                 state_root: Hash32=BLANK_ROOT_HASH,
-                 transaction_root: Hash32=BLANK_ROOT_HASH,
-                 receipt_root: Hash32=BLANK_ROOT_HASH,
-                 bloom: int=0,
-                 gas_used: int=0,
-                 extra_data: bytes=b'',
-                 mix_hash: Hash32=ZERO_HASH32,
-                 nonce: bytes=GENESIS_NONCE) -> None:
+                 timestamp: int = None,
+                 coinbase: Address = ZERO_ADDRESS,
+                 parent_hash: Hash32 = ZERO_HASH32,
+                 uncles_hash: Hash32 = EMPTY_UNCLE_HASH,
+                 state_root: Hash32 = BLANK_ROOT_HASH,
+                 transaction_root: Hash32 = BLANK_ROOT_HASH,
+                 receipt_root: Hash32 = BLANK_ROOT_HASH,
+                 bloom: int = 0,
+                 gas_used: int = 0,
+                 extra_data: bytes = b'',
+                 mix_hash: Hash32 = ZERO_HASH32,
+                 nonce: bytes = GENESIS_NONCE) -> None:
         if timestamp is None:
             timestamp = int(time.time())
         super().__init__(
@@ -166,11 +166,11 @@ class BlockHeader(rlp.Serializable, BlockHeaderAPI):
                     gas_limit: int,
                     difficulty: int,
                     timestamp: int,
-                    coinbase: Address=ZERO_ADDRESS,
-                    nonce: bytes=None,
-                    extra_data: bytes=None,
-                    transaction_root: bytes=None,
-                    receipt_root: bytes=None) -> 'BlockHeader':
+                    coinbase: Address = ZERO_ADDRESS,
+                    nonce: bytes = None,
+                    extra_data: bytes = None,
+                    transaction_root: bytes = None,
+                    receipt_root: bytes = None) -> 'BlockHeader':
         """
         Initialize a new block header with the `parent` header as the block's
         parent hash.

--- a/eth/rlp/receipts.py
+++ b/eth/rlp/receipts.py
@@ -33,7 +33,7 @@ class Receipt(rlp.Serializable, ReceiptAPI):
                  state_root: bytes,
                  gas_used: int,
                  logs: Iterable[Log],
-                 bloom: int=None) -> None:
+                 bloom: int = None) -> None:
 
         if bloom is None:
             bloomables = itertools.chain.from_iterable(log.bloomables for log in logs)

--- a/eth/tools/_utils/normalization.py
+++ b/eth/tools/_utils/normalization.py
@@ -137,8 +137,8 @@ robust_decode_hex = hexstr_if_str(to_bytes)
 # Containers
 #
 def dict_normalizer(formatters: Dict[Any, Callable[..., Any]],
-                    required: Iterable[Any]=None,
-                    optional: Iterable[Any]=None) -> Normalizer:
+                    required: Iterable[Any] = None,
+                    optional: Iterable[Any] = None) -> Normalizer:
 
     all_keys = set(formatters.keys())
 

--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -324,9 +324,9 @@ def _fill_and_normalize_state(simple_state: GeneralState) -> AccountState:
 
 @curry
 def genesis(chain_class: ChainAPI,
-            db: AtomicDatabaseAPI=None,
-            params: Dict[str, HeaderParams]=None,
-            state: GeneralState=None) -> ChainAPI:
+            db: AtomicDatabaseAPI = None,
+            params: Dict[str, HeaderParams] = None,
+            state: GeneralState = None) -> ChainAPI:
     """
     Initialize the given chain class with the given genesis header parameters
     and chain state.

--- a/eth/tools/fixtures/fillers/common.py
+++ b/eth/tools/fixtures/fillers/common.py
@@ -101,7 +101,7 @@ Test.__new__.__defaults__ = (None,)  # type: ignore
 # Filler Generation
 #
 
-def setup_filler(name: str, environment: Dict[Any, Any]=None) -> Dict[str, Dict[str, Any]]:
+def setup_filler(name: str, environment: Dict[Any, Any] = None) -> Dict[str, Dict[str, Any]]:
     environment = normalize_environment(environment or {})
     return {name: {
         "env": environment,
@@ -109,7 +109,7 @@ def setup_filler(name: str, environment: Dict[Any, Any]=None) -> Dict[str, Dict[
     }}
 
 
-def setup_main_filler(name: str, environment: Dict[Any, Any]=None) -> Dict[str, Dict[str, Any]]:
+def setup_main_filler(name: str, environment: Dict[Any, Any] = None) -> Dict[str, Dict[str, Any]]:
     """
     Kick off the filler generation process by creating the general filler scaffold with
     a test name and general information about the testing environment.
@@ -240,9 +240,9 @@ def _expect(post_state: Dict[str, Any],
     return deep_merge(filler, test_update)
 
 
-def expect(post_state: Dict[str, Any]=None,
-           networks: Any=None,
-           transaction: TransactionDict=None) -> Callable[..., Dict[str, Any]]:
+def expect(post_state: Dict[str, Any] = None,
+           networks: Any = None,
+           transaction: TransactionDict = None) -> Callable[..., Dict[str, Any]]:
 
     """
     Specify the expected result for the test.

--- a/eth/tools/fixtures/fillers/main.py
+++ b/eth/tools/fixtures/fillers/main.py
@@ -28,8 +28,8 @@ FILLED_WITH_TEMPLATE = "py-evm-{version}"
 # Primary test filler
 #
 def fill_test(filler: Dict[str, Any],
-              info: Dict[str, Any]=None,
-              apply_formatter: bool=True,
+              info: Dict[str, Any] = None,
+              apply_formatter: bool = True,
               **kwargs: Any) -> Dict[str, Any]:
 
     test_name = get_test_name(filler)

--- a/eth/tools/fixtures/fillers/vm.py
+++ b/eth/tools/fixtures/fillers/vm.py
@@ -25,11 +25,11 @@ from eth.tools._utils.mappings import deep_merge
 def fill_vm_test(
         filler: Dict[str, Any],
         *,
-        call_creates: Any=None,
-        gas_price: Union[int, str]=None,
-        gas_remaining: Union[int, str]=0,
-        logs: Iterable[Tuple[bytes, Tuple[int, ...], bytes]]=None,
-        output: bytes=b"") -> Dict[str, Dict[str, Any]]:
+        call_creates: Any = None,
+        gas_price: Union[int, str] = None,
+        gas_remaining: Union[int, str] = 0,
+        logs: Iterable[Tuple[bytes, Tuple[int, ...], bytes]] = None,
+        output: bytes = b"") -> Dict[str, Dict[str, Any]]:
 
     test_name = get_test_name(filler)
     test = filler[test_name]

--- a/eth/tools/fixtures/generation.py
+++ b/eth/tools/fixtures/generation.py
@@ -42,8 +42,8 @@ def get_fixtures_file_hash(all_fixture_paths: Iterable[str]) -> str:
 @curry
 def generate_fixture_tests(metafunc: Any,
                            base_fixture_path: str,
-                           filter_fn: Callable[..., Any]=identity,
-                           preprocess_fn: Callable[..., Any]=identity) -> None:
+                           filter_fn: Callable[..., Any] = identity,
+                           preprocess_fn: Callable[..., Any] = identity) -> None:
     """
     Helper function for use with `pytest_generate_tests` which will use the
     pytest caching facilities to reduce the load time for fixture tests.

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -204,7 +204,7 @@ def new_chain_from_fixture(fixture: Dict[str, Any],
 def apply_fixture_block_to_chain(
         block_fixture: Dict[str, Any],
         chain: ChainAPI,
-        perform_validation: bool=True) -> Tuple[BlockAPI, BlockAPI, bytes]:
+        perform_validation: bool = True) -> Tuple[BlockAPI, BlockAPI, bytes]:
     """
     :return: (premined_block, mined_block, rlp_encoded_mined_block)
     """

--- a/eth/tools/fixtures/loading.py
+++ b/eth/tools/fixtures/loading.py
@@ -62,7 +62,7 @@ def load_json_fixture(fixture_path: str) -> Dict[str, Any]:
 
 def load_fixture(fixture_path: str,
                  fixture_key: str,
-                 normalize_fn: Callable[..., Any]=identity) -> Dict[str, Any]:
+                 normalize_fn: Callable[..., Any] = identity) -> Dict[str, Any]:
     """
     Loads a specific fixture from a fixture file, optionally passing it through
     a normalization function.
@@ -76,8 +76,8 @@ def load_fixture(fixture_path: str,
 @curry
 def filter_fixtures(all_fixtures: Iterable[Any],
                     fixtures_base_dir: str,
-                    mark_fn: Callable[[str, str], bool]=None,
-                    ignore_fn: Callable[..., bool]=None) -> Any:
+                    mark_fn: Callable[[str, str], bool] = None,
+                    ignore_fn: Callable[..., bool] = None) -> Any:
     """
     Helper function for filtering test fixtures.
 

--- a/eth/validation.py
+++ b/eth/validation.py
@@ -39,14 +39,14 @@ from eth.typing import (
 )
 
 
-def validate_is_bytes(value: bytes, title: str="Value") -> None:
+def validate_is_bytes(value: bytes, title: str = "Value") -> None:
     if not isinstance(value, bytes):
         raise ValidationError(
             f"{title} must be a byte string.  Got: {type(value)}"
         )
 
 
-def validate_is_bytes_or_view(value: BytesOrView, title: str="Value") -> None:
+def validate_is_bytes_or_view(value: BytesOrView, title: str = "Value") -> None:
     if isinstance(value, (bytes, memoryview)):
         return
     raise ValidationError(
@@ -54,21 +54,21 @@ def validate_is_bytes_or_view(value: BytesOrView, title: str="Value") -> None:
     )
 
 
-def validate_is_integer(value: Union[int, bool], title: str="Value") -> None:
+def validate_is_integer(value: Union[int, bool], title: str = "Value") -> None:
     if not isinstance(value, int) or isinstance(value, bool):
         raise ValidationError(
             f"{title} must be a an integer.  Got: {type(value)}"
         )
 
 
-def validate_length(value: Sequence[Any], length: int, title: str="Value") -> None:
+def validate_length(value: Sequence[Any], length: int, title: str = "Value") -> None:
     if not len(value) == length:
         raise ValidationError(
             f"{title} must be of length {length}.  Got {value} of length {len(value)}"
         )
 
 
-def validate_length_lte(value: Sequence[Any], maximum_length: int, title: str="Value") -> None:
+def validate_length_lte(value: Sequence[Any], maximum_length: int, title: str = "Value") -> None:
     if len(value) > maximum_length:
         raise ValidationError(
             f"{title} must be of length less than or equal to {maximum_length}.  "
@@ -76,7 +76,7 @@ def validate_length_lte(value: Sequence[Any], maximum_length: int, title: str="V
         )
 
 
-def validate_gte(value: int, minimum: int, title: str="Value") -> None:
+def validate_gte(value: int, minimum: int, title: str = "Value") -> None:
     if value < minimum:
         raise ValidationError(
             f"{title} {value} is not greater than or equal to {minimum}"
@@ -84,7 +84,7 @@ def validate_gte(value: int, minimum: int, title: str="Value") -> None:
     validate_is_integer(value)
 
 
-def validate_gt(value: int, minimum: int, title: str="Value") -> None:
+def validate_gt(value: int, minimum: int, title: str = "Value") -> None:
     if value <= minimum:
         raise ValidationError(
             f"{title} {value} is not greater than {minimum}"
@@ -92,7 +92,7 @@ def validate_gt(value: int, minimum: int, title: str="Value") -> None:
     validate_is_integer(value, title=title)
 
 
-def validate_lte(value: int, maximum: int, title: str="Value") -> None:
+def validate_lte(value: int, maximum: int, title: str = "Value") -> None:
     if value > maximum:
         raise ValidationError(
             f"{title} {value} is not less than or equal to {maximum}"
@@ -100,7 +100,7 @@ def validate_lte(value: int, maximum: int, title: str="Value") -> None:
     validate_is_integer(value, title=title)
 
 
-def validate_lt(value: int, maximum: int, title: str="Value") -> None:
+def validate_lt(value: int, maximum: int, title: str = "Value") -> None:
     if value >= maximum:
         raise ValidationError(
             f"{title} {value} is not less than {maximum}"
@@ -108,28 +108,28 @@ def validate_lt(value: int, maximum: int, title: str="Value") -> None:
     validate_is_integer(value, title=title)
 
 
-def validate_canonical_address(value: Address, title: str="Value") -> None:
+def validate_canonical_address(value: Address, title: str = "Value") -> None:
     if not isinstance(value, bytes) or not len(value) == 20:
         raise ValidationError(
             f"{title} {value!r} is not a valid canonical address"
         )
 
 
-def validate_multiple_of(value: int, multiple_of: int, title: str="Value") -> None:
+def validate_multiple_of(value: int, multiple_of: int, title: str = "Value") -> None:
     if not value % multiple_of == 0:
         raise ValidationError(
             f"{title} {value} is not a multiple of {multiple_of}"
         )
 
 
-def validate_is_boolean(value: bool, title: str="Value") -> None:
+def validate_is_boolean(value: bool, title: str = "Value") -> None:
     if not isinstance(value, bool):
         raise ValidationError(
             f"{title} must be an boolean.  Got type: {type(value)}"
         )
 
 
-def validate_word(value: Hash32, title: str="Value") -> None:
+def validate_word(value: Hash32, title: str = "Value") -> None:
     if not isinstance(value, bytes):
         raise ValidationError(
             f"{title} is not a valid word. Must be of bytes type: Got: {type(value)}"
@@ -140,7 +140,7 @@ def validate_word(value: Hash32, title: str="Value") -> None:
         )
 
 
-def validate_uint64(value: int, title: str="Value") -> None:
+def validate_uint64(value: int, title: str = "Value") -> None:
     if not isinstance(value, int) or isinstance(value, bool):
         raise ValidationError(
             f"{title} must be an integer: Got: {type(value)}"
@@ -155,7 +155,7 @@ def validate_uint64(value: int, title: str="Value") -> None:
         )
 
 
-def validate_uint256(value: int, title: str="Value") -> None:
+def validate_uint256(value: int, title: str = "Value") -> None:
     if not isinstance(value, int) or isinstance(value, bool):
         raise ValidationError(
             f"{title} must be an integer: Got: {type(value)}"
@@ -190,7 +190,7 @@ validate_lt_secpk1n = functools.partial(validate_lte, maximum=SECPK1_N - 1)
 validate_lt_secpk1n2 = functools.partial(validate_lte, maximum=SECPK1_N // 2 - 1)
 
 
-def validate_unique(values: Iterable[Any], title: str="Value") -> None:
+def validate_unique(values: Iterable[Any], title: str = "Value") -> None:
     if not itertoolz.isdistinct(values):
         duplicates = functoolz.pipe(
             values,
@@ -207,7 +207,7 @@ def validate_unique(values: Iterable[Any], title: str="Value") -> None:
         )
 
 
-def validate_block_number(block_number: int, title: str="Block Number") -> None:
+def validate_block_number(block_number: int, title: str = "Block Number") -> None:
     validate_is_integer(block_number, title)
     validate_gte(block_number, 0, title)
 

--- a/eth/vm/forks/byzantium/transactions.py
+++ b/eth/vm/forks/byzantium/transactions.py
@@ -27,7 +27,7 @@ class ByzantiumTransaction(SpuriousDragonTransaction):
 class ByzantiumUnsignedTransaction(SpuriousDragonUnsignedTransaction):
     def as_signed_transaction(self,
                               private_key: PrivateKey,
-                              chain_id: int=None) -> ByzantiumTransaction:
+                              chain_id: int = None) -> ByzantiumTransaction:
         v, r, s = create_transaction_signature(self, private_key, chain_id=chain_id)
         return ByzantiumTransaction(
             nonce=self.nonce,

--- a/eth/vm/forks/constantinople/transactions.py
+++ b/eth/vm/forks/constantinople/transactions.py
@@ -27,7 +27,7 @@ class ConstantinopleTransaction(ByzantiumTransaction):
 class ConstantinopleUnsignedTransaction(ByzantiumUnsignedTransaction):
     def as_signed_transaction(self,
                               private_key: PrivateKey,
-                              chain_id: int=None) -> ConstantinopleTransaction:
+                              chain_id: int = None) -> ConstantinopleTransaction:
         v, r, s = create_transaction_signature(self, private_key, chain_id=chain_id)
         return ConstantinopleTransaction(
             nonce=self.nonce,

--- a/eth/vm/forks/frontier/blocks.py
+++ b/eth/vm/forks/frontier/blocks.py
@@ -61,8 +61,8 @@ class FrontierBlock(BaseBlock):
 
     def __init__(self,
                  header: BlockHeaderAPI,
-                 transactions: Sequence[SignedTransactionAPI]=None,
-                 uncles: Sequence[BlockHeaderAPI]=None) -> None:
+                 transactions: Sequence[SignedTransactionAPI] = None,
+                 uncles: Sequence[BlockHeaderAPI] = None) -> None:
         if transactions is None:
             transactions = []
         if uncles is None:

--- a/eth/vm/forks/istanbul/transactions.py
+++ b/eth/vm/forks/istanbul/transactions.py
@@ -47,7 +47,7 @@ class IstanbulTransaction(PetersburgTransaction):
 class IstanbulUnsignedTransaction(PetersburgUnsignedTransaction):
     def as_signed_transaction(self,
                               private_key: PrivateKey,
-                              chain_id: int=None) -> IstanbulTransaction:
+                              chain_id: int = None) -> IstanbulTransaction:
         v, r, s = create_transaction_signature(self, private_key, chain_id=chain_id)
         return IstanbulTransaction(
             nonce=self.nonce,

--- a/eth/vm/forks/muir_glacier/transactions.py
+++ b/eth/vm/forks/muir_glacier/transactions.py
@@ -27,7 +27,7 @@ class MuirGlacierTransaction(IstanbulTransaction):
 class MuirGlacierUnsignedTransaction(IstanbulUnsignedTransaction):
     def as_signed_transaction(self,
                               private_key: PrivateKey,
-                              chain_id: int=None) -> MuirGlacierTransaction:
+                              chain_id: int = None) -> MuirGlacierTransaction:
         v, r, s = create_transaction_signature(self, private_key, chain_id=chain_id)
         return MuirGlacierTransaction(
             nonce=self.nonce,

--- a/eth/vm/forks/petersburg/transactions.py
+++ b/eth/vm/forks/petersburg/transactions.py
@@ -27,7 +27,7 @@ class PetersburgTransaction(ByzantiumTransaction):
 class PetersburgUnsignedTransaction(ByzantiumUnsignedTransaction):
     def as_signed_transaction(self,
                               private_key: PrivateKey,
-                              chain_id: int=None) -> PetersburgTransaction:
+                              chain_id: int = None) -> PetersburgTransaction:
         v, r, s = create_transaction_signature(self, private_key, chain_id=chain_id)
         return PetersburgTransaction(
             nonce=self.nonce,

--- a/eth/vm/forks/spurious_dragon/transactions.py
+++ b/eth/vm/forks/spurious_dragon/transactions.py
@@ -76,7 +76,7 @@ class SpuriousDragonTransaction(HomesteadTransaction):
 class SpuriousDragonUnsignedTransaction(HomesteadUnsignedTransaction):
     def as_signed_transaction(self,
                               private_key: PrivateKey,
-                              chain_id: int=None) -> SpuriousDragonTransaction:
+                              chain_id: int = None) -> SpuriousDragonTransaction:
         v, r, s = create_transaction_signature(self, private_key, chain_id=chain_id)
         return SpuriousDragonTransaction(
             nonce=self.nonce,

--- a/eth/vm/message.py
+++ b/eth/vm/message.py
@@ -35,11 +35,11 @@ class Message(MessageAPI):
                  value: int,
                  data: BytesOrView,
                  code: bytes,
-                 depth: int=0,
-                 create_address: Address=None,
-                 code_address: Address=None,
-                 should_transfer_value: bool=True,
-                 is_static: bool=False) -> None:
+                 depth: int = 0,
+                 create_address: Address = None,
+                 code_address: Address = None,
+                 should_transfer_value: bool = True,
+                 is_static: bool = False) -> None:
         validate_uint256(gas, title="Message.gas")
         self.gas: int = gas
 

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -104,7 +104,7 @@ class BaseState(Configurable, StateAPI):
     def make_state_root(self) -> Hash32:
         return self._account_db.make_state_root()
 
-    def get_storage(self, address: Address, slot: int, from_journal: bool=True) -> int:
+    def get_storage(self, address: Address, slot: int, from_journal: bool = True) -> int:
         return self._account_db.get_storage(address, slot, from_journal)
 
     def set_storage(self, address: Address, slot: int, value: int) -> None:

--- a/scripts/benchmark/_utils/chain_plumbing.py
+++ b/scripts/benchmark/_utils/chain_plumbing.py
@@ -99,6 +99,6 @@ def get_chain(vm: Type[VirtualMachineAPI], genesis_state: GenesisState) -> Itera
         yield level_db_chain
 
 
-def get_all_chains(genesis_state: GenesisState=DEFAULT_GENESIS_STATE) -> Iterable[MiningChain]:
+def get_all_chains(genesis_state: GenesisState = DEFAULT_GENESIS_STATE) -> Iterable[MiningChain]:
     for vm in ALL_VM:
         yield from get_chain(vm, genesis_state)

--- a/scripts/benchmark/_utils/meters.py
+++ b/scripts/benchmark/_utils/meters.py
@@ -13,7 +13,7 @@ class TimedResult(NamedTuple):
     wrapped_value: Any
 
 
-def time_call(fn: Callable[..., Any]=None) -> TimedResult:
+def time_call(fn: Callable[..., Any] = None) -> TimedResult:
     start = time.perf_counter()
     return_value = fn()
     duration = time.perf_counter() - start

--- a/scripts/benchmark/_utils/reporting.py
+++ b/scripts/benchmark/_utils/reporting.py
@@ -44,7 +44,7 @@ class DefaultStat(NamedTuple):
     def avg_total_gas(self) -> float:
         return self.total_gas / self.counter
 
-    def cumulate(self, stat: 'DefaultStat', increment_by_counter: bool=False) -> 'DefaultStat':
+    def cumulate(self, stat: 'DefaultStat', increment_by_counter: bool = False) -> 'DefaultStat':
         increment_step = 1 if not increment_by_counter else stat.counter
         return DefaultStat(
             counter=self.counter + increment_step,

--- a/scripts/benchmark/checks/base_benchmark.py
+++ b/scripts/benchmark/checks/base_benchmark.py
@@ -54,5 +54,5 @@ class BaseBenchmark(ABC):
         self.print_total_line(stat)
         return stat
 
-    def as_timed_result(self, fn: Callable[..., Any]=None) -> TimedResult:
+    def as_timed_result(self, fn: Callable[..., Any] = None) -> TimedResult:
         return time_call(fn)

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ exclude=
 ignore =
     # W503 line break before binary operator
     # It's either this or W504 (line break _after_ binary operator), pick your poison.
-    # W503 gets enabled when E252 gets ignored, see:
+    # W503 gets enabled when any "ignore =" config is added (even the empty one), see:
     # https://github.com/ethereum/py-evm/pull/1940#discussion_r432606845
     W503
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,6 @@ envlist=
 max-line-length= 100
 exclude=
 ignore =
-    # E252 missing whitespace around parameter equals
-    # Already used too much in the codebase at the point of introduction.
-    E252,
     # W503 line break before binary operator
     # It's either this or W504 (line break _after_ binary operator), pick your poison.
     # W503 gets enabled when E252 gets ignored, see:


### PR DESCRIPTION
### What was wrong?
PR #1940 added the flake8 error code E252 to be ignored, which was a temporary solution to wait until all these errors were fixed in the codebase.

### How was it fixed?
 - E252 has been removed from the ignore section of flake8 in tox.ini
 - All errors raised by tox were fixed by adding a space around operators where missing

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://1.bp.blogspot.com/-IlsU4ytILBU/Unk-PPc8wCI/AAAAAAAApUU/6RTZVhgPfRw/s1600/Fennec+Fox+is+the+Most+Cute+Animal+in+the+World++6.jpg)
