### PR TITLE
Add step to quick start guide to update pip

### DIFF
--- a/docs/guides/building_an_app_that_uses_pyevm.rst
+++ b/docs/guides/building_an_app_that_uses_pyevm.rst
@@ -105,8 +105,8 @@ Next, we'll create a new directory ``app`` and create a file ``main.py`` inside.
   ... )
   The balance of address 0x0000000000000000000000000000000000000000 is 10000000000000000000000 wei
 
-Runing the script
------------------
+Running the script
+------------------
 
 Let's run the script by invoking the following command.
 

--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -28,6 +28,12 @@ we need to install the ``python3-pip`` package through the following command.
 .. note::
   .. include:: /fragments/virtualenv_explainer.rst
 
+Then, we need make to sure you have the latest version of ``pip`` so that all dependencies can be installed correctly:
+
+.. code:: sh
+
+  pip3 install -U pip
+
 Finally, we can install the ``py-evm`` package via pip.
 
 .. code:: sh
@@ -46,7 +52,13 @@ First, install Python 3 with brew:
 .. note::
   .. include:: /fragments/virtualenv_explainer.rst
 
-Then, install the ``py-evm`` package via pip:
+Then, make sure to have the latest version of ``pip`` so that all dependencies can be installed correctly:
+
+.. code:: sh
+
+  pip3 install -U pip
+
+Finally, install the ``py-evm`` package via pip:
 
 .. code:: sh
 


### PR DESCRIPTION
Hi!

### What was wrong?

When trying to install `py-evm` following the quick start guide I noticed that pip 9 (the default version installed by `apt install python3-pip` on Ubuntu 18.04) fails to install `blake2b-py` version 0.1.4. This is probably because the wheel for that version of `blake2b-py` is tagged as `manylinux2010`, whose support was introduced in PEP 571/pip 19.0.

```
ftruzzi@thinkpad:~/projects/ethereum/py-evm$ python3.8 -m venv .venv
ftruzzi@thinkpad:~/projects/ethereum/py-evm$ source .venv/bin/activate
ftruzzi@thinkpad:~/projects/ethereum/py-evm$ pip install .
Processing /home/ftruzzi/projects/ethereum/py-evm
Collecting blake2b-py<0.2,>=0.1.4 (from py-evm==0.4.0a4)
  Could not find a version that satisfies the requirement blake2b-py<0.2,>=0.1.4 (from py-evm==0.4.0a4) (from versions: 0.1.2, 0.1.3)
No matching distribution found for blake2b-py<0.2,>=0.1.4 (from py-evm==0.4.0a4)
```


### How was it fixed?

This PR updates the install docs so that users make sure they have the latest pip before trying to install `py-evm`.

#### Cute Animal Picture

Meet my cat, Topì :)

![image](https://user-images.githubusercontent.com/461133/116451511-d80b2a00-a85c-11eb-807a-032bfa5d7bed.png)

