### PR TITLE
Calculate modexp gas fee correctly EIP-2565

### DIFF
--- a/eth/precompiles/modexp.py
+++ b/eth/precompiles/modexp.py
@@ -27,8 +27,8 @@ from eth.vm.computation import (
 )
 
 
-def compute_adjusted_exponent_length(exponent_length: int,
-                                     first_32_exponent_bytes: bytes) -> int:
+def _compute_adjusted_exponent_length(exponent_length: int,
+                                      first_32_exponent_bytes: bytes) -> int:
     exponent = big_endian_to_int(first_32_exponent_bytes)
 
     if exponent_length <= 32 and exponent == 0:
@@ -75,7 +75,7 @@ def _compute_modexp_gas_fee_eip_198(data: bytes) -> int:
         data[96 + base_length:96 + base_length + exponent_length],
         to_size=min(exponent_length, 32),
     )[:32]
-    adjusted_exponent_length = compute_adjusted_exponent_length(
+    adjusted_exponent_length = _compute_adjusted_exponent_length(
         exponent_length,
         first_32_exponent_bytes,
     )

--- a/eth/vm/forks/berlin/computation.py
+++ b/eth/vm/forks/berlin/computation.py
@@ -1,16 +1,21 @@
 import math
 
+from eth_utils import (
+    big_endian_to_int,
+)
 from eth_utils.toolz import (
     merge,
 )
 
 from eth.precompiles.modexp import (
-    compute_adjusted_exponent_length,
     extract_lengths,
     modexp,
 )
 from eth._utils.address import (
     force_bytes_to_address,
+)
+from eth._utils.numeric import (
+    get_highest_bit_index,
 )
 from eth._utils.padding import (
     zpad_right,
@@ -34,19 +39,36 @@ def _calculate_multiplication_complexity(base_length: int, modulus_length: int) 
     return words**2
 
 
+def _calculate_iteration_count(exponent_length: int, first_32_exponent_bytes: bytes) -> int:
+    iteration_count = 0
+    exponent = big_endian_to_int(first_32_exponent_bytes)
+
+    if exponent_length <= 32 and exponent == 0:
+        iteration_count = 0
+    elif exponent_length <= 32:
+        iteration_count = get_highest_bit_index(exponent)
+    else:
+        iteration_count = (
+            8 * (exponent_length - 32)) + (get_highest_bit_index(exponent & (2**256 - 1)))
+    return max(iteration_count, 1)
+
+
 def _compute_modexp_gas_fee_eip_2565(data: bytes) -> int:
     base_length, exponent_length, modulus_length = extract_lengths(data)
 
     base_end_idx = 96 + base_length
     exponent_end_idx = base_end_idx + exponent_length
 
-    exponent_bytes = zpad_right(
+    first_32_exponent_bytes = zpad_right(
         data[base_end_idx:exponent_end_idx],
-        to_size=exponent_length,
+        to_size=min(exponent_length, 32),
+    )[:32]
+    iteration_count = _calculate_iteration_count(
+        exponent_length,
+        first_32_exponent_bytes,
     )
 
     multiplication_complexity = _calculate_multiplication_complexity(base_length, modulus_length)
-    iteration_count = compute_adjusted_exponent_length(exponent_length, exponent_bytes)
     return max(200,
                multiplication_complexity * iteration_count
                // constants.GAS_MOD_EXP_QUADRATIC_DENOMINATOR_EIP_2565)

--- a/eth/vm/forks/berlin/computation.py
+++ b/eth/vm/forks/berlin/computation.py
@@ -40,16 +40,15 @@ def _calculate_multiplication_complexity(base_length: int, modulus_length: int) 
 
 
 def _calculate_iteration_count(exponent_length: int, first_32_exponent_bytes: bytes) -> int:
-    iteration_count = 0
-    exponent = big_endian_to_int(first_32_exponent_bytes)
+    first_32_exponent = big_endian_to_int(first_32_exponent_bytes)
 
-    if exponent_length <= 32 and exponent == 0:
-        iteration_count = 0
-    elif exponent_length <= 32:
-        iteration_count = get_highest_bit_index(exponent)
+    highest_bit_index = get_highest_bit_index(first_32_exponent)
+
+    if exponent_length <= 32:
+        iteration_count = highest_bit_index
     else:
-        iteration_count = (
-            8 * (exponent_length - 32)) + (get_highest_bit_index(exponent & (2**256 - 1)))
+        iteration_count = highest_bit_index + (8 * (exponent_length - 32))
+
     return max(iteration_count, 1)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands=
     native-blockchain-constantinople: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Constantinople}
     native-blockchain-petersburg: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork ConstantinopleFix}
     native-blockchain-istanbul: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Istanbul}
-    native-blockchain-berlin: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py -k "not modexp" --fork Berlin}
+    native-blockchain-berlin: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Berlin}
     native-blockchain-metropolis: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Metropolis}
     native-blockchain-transition: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py -k BlockchainTests/TransitionTests}
     lint: flake8 {toxinidir}/eth {toxinidir}/tests {toxinidir}/scripts


### PR DESCRIPTION
### What was wrong?
Modexp wasn't being calculated quite correctly. 


### How was it fixed?
Removed reuse of `compute_adjusted_exponent_length`, and made a new method called `calculate_iteration_count` that's pulled pretty much verbatim from [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md) - @carver do we want a release note for this? Happy to add one if so!

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/6540608/111523871-600bf900-8721-11eb-80d0-fec7e1c656e1.png)

