### PR TITLE
Pin trie package to 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ deps = {
         "py-ecc>=1.4.7,<6.0.0",
         "pyethash>=0.1.27,<1.0.0",
         "rlp>=2,<3",
-        "trie==2.0.0-alpha.5",
+        "trie==2.0.0",
     ],
     # The eth-extra sections is for libraries that the evm does not
     # explicitly need to function and hence should not depend on.


### PR DESCRIPTION
### What was wrong?

FIX: https://github.com/ethereum/py-evm/issues/2054
Unable to install in environments where typing extensions >= 4.0 (which is most environments these days).
This has been fixed in the newer trie packages but this package still uses an older one.
This all trickles down the line and causes issues installing other applications.


### How was it fixed?

Pin to trie==2.0.0 instead of trie==2.0.0a5.

### Todo:

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
