### PR TITLE
Drop Python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,217 +40,188 @@ common: &common
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  py36-native-blockchain-berlin:
+  py39-native-blockchain-berlin:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-berlin
-  py36-native-blockchain-byzantium:
+          TOXENV: py39-native-blockchain-berlin
+  py39-native-blockchain-byzantium:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-byzantium
-  py36-native-blockchain-constantinople:
+          TOXENV: py39-native-blockchain-byzantium
+  py39-native-blockchain-constantinople:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-constantinople
-  py36-native-blockchain-frontier:
+          TOXENV: py39-native-blockchain-constantinople
+  py39-native-blockchain-frontier:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-frontier
-  py36-native-blockchain-homestead:
+          TOXENV: py39-native-blockchain-frontier
+  py39-native-blockchain-homestead:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-homestead
-  py36-native-blockchain-istanbul:
+          TOXENV: py39-native-blockchain-homestead
+  py39-native-blockchain-istanbul:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-istanbul
-  py36-native-blockchain-london:
+          TOXENV: py39-native-blockchain-istanbul
+  py39-native-blockchain-london:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-london
-  py36-native-blockchain-petersburg:
+          TOXENV: py39-native-blockchain-london
+  py39-native-blockchain-petersburg:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-petersburg
-  py36-native-blockchain-tangerine_whistle:
+          TOXENV: py39-native-blockchain-petersburg
+  py39-native-blockchain-tangerine_whistle:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-tangerine_whistle
-  py36-native-blockchain-spurious_dragon:
+          TOXENV: py39-native-blockchain-tangerine_whistle
+  py39-native-blockchain-spurious_dragon:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-spurious_dragon
-  py36-native-blockchain-transition:
+          TOXENV: py39-native-blockchain-spurious_dragon
+  py39-native-blockchain-transition:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-native-blockchain-transition
-  py36-core:
+          TOXENV: py39-native-blockchain-transition
+
+  py39-docs:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.9
         environment:
-          TOXENV: py36-core
-  py36-database:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-database
-  py36-transactions:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-transactions
-  py36-vm:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-vm
-  py36-lint:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-lint
-  py36-docs:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-docs
+          TOXENV: py39-docs
 
   py37-core:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-core
   py37-database:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-database
   py37-difficulty:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-difficulty
   py37-transactions:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-transactions
   py37-vm:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-vm
   py37-lint:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-lint
 
   py38-core:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-core
   py38-database:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-database
   py38-difficulty:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-difficulty
   py38-transactions:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-transactions
   py38-vm:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-vm
   py38-lint:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-lint
 
   py39-core:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-core
   py39-database:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-database
   py39-difficulty:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-difficulty
   py39-transactions:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-transactions
   py39-vm:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-vm
   py39-lint:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-lint
 
@@ -258,38 +229,33 @@ workflows:
   version: 2
   test:
     jobs:
-      - py36-native-blockchain-berlin
-      - py36-native-blockchain-byzantium
-      - py36-native-blockchain-constantinople
-      - py36-native-blockchain-frontier
-      - py36-native-blockchain-homestead
-      - py36-native-blockchain-istanbul
-      - py36-native-blockchain-london
-      - py36-native-blockchain-petersburg
-      - py36-native-blockchain-tangerine_whistle
-      - py36-native-blockchain-spurious_dragon
-      - py36-native-blockchain-transition
-      - py36-vm
+      - py39-native-blockchain-berlin
+      - py39-native-blockchain-byzantium
+      - py39-native-blockchain-constantinople
+      - py39-native-blockchain-frontier
+      - py39-native-blockchain-homestead
+      - py39-native-blockchain-istanbul
+      - py39-native-blockchain-london
+      - py39-native-blockchain-petersburg
+      - py39-native-blockchain-tangerine_whistle
+      - py39-native-blockchain-spurious_dragon
+      - py39-native-blockchain-transition
       - py37-vm
       - py38-vm
       - py39-vm
-      - py36-core
       - py37-core
       - py38-core
       - py39-core
-      - py36-transactions
       - py37-transactions
       - py38-transactions
       - py39-transactions
       - py37-difficulty
       - py38-difficulty
       - py39-difficulty
-      - py36-database
       - py37-database
       - py38-database
       - py39-database
-      - py36-docs
-      - py36-lint
+      - py39-docs
       - py37-lint
       - py38-lint
       - py39-lint

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@
 build:
   image: latest
 python:
-  version: 3.6
+  version: 3.9
   pip_install: True
   extra_requirements:
     - doc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,7 +187,7 @@ texinfo_documents = [
 # -- Intersphinx configuration ------------------------------------------------
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.6', None),
+    'python': ('https://docs.python.org/3.9', None),
     'eth-typing': ('https://eth-typing.readthedocs.io/en/latest', None),
 }
 

--- a/eth/_utils/version.py
+++ b/eth/_utils/version.py
@@ -7,7 +7,7 @@ def construct_evm_runtime_identifier() -> str:
     """
     Constructs the EVM runtime identifier string
 
-    e.g. 'Py-EVM/v1.2.3/darwin-amd64/python3.6.5'
+    e.g. 'Py-EVM/v1.2.3/darwin-amd64/python3.9.13'
     """
 
     platform = sys.platform

--- a/eth/abc.py
+++ b/eth/abc.py
@@ -3090,7 +3090,7 @@ class VirtualMachineAPI(ConfigurableAPI):
         - ``_state_class``: The :class:`~eth.abc.StateAPI` class used by this VM for execution.
     """
 
-    fork: str  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
+    fork: str
     chaindb: ChainDatabaseAPI
     extra_data_max_bytes: ClassVar[int]
     consensus_class: Type[ConsensusAPI]

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -88,7 +88,7 @@ class VM(Configurable, VirtualMachineAPI):
     block_class: Type[BlockAPI] = None
     consensus_class: Type[ConsensusAPI] = PowConsensus
     extra_data_max_bytes: ClassVar[int] = 32
-    fork: str = None  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
+    fork: str = None
     chaindb: ChainDatabaseAPI = None
     _state_class: Type[StateAPI] = None
 

--- a/eth/vm/forks/frontier/__init__.py
+++ b/eth/vm/forks/frontier/__init__.py
@@ -58,7 +58,7 @@ def make_frontier_receipt(computation: ComputationAPI,
 
 class FrontierVM(VM):
     # fork name
-    fork: str = 'frontier'  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
+    fork: str = 'frontier'
 
     # classes
     block_class: Type[BlockAPI] = FrontierBlock

--- a/eth/vm/forks/homestead/__init__.py
+++ b/eth/vm/forks/homestead/__init__.py
@@ -30,7 +30,7 @@ class MetaHomesteadVM(FrontierVM):
 
 class HomesteadVM(MetaHomesteadVM):
     # fork name
-    fork: str = 'homestead'  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
+    fork: str = 'homestead'
 
     # classes
     block_class: Type[BlockAPI] = HomesteadBlock

--- a/eth/vm/forks/spurious_dragon/__init__.py
+++ b/eth/vm/forks/spurious_dragon/__init__.py
@@ -13,7 +13,7 @@ from .state import SpuriousDragonState
 
 class SpuriousDragonVM(TangerineWhistleVM):
     # fork name
-    fork: str = 'spurious-dragon'  # noqa: E701  # flake8 bug that's fixed in 3.6.0+
+    fork: str = 'spurious-dragon'
 
     # classes
     block_class: Type[BlockAPI] = SpuriousDragonBlock

--- a/newsfragments/2070.removal.rst
+++ b/newsfragments/2070.removal.rst
@@ -1,0 +1,1 @@
+Drop python 3.6 support

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,10 @@ deps = {
         "py-evm>=0.2.0-alpha.14",
         # We need to have pysha for autodoc to be able to extract API docs
         "pysha3>=1.0.0,<2.0.0",
-        # Sphinx pined to `<1.8.0`: https://github.com/sphinx-doc/sphinx/issues/3494
-        "Sphinx>=1.5.5,<1.8.0",
+        "Sphinx>=1.5.5,<2",
+        "jinja2>=3.0.0,<3.1.0",  # jinja2<3.0 or >=3.1.0 cause doc build failures.
         "sphinx_rtd_theme>=0.1.9",
-        "sphinxcontrib-asyncio>=0.2.0,<0.3",
+        "sphinxcontrib-asyncio>=0.2.0,<0.4",
         "towncrier>=19.2.0, <20",
     ],
     'dev': [
@@ -112,7 +112,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from eth_utils import (
@@ -9,11 +7,6 @@ from eth_utils import (
 
 from eth.chains.base import MiningChain
 from eth.tools.factories.transaction import new_transaction
-
-greater_equal_python36 = pytest.mark.skipif(
-    sys.version_info < (3, 6),
-    reason="requires python3.6 or higher"
-)
 
 
 def fill_block(chain, from_, key, gas, data):

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist=
-    py{36,37,38,39}-{core,database,difficulty,transactions,vm}
-    py36-native-blockchain-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul,berlin,london,metropolis,transition}
-    py{36,37,38,39}-lint
-    py36-docs
+    py{37,38,39}-{core,database,difficulty,transactions,vm}
+    py39-native-blockchain-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul,berlin,london,metropolis,transition}
+    py{37,38,39}-lint
+    py39-docs
 
 [flake8]
 max-line-length= 100
@@ -46,13 +46,12 @@ deps =
     lint: .[eth,lint]
 
 basepython =
-    py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.9
 
 
-[testenv:py36-docs]
+[testenv:py39-docs]
 whitelist_externals=
     make
 deps = .[doc,eth-extra]


### PR DESCRIPTION
### What was wrong?
Python 3.6 is no longer supported, so dropping here. 


### How was it fixed?
Removed CI runs, and updated any runs using 3.6 to use Python 3.9 now.


### Todo:

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://bestlifeonline.com/wp-content/uploads/sites/3/2019/07/what-is-quokka.jpg?quality=82&strip=all)
