### PR TITLE
Fixed: Outdated py-evm version in Guide Doc - #1983

### DIFF
--- a/docs/guides/building_an_app_that_uses_pyevm.rst
+++ b/docs/guides/building_an_app_that_uses_pyevm.rst
@@ -41,7 +41,7 @@ and change the ``install_requires`` section as follows.
 
   install_requires=[
       "eth-utils>=1,<2",
-      "py-evm==0.2.0a40",
+      "py-evm==0.3.0a20",
   ],
 
 .. warning::


### PR DESCRIPTION
* OS: macOS 11.2.2
* Python Version (python --version): Python 3.6.13

### What is wrong?

1. Guide Doc [building_an_app_that_uses_pyevm](https://py-evm.readthedocs.io/en/latest/guides/building_an_app_that_uses_pyevm.html#add-the-py-evm-library-as-a-dependency) is outdated, py-evm old version `0.2.0a40` causes script below to fail.
> chain.get_vm().state.get_balance(MOCK_ADDRESS)

2. "Edit on GitHub" link redirects to 404 page.
> https://py-evm.readthedocs.io/en/latest/guides/building_an_app_that_uses_pyevm.html

 
### How can it be fixed
Update py-evm in doc to the latest version "py-evm==0.3.0a20"
https://github.com/ethereum/py-evm/blob/master/docs/guides/building_an_app_that_uses_pyevm.rst


