### PR TITLE
Update `trie` to v2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ deps = {
         "py-ecc>=1.4.7,<6.0.0",
         "pyethash>=0.1.27,<1.0.0",
         "rlp>=2,<3",
-        "trie==2.0.0-alpha.5",
+        "trie==2.0.0",
     ],
     # The eth-extra sections is for libraries that the evm does not
     # explicitly need to function and hence should not depend on.


### PR DESCRIPTION
- Fix dependency issues with typing-extensions
