### PR TITLE
Erase return data on appropriate exceptions

### DIFF
--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -489,6 +489,10 @@ class BaseComputation(Configurable, ComputationAPI):
                     )),
                 )
 
+            # When we raise an exception that erases return data, erase the return data.
+            if self.should_erase_return_data:
+                self.return_data = b''
+
             # suppress VM exceptions
             return True
         elif exc_type is None and self.logger.show_debug2:

--- a/eth/vm/logic/system.py
+++ b/eth/vm/logic/system.py
@@ -7,9 +7,7 @@ from eth_utils import (
 from eth import constants
 from eth.exceptions import (
     Halt,
-    InsufficientFunds,
     Revert,
-    StackDepthLimit,
     WriteProtection,
 )
 
@@ -163,12 +161,13 @@ class Create(Opcode):
 
         if insufficient_funds or stack_too_deep:
             computation.stack_push_int(0)
+            computation.return_data = b''
             if insufficient_funds:
-                raise InsufficientFunds(
-                    f"Insufficient funds: {storage_address_balance} < {stack_data.endowment}"
-                )
+                err_msg = f"Insufficient Funds: {storage_address_balance} < {stack_data.endowment}"
             elif stack_too_deep:
-                raise StackDepthLimit("Stack depth limit reached")
+                err_msg = "Stack limit reached"
+            self.logger.debug2("%s failure: %s", self.mnemonic, err_msg,)
+            return
 
         call_data = computation.memory_read_bytes(
             stack_data.memory_start, stack_data.memory_length

--- a/newsfragments/2023.bugfix.rst
+++ b/newsfragments/2023.bugfix.rst
@@ -1,0 +1,1 @@
+Erase return data for exceptions with `erases_return_data` flag set to True

--- a/newsfragments/2023.bugfix.rst
+++ b/newsfragments/2023.bugfix.rst
@@ -1,1 +1,1 @@
-Erase return data for exceptions with `erases_return_data` flag set to True
+Erase return data for exceptions with `erases_return_data` flag set to True and for CREATE / CREATE2 computations with insufficient funds

--- a/tests/core/vm/test_base_computation.py
+++ b/tests/core/vm/test_base_computation.py
@@ -346,31 +346,39 @@ def test_get_gas_used_with_revert(computation):
 
 def test_should_burn_gas_with_vm_error(computation):
     assert computation.get_gas_remaining() == 100
-    # Trigger an out of gas error causing get gas remaining to be 0
+    # Trigger an out of gas error causing remaining gas to be 0
     with computation:
         raise VMError('Triggered VMError for tests')
     assert computation.should_burn_gas
+    assert computation.get_gas_used() == 100
+    assert computation.get_gas_remaining() == 0
 
 
 def test_should_burn_gas_with_revert(computation):
     assert computation.get_gas_remaining() == 100
-    # Trigger an out of gas error causing get gas remaining to be 0
+    # Trigger a Revert which should not burn gas
     with computation:
         raise Revert('Triggered VMError for tests')
     assert not computation.should_burn_gas
+    assert computation.get_gas_used() == 0
+    assert computation.get_gas_remaining() == 100
 
 
 def test_should_erase_return_data_with_vm_error(computation):
     assert computation.get_gas_remaining() == 100
-    # Trigger an out of gas error causing get gas remaining to be 0
+    computation.return_data = b'\x1337'
+    # Trigger a VMError which should erase the return data
     with computation:
         raise VMError('Triggered VMError for tests')
     assert computation.should_erase_return_data
+    assert computation.return_data == b''
 
 
 def test_should_erase_return_data_with_revert(computation):
     assert computation.get_gas_remaining() == 100
-    # Trigger an out of gas error causing get gas remaining to be 0
+    computation.return_data = b'\x1337'
+    # Trigger a Revert which should not erase return data
     with computation:
         raise Revert('Triggered VMError for tests')
     assert not computation.should_erase_return_data
+    assert computation.return_data == b'\x1337'

--- a/tests/core/vm/test_computation.py
+++ b/tests/core/vm/test_computation.py
@@ -1,0 +1,95 @@
+# test computation class behavior across VMs
+import pytest
+from eth_typing import Address
+
+from eth_utils import decode_hex
+
+from eth.chains.base import MiningChain
+from eth.chains.mainnet import MAINNET_VMS
+
+from eth import constants
+from eth.consensus import NoProofConsensus
+from eth.exceptions import (
+    InsufficientFunds,
+    InvalidInstruction,
+)
+
+
+def _configure_mining_chain(starting_vm, vm_under_test):
+    return MiningChain.configure(
+        __name__="AllVMs",
+        vm_configuration=(
+            (
+                constants.GENESIS_BLOCK_NUMBER,
+                starting_vm.configure(consensus_class=NoProofConsensus),
+            ),
+            (
+                constants.GENESIS_BLOCK_NUMBER + 1,
+                vm_under_test.configure(consensus_class=NoProofConsensus),
+            ),
+        ),
+        chain_id=1337,
+    )
+
+
+# CREATE, RETURNDATASIZE, and RETURNDATACOPY opcodes not added until Byzantium
+@pytest.fixture(params=MAINNET_VMS[4:])
+def byzantium_plus_miner(request, base_db, genesis_state):
+    byzantium_vm = MAINNET_VMS[4]
+    vm_under_test = request.param
+
+    klass = _configure_mining_chain(byzantium_vm, vm_under_test)
+    header_fields = dict(
+        difficulty=1,
+        gas_limit=100000,  # arbitrary, just enough for testing
+    )
+    return klass.from_genesis(base_db, header_fields, genesis_state)
+
+
+@pytest.mark.parametrize(
+    "code",
+    (
+        # generate some return data, then call CREATE (third-to-last opcode - 0xf0)
+        decode_hex('0x5b595958333d5859858585858585858585f195858585858585858485858585f195858585858585f1f03d30'),  # noqa: E501
+        # generate some return data, then call CREATE2 (third-to-last opcode - 0xf5)
+        decode_hex('0x5b595958333d5859858585858585858585f195858585858585858485858585f195858585858585f1f53d30'),  # noqa: E501
+    )
+)
+def test_CREATE_and_CREATE2_resets_return_data_if_account_has_insufficient_funds(
+    byzantium_plus_miner,
+    canonical_address_a,
+    transaction_context,
+    code,
+):
+    chain = byzantium_plus_miner
+    vm = chain.get_vm()
+    state = vm.state
+
+    assert state.get_balance(canonical_address_a) == 0
+
+    computation = vm.execute_bytecode(
+        origin=canonical_address_a,
+        to=canonical_address_a,
+        sender=Address(
+            b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x12\x34'
+        ),
+        value=0,
+        code=code,
+        data=code,
+        gas=400000,
+        gas_price=1,
+    )
+
+    assert computation.is_error
+
+    if isinstance(computation.error, InvalidInstruction):
+        # only test CREATE case for byzantium as the CREATE2 opcode (0xf5) was not yet introduced
+        assert vm.fork == "byzantium"
+        assert "0xf5" in repr(computation.error).lower()
+
+    else:
+        assert isinstance(computation.error, InsufficientFunds)
+
+        assert computation.get_gas_used() == 400000
+        assert computation.get_gas_refund() == 0
+        assert computation.return_data == b''


### PR DESCRIPTION
### What was wrong?

1. We did not reset return data on CREATE or CREATE2 calls for an insufficient funds case.
2. We also never reset return data on exceptions that have `erases_return_data` flag set to `True`. Some tests that were in place to test this did not test it appropriately.

### How was it fixed?

1. Erase return data and error log when insufficient funds or stack depth limit reached during CREATE or CREATE2.
2. Check the `erases_return_data` flag on the raised exception and erase the return data in the same way that we burn gas when the `burns_gas` flag is set to `True`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [X] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![Image from iOS (2)](https://user-images.githubusercontent.com/3532824/131923345-b02fab44-19fe-4e79-8812-ef8443d9ff32.jpg)

