### PR TITLE
Downgrade dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ deps = {
     'eth': [
         "cached-property>=1.5.1,<2",
         "eth-bloom>=1.0.3,<2.0.0",
-        "eth-keys>=0.4.0,<0.5.0",
-        "eth-typing>=3.0.0,<4.0.0",
-        "eth-utils>=2.0.0,<3.0.0",
+        "eth-keys>=0.3.4,<0.4.0",
+        "eth-typing>=2.3.0,<3.0.0",
+        "eth-utils>=1.9.4,<2.0.0",
         "lru-dict>=1.1.6",
         "mypy_extensions>=0.4.1,<1.0.0",
-        "py-ecc>=1.4.7,<7.0.0",
+        "py-ecc>=1.4.7,<6.0.0",
         "pyethash>=0.1.27,<1.0.0",
-        "rlp>=3,<4",
-        "trie>=2.0.0,<3",
+        "rlp>=2,<3",
+        "trie==2.0.0-alpha.5",
     ],
     # The eth-extra sections is for libraries that the evm does not
     # explicitly need to function and hence should not depend on.


### PR DESCRIPTION
### What was wrong?
With the updated dependencies, we couldn't update the tester dependency of web3py to the latest py-evm without breaking it. We need to wait until web3py has a v6 beta release to do that. 


### How was it fixed?

Reverted most of the dependency updates for now. I will pull them back in once we're ready to cut our web3py v6 branch soon. 

Released a new v2.3.0 `eth-typing` that had the enum for the `London` and `ArrowGlacier` fork names, which are needed for the update of `ethereum/tests` to v10.1. Also released a v0.3.4 of `eth-keys` which has the bugfix for the ecrecover point at infinity.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/b2/6c/99/b26c998d89d23f06e315107f88927e9b.jpg)
