### PR TITLE
Upgrade dependencies

### DIFF
--- a/newsfragments/2068.removal.rst
+++ b/newsfragments/2068.removal.rst
@@ -1,0 +1,1 @@
+Upgrade dependencies: eth-keys, eth-typing, eth-utils, py-ecc, rlp, trie

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ deps = {
     'eth': [
         "cached-property>=1.5.1,<2",
         "eth-bloom>=1.0.3,<2.0.0",
-        "eth-keys>=0.3.4,<0.4.0",
-        "eth-typing>=2.3.0,<3.0.0",
-        "eth-utils>=1.9.4,<2.0.0",
+        "eth-keys>=0.4.0,<0.5.0",
+        "eth-typing>=3.0.0,<4.0.0",
+        "eth-utils>=2.0.0,<3.0.0",
         "lru-dict>=1.1.6",
         "mypy_extensions>=0.4.1,<1.0.0",
-        "py-ecc>=1.4.7,<6.0.0",
+        "py-ecc>=1.4.7,<7.0.0",
         "pyethash>=0.1.27,<1.0.0",
-        "rlp>=2,<3",
-        "trie==2.0.0-alpha.5",
+        "rlp>=3,<4",
+        "trie>=2.0.0,<3",
     ],
     # The eth-extra sections is for libraries that the evm does not
     # explicitly need to function and hence should not depend on.
@@ -42,7 +42,8 @@ deps = {
     'lint': [
         "flake8==3.8.2",
         "flake8-bugbear==20.1.4",
-        "mypy==0.782",
+        "mypy==0.910",
+        "types-setuptools"
     ],
     'benchmark': [
         "termcolor>=1.1.0,<2.0.0",


### PR DESCRIPTION
### What was wrong?
I should have released 0.5.0-b.2 as 0.6.0-b.1. So this ports the dependency upgrades from 0.5.0-b.2 to master so that we can cut a new 0.6.0-b.1 release.


### How was it fixed?
Upgraded dependencies, added python 3.10 support. 


### Todo:

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.boredpanda.com/blog/wp-content/uploads/2021/09/fb_thumb_6144939ce0bc5.jpg)
