### PR TITLE
London basefee opcode 0x48

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -2672,9 +2672,9 @@ class StateAPI(ConfigurableAPI):
 
     @property
     @abstractmethod
-    def basefee(self) -> int:
+    def base_fee(self) -> int:
         """
-        Return the current ``basefee`` from the current :attr:`~execution_context`
+        Return the current ``base_fee`` from the current :attr:`~execution_context`
         """
         ...
 

--- a/eth/abc.py
+++ b/eth/abc.py
@@ -2674,7 +2674,7 @@ class StateAPI(ConfigurableAPI):
     @abstractmethod
     def basefee(self) -> int:
         """
-        Return the current ``base_fee_per_gas`` from the current :attr:`~execution_context`
+        Return the current ``basefee`` from the current :attr:`~execution_context`
         """
         ...
 

--- a/eth/abc.py
+++ b/eth/abc.py
@@ -2670,6 +2670,14 @@ class StateAPI(ConfigurableAPI):
         """
         ...
 
+    @property
+    @abstractmethod
+    def basefee(self) -> int:
+        """
+        Return the current ``base_fee_per_gas`` from the current :attr:`~execution_context`
+        """
+        ...
+
     @abstractmethod
     def get_gas_price(self, transaction: SignedTransactionAPI) -> int:
         """

--- a/eth/abc.py
+++ b/eth/abc.py
@@ -2675,6 +2675,9 @@ class StateAPI(ConfigurableAPI):
     def base_fee(self) -> int:
         """
         Return the current ``base_fee`` from the current :attr:`~execution_context`
+
+        Raises a ``NotImplementedError`` if called in an execution context
+        prior to the London hard fork.
         """
         ...
 

--- a/eth/vm/forks/london/computation.py
+++ b/eth/vm/forks/london/computation.py
@@ -2,10 +2,12 @@ from eth.vm.forks.berlin.computation import (
     BerlinComputation,
 )
 
+from .opcodes import LONDON_OPCODES
+
 
 class LondonComputation(BerlinComputation):
     """
     A class for all execution computations in the ``London`` fork.
     Inherits from :class:`~eth.vm.forks.berlin.BerlinComputation`
     """
-    pass
+    opcodes = LONDON_OPCODES

--- a/eth/vm/forks/london/opcodes.py
+++ b/eth/vm/forks/london/opcodes.py
@@ -1,0 +1,36 @@
+import copy
+from typing import Dict
+
+from eth_utils.toolz import merge
+
+from eth.vm.logic import (
+    block,
+)
+from eth.vm import (
+    mnemonics,
+    opcode_values,
+)
+from eth.vm.opcode import (
+    Opcode,
+    as_opcode,
+)
+from eth import constants
+
+from eth.vm.forks.berlin.opcodes import (
+    BERLIN_OPCODES,
+)
+
+
+UPDATED_OPCODES: Dict[int, Opcode] = {
+    opcode_values.BASEFEE: as_opcode(
+        gas_cost=constants.GAS_BASE,
+        logic_fn=block.basefee,
+        mnemonic=mnemonics.BASEFEE,
+    ),
+}
+
+
+LONDON_OPCODES = merge(
+    copy.deepcopy(BERLIN_OPCODES),
+    UPDATED_OPCODES,
+)

--- a/eth/vm/forks/london/state.py
+++ b/eth/vm/forks/london/state.py
@@ -137,5 +137,5 @@ class LondonState(BerlinState):
         )
 
     @property
-    def basefee(self: StateAPI) -> int:
+    def base_fee(self: StateAPI) -> int:
         return self.execution_context.base_fee_per_gas

--- a/eth/vm/forks/london/state.py
+++ b/eth/vm/forks/london/state.py
@@ -135,3 +135,7 @@ class LondonState(BerlinState):
             gas_price=effective_gas_price,
             origin=transaction.sender
         )
+
+    @property
+    def basefee(self: StateAPI) -> int:
+        return self.execution_context.base_fee_per_gas

--- a/eth/vm/logic/block.py
+++ b/eth/vm/logic/block.py
@@ -30,4 +30,4 @@ def gaslimit(computation: BaseComputation) -> None:
 
 
 def basefee(computation: BaseComputation) -> None:
-    computation.stack_push_int(computation.state.basefee)
+    computation.stack_push_int(computation.state.base_fee)

--- a/eth/vm/logic/block.py
+++ b/eth/vm/logic/block.py
@@ -27,3 +27,7 @@ def difficulty(computation: BaseComputation) -> None:
 
 def gaslimit(computation: BaseComputation) -> None:
     computation.stack_push_int(computation.state.gas_limit)
+
+
+def basefee(computation: BaseComputation) -> None:
+    computation.stack_push_int(computation.state.basefee)

--- a/eth/vm/mnemonics.py
+++ b/eth/vm/mnemonics.py
@@ -64,6 +64,7 @@ TIMESTAMP = 'TIMESTAMP'
 NUMBER = 'NUMBER'
 DIFFICULTY = 'DIFFICULTY'
 GASLIMIT = 'GASLIMIT'
+BASEFEE = 'BASEFEE'
 #
 # Stack, Memory, Storage and Flow Operations
 #

--- a/eth/vm/opcode_values.py
+++ b/eth/vm/opcode_values.py
@@ -63,6 +63,7 @@ EXTCODEHASH = 0x3f
 # These opcodes seem to belong in the environment block, but we are out of opcode space in 0x3*
 CHAINID = 0x46
 SELFBALANCE = 0x47
+BASEFEE = 0x48
 
 #
 # Block Information

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -88,6 +88,10 @@ class BaseState(Configurable, StateAPI):
     def gas_limit(self) -> int:
         return self.execution_context.gas_limit
 
+    @property
+    def basefee(self) -> int:
+        raise NotImplementedError("Basefee opcode is not implemented until London")
+
     def get_tip(self, transaction: SignedTransactionAPI) -> int:
         return transaction.gas_price
 

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -89,7 +89,7 @@ class BaseState(Configurable, StateAPI):
         return self.execution_context.gas_limit
 
     @property
-    def basefee(self) -> int:
+    def base_fee(self) -> int:
         raise NotImplementedError("Basefee opcode is not implemented until London")
 
     def get_tip(self, transaction: SignedTransactionAPI) -> int:

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -90,7 +90,7 @@ class BaseState(Configurable, StateAPI):
 
     @property
     def base_fee(self) -> int:
-        raise NotImplementedError("Basefee opcode is not implemented until London")
+        raise NotImplementedError("Basefee opcode is not implemented prior to London hard fork")
 
     def get_tip(self, transaction: SignedTransactionAPI) -> int:
         return transaction.gas_price

--- a/newsfragments/2015.feature.rst
+++ b/newsfragments/2015.feature.rst
@@ -1,0 +1,1 @@
+Add basefee opcode per EIP-3198

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -160,6 +160,15 @@ def test_add(vm_class, val1, val2, expected):
     assert result == expected
 
 
+def test_basefee():
+    computation = run_general_computation(LondonVM)
+    computation.opcodes[opcode_values.BASEFEE](computation)
+
+    result = computation.stack_pop1_int()
+
+    assert result == 10 ** 9  # 1 gwei
+
+
 @pytest.mark.parametrize(
     'opcode_value, expected',
     (

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -164,7 +164,7 @@ def test_base_fee():
     computation = run_general_computation(LondonVM)
     computation.opcodes[opcode_values.BASEFEE](computation)
 
-    result = computation.stack_pop1_int()
+    result = computation.stack_pop1_any()
 
     assert result == 10 ** 9  # 1 gwei
 

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -160,7 +160,7 @@ def test_add(vm_class, val1, val2, expected):
     assert result == expected
 
 
-def test_basefee():
+def test_base_fee():
     computation = run_general_computation(LondonVM)
     computation.opcodes[opcode_values.BASEFEE](computation)
 


### PR DESCRIPTION
### What was wrong?

The BASEFEE opcode for London hadn't been implemented yet. 


### How was it fixed?

Added it! 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![image](https://user-images.githubusercontent.com/6540608/130274340-afabcb71-300e-4aef-90dc-d33dd717c291.png)

