### PR TITLE
Arrow glacier block header serialization fix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,13 @@
 ### What was wrong?
 
 
-
 ### How was it fixed?
 
 
-### To-Do
+### Todo:
 
 [//]: # (Stay ahead of things, add list items here!)
 - [ ] Clean up commit history
-
-[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)
 
 [//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
 - [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ monkeytype.sqlite3
 
 # idea
 .idea/**
+
+# .DS_Store files
+.DS_Store

--- a/eth/vm/forks/arrow_glacier/blocks.py
+++ b/eth/vm/forks/arrow_glacier/blocks.py
@@ -1,5 +1,7 @@
 from abc import ABC
+from typing import Type
 
+from eth.abc import TransactionBuilderAPI
 from eth_utils import (
     encode_hex,
 )
@@ -7,15 +9,18 @@ from eth_utils import (
 from rlp.sedes import (
     CountableList,
 )
-from eth.rlp.headers import (
-    BlockHeader,
-)
 
 from .transactions import (
     ArrowGlacierTransactionBuilder,
 )
-from ..london import LondonBlock
-from ..london.blocks import LondonBlockHeader, LondonMiningHeader
+from ..london import (
+    LondonBlock,
+)
+from ..london.blocks import (
+    LondonBackwardsHeader,
+    LondonBlockHeader,
+    LondonMiningHeader,
+)
 
 
 class ArrowGlacierMiningHeader(LondonMiningHeader, ABC):
@@ -28,9 +33,9 @@ class ArrowGlacierBlockHeader(LondonBlockHeader, ABC):
 
 
 class ArrowGlacierBlock(LondonBlock):
-    transaction_builder = ArrowGlacierTransactionBuilder
+    transaction_builder: Type[TransactionBuilderAPI] = ArrowGlacierTransactionBuilder
     fields = [
-        ('header', BlockHeader),
+        ('header', ArrowGlacierBlockHeader),
         ('transactions', CountableList(transaction_builder)),
-        ('uncles', CountableList(BlockHeader))
+        ('uncles', CountableList(LondonBackwardsHeader))
     ]

--- a/newsfragments/2047.bugfix.rst
+++ b/newsfragments/2047.bugfix.rst
@@ -1,0 +1,1 @@
+Arrow Glacier header serialization fixed to properly inherit from LondonBlockHeader

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -1,5 +1,6 @@
 import pytest
 
+import rlp
 from eth_utils import (
     decode_hex,
     ValidationError,
@@ -67,6 +68,15 @@ def test_apply_transaction(
     assert state.get_balance(recipient) == amount
 
     assert new_header.gas_used == constants.GAS_TX
+
+
+def test_block_serialization(chain):
+    if not isinstance(chain, MiningChain):
+        pytest.skip("Only test mining on a MiningChain")
+        return
+
+    block = chain.mine_block()
+    rlp.encode(block)
 
 
 def test_mine_block_issues_block_reward(chain):


### PR DESCRIPTION
### What was wrong?

- Arrow Glacier block serialization was not properly set up to inherit from London block header.

### How was it fixed?

- Arrow Glacier block header should now be set up properly by actually using the `ArrowGlacierBlockHeader` 😅 .
- Test added to try to catch copy / paste issues like these in the future.

### Todo:

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20220206_111501](https://user-images.githubusercontent.com/3532824/152878760-e517c500-56dd-492a-8aef-197db7d54fc0.jpg)