### PR TITLE
Remove extra newsfragment

### DIFF
--- a/newsfragments/1999.feature.rst
+++ b/newsfragments/1999.feature.rst
@@ -1,1 +1,1 @@
-Add Python 3.9 support
+Adds Python 3.9 support. Update blake2b-py requirement from >=0.1.2 to >=0.1.4

--- a/newsfragments/1999.misc.rst
+++ b/newsfragments/1999.misc.rst
@@ -1,1 +1,0 @@
-Update blake2b-py requirement from >=0.1.2 to >=0.1.4


### PR DESCRIPTION
### What was wrong?
Was moving too fast and accidentally added two newsfragments for the python 3.9 PR 🤦 


### How was it fixed?
Removed the duplicate. 


#### Cute Animal Picture
![](https://www.gannett-cdn.com/presto/2019/10/03/USAT/a027273c-4c89-44fb-b896-d0121a3814a8-ANIMALKIND_GUILTY_GOLDEN_DESK_THUMB.jpg)
