### PR TITLE
Upgrade pytest-timeout to resolve xdist crash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ deps = {
         "pytest>=6.2.4,<7",
         "pytest-asyncio>=0.10.0,<0.11",
         "pytest-cov==2.5.1",
-        "pytest-timeout>=1.4.2,<2",
+        "pytest-timeout>=2,<3",
         "pytest-watch>=4.1.0,<5",
         "pytest-xdist==2.3.0",
     ],


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest-xdist/issues/117

### Todo:

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.istockphoto.com/photos/cute-red-and-white-corgi-sleeps-on-the-bed-on-its-back-with-alarm-in-picture-id1196522556?s=612x612)