### PR TITLE
Fix uncle timestamp check against its parent

### DIFF
--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -634,10 +634,10 @@ class VM(Configurable, VirtualMachineAPI):
                 f"Uncle number ({uncle.block_number}) is not one above "
                 f"ancestor's number ({uncle_parent.block_number})"
             )
-        if uncle.timestamp < uncle_parent.timestamp:
+        if uncle.timestamp <= uncle_parent.timestamp:
             raise ValidationError(
-                f"Uncle timestamp ({uncle.timestamp}) is before "
-                f"ancestor's timestamp ({uncle_parent.timestamp})"
+                f"Uncle timestamp ({uncle.timestamp}) is not newer than its "
+                f"parent's timestamp ({uncle_parent.timestamp})"
             )
         if uncle.gas_used > uncle.gas_limit:
             raise ValidationError(

--- a/newsfragments/1979.bugfix.rst
+++ b/newsfragments/1979.bugfix.rst
@@ -1,0 +1,2 @@
+Uncles with the same timestamp as their parents are invalid. Reject them, and add the test from
+ethereum/tests.

--- a/tests/json-fixtures/test_blockchain.py
+++ b/tests/json-fixtures/test_blockchain.py
@@ -196,12 +196,6 @@ INCORRECT_UPSTREAM_TESTS = {
     # but only in Istanbul, not in Constantinople.
     ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d2g0v0_Istanbul'),
     ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d3g0v0_Istanbul'),
-    # It's not clear how or why this test changed. It doesn't make sense that it only tests Istanbul
-    # either. See: https://github.com/ethereum/tests/issues/787
-    # The test seems to claim to test what happens if the uncle timestamp is the same as
-    # the block, but the RLP doesn't encode a matching timestamp.
-    ('InvalidBlocks/bcUncleHeaderValidity/incorrectUncleTimestamp.json', 'incorrectUncleTimestamp_Istanbul'),  # noqa: E501
-    ('InvalidBlocks/bcUncleHeaderValidity/incorrectUncleTimestamp.json', 'incorrectUncleTimestamp_Berlin'),  # noqa: E501
 }
 
 


### PR DESCRIPTION
### What was wrong?

The uncle header may not have the same timestamp as its parent. I ignored the test at first due to https://github.com/ethereum/tests/issues/787 - but it turns out the test is correct.

### How was it fixed?

Update the inequality, and stop ignoring the valid test.
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.queensland.com/au/en/places-to-see/experiences/nature-and-wildlife/cute-baby-animals-at-australia-zoo.thumb.800.480.png?ck=1599610055)
