### PR TITLE
Reference to the project template in the docs updated

### DIFF
--- a/docs/guides/building_an_app_that_uses_pyevm.rst
+++ b/docs/guides/building_an_app_that_uses_pyevm.rst
@@ -15,14 +15,14 @@ Setting up the application
 
 Let's get started by setting up a new application. Often, that process involves lots of repetitive
 boilerplate code, so instead of doing it all by hand, let's just clone the
-`Ethereum Python Project Template <https://github.com/carver/ethereum-python-project-template>`_
+`Ethereum Python Project Template <https://github.com/ethereum/ethereum-python-project-template>`_
 which contains all the typical things that we want.
 
 To clone this into a new directory ``demo-app`` run:
 
 .. code:: sh
 
-  git clone https://github.com/carver/ethereum-python-project-template.git demo-app
+  git clone https://github.com/ethereum/ethereum-python-project-template.git demo-app
 
 Then, change into the directory
 

--- a/newsfragments/2032.doc.rst
+++ b/newsfragments/2032.doc.rst
@@ -1,0 +1,1 @@
+Updated the reference to the project template in the docs to https://github.com/ethereum/ethereum-python-project-template and changed the location in the git clone command accordingly.


### PR DESCRIPTION
### What was wrong?
Project templates URL in https://github.com/ethereum/py-evm/blob/master/docs/guides/building_an_app_that_uses_pyevm.rst was redirecting to https://github.com/carver/ethereum-python-project-template.

Fixes #2032 
### How was it fixed?
I changed the URL to https://github.com/ethereum/ethereum-python-project-template and also changed the location in the git clone command accordingly.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute A

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/78664749/135646074-ff71b19d-a782-4dd2-8e7e-30ac16e19d0d.jpg)
