### PR TITLE
Run Berlin ethethereum/tests, except for modexp-related ones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,7 @@ workflows:
   test:
     jobs:
       - py36-benchmark
+      - py36-native-blockchain-berlin
       - py36-native-blockchain-byzantium
       - py36-native-blockchain-constantinople
       - py36-native-blockchain-frontier

--- a/eth/tools/rlp.py
+++ b/eth/tools/rlp.py
@@ -15,7 +15,7 @@ assert_imported_genesis_header_unchanged = replace_exceptions({
 
 assert_mined_block_unchanged = replace_exceptions({
     ValidationError: AssertionError,
-})(validate_rlp_equal(obj_a_name='block', obj_b_name='mined block'))
+})(validate_rlp_equal(obj_a_name='provided block', obj_b_name='executed block'))
 
 
 assert_headers_eq = replace_exceptions({

--- a/newsfragments/1991.internal.rst
+++ b/newsfragments/1991.internal.rst
@@ -1,0 +1,1 @@
+py-evm PRs now run Berlin integration tests, indicating Berlin-readiness (except for modexp)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts= --showlocals --durations 10
+addopts= --showlocals --durations 50
 python_paths= .
 xfail_strict=true
 log_format = %(levelname)8s  %(asctime)s  %(filename)20s  %(message)s

--- a/tests/json-fixtures/blockchain/test_blockchain.py
+++ b/tests/json-fixtures/blockchain/test_blockchain.py
@@ -198,6 +198,7 @@ INCORRECT_UPSTREAM_TESTS = {
     ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_Constantinople'),  # noqa: E501
     ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_ConstantinopleFix'),  # noqa: E501
     ('GeneralStateTests/stRevertTest/RevertInCreateInInit.json', 'RevertInCreateInInit_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stRevertTest/RevertInCreateInInit.json', 'RevertInCreateInInit_d0g0v0_Berlin'),  # noqa: E501
 
     # The CREATE2 variant seems to have been derived from the one above - it, too,
     # has a "synthetic" state, on which py-evm flips.
@@ -205,6 +206,7 @@ INCORRECT_UPSTREAM_TESTS = {
     ('GeneralStateTests/stCreate2/RevertInCreateInInitCreate2_d0g0v0.json', 'RevertInCreateInInitCreate2_d0g0v0_Constantinople'),  # noqa: E501
     ('GeneralStateTests/stCreate2/RevertInCreateInInitCreate2_d0g0v0.json', 'RevertInCreateInInitCreate2_d0g0v0_ConstantinopleFix'),  # noqa: E501
     ('GeneralStateTests/stCreate2/RevertInCreateInInitCreate2.json', 'RevertInCreateInInitCreate2_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stCreate2/RevertInCreateInInitCreate2.json', 'RevertInCreateInInitCreate2_d0g0v0_Berlin'),  # noqa: E501
 
     # Four variants have been specifically added to test a collision type
     # like the above; therefore, they fail in the same manner.
@@ -219,14 +221,15 @@ INCORRECT_UPSTREAM_TESTS = {
     ('GeneralStateTests/stSStoreTest/InitCollision_d1g0v0.json', 'InitCollision_d1g0v0_ConstantinopleFix'),  # noqa: E501
     ('GeneralStateTests/stSStoreTest/InitCollision_d3g0v0.json', 'InitCollision_d3g0v0_ConstantinopleFix'),  # noqa: E501
     ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d0g0v0_Istanbul'),  # noqa: E501
-    # Perhaps even stranger, d2 starts failing again after fixing a long-hidden consensus bug
-    # but not in Constantinople, only in Istanbul.
-    ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d2g0v0_Istanbul'),
     ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d1g0v0_Istanbul'),
     # The d2 variant started failing again after fixing a long-hidden consensus bug
     # but only in Istanbul, not in Constantinople.
     ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d2g0v0_Istanbul'),
     ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d3g0v0_Istanbul'),
+    ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d0g0v0_Berlin'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d1g0v0_Berlin'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d2g0v0_Berlin'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d3g0v0_Berlin'),  # noqa: E501
 }
 
 

--- a/tests/json-fixtures/blockchain/test_blockchain.py
+++ b/tests/json-fixtures/blockchain/test_blockchain.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import pytest
 import rlp
 
@@ -30,7 +31,7 @@ from eth.tools.fixtures import (
 )
 
 
-ROOT_PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+ROOT_PROJECT_DIR = Path(__file__).parents[3]
 
 
 BASE_FIXTURE_PATH = os.path.join(ROOT_PROJECT_DIR, 'fixtures', 'BlockchainTests')
@@ -296,13 +297,13 @@ def test_blockchain_fixtures(fixture_data, fixture):
             continue
 
         if should_be_good_block:
-            (block, mined_block, block_rlp) = apply_fixture_block_to_chain(
+            (original_block, executed_block, block_rlp) = apply_fixture_block_to_chain(
                 block_fixture,
                 chain,
                 perform_validation=False  # we manually validate below
             )
-            assert_mined_block_unchanged(block, mined_block)
-            chain.validate_block(block)
+            assert_mined_block_unchanged(original_block, executed_block)
+            chain.validate_block(original_block)
         else:
             try:
                 apply_fixture_block_to_chain(block_fixture, chain)

--- a/tests/json-fixtures/blockchain/test_blockchain.py
+++ b/tests/json-fixtures/blockchain/test_blockchain.py
@@ -43,6 +43,7 @@ BASE_FIXTURE_PATH = os.path.join(ROOT_PROJECT_DIR, 'fixtures', 'BlockchainTests'
 # Then sort alphabetically, to reduce churn (lines just being pushed up/down).
 SLOWEST_TESTS = {
     ('GeneralStateTests/stAttackTest/ContractCreationSpam.json', 'ContractCreationSpam_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stAttackTest/ContractCreationSpam.json', 'ContractCreationSpam_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stCallCreateCallCodeTest/Call1024BalanceTooLow.json', 'Call1024BalanceTooLow_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stCallCreateCallCodeTest/Call1024PreCalls.json', 'Call1024PreCalls_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stCallCreateCallCodeTest/Call1024PreCalls.json', 'Call1024PreCalls_d0g1v0_Istanbul'),  # noqa: E501
@@ -54,7 +55,9 @@ SLOWEST_TESTS = {
     ('GeneralStateTests/stChangedEIP150/Callcode1024BalanceTooLow.json', 'Callcode1024BalanceTooLow_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stCreate2/Create2OnDepth1024.json', 'Create2OnDepth1024_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stCreate2/Create2Recursive.json', 'Create2Recursive_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stCreate2/Create2Recursive.json', 'Create2Recursive_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stCreate2/Create2Recursive.json', 'Create2Recursive_d0g1v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stCreate2/Create2Recursive.json', 'Create2Recursive_d0g1v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stDelegatecallTestHomestead/Call1024BalanceTooLow.json', 'Call1024BalanceTooLow_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stDelegatecallTestHomestead/Call1024PreCalls.json', 'Call1024PreCalls_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stDelegatecallTestHomestead/Call1024PreCalls.json', 'Call1024PreCalls_d0g1v0_Istanbul'),  # noqa: E501
@@ -68,7 +71,9 @@ SLOWEST_TESTS = {
     ('GeneralStateTests/stRevertTest/LoopCallsDepthThenRevert2.json', 'LoopCallsDepthThenRevert2_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stRevertTest/LoopCallsDepthThenRevert3.json', 'LoopCallsDepthThenRevert3_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stRevertTest/LoopCallsThenRevert.json', 'LoopCallsThenRevert_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stRevertTest/LoopCallsThenRevert.json', 'LoopCallsThenRevert_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stRevertTest/LoopCallsThenRevert.json', 'LoopCallsThenRevert_d0g1v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stRevertTest/LoopCallsThenRevert.json', 'LoopCallsThenRevert_d0g1v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stShift/shiftCombinations.json', 'shiftCombinations_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call1024BalanceTooLow.json', 'static_Call1024BalanceTooLow_d1g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call1024BalanceTooLow2.json', 'static_Call1024BalanceTooLow2_d1g0v0_Istanbul'),  # noqa: E501
@@ -78,15 +83,25 @@ SLOWEST_TESTS = {
     ('GeneralStateTests/stStaticCall/static_Call1024PreCalls3.json', 'static_Call1024PreCalls3_d1g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call1MB1024Calldepth.json', 'static_Call1MB1024Calldepth_d1g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000.json', 'static_Call50000_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Call50000.json', 'static_Call50000_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000.json', 'static_Call50000_d1g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Call50000.json', 'static_Call50000_d1g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000_ecrec.json', 'static_Call50000_ecrec_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Call50000_ecrec.json', 'static_Call50000_ecrec_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000_ecrec.json', 'static_Call50000_ecrec_d1g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Call50000_ecrec.json', 'static_Call50000_ecrec_d1g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000_identity.json', 'static_Call50000_identity_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Call50000_identity.json', 'static_Call50000_identity_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000_identity.json', 'static_Call50000_identity_d1g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Call50000_identity.json', 'static_Call50000_identity_d1g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000_identity2.json', 'static_Call50000_identity2_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Call50000_identity2.json', 'static_Call50000_identity2_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000_identity2.json', 'static_Call50000_identity2_d1g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Call50000_identity2.json', 'static_Call50000_identity2_d1g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000_rip160.json', 'static_Call50000_rip160_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Call50000_rip160.json', 'static_Call50000_rip160_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000_rip160.json', 'static_Call50000_rip160_d1g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Call50000_rip160.json', 'static_Call50000_rip160_d1g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000bytesContract50_1.json', 'static_Call50000bytesContract50_1_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000bytesContract50_1.json', 'static_Call50000bytesContract50_1_d1g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Call50000bytesContract50_2.json', 'static_Call50000bytesContract50_2_d0g0v0_Istanbul'),  # noqa: E501
@@ -94,12 +109,18 @@ SLOWEST_TESTS = {
     ('GeneralStateTests/stStaticCall/static_LoopCallsDepthThenRevert2.json', 'static_LoopCallsDepthThenRevert2_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_LoopCallsDepthThenRevert3.json', 'static_LoopCallsDepthThenRevert3_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_LoopCallsThenRevert.json', 'static_LoopCallsThenRevert_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_LoopCallsThenRevert.json', 'static_LoopCallsThenRevert_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_LoopCallsThenRevert.json', 'static_LoopCallsThenRevert_d0g1v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_LoopCallsThenRevert.json', 'static_LoopCallsThenRevert_d0g1v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stStaticCall/static_Return50000_2.json', 'static_Return50000_2_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stStaticCall/static_Return50000_2.json', 'static_Return50000_2_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stSystemOperationsTest/CallRecursiveBomb0_OOG_atMaxCallDepth.json', 'CallRecursiveBomb0_OOG_atMaxCallDepth_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stTimeConsuming/CALLBlake2f_MaxRounds.json', 'CALLBlake2f_MaxRounds_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stTimeConsuming/CALLBlake2f_MaxRounds.json', 'CALLBlake2f_MaxRounds_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stTimeConsuming/static_Call50000_sha256.json', 'static_Call50000_sha256_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stTimeConsuming/static_Call50000_sha256.json', 'static_Call50000_sha256_d0g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stTimeConsuming/static_Call50000_sha256.json', 'static_Call50000_sha256_d1g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stTimeConsuming/static_Call50000_sha256.json', 'static_Call50000_sha256_d1g0v0_Berlin'),  # noqa: E501
     ('GeneralStateTests/stZeroKnowledge/ecpairing_one_point_fail.json', 'ecpairing_one_point_fail_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stZeroKnowledge/ecpairing_three_point_fail_1.json', 'ecpairing_three_point_fail_1_d0g0v0_Istanbul'),  # noqa: E501
     ('GeneralStateTests/stZeroKnowledge/ecpairing_three_point_match_1.json', 'ecpairing_three_point_match_1_d0g0v0_Istanbul'),  # noqa: E501
@@ -143,14 +164,23 @@ SLOWEST_TESTS = {
     ('ValidBlocks/bcStateTests/randomStatetest94.json', 'randomStatetest94_Homestead'),  # noqa: E501
     ('ValidBlocks/bcStateTests/randomStatetest94.json', 'randomStatetest94_Istanbul'),  # noqa: E501
     ('ValidBlocks/VMTests/vmPerformance/loop-add-10M.json', 'loop-add-10M_Istanbul'),
+    ('ValidBlocks/VMTests/vmPerformance/loop-add-10M.json', 'loop-add-10M_Berlin'),
     ('ValidBlocks/VMTests/vmPerformance/loop-divadd-10M.json', 'loop-divadd-10M_Istanbul'),
+    ('ValidBlocks/VMTests/vmPerformance/loop-divadd-10M.json', 'loop-divadd-10M_Berlin'),
     ('ValidBlocks/VMTests/vmPerformance/loop-divadd-unr100-10M.json', 'loop-divadd-unr100-10M_Istanbul'),  # noqa: E501
+    ('ValidBlocks/VMTests/vmPerformance/loop-divadd-unr100-10M.json', 'loop-divadd-unr100-10M_Berlin'),  # noqa: E501
     ('ValidBlocks/VMTests/vmPerformance/loop-exp-16b-100k.json', 'loop-exp-16b-100k_Istanbul'),
+    ('ValidBlocks/VMTests/vmPerformance/loop-exp-16b-100k.json', 'loop-exp-16b-100k_Berlin'),
     ('ValidBlocks/VMTests/vmPerformance/loop-exp-1b-1M.json', 'loop-exp-1b-1M_Istanbul'),
+    ('ValidBlocks/VMTests/vmPerformance/loop-exp-1b-1M.json', 'loop-exp-1b-1M_Berlin'),
     ('ValidBlocks/VMTests/vmPerformance/loop-exp-32b-100k.json', 'loop-exp-32b-100k_Istanbul'),
+    ('ValidBlocks/VMTests/vmPerformance/loop-exp-32b-100k.json', 'loop-exp-32b-100k_Berlin'),
     ('ValidBlocks/VMTests/vmPerformance/loop-exp-nop-1M.json', 'loop-exp-nop-1M_Istanbul'),
+    ('ValidBlocks/VMTests/vmPerformance/loop-exp-nop-1M.json', 'loop-exp-nop-1M_Berlin'),
     ('ValidBlocks/VMTests/vmPerformance/loop-mul.json', 'loop-mul_Istanbul'),
+    ('ValidBlocks/VMTests/vmPerformance/loop-mul.json', 'loop-mul_Berlin'),
     ('ValidBlocks/VMTests/vmPerformance/loop-mulmod-2M.json', 'loop-mulmod-2M_Istanbul'),
+    ('ValidBlocks/VMTests/vmPerformance/loop-mulmod-2M.json', 'loop-mulmod-2M_Berlin'),
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     py{36,37,38}-{core,database,transactions,vm}
     py36-benchmark
-    py36-native-blockchain-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul,metropolis,transition}
+    py36-native-blockchain-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul,berlin,metropolis,transition}
     py{36,37,38}-lint
     py36-docs
 
@@ -34,7 +34,7 @@ commands=
     native-blockchain-constantinople: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Constantinople}
     native-blockchain-petersburg: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork ConstantinopleFix}
     native-blockchain-istanbul: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Istanbul}
-    native-blockchain-berlin: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Berlin}
+    native-blockchain-berlin: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py -k "not modexp" --fork Berlin}
     native-blockchain-metropolis: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Metropolis}
     native-blockchain-transition: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py -k BlockchainTests/TransitionTests}
     lint: flake8 {toxinidir}/eth {toxinidir}/tests {toxinidir}/scripts

--- a/tox.ini
+++ b/tox.ini
@@ -26,17 +26,17 @@ commands=
     database: pytest {posargs:tests/database}
     transactions: pytest {posargs:tests/json-fixtures/test_transactions.py}
     vm: pytest {posargs:tests/json-fixtures/test_virtual_machine.py}
-    native-blockchain-frontier: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Frontier}
-    native-blockchain-homestead: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Homestead}
-    native-blockchain-tangerine_whistle: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork EIP150}
-    native-blockchain-spurious_dragon: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork EIP158}
-    native-blockchain-byzantium: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Byzantium}
-    native-blockchain-constantinople: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Constantinople}
-    native-blockchain-petersburg: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork ConstantinopleFix}
-    native-blockchain-istanbul: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Istanbul}
-    native-blockchain-berlin: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Berlin}
-    native-blockchain-metropolis: pytest {posargs:tests/json-fixtures/test_blockchain.py --fork Metropolis}
-    native-blockchain-transition: pytest {posargs:tests/json-fixtures/test_blockchain.py -k BlockchainTests/TransitionTests}
+    native-blockchain-frontier: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Frontier}
+    native-blockchain-homestead: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Homestead}
+    native-blockchain-tangerine_whistle: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork EIP150}
+    native-blockchain-spurious_dragon: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork EIP158}
+    native-blockchain-byzantium: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Byzantium}
+    native-blockchain-constantinople: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Constantinople}
+    native-blockchain-petersburg: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork ConstantinopleFix}
+    native-blockchain-istanbul: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Istanbul}
+    native-blockchain-berlin: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Berlin}
+    native-blockchain-metropolis: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Metropolis}
+    native-blockchain-transition: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py -k BlockchainTests/TransitionTests}
     lint: flake8 {toxinidir}/eth {toxinidir}/tests {toxinidir}/scripts
     lint: mypy -p eth --config-file {toxinidir}/mypy.ini
 


### PR DESCRIPTION
### What was wrong?

Need to run Berlin tests #1991

(Can't close the issue until #1988 and maybe other modexp issues are solved)

### How was it fixed?

When #1988 is resolved, remove the `-k "not modexp"`. (Presumably in a different PR, depending on merge order)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] Rebase on #1986 

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/7c/10/54/7c105472302849b2e0e957a1523742f0.png)