### PR TITLE
Preliminary london fixups

### DIFF
--- a/eth/tools/_utils/normalization.py
+++ b/eth/tools/_utils/normalization.py
@@ -542,6 +542,8 @@ def normalize_block_header(header: Dict[str, Any]) -> Dict[str, Any]:
     }
     if 'blocknumber' in header:
         normalized_header['blocknumber'] = to_int(header['blocknumber'])
+    if 'baseFeePerGas' in header:
+        normalized_header['baseFeePerGas'] = to_int(header['baseFeePerGas'])
     if 'chainname' in header:
         normalized_header['chainname'] = header['chainname']
     if 'chainnetwork' in header:

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -133,6 +133,10 @@ def chain_vm_configuration(fixture: Dict[str, Any]) -> Iterable[Tuple[int, Type[
         return (
             (0, BerlinVM),
         )
+    elif network == 'London':
+        return (
+            (0, LondonVM),
+        )
     elif network == 'FrontierToHomesteadAt5':
         HomesteadVM = BaseHomesteadVM.configure(support_dao_fork=False)
         return (

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -11,7 +11,10 @@ from typing import (
     Type,
 )
 
-from eth_utils.toolz import first
+from eth_utils.toolz import (
+    assoc,
+    first,
+)
 
 from eth_utils import (
     to_normalized_address,
@@ -181,23 +184,28 @@ def genesis_fields_from_fixture(fixture: Dict[str, Any]) -> Dict[str, Any]:
     Convert all genesis fields in a fixture to a dictionary of header fields and values.
     """
 
-    return {
-        'parent_hash': fixture['genesisBlockHeader']['parentHash'],
-        'uncles_hash': fixture['genesisBlockHeader']['uncleHash'],
-        'coinbase': fixture['genesisBlockHeader']['coinbase'],
-        'state_root': fixture['genesisBlockHeader']['stateRoot'],
-        'transaction_root': fixture['genesisBlockHeader']['transactionsTrie'],
-        'receipt_root': fixture['genesisBlockHeader']['receiptTrie'],
-        'bloom': fixture['genesisBlockHeader']['bloom'],
-        'difficulty': fixture['genesisBlockHeader']['difficulty'],
-        'block_number': fixture['genesisBlockHeader']['number'],
-        'gas_limit': fixture['genesisBlockHeader']['gasLimit'],
-        'gas_used': fixture['genesisBlockHeader']['gasUsed'],
-        'timestamp': fixture['genesisBlockHeader']['timestamp'],
-        'extra_data': fixture['genesisBlockHeader']['extraData'],
-        'mix_hash': fixture['genesisBlockHeader']['mixHash'],
-        'nonce': fixture['genesisBlockHeader']['nonce'],
+    header_fields = fixture['genesisBlockHeader']
+    base_fields = {
+        'parent_hash': header_fields['parentHash'],
+        'uncles_hash': header_fields['uncleHash'],
+        'coinbase': header_fields['coinbase'],
+        'state_root': header_fields['stateRoot'],
+        'transaction_root': header_fields['transactionsTrie'],
+        'receipt_root': header_fields['receiptTrie'],
+        'bloom': header_fields['bloom'],
+        'difficulty': header_fields['difficulty'],
+        'block_number': header_fields['number'],
+        'gas_limit': header_fields['gasLimit'],
+        'gas_used': header_fields['gasUsed'],
+        'timestamp': header_fields['timestamp'],
+        'extra_data': header_fields['extraData'],
+        'mix_hash': header_fields['mixHash'],
+        'nonce': header_fields['nonce'],
     }
+    if 'baseFeePerGas' in header_fields:
+        return assoc(base_fields, 'base_fee_per_gas', header_fields['baseFeePerGas'])
+    else:
+        return base_fields
 
 
 def genesis_params_from_fixture(fixture: Dict[str, Any]) -> Dict[str, Any]:

--- a/newsfragments/2022.internal.rst
+++ b/newsfragments/2022.internal.rst
@@ -1,0 +1,1 @@
+During fixture tests, verify that the generated genesis block matches the fixture's RLP-encoding.


### PR DESCRIPTION
### What was wrong?

When enabling London tests, some basic missing/broken functionality showed up.

### How was it fixed?

- [x] Parse fixture configurations named "London"
- [x] Parse base fee from fixture header fields
- [x] Test that fixture-generated genesis block matches fixture's RLP-encoding
- [x] Crash-fix: configure base fee on genesis header


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.theconversation.com/files/221965/original/file-20180606-137312-1g137u.jpg?ixlib=rb-1.1.0&q=45&auto=format&w=1200&h=900.0&fit=crop)