### PR TITLE
Make type_id accessible on all transactions

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -534,6 +534,17 @@ class SignedTransactionAPI(BaseTransactionAPI, TransactionFieldsAPI):
         """
         ...
 
+    type_id: Optional[int]
+    """
+    The type of EIP-2718 transaction
+
+    Each EIP-2718 transaction includes a type id (which is the leading
+    byte, as encoded).
+
+    If this transaction is a legacy transaction, that it has no type. Then,
+    type_id will be None.
+    """
+
     # +-------------------------------------------------------------+
     # | API that must be implemented by all Transaction subclasses. |
     # +-------------------------------------------------------------+

--- a/eth/rlp/transactions.py
+++ b/eth/rlp/transactions.py
@@ -76,6 +76,8 @@ class BaseTransactionFields(rlp.Serializable, TransactionFieldsAPI):
 
 
 class SignedTransactionMethods(BaseTransactionMethods, SignedTransactionAPI):
+    type_id: Optional[int] = None
+
     @cached_property
     def sender(self) -> Address:
         return self.get_sender()

--- a/eth/vm/forks/berlin/transactions.py
+++ b/eth/vm/forks/berlin/transactions.py
@@ -221,7 +221,6 @@ class AccessListPayloadDecoder(TransactionDecoderAPI):
 
 
 class TypedTransaction(SignedTransactionMethods, SignedTransactionAPI, TransactionDecoderAPI):
-    type_id: int
     rlp_type = Binary(min_length=1)  # must have at least one byte for the type
     _inner: SignedTransactionAPI
 

--- a/newsfragments/1996.feature.rst
+++ b/newsfragments/1996.feature.rst
@@ -1,0 +1,1 @@
+Expose a ``type_id`` on all transactions. It is ``None`` for legacy transactions.


### PR DESCRIPTION
### What was wrong?

The most obvious way to determine if transactions are typed is an `isinstance` call. 

### How was it fixed?

Just expose a `type_id` on all transactions instead.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/vvmMxju9xNE/maxresdefault.jpg)
