### PR TITLE
Add typed transactions - EIP 2718 - Berlin

### DIFF
--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -391,7 +391,7 @@ class Chain(BaseChain):
         return self.chaindb.get_transaction_by_index(
             block_number,
             index,
-            VM_class.get_transaction_class(),
+            VM_class.get_transaction_builder(),
         )
 
     def create_transaction(self, *args: Any, **kwargs: Any) -> SignedTransactionAPI:

--- a/eth/exceptions.py
+++ b/eth/exceptions.py
@@ -46,6 +46,18 @@ class TransactionNotFound(PyEVMError):
     pass
 
 
+class UnrecognizedTransactionType(PyEVMError):
+    """
+    Raised when an encoded transaction is using a first byte that is valid, but
+    unrecognized. According to EIP 2718, the byte may be in the range [0, 0x7f].
+    As of the Berlin hard fork, all of those versions are undefined, except for
+    0x01 in EIP 2930.
+    """
+    @property
+    def type_int(self) -> int:
+        return self.args[0]
+
+
 class ReceiptNotFound(PyEVMError):
     """
     Raised when the Receipt with the given receipt index does not exist.

--- a/eth/rlp/blocks.py
+++ b/eth/rlp/blocks.py
@@ -12,18 +12,18 @@ from eth._utils.datatypes import (
 )
 from eth.abc import (
     BlockAPI,
-    SignedTransactionAPI,
+    TransactionBuilderAPI,
 )
 
 
 class BaseBlock(Configurable, rlp.Serializable, BlockAPI):
-    transaction_class: Type[SignedTransactionAPI] = None
+    transaction_builder: Type[TransactionBuilderAPI] = None
 
     @classmethod
-    def get_transaction_class(cls) -> Type[SignedTransactionAPI]:
-        if cls.transaction_class is None:
-            raise AttributeError("Block subclasses must declare a transaction_class")
-        return cls.transaction_class
+    def get_transaction_builder(cls) -> Type[TransactionBuilderAPI]:
+        if cls.transaction_builder is None:
+            raise AttributeError("Block subclasses must declare a transaction_builder")
+        return cls.transaction_builder
 
     @property
     def is_genesis(self) -> bool:

--- a/eth/rlp/transactions.py
+++ b/eth/rlp/transactions.py
@@ -19,6 +19,7 @@ from eth.abc import (
     BaseTransactionAPI,
     ComputationAPI,
     SignedTransactionAPI,
+    TransactionBuilderAPI,
     TransactionFieldsAPI,
     UnsignedTransactionAPI,
 )
@@ -60,7 +61,13 @@ class BaseTransactionFields(rlp.Serializable, TransactionFieldsAPI):
         return keccak(rlp.encode(self))
 
 
-class BaseTransaction(BaseTransactionFields, BaseTransactionMethods, SignedTransactionAPI):  # noqa: E501
+class BaseTransaction(BaseTransactionFields, BaseTransactionMethods, SignedTransactionAPI, TransactionBuilderAPI):  # noqa: E501
+    # "Legacy" transactions implemented by BaseTransaction are a combination of
+    # the transaction codec (TransactionBuilderAPI) *and* the transaction
+    # object (SignedTransactionAPI). In a multi-transaction-type world, that
+    # becomes less desirable, and that responsibility splits up. See Berlin
+    # transactions, for example.
+
     # this is duplicated to make the rlp library happy, otherwise it complains
     # about no fields being defined but inheriting from multiple `Serializable`
     # bases.

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -39,6 +39,7 @@ from eth.abc import (
     ReceiptAPI,
     SignedTransactionAPI,
     StateAPI,
+    TransactionBuilderAPI,
     UnsignedTransactionAPI,
     VirtualMachineAPI,
 )
@@ -477,7 +478,7 @@ class VM(Configurable, VirtualMachineAPI):
     # Transactions
     #
     def create_transaction(self, *args: Any, **kwargs: Any) -> SignedTransactionAPI:
-        return self.get_transaction_class()(*args, **kwargs)
+        return self.get_transaction_builder().new_transaction(*args, **kwargs)
 
     @classmethod
     def create_unsigned_transaction(cls,
@@ -488,7 +489,7 @@ class VM(Configurable, VirtualMachineAPI):
                                     to: Address,
                                     value: int,
                                     data: bytes) -> UnsignedTransactionAPI:
-        return cls.get_transaction_class().create_unsigned_transaction(
+        return cls.get_transaction_builder().create_unsigned_transaction(
             nonce=nonce,
             gas_price=gas_price,
             gas=gas,
@@ -498,8 +499,8 @@ class VM(Configurable, VirtualMachineAPI):
         )
 
     @classmethod
-    def get_transaction_class(cls) -> Type[SignedTransactionAPI]:
-        return cls.get_block_class().get_transaction_class()
+    def get_transaction_builder(cls) -> Type[TransactionBuilderAPI]:
+        return cls.get_block_class().get_transaction_builder()
 
     #
     # Validate

--- a/eth/vm/forks/berlin/blocks.py
+++ b/eth/vm/forks/berlin/blocks.py
@@ -1,5 +1,11 @@
+from typing import Type
+
 from rlp.sedes import (
     CountableList,
+)
+
+from eth.abc import (
+    TransactionBuilderAPI,
 )
 from eth.rlp.headers import (
     BlockHeader,
@@ -9,14 +15,14 @@ from eth.vm.forks.muir_glacier.blocks import (
 )
 
 from .transactions import (
-    BerlinTransaction,
+    BerlinTransactionBuilder,
 )
 
 
 class BerlinBlock(MuirGlacierBlock):
-    transaction_class = BerlinTransaction
+    transaction_builder: Type[TransactionBuilderAPI] = BerlinTransactionBuilder  # type: ignore
     fields = [
         ('header', BlockHeader),
-        ('transactions', CountableList(transaction_class)),
+        ('transactions', CountableList(transaction_builder)),
         ('uncles', CountableList(BlockHeader))
     ]

--- a/eth/vm/forks/berlin/transactions.py
+++ b/eth/vm/forks/berlin/transactions.py
@@ -1,6 +1,18 @@
 from eth_keys.datatypes import PrivateKey
 from eth_typing import Address
+from eth_utils import (
+    to_int,
+)
+from rlp.exceptions import (
+    DeserializationError,
+)
 
+from eth.abc import (
+    SignedTransactionAPI,
+    TransactionBuilderAPI,
+    UnsignedTransactionAPI,
+)
+from eth.exceptions import UnrecognizedTransactionType
 from eth.vm.forks.muir_glacier.transactions import (
     MuirGlacierTransaction,
     MuirGlacierUnsignedTransaction,
@@ -11,25 +23,16 @@ from eth._utils.transactions import (
 )
 
 
-class BerlinTransaction(MuirGlacierTransaction):
-    @classmethod
-    def create_unsigned_transaction(cls,
-                                    *,
-                                    nonce: int,
-                                    gas_price: int,
-                                    gas: int,
-                                    to: Address,
-                                    value: int,
-                                    data: bytes) -> 'BerlinUnsignedTransaction':
-        return BerlinUnsignedTransaction(nonce, gas_price, gas, to, value, data)
+class BerlinLegacyTransaction(MuirGlacierTransaction):
+    pass
 
 
-class BerlinUnsignedTransaction(MuirGlacierUnsignedTransaction):
+class BerlinUnsignedLegacyTransaction(MuirGlacierUnsignedTransaction):
     def as_signed_transaction(self,
                               private_key: PrivateKey,
-                              chain_id: int = None) -> BerlinTransaction:
+                              chain_id: int = None) -> BerlinLegacyTransaction:
         v, r, s = create_transaction_signature(self, private_key, chain_id=chain_id)
-        return BerlinTransaction(
+        return BerlinLegacyTransaction(
             nonce=self.nonce,
             gas_price=self.gas_price,
             gas=self.gas,
@@ -40,3 +43,65 @@ class BerlinUnsignedTransaction(MuirGlacierUnsignedTransaction):
             r=r,
             s=s,
         )
+
+
+class BerlinTransactionBuilder(TransactionBuilderAPI):
+    """
+    Responsible for serializing transactions of ambiguous type.
+
+    It dispatches to either the legacy transaction type or the new typed
+    transaction, depending on the nature of the encoded/decoded transaction.
+    """
+    legacy_signed = BerlinLegacyTransaction
+    legacy_unsigned = BerlinUnsignedLegacyTransaction
+
+    @classmethod
+    def deserialize(cls, encoded: bytes) -> SignedTransactionAPI:
+        if len(encoded) == 0:
+            raise DeserializationError(
+                "Encoded transaction was empty, which makes it invalid",
+                encoded,
+            )
+
+        if isinstance(encoded, bytes):
+            transaction_type = to_int(encoded[0])
+            if transaction_type == 1:
+                raise UnrecognizedTransactionType(transaction_type, "TODO: Implement EIP-2930")
+            elif transaction_type in range(0, 0x80):
+                raise UnrecognizedTransactionType(transaction_type, "Unknown transaction type")
+            else:
+                raise DeserializationError(
+                    f"Typed Transaction must start with 0-0x7f, but got {hex(transaction_type)}",
+                    encoded,
+                )
+        else:
+            return cls.legacy_signed.deserialize(encoded)
+
+    @classmethod
+    def serialize(cls, obj: SignedTransactionAPI) -> bytes:
+        return cls.legacy_signed.serialize(obj)
+
+    @classmethod
+    def create_unsigned_transaction(cls,
+                                    *,
+                                    nonce: int,
+                                    gas_price: int,
+                                    gas: int,
+                                    to: Address,
+                                    value: int,
+                                    data: bytes) -> UnsignedTransactionAPI:
+        return cls.legacy_unsigned(nonce, gas_price, gas, to, value, data)
+
+    @classmethod
+    def new_transaction(
+            cls,
+            nonce: int,
+            gas_price: int,
+            gas: int,
+            to: Address,
+            value: int,
+            data: bytes,
+            v: int,
+            r: int,
+            s: int) -> SignedTransactionAPI:
+        return cls.legacy_signed(nonce, gas_price, gas, to, value, data, v, r, s)

--- a/eth/vm/forks/byzantium/blocks.py
+++ b/eth/vm/forks/byzantium/blocks.py
@@ -14,9 +14,9 @@ from .transactions import (
 
 
 class ByzantiumBlock(SpuriousDragonBlock):
-    transaction_class = ByzantiumTransaction
+    transaction_builder = ByzantiumTransaction
     fields = [
         ('header', BlockHeader),
-        ('transactions', CountableList(transaction_class)),
+        ('transactions', CountableList(transaction_builder)),
         ('uncles', CountableList(BlockHeader))
     ]

--- a/eth/vm/forks/constantinople/blocks.py
+++ b/eth/vm/forks/constantinople/blocks.py
@@ -14,9 +14,9 @@ from .transactions import (
 
 
 class ConstantinopleBlock(ByzantiumBlock):
-    transaction_class = ConstantinopleTransaction
+    transaction_builder = ConstantinopleTransaction
     fields = [
         ('header', BlockHeader),
-        ('transactions', CountableList(transaction_class)),
+        ('transactions', CountableList(transaction_builder)),
         ('uncles', CountableList(BlockHeader))
     ]

--- a/eth/vm/forks/frontier/blocks.py
+++ b/eth/vm/forks/frontier/blocks.py
@@ -26,6 +26,7 @@ from eth.abc import (
     ChainDatabaseAPI,
     ReceiptAPI,
     SignedTransactionAPI,
+    TransactionBuilderAPI,
 )
 from eth.constants import (
     EMPTY_UNCLE_HASH,
@@ -50,10 +51,10 @@ from .transactions import (
 
 
 class FrontierBlock(BaseBlock):
-    transaction_class = FrontierTransaction
+    transaction_builder = FrontierTransaction
     fields = [
         ('header', BlockHeader),
-        ('transactions', CountableList(transaction_class)),
+        ('transactions', CountableList(transaction_builder)),
         ('uncles', CountableList(BlockHeader))
     ]
 
@@ -92,8 +93,8 @@ class FrontierBlock(BaseBlock):
     # Transaction class for this block class
     #
     @classmethod
-    def get_transaction_class(cls) -> Type[SignedTransactionAPI]:
-        return cls.transaction_class
+    def get_transaction_builder(cls) -> Type[TransactionBuilderAPI]:
+        return cls.transaction_builder
 
     #
     # Receipts API
@@ -120,7 +121,7 @@ class FrontierBlock(BaseBlock):
                 raise BlockNotFound(f"Uncles not found in database for {header}: {exc}") from exc
 
         try:
-            transactions = chaindb.get_block_transactions(header, cls.get_transaction_class())
+            transactions = chaindb.get_block_transactions(header, cls.get_transaction_builder())
         except MissingTrieNode as exc:
             raise BlockNotFound(f"Transactions not found in database for {header}: {exc}") from exc
 

--- a/eth/vm/forks/frontier/transactions.py
+++ b/eth/vm/forks/frontier/transactions.py
@@ -8,6 +8,9 @@ from eth_typing import (
     Address,
 )
 
+from eth.abc import (
+    SignedTransactionAPI,
+)
 from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
     GAS_TX,
@@ -111,6 +114,20 @@ class FrontierTransaction(BaseTransaction):
                                     value: int,
                                     data: bytes) -> 'FrontierUnsignedTransaction':
         return FrontierUnsignedTransaction(nonce, gas_price, gas, to, value, data)
+
+    @classmethod
+    def new_transaction(
+            cls,
+            nonce: int,
+            gas_price: int,
+            gas: int,
+            to: Address,
+            value: int,
+            data: bytes,
+            v: int,
+            r: int,
+            s: int) -> SignedTransactionAPI:
+        return cls(nonce, gas_price, gas, to, value, data, v, r, s)
 
 
 class FrontierUnsignedTransaction(BaseUnsignedTransaction):

--- a/eth/vm/forks/homestead/blocks.py
+++ b/eth/vm/forks/homestead/blocks.py
@@ -13,9 +13,9 @@ from .transactions import (
 
 
 class HomesteadBlock(FrontierBlock):
-    transaction_class = HomesteadTransaction
+    transaction_builder = HomesteadTransaction
     fields = [
         ('header', BlockHeader),
-        ('transactions', CountableList(transaction_class)),
+        ('transactions', CountableList(transaction_builder)),
         ('uncles', CountableList(BlockHeader))
     ]

--- a/eth/vm/forks/istanbul/blocks.py
+++ b/eth/vm/forks/istanbul/blocks.py
@@ -14,9 +14,9 @@ from .transactions import (
 
 
 class IstanbulBlock(PetersburgBlock):
-    transaction_class = IstanbulTransaction
+    transaction_builder = IstanbulTransaction
     fields = [
         ('header', BlockHeader),
-        ('transactions', CountableList(transaction_class)),
+        ('transactions', CountableList(transaction_builder)),
         ('uncles', CountableList(BlockHeader))
     ]

--- a/eth/vm/forks/muir_glacier/blocks.py
+++ b/eth/vm/forks/muir_glacier/blocks.py
@@ -14,9 +14,9 @@ from .transactions import (
 
 
 class MuirGlacierBlock(IstanbulBlock):
-    transaction_class = MuirGlacierTransaction
+    transaction_builder = MuirGlacierTransaction
     fields = [
         ('header', BlockHeader),
-        ('transactions', CountableList(transaction_class)),
+        ('transactions', CountableList(transaction_builder)),
         ('uncles', CountableList(BlockHeader))
     ]

--- a/eth/vm/forks/petersburg/blocks.py
+++ b/eth/vm/forks/petersburg/blocks.py
@@ -14,9 +14,9 @@ from .transactions import (
 
 
 class PetersburgBlock(ByzantiumBlock):
-    transaction_class = PetersburgTransaction
+    transaction_builder = PetersburgTransaction
     fields = [
         ('header', BlockHeader),
-        ('transactions', CountableList(transaction_class)),
+        ('transactions', CountableList(transaction_builder)),
         ('uncles', CountableList(BlockHeader))
     ]

--- a/eth/vm/forks/spurious_dragon/blocks.py
+++ b/eth/vm/forks/spurious_dragon/blocks.py
@@ -13,9 +13,9 @@ from .transactions import (
 
 
 class SpuriousDragonBlock(HomesteadBlock):
-    transaction_class = SpuriousDragonTransaction
+    transaction_builder = SpuriousDragonTransaction
     fields = [
         ('header', BlockHeader),
-        ('transactions', CountableList(transaction_class)),
+        ('transactions', CountableList(transaction_builder)),
         ('uncles', CountableList(BlockHeader))
     ]

--- a/newsfragments/1973.feature.rst
+++ b/newsfragments/1973.feature.rst
@@ -1,0 +1,2 @@
+Implement EIP-2718: Typed Transactions -- not much action here, mostly refactoring in preparation
+for EIP-2930. (Though it does churn the code a fair bit, to support multiple transaction formats)

--- a/tests/core/transaction-utils/test_transaction_encoding.py
+++ b/tests/core/transaction-utils/test_transaction_encoding.py
@@ -1,0 +1,64 @@
+from eth_utils import (
+    decode_hex,
+    to_bytes,
+)
+import pytest
+import rlp
+
+from eth.exceptions import UnrecognizedTransactionType
+from eth.vm.forks import (
+    BerlinVM,
+)
+
+UNRECOGNIZED_TRANSACTION_TYPES = tuple(
+    (to_bytes(val), UnrecognizedTransactionType)
+    for val in range(0, 0x80)
+)
+
+# These are valid RLP byte-strings, but invalid for EIP-2718
+INVALID_TRANSACTION_TYPES = tuple(
+    (rlp.encode(to_bytes(val)), rlp.exceptions.DeserializationError)
+    for val in range(0x80, 0x100)
+)
+
+
+@pytest.mark.parametrize('vm_class', [BerlinVM])
+@pytest.mark.parametrize(
+    'encoded, expected',
+    (
+        (
+            decode_hex('0xdd80010294ffffffffffffffffffffffffffffffffffffffff0380040506'),
+            dict(
+                nonce=0,
+                gas_price=1,
+                gas=2,
+                to=b'\xff' * 20,
+                value=3,
+                data=b'',
+                v=4,
+                r=5,
+                s=6,
+            ),
+        ),
+        (
+            decode_hex('0xc0'),
+            rlp.exceptions.DeserializationError,
+        ),
+    )
+    + UNRECOGNIZED_TRANSACTION_TYPES
+    + INVALID_TRANSACTION_TYPES
+)
+def test_transaction_decode(vm_class, encoded, expected):
+    sedes = vm_class.get_transaction_builder()
+    if type(expected) is type and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            rlp.decode(encoded, sedes=sedes)
+    else:
+        # Check that the given transaction encodes to the start encoding
+        expected_txn = sedes.new_transaction(**expected)
+        expected_encoding = rlp.encode(expected_txn)
+        assert encoded == expected_encoding
+
+        # Check that the encoded bytes decode to the given data
+        decoded = rlp.decode(encoded, sedes=sedes)
+        assert decoded == expected_txn

--- a/tests/database/test_eth1_chaindb.py
+++ b/tests/database/test_eth1_chaindb.py
@@ -332,7 +332,7 @@ def test_chaindb_get_receipt_and_tx_by_index(chain, funded_address, funded_addre
         if block.header.block_number == REQUIRED_BLOCK_NUMBER:
             actual_receipt = receipts[REQUIRED_RECEIPT_INDEX]
             actual_tx = block.transactions[REQUIRED_RECEIPT_INDEX]
-            tx_class = block.transaction_class
+            tx_class = block.transaction_builder
 
     # Check that the receipt retrieved is indeed the actual one
     chaindb_retrieved_receipt = chain.chaindb.get_receipt_by_index(
@@ -402,7 +402,7 @@ def test_chaindb_persist_unexecuted_block(chain,
         if block.header.block_number == REQUIRED_BLOCK_NUMBER:
             actual_receipt = receipts[REQUIRED_RECEIPT_INDEX]
             actual_tx = block.transactions[REQUIRED_RECEIPT_INDEX]
-            tx_class = block.transaction_class
+            tx_class = block.transaction_builder
 
         if use_persist_unexecuted_block:
             second_chain.chaindb.persist_unexecuted_block(block, receipts)

--- a/tests/json-fixtures/test_transactions.py
+++ b/tests/json-fixtures/test_transactions.py
@@ -37,12 +37,6 @@ from eth.vm.forks.petersburg.transactions import (
 from eth.vm.forks.istanbul.transactions import (
     IstanbulTransaction
 )
-from eth.vm.forks.muir_glacier.transactions import (
-    MuirGlacierTransaction
-)
-from eth.vm.forks.berlin.transactions import (
-    BerlinTransaction
-)
 
 from eth_typing.enums import (
     ForkName
@@ -111,11 +105,7 @@ def fixture_transaction_class(fixture_data):
     elif fork_name == ForkName.ConstantinopleFix:
         return PetersburgTransaction
     elif fork_name == ForkName.Istanbul:
-        return IstanbulTransaction
-    elif fork_name == ForkName.MuirGlacier:
-        return MuirGlacierTransaction
-    elif fork_name == ForkName.Berlin:
-        return BerlinTransaction
+        return IstanbulTransaction  # There seem to be no new transaction tests since Istanbul
     elif fork_name == ForkName.Metropolis:
         pytest.skip("Metropolis Transaction class has not been implemented")
     else:


### PR DESCRIPTION
### What was wrong?

Fixes #1973 

### How was it fixed?

Uses the basic structure from https://github.com/ethereum/pyrlp/pull/131 to enable dynamic encodings. It kicks the can down the road a bit to #1975 for actually supported any specific typed transactions, since they aren't defined until then.

Had to split the transaction responsibility up a bit: isolated a transaction builder/serializer from the actual transaction API. It causes some code churn, but not quite as much as I feared.

### To-Do

- [x] Rebase on #1977 after merge
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcScIojovOcjkUlsquJSwqfN_p2AWuGkiC59yg&usqp=CAU)
