### PR TITLE
Update ethereum/tests to v8.0.1

### DIFF
--- a/newsfragments/1987.internal.rst
+++ b/newsfragments/1987.internal.rst
@@ -1,0 +1,1 @@
+Update ethereum/tests to v8.0.1


### PR DESCRIPTION
### What was wrong?

Tests were running against ethereum/tests v7. 

### How was it fixed?
Updated the commit hash in the fixtures directory!

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/110706058-80353880-81b4-11eb-90ac-ceb1f1531beb.png)

