### PR TITLE
EIP-3541 london test fixes

### DIFF
--- a/eth/vm/forks/london/computation.py
+++ b/eth/vm/forks/london/computation.py
@@ -15,7 +15,9 @@ class LondonComputation(BerlinComputation):
     opcodes = LONDON_OPCODES
 
     @classmethod
-    def validate_new_contract_code(cls, contract_code: bytes) -> None:
+    def validate_contract_code(cls, contract_code: bytes) -> None:
+        super().validate_contract_code(contract_code)
+
         if contract_code[:1] == EIP3541_RESERVED_STARTING_BYTE:
             raise ReservedBytesInCode(
                 "Contract code begins with EIP3541 reserved byte '0xEF'."


### PR DESCRIPTION
### What was wrong?

- LondonComputation was raising an error where it should set the error and return the computation. This fixes broken ethereum tests related to this new logic from EIP-3541.
- Ethereum tests released a new version (v10.0)

### How was it fixed?

- Set the `computation.error` and return the computation rather than raise the VMError
- Updated ethereum tests submodule to new version v10.0

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [X] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![IMG_20210915_165945](https://user-images.githubusercontent.com/3532824/133849611-18578335-3b41-4cf4-b22e-400891ecb1b5.jpg)
