### PR TITLE
Fix get receipt from chain

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -1078,7 +1078,7 @@ class ChainDatabaseAPI(HeaderDatabaseAPI):
     def get_block_transactions(
             self,
             block_header: BlockHeaderAPI,
-            transaction_builder: Type[TransactionBuilderAPI]) -> Tuple[SignedTransactionAPI, ...]:
+            transaction_decoder: Type[TransactionDecoderAPI]) -> Tuple[SignedTransactionAPI, ...]:
         """
         Return an iterable of transactions for the block speficied by the
         given block header.
@@ -1096,7 +1096,7 @@ class ChainDatabaseAPI(HeaderDatabaseAPI):
     def get_receipt_by_index(self,
                              block_number: BlockNumber,
                              receipt_index: int,
-                             receipt_builder: Type[ReceiptBuilderAPI]) -> ReceiptAPI:
+                             receipt_decoder: Type[ReceiptDecoderAPI]) -> ReceiptAPI:
         """
         Return the receipt of the transaction at specified index
         for the block header obtained by the specified block number
@@ -1106,7 +1106,7 @@ class ChainDatabaseAPI(HeaderDatabaseAPI):
     @abstractmethod
     def get_receipts(self,
                      header: BlockHeaderAPI,
-                     receipt_class: Type[ReceiptBuilderAPI]) -> Tuple[ReceiptAPI, ...]:
+                     receipt_decoder: Type[ReceiptDecoderAPI]) -> Tuple[ReceiptAPI, ...]:
         """
         Return a tuple of receipts for the block specified by the given
         block header.
@@ -1118,7 +1118,7 @@ class ChainDatabaseAPI(HeaderDatabaseAPI):
             self,
             block_number: BlockNumber,
             transaction_index: int,
-            transaction_builder: Type[TransactionBuilderAPI]) -> SignedTransactionAPI:
+            transaction_decoder: Type[TransactionDecoderAPI]) -> SignedTransactionAPI:
         """
         Return the transaction at the specified `transaction_index` from the
         block specified by `block_number` from the canonical chain.

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -427,9 +427,9 @@ class Chain(BaseChain):
         vm = self.get_vm_class_for_block_number(block_number)
 
         receipt = self.chaindb.get_receipt_by_index(
-            block_number=block_number,
-            receipt_index=index,
-            receipt_builder=vm.get_receipt_builder(),
+            block_number,
+            index,
+            vm.get_receipt_builder(),
         )
 
         return receipt

--- a/newsfragments/1994.bugfix.rst
+++ b/newsfragments/1994.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a crash in :meth:`eth.chains.base.Chain.get_transaction_receipt` and
+:meth:`eth.chains.base.Chain.get_transaction_receipt_by_index` that resulted in this exception:
+``TypeError: get_receipt_by_index() got an unexpected keyword argument 'receipt_builder'``


### PR DESCRIPTION
### What was wrong?

There was a bug when loading a the receipt from the chain object. (and apparently no test for it!)

### How was it fixed?

Added a test, fixed the bug.

Note that the `ChainDB` uses the keyword `receipt_decoder` instead of `receipt_builder` (and the same for `transaction_decoder`), because it *only* uses the "decode from bytestring" API. It doesn't use the full RLP serialize/deserialize functionality.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/5d/4d/b8/5d4db826718ec056fa015eb071e1d048.jpg)
