### PR TITLE
Add v to special legacy transaction API

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -380,6 +380,19 @@ class TransactionFieldsAPI(ABC):
         ...
 
 
+class LegacyTransactionFieldsAPI(TransactionFieldsAPI):
+    @property
+    @abstractmethod
+    def v(self) -> int:
+        """
+        In old transactions, this v field combines the y_parity bit and the
+        chain ID. All new usages should prefer accessing those fields directly.
+        But if you must access the original v, then you can cast to this API
+        first (after checking that type_id is None).
+        """
+        ...
+
+
 class UnsignedTransactionAPI(BaseTransactionAPI):
 
     """

--- a/eth/rlp/transactions.py
+++ b/eth/rlp/transactions.py
@@ -24,6 +24,7 @@ from eth_utils import (
 from eth.abc import (
     BaseTransactionAPI,
     ComputationAPI,
+    LegacyTransactionFieldsAPI,
     SignedTransactionAPI,
     TransactionBuilderAPI,
     TransactionFieldsAPI,
@@ -103,12 +104,20 @@ class SignedTransactionMethods(BaseTransactionMethods, SignedTransactionAPI):
             return True
 
 
-class BaseTransaction(BaseTransactionFields, SignedTransactionMethods, TransactionBuilderAPI):
+class BaseTransaction(
+        LegacyTransactionFieldsAPI,
+        BaseTransactionFields,
+        SignedTransactionMethods,
+        TransactionBuilderAPI):
     # "Legacy" transactions implemented by BaseTransaction are a combination of
     # the transaction codec (TransactionBuilderAPI) *and* the transaction
     # object (SignedTransactionAPI). In a multi-transaction-type world, that
     # becomes less desirable, and that responsibility splits up. See Berlin
     # transactions, for example.
+
+    # Note that it includes at least one legacy field (v) that is not
+    # explicitly accessible in new transaction types. See the v docstring in
+    # LegacyTransactionFieldsAPI for more.
 
     # this is duplicated to make the rlp library happy, otherwise it complains
     # about no fields being defined but inheriting from multiple `Serializable`

--- a/newsfragments/1997.feature.rst
+++ b/newsfragments/1997.feature.rst
@@ -1,0 +1,1 @@
+Add new LegacyTransactionFieldsAPI, with a v field for callers that want to access v directly.


### PR DESCRIPTION
### What was wrong?

Type-checking complains about accessing `v` on legacy transactions.

### How was it fixed?

Add an API that a transaction can be cast to, if `type_id` is `None`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2016/10/fb_image_5808c83fa24c1__700.jpg)
