### PR TITLE
Update blake2b-py version requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.0
 
-# heavily inspired by: 
+# heavily inspired by:
 # https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
 
 common: &common
@@ -205,6 +205,37 @@ jobs:
         environment:
           TOXENV: py38-lint
 
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core
+  py39-database:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-database
+  py39-transactions:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-transactions
+  py39-vm:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-vm
+  py39-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-lint
+
 workflows:
   version: 2
   test:
@@ -223,16 +254,21 @@ workflows:
       - py36-vm
       - py37-vm
       - py38-vm
+      - py39-vm
       - py36-core
       - py37-core
       - py38-core
+      - py39-core
       - py36-transactions
       - py37-transactions
       - py38-transactions
+      - py39-transactions
       - py36-database
       - py37-database
       - py38-database
+      - py39-database
       - py36-docs
       - py36-lint
       - py37-lint
       - py38-lint
+      - py39-lint

--- a/newsfragments/1999.feature.rst
+++ b/newsfragments/1999.feature.rst
@@ -1,0 +1,1 @@
+Add Python 3.9 support

--- a/newsfragments/1999.misc.rst
+++ b/newsfragments/1999.misc.rst
@@ -1,0 +1,1 @@
+Update blake2b-py requirement from >=0.1.2 to >=0.1.4

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 deps = {
     'eth': [
-        "blake2b-py>=0.1.2,<0.2",
+        "blake2b-py>=0.1.4,<0.2",
         "cached-property>=1.5.1,<2",
         "eth-bloom>=1.0.3,<2.0.0",
         "eth-keys>=0.2.1,<0.4.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist=
-    py{36,37,38}-{core,database,transactions,vm}
+    py{36,37,38,39}-{core,database,transactions,vm}
     py36-benchmark
     py36-native-blockchain-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul,berlin,metropolis,transition}
-    py{36,37,38}-lint
+    py{36,37,38,39}-lint
     py36-docs
 
 [flake8]
@@ -48,6 +48,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 
 
 [testenv:py36-docs]


### PR DESCRIPTION
### What was wrong?
Web3py needs blake2b-py>=0.1.4 to support python 3.9. It looks like the only libraries that require py-evm are Trinity and eth-tester, so I'm hopeful that the impacts of updating this will be minimal.


### How was it fixed?
Updated blake2b-py dep to >=0.1.4.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://www.branding.news/wp-content/uploads/2019/01/Where-Magic-Gets-Real-Disneyland-cover.jpg)
