### PR TITLE
fix: make blake2b optional

### DIFF
--- a/eth/precompiles/blake2.py
+++ b/eth/precompiles/blake2.py
@@ -12,7 +12,7 @@ from eth.vm.computation import (
 
 try:
     from blake2b import compress as blake2b_compress
-except ModuleNotFoundError:
+except ImportError:
     from eth._utils.blake2.compression import blake2b_compress
 
 GAS_COST_PER_ROUND = 1

--- a/eth/precompiles/blake2.py
+++ b/eth/precompiles/blake2.py
@@ -1,4 +1,3 @@
-import blake2b
 from eth_utils import (
     ValidationError,
 )
@@ -10,6 +9,11 @@ from eth.exceptions import (
 from eth.vm.computation import (
     BaseComputation,
 )
+
+try:
+    from blake2b import compress as blake2b_compress
+except ModuleNotFoundError:
+    from eth._utils.blake2.compression import blake2b_compress
 
 GAS_COST_PER_ROUND = 1
 
@@ -25,5 +29,5 @@ def blake2b_fcompress(computation: BaseComputation) -> BaseComputation:
 
     computation.consume_gas(gas_cost, reason=f"Blake2b Compress Precompile w/ {num_rounds} rounds")
 
-    computation.output = blake2b.compress(*parameters)
+    computation.output = blake2b_compress(*parameters)
     return computation

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ deps = {
 deps['dev'] = (
     deps['dev'] +
     deps['eth'] +
-    deps['eth-extra'] +
     deps['test'] +
     deps['doc'] +
     deps['lint']

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools import setup, find_packages
 
 deps = {
     'eth': [
-        "blake2b-py>=0.1.4,<0.2",
         "cached-property>=1.5.1,<2",
         "eth-bloom>=1.0.3,<2.0.0",
         "eth-keys>=0.2.1,<0.4.0",
@@ -23,6 +22,7 @@ deps = {
     # Installing these libraries may make the evm perform better than
     # using the default fallbacks though.
     'eth-extra': [
+        "blake2b-py>=0.1.4,<0.2",
         "coincurve>=13.0.0,<14.0.0",
         "eth-hash[pysha3];implementation_name=='cpython'",
         "eth-hash[pycryptodome];implementation_name=='pypy'",


### PR DESCRIPTION
### What was wrong?
fixes: #1959
may fix: #1941

### How was it fixed?
Used the native implementation of blake2b compression function if `blake2b-py` is not installed.
Made `blake2b-py` an optional dependency via `eth-extra`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![cute elephant](https://top13.net/wp-content/uploads/2017/04/adorable-baby-elephants-12.jpg)
