### PR TITLE
Update test fixtures to v10.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,12 +40,6 @@ common: &common
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  py36-benchmark:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-benchmark
   py36-native-blockchain-berlin:
     <<: *common
     docker:
@@ -246,7 +240,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - py36-benchmark
       - py36-native-blockchain-berlin
       - py36-native-blockchain-byzantium
       - py36-native-blockchain-constantinople

--- a/eth/tools/_utils/normalization.py
+++ b/eth/tools/_utils/normalization.py
@@ -505,12 +505,12 @@ def normalize_transactiontest_fixture(fixture: Dict[str, Any], fork: str) -> Dic
 
     normalized_fixture = {}
 
-    fork_data = fixture[fork]
+    fork_data = fixture['result'][fork]
 
     try:
-        normalized_fixture['rlp'] = decode_hex(fixture['rlp'])
+        normalized_fixture['txbytes'] = decode_hex(fixture['txbytes'])
     except binascii.Error:
-        normalized_fixture['rlpHex'] = fixture['rlp']
+        normalized_fixture['rlpHex'] = fixture['txbytes']
 
     if "sender" in fork_data:
         normalized_fixture['sender'] = fork_data['sender']

--- a/newsfragments/2040.misc.rst
+++ b/newsfragments/2040.misc.rst
@@ -1,0 +1,1 @@
+Update ethereum/tests to v10.1

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ deps = {
     'eth': [
         "cached-property>=1.5.1,<2",
         "eth-bloom>=1.0.3,<2.0.0",
-        "eth-keys>=0.2.1,<0.4.0",
-        "eth-typing>=2.2.0,<3.0.0",
-        "eth-utils>=1.9.4,<2.0.0",
+        "eth-keys>=0.4.0,<0.5.0",
+        "eth-typing>=3.0.0,<4.0.0",
+        "eth-utils>=2.0.0,<3.0.0",
         "lru-dict>=1.1.6",
         "mypy_extensions>=0.4.1,<1.0.0",
         "py-ecc>=1.4.7,<5.0.0",
         "pyethash>=0.1.27,<1.0.0",
-        "rlp>=2,<3",
-        "trie==2.0.0-alpha.5",
+        "rlp>=3,<4",
+        "trie>=2.0.0,<3",
     ],
     # The eth-extra sections is for libraries that the evm does not
     # explicitly need to function and hence should not depend on.

--- a/tests/json-fixtures/test_transactions.py
+++ b/tests/json-fixtures/test_transactions.py
@@ -37,6 +37,12 @@ from eth.vm.forks.petersburg.transactions import (
 from eth.vm.forks.istanbul.transactions import (
     IstanbulTransaction
 )
+from eth.vm.forks.berlin.transactions import (
+    BerlinTransactionBuilder
+)
+from eth.vm.forks.london.transactions import (
+    LondonTransactionBuilder
+)
 
 from eth_typing.enums import (
     ForkName
@@ -50,7 +56,7 @@ BASE_FIXTURE_PATH = os.path.join(ROOT_PROJECT_DIR, 'fixtures', 'TransactionTests
 
 
 # Fixtures have an `_info` key at their root which we need to skip over.
-FIXTURE_FORK_SKIPS = {'_info', 'rlp'}
+FIXTURE_FORK_SKIPS = {'_info', 'txbytes'}
 
 
 @to_tuple
@@ -62,7 +68,7 @@ def expand_fixtures_forks(all_fixtures):
     """
     for fixture_path, fixture_key in all_fixtures:
         fixture = load_fixture(fixture_path, fixture_key)
-        for fixture_fork, _ in fixture.items():
+        for fixture_fork, _ in fixture['result'].items():
             if fixture_fork not in FIXTURE_FORK_SKIPS:
                 yield fixture_path, fixture_key, fixture_fork
 
@@ -105,7 +111,11 @@ def fixture_transaction_class(fixture_data):
     elif fork_name == ForkName.ConstantinopleFix:
         return PetersburgTransaction
     elif fork_name == ForkName.Istanbul:
-        return IstanbulTransaction  # There seem to be no new transaction tests since Istanbul
+        return IstanbulTransaction
+    elif fork_name == ForkName.Berlin:
+        return BerlinTransactionBuilder
+    elif fork_name == ForkName.London:
+        return LondonTransactionBuilder
     elif fork_name == ForkName.Metropolis:
         pytest.skip("Metropolis Transaction class has not been implemented")
     else:
@@ -117,7 +127,7 @@ def test_transaction_fixtures(fixture, fixture_transaction_class):
     TransactionClass = fixture_transaction_class
 
     try:
-        txn = rlp.decode(fixture['rlp'], sedes=TransactionClass)
+        txn = rlp.decode(fixture['txbytes'], sedes=TransactionClass)
     except (rlp.DeserializationError, rlp.exceptions.DecodingError):
         assert 'hash' not in fixture, "Transaction was supposed to be valid"
     except TypeError as err:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist=
     py{36,37,38,39}-{core,database,transactions,vm}
-    py36-benchmark
     py36-native-blockchain-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul,berlin,london,metropolis,transition}
     py{36,37,38,39}-lint
     py36-docs
@@ -61,9 +60,3 @@ passenv =
     TRAVIS_EVENT_TYPE
 commands=
     make validate-docs
-
-
-[testenv:py36-benchmark]
-deps = .[eth-extra,benchmark]
-commands=
-    benchmark: {toxinidir}/scripts/benchmark/run.py


### PR DESCRIPTION
### What was wrong?

ethereum/tests submodule needed an update.

### How was it fixed?

Changed the commit to point at the right version. Fixes: #2039 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] Update eth-keys dependency

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://wallpaperaccess.com/full/86182.jpg)
