### PR TITLE
feat: improve py-evm performance

### DIFF
--- a/eth/_utils/numeric.py
+++ b/eth/_utils/numeric.py
@@ -30,16 +30,12 @@ def int_to_bytes32(value: Union[int, bool]) -> Hash32:
     return Hash32(value_bytes)
 
 
-def ceilXX(value: int, ceiling: int) -> int:
-    remainder = value % ceiling
-    if remainder == 0:
-        return value
-    else:
-        return value + ceiling - remainder
+# hotspot, optimized
+def ceil32(x):
+    return (x + 31) & ~31
 
-
-ceil32 = functools.partial(ceilXX, ceiling=32)
-ceil8 = functools.partial(ceilXX, ceiling=8)
+def ceil8(x):
+    return (x + 7) & ~7
 
 
 def unsigned_to_signed(value: int) -> int:

--- a/eth/_utils/numeric.py
+++ b/eth/_utils/numeric.py
@@ -1,5 +1,4 @@
 import decimal
-import functools
 import itertools
 from typing import (
     Union,
@@ -31,10 +30,11 @@ def int_to_bytes32(value: Union[int, bool]) -> Hash32:
 
 
 # hotspot, optimized
-def ceil32(x):
+def ceil32(x: int) -> int:
     return (x + 31) & ~31
 
-def ceil8(x):
+
+def ceil8(x: int) -> int:
     return (x + 7) & ~7
 
 

--- a/eth/abc.py
+++ b/eth/abc.py
@@ -1507,23 +1507,9 @@ class OpcodeAPI(ABC):
         logic_fn: Callable[["ComputationAPI"], None],
         mnemonic: str,
         gas_cost: int,
-    ) -> T:
+    ) -> "OpcodeAPI":
         """
         Class factory method for turning vanilla functions into Opcodes.
-        """
-        ...
-
-    @abstractmethod
-    def __copy__(self) -> "OpcodeAPI":
-        """
-        Return a copy of the opcode.
-        """
-        ...
-
-    @abstractmethod
-    def __deepcopy__(self, memo: Any) -> "OpcodeAPI":
-        """
-        Return a deep copy of the opcode.
         """
         ...
 

--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -54,14 +54,16 @@ class CodeStream(CodeStreamAPI):
         return self._raw_code_bytes[i]
 
     def __iter__(self) -> Iterator[int]:
-        # a very performance-sensitive method
-        pc = self.program_counter
-        while pc < self._length_cache:
-            opcode = self._raw_code_bytes[pc]
-            self.program_counter = pc + 1
+        # a performance-sensitive method
+        while True:
+            try:
+                opcode = self._raw_code_bytes[self.program_counter]
+            except IndexError:
+                break
+
+            self.program_counter += 1
             yield opcode
-            # a read might have adjusted the pc during the last yield
-            pc = self.program_counter
+            # note: a read might have adjusted the pc during the yield
 
         yield STOP
 

--- a/eth/vm/forks/berlin/opcodes.py
+++ b/eth/vm/forks/berlin/opcodes.py
@@ -10,6 +10,9 @@ from eth_utils.toolz import (
 from eth import (
     constants,
 )
+from eth.abc import (
+    OpcodeAPI,
+)
 from eth.vm import (
     mnemonics,
     opcode_values,
@@ -24,7 +27,6 @@ from eth.vm.forks.tangerine_whistle.constants import (
     GAS_SELFDESTRUCT_EIP150,
 )
 from eth.vm.opcode import (
-    Opcode,
     as_opcode,
 )
 
@@ -32,7 +34,7 @@ from . import (
     logic,
 )
 
-UPDATED_OPCODES: Dict[int, Opcode] = {
+UPDATED_OPCODES: Dict[int, OpcodeAPI] = {
     opcode_values.BALANCE: as_opcode(
         gas_cost=constants.GAS_NULL,
         logic_fn=logic.balance_eip2929,

--- a/eth/vm/forks/london/opcodes.py
+++ b/eth/vm/forks/london/opcodes.py
@@ -10,6 +10,9 @@ from eth_utils.toolz import (
 from eth import (
     constants,
 )
+from eth.abc import (
+    OpcodeAPI,
+)
 from eth.vm import (
     mnemonics,
     opcode_values,
@@ -24,7 +27,6 @@ from eth.vm.logic import (
     block,
 )
 from eth.vm.opcode import (
-    Opcode,
     as_opcode,
 )
 
@@ -32,7 +34,7 @@ from . import (
     storage,
 )
 
-UPDATED_OPCODES: Dict[int, Opcode] = {
+UPDATED_OPCODES: Dict[int, OpcodeAPI] = {
     opcode_values.BASEFEE: as_opcode(
         gas_cost=constants.GAS_BASE,
         logic_fn=block.basefee,

--- a/eth/vm/logic/duplication.py
+++ b/eth/vm/logic/duplication.py
@@ -1,45 +1,67 @@
-import functools
-
 from eth.abc import (
     ComputationAPI,
 )
 
 
-def dup_XX(computation: ComputationAPI, position: int) -> None:
-    """
-    Stack item duplication.
-    """
-    computation.stack_dup(position)
+def dup1(computation: ComputationAPI) -> None:
+    computation.stack_dup(1)
 
-def dup1(computation):
-    dup_XX(computation, 1)
-def dup2(computation):
-    dup_XX(computation, 2)
-def dup3(computation):
-    dup_XX(computation, 3)
-def dup4(computation):
-    dup_XX(computation, 4)
-def dup5(computation):
-    dup_XX(computation, 5)
-def dup6(computation):
-    dup_XX(computation, 6)
-def dup7(computation):
-    dup_XX(computation, 7)
-def dup8(computation):
-    dup_XX(computation, 8)
-def dup9(computation):
-    dup_XX(computation, 9)
-def dup10(computation):
-    dup_XX(computation, 10)
-def dup11(computation):
-    dup_XX(computation, 11)
-def dup12(computation):
-    dup_XX(computation, 12)
-def dup13(computation):
-    dup_XX(computation, 13)
-def dup14(computation):
-    dup_XX(computation, 14)
-def dup15(computation):
-    dup_XX(computation, 15)
-def dup16(computation):
-    dup_XX(computation, 16)
+
+def dup2(computation: ComputationAPI) -> None:
+    computation.stack_dup(2)
+
+
+def dup3(computation: ComputationAPI) -> None:
+    computation.stack_dup(3)
+
+
+def dup4(computation: ComputationAPI) -> None:
+    computation.stack_dup(4)
+
+
+def dup5(computation: ComputationAPI) -> None:
+    computation.stack_dup(5)
+
+
+def dup6(computation: ComputationAPI) -> None:
+    computation.stack_dup(6)
+
+
+def dup7(computation: ComputationAPI) -> None:
+    computation.stack_dup(7)
+
+
+def dup8(computation: ComputationAPI) -> None:
+    computation.stack_dup(8)
+
+
+def dup9(computation: ComputationAPI) -> None:
+    computation.stack_dup(9)
+
+
+def dup10(computation: ComputationAPI) -> None:
+    computation.stack_dup(10)
+
+
+def dup11(computation: ComputationAPI) -> None:
+    computation.stack_dup(11)
+
+
+def dup12(computation: ComputationAPI) -> None:
+    computation.stack_dup(12)
+
+
+def dup13(computation: ComputationAPI) -> None:
+    computation.stack_dup(13)
+
+
+def dup14(computation: ComputationAPI) -> None:
+    computation.stack_dup(14)
+
+
+def dup15(computation: ComputationAPI) -> None:
+    computation.stack_dup(15)
+
+
+def dup16(computation: ComputationAPI) -> None:
+    computation.stack_dup(16)

--- a/eth/vm/logic/duplication.py
+++ b/eth/vm/logic/duplication.py
@@ -11,20 +11,35 @@ def dup_XX(computation: ComputationAPI, position: int) -> None:
     """
     computation.stack_dup(position)
 
-
-dup1 = functools.partial(dup_XX, position=1)
-dup2 = functools.partial(dup_XX, position=2)
-dup3 = functools.partial(dup_XX, position=3)
-dup4 = functools.partial(dup_XX, position=4)
-dup5 = functools.partial(dup_XX, position=5)
-dup6 = functools.partial(dup_XX, position=6)
-dup7 = functools.partial(dup_XX, position=7)
-dup8 = functools.partial(dup_XX, position=8)
-dup9 = functools.partial(dup_XX, position=9)
-dup10 = functools.partial(dup_XX, position=10)
-dup11 = functools.partial(dup_XX, position=11)
-dup12 = functools.partial(dup_XX, position=12)
-dup13 = functools.partial(dup_XX, position=13)
-dup14 = functools.partial(dup_XX, position=14)
-dup15 = functools.partial(dup_XX, position=15)
-dup16 = functools.partial(dup_XX, position=16)
+def dup1(computation):
+    dup_XX(computation, 1)
+def dup2(computation):
+    dup_XX(computation, 2)
+def dup3(computation):
+    dup_XX(computation, 3)
+def dup4(computation):
+    dup_XX(computation, 4)
+def dup5(computation):
+    dup_XX(computation, 5)
+def dup6(computation):
+    dup_XX(computation, 6)
+def dup7(computation):
+    dup_XX(computation, 7)
+def dup8(computation):
+    dup_XX(computation, 8)
+def dup9(computation):
+    dup_XX(computation, 9)
+def dup10(computation):
+    dup_XX(computation, 10)
+def dup11(computation):
+    dup_XX(computation, 11)
+def dup12(computation):
+    dup_XX(computation, 12)
+def dup13(computation):
+    dup_XX(computation, 13)
+def dup14(computation):
+    dup_XX(computation, 14)
+def dup15(computation):
+    dup_XX(computation, 15)
+def dup16(computation):
+    dup_XX(computation, 16)

--- a/eth/vm/logic/stack.py
+++ b/eth/vm/logic/stack.py
@@ -1,5 +1,3 @@
-import functools
-
 from eth.abc import (
     ComputationAPI,
 )
@@ -24,67 +22,133 @@ def push_XX(computation: ComputationAPI, size: int) -> None:
         computation.stack_push_bytes(padded_value)
 
 
-def push1(computation):
+def push0(computation: ComputationAPI) -> None:
+    return push_XX(computation, 0)
+
+
+def push1(computation: ComputationAPI) -> None:
     return push_XX(computation, 1)
-def push2(computation):
+
+
+def push2(computation: ComputationAPI) -> None:
     return push_XX(computation, 2)
-def push3(computation):
+
+
+def push3(computation: ComputationAPI) -> None:
     return push_XX(computation, 3)
-def push4(computation):
+
+
+def push4(computation: ComputationAPI) -> None:
     return push_XX(computation, 4)
-def push5(computation):
+
+
+def push5(computation: ComputationAPI) -> None:
     return push_XX(computation, 5)
-def push6(computation):
+
+
+def push6(computation: ComputationAPI) -> None:
     return push_XX(computation, 6)
-def push7(computation):
+
+
+def push7(computation: ComputationAPI) -> None:
     return push_XX(computation, 7)
-def push8(computation):
+
+
+def push8(computation: ComputationAPI) -> None:
     return push_XX(computation, 8)
-def push9(computation):
+
+
+def push9(computation: ComputationAPI) -> None:
     return push_XX(computation, 9)
-def push10(computation):
+
+
+def push10(computation: ComputationAPI) -> None:
     return push_XX(computation, 10)
-def push11(computation):
+
+
+def push11(computation: ComputationAPI) -> None:
     return push_XX(computation, 11)
-def push12(computation):
+
+
+def push12(computation: ComputationAPI) -> None:
     return push_XX(computation, 12)
-def push13(computation):
+
+
+def push13(computation: ComputationAPI) -> None:
     return push_XX(computation, 13)
-def push14(computation):
+
+
+def push14(computation: ComputationAPI) -> None:
     return push_XX(computation, 14)
-def push15(computation):
+
+
+def push15(computation: ComputationAPI) -> None:
     return push_XX(computation, 15)
-def push16(computation):
+
+
+def push16(computation: ComputationAPI) -> None:
     return push_XX(computation, 16)
-def push17(computation):
+
+
+def push17(computation: ComputationAPI) -> None:
     return push_XX(computation, 17)
-def push18(computation):
+
+
+def push18(computation: ComputationAPI) -> None:
     return push_XX(computation, 18)
-def push19(computation):
+
+
+def push19(computation: ComputationAPI) -> None:
     return push_XX(computation, 19)
-def push20(computation):
+
+
+def push20(computation: ComputationAPI) -> None:
     return push_XX(computation, 20)
-def push21(computation):
+
+
+def push21(computation: ComputationAPI) -> None:
     return push_XX(computation, 21)
-def push22(computation):
+
+
+def push22(computation: ComputationAPI) -> None:
     return push_XX(computation, 22)
-def push23(computation):
+
+
+def push23(computation: ComputationAPI) -> None:
     return push_XX(computation, 23)
-def push24(computation):
+
+
+def push24(computation: ComputationAPI) -> None:
     return push_XX(computation, 24)
-def push25(computation):
+
+
+def push25(computation: ComputationAPI) -> None:
     return push_XX(computation, 25)
-def push26(computation):
+
+
+def push26(computation: ComputationAPI) -> None:
     return push_XX(computation, 26)
-def push27(computation):
+
+
+def push27(computation: ComputationAPI) -> None:
     return push_XX(computation, 27)
-def push28(computation):
+
+
+def push28(computation: ComputationAPI) -> None:
     return push_XX(computation, 28)
-def push29(computation):
+
+
+def push29(computation: ComputationAPI) -> None:
     return push_XX(computation, 29)
-def push30(computation):
+
+
+def push30(computation: ComputationAPI) -> None:
     return push_XX(computation, 30)
-def push31(computation):
+
+
+def push31(computation: ComputationAPI) -> None:
     return push_XX(computation, 31)
-def push32(computation):
+
+
+def push32(computation: ComputationAPI) -> None:
     return push_XX(computation, 32)

--- a/eth/vm/logic/stack.py
+++ b/eth/vm/logic/stack.py
@@ -24,36 +24,67 @@ def push_XX(computation: ComputationAPI, size: int) -> None:
         computation.stack_push_bytes(padded_value)
 
 
-push0 = functools.partial(push_XX, size=0)
-push1 = functools.partial(push_XX, size=1)
-push2 = functools.partial(push_XX, size=2)
-push3 = functools.partial(push_XX, size=3)
-push4 = functools.partial(push_XX, size=4)
-push5 = functools.partial(push_XX, size=5)
-push6 = functools.partial(push_XX, size=6)
-push7 = functools.partial(push_XX, size=7)
-push8 = functools.partial(push_XX, size=8)
-push9 = functools.partial(push_XX, size=9)
-push10 = functools.partial(push_XX, size=10)
-push11 = functools.partial(push_XX, size=11)
-push12 = functools.partial(push_XX, size=12)
-push13 = functools.partial(push_XX, size=13)
-push14 = functools.partial(push_XX, size=14)
-push15 = functools.partial(push_XX, size=15)
-push16 = functools.partial(push_XX, size=16)
-push17 = functools.partial(push_XX, size=17)
-push18 = functools.partial(push_XX, size=18)
-push19 = functools.partial(push_XX, size=19)
-push20 = functools.partial(push_XX, size=20)
-push21 = functools.partial(push_XX, size=21)
-push22 = functools.partial(push_XX, size=22)
-push23 = functools.partial(push_XX, size=23)
-push24 = functools.partial(push_XX, size=24)
-push25 = functools.partial(push_XX, size=25)
-push26 = functools.partial(push_XX, size=26)
-push27 = functools.partial(push_XX, size=27)
-push28 = functools.partial(push_XX, size=28)
-push29 = functools.partial(push_XX, size=29)
-push30 = functools.partial(push_XX, size=30)
-push31 = functools.partial(push_XX, size=31)
-push32 = functools.partial(push_XX, size=32)
+def push1(computation):
+    return push_XX(computation, 1)
+def push2(computation):
+    return push_XX(computation, 2)
+def push3(computation):
+    return push_XX(computation, 3)
+def push4(computation):
+    return push_XX(computation, 4)
+def push5(computation):
+    return push_XX(computation, 5)
+def push6(computation):
+    return push_XX(computation, 6)
+def push7(computation):
+    return push_XX(computation, 7)
+def push8(computation):
+    return push_XX(computation, 8)
+def push9(computation):
+    return push_XX(computation, 9)
+def push10(computation):
+    return push_XX(computation, 10)
+def push11(computation):
+    return push_XX(computation, 11)
+def push12(computation):
+    return push_XX(computation, 12)
+def push13(computation):
+    return push_XX(computation, 13)
+def push14(computation):
+    return push_XX(computation, 14)
+def push15(computation):
+    return push_XX(computation, 15)
+def push16(computation):
+    return push_XX(computation, 16)
+def push17(computation):
+    return push_XX(computation, 17)
+def push18(computation):
+    return push_XX(computation, 18)
+def push19(computation):
+    return push_XX(computation, 19)
+def push20(computation):
+    return push_XX(computation, 20)
+def push21(computation):
+    return push_XX(computation, 21)
+def push22(computation):
+    return push_XX(computation, 22)
+def push23(computation):
+    return push_XX(computation, 23)
+def push24(computation):
+    return push_XX(computation, 24)
+def push25(computation):
+    return push_XX(computation, 25)
+def push26(computation):
+    return push_XX(computation, 26)
+def push27(computation):
+    return push_XX(computation, 27)
+def push28(computation):
+    return push_XX(computation, 28)
+def push29(computation):
+    return push_XX(computation, 29)
+def push30(computation):
+    return push_XX(computation, 30)
+def push31(computation):
+    return push_XX(computation, 31)
+def push32(computation):
+    return push_XX(computation, 32)

--- a/eth/vm/logic/swap.py
+++ b/eth/vm/logic/swap.py
@@ -11,20 +11,35 @@ def swap_XX(computation: ComputationAPI, position: int) -> None:
     """
     computation.stack_swap(position)
 
-
-swap1 = functools.partial(swap_XX, position=1)
-swap2 = functools.partial(swap_XX, position=2)
-swap3 = functools.partial(swap_XX, position=3)
-swap4 = functools.partial(swap_XX, position=4)
-swap5 = functools.partial(swap_XX, position=5)
-swap6 = functools.partial(swap_XX, position=6)
-swap7 = functools.partial(swap_XX, position=7)
-swap8 = functools.partial(swap_XX, position=8)
-swap9 = functools.partial(swap_XX, position=9)
-swap10 = functools.partial(swap_XX, position=10)
-swap11 = functools.partial(swap_XX, position=11)
-swap12 = functools.partial(swap_XX, position=12)
-swap13 = functools.partial(swap_XX, position=13)
-swap14 = functools.partial(swap_XX, position=14)
-swap15 = functools.partial(swap_XX, position=15)
-swap16 = functools.partial(swap_XX, position=16)
+def swap1(computation):
+    swap_XX(computation, 1)
+def swap2(computation):
+    swap_XX(computation, 2)
+def swap3(computation):
+    swap_XX(computation, 3)
+def swap4(computation):
+    swap_XX(computation, 4)
+def swap5(computation):
+    swap_XX(computation, 5)
+def swap6(computation):
+    swap_XX(computation, 6)
+def swap7(computation):
+    swap_XX(computation, 7)
+def swap8(computation):
+    swap_XX(computation, 8)
+def swap9(computation):
+    swap_XX(computation, 9)
+def swap10(computation):
+    swap_XX(computation, 10)
+def swap11(computation):
+    swap_XX(computation, 11)
+def swap12(computation):
+    swap_XX(computation, 12)
+def swap13(computation):
+    swap_XX(computation, 13)
+def swap14(computation):
+    swap_XX(computation, 14)
+def swap15(computation):
+    swap_XX(computation, 15)
+def swap16(computation):
+    swap_XX(computation, 16)

--- a/eth/vm/logic/swap.py
+++ b/eth/vm/logic/swap.py
@@ -1,45 +1,67 @@
-import functools
-
 from eth.abc import (
     ComputationAPI,
 )
 
 
-def swap_XX(computation: ComputationAPI, position: int) -> None:
-    """
-    Stack item swapping
-    """
-    computation.stack_swap(position)
+def swap1(computation: ComputationAPI) -> None:
+    computation.stack_swap(1)
 
-def swap1(computation):
-    swap_XX(computation, 1)
-def swap2(computation):
-    swap_XX(computation, 2)
-def swap3(computation):
-    swap_XX(computation, 3)
-def swap4(computation):
-    swap_XX(computation, 4)
-def swap5(computation):
-    swap_XX(computation, 5)
-def swap6(computation):
-    swap_XX(computation, 6)
-def swap7(computation):
-    swap_XX(computation, 7)
-def swap8(computation):
-    swap_XX(computation, 8)
-def swap9(computation):
-    swap_XX(computation, 9)
-def swap10(computation):
-    swap_XX(computation, 10)
-def swap11(computation):
-    swap_XX(computation, 11)
-def swap12(computation):
-    swap_XX(computation, 12)
-def swap13(computation):
-    swap_XX(computation, 13)
-def swap14(computation):
-    swap_XX(computation, 14)
-def swap15(computation):
-    swap_XX(computation, 15)
-def swap16(computation):
-    swap_XX(computation, 16)
+
+def swap2(computation: ComputationAPI) -> None:
+    computation.stack_swap(2)
+
+
+def swap3(computation: ComputationAPI) -> None:
+    computation.stack_swap(3)
+
+
+def swap4(computation: ComputationAPI) -> None:
+    computation.stack_swap(4)
+
+
+def swap5(computation: ComputationAPI) -> None:
+    computation.stack_swap(5)
+
+
+def swap6(computation: ComputationAPI) -> None:
+    computation.stack_swap(6)
+
+
+def swap7(computation: ComputationAPI) -> None:
+    computation.stack_swap(7)
+
+
+def swap8(computation: ComputationAPI) -> None:
+    computation.stack_swap(8)
+
+
+def swap9(computation: ComputationAPI) -> None:
+    computation.stack_swap(9)
+
+
+def swap10(computation: ComputationAPI) -> None:
+    computation.stack_swap(10)
+
+
+def swap11(computation: ComputationAPI) -> None:
+    computation.stack_swap(11)
+
+
+def swap12(computation: ComputationAPI) -> None:
+    computation.stack_swap(12)
+
+
+def swap13(computation: ComputationAPI) -> None:
+    computation.stack_swap(13)
+
+
+def swap14(computation: ComputationAPI) -> None:
+    computation.stack_swap(14)
+
+
+def swap15(computation: ComputationAPI) -> None:
+    computation.stack_swap(15)
+
+
+def swap16(computation: ComputationAPI) -> None:
+    computation.stack_swap(16)

--- a/eth/vm/memory.py
+++ b/eth/vm/memory.py
@@ -53,8 +53,7 @@ class Memory(MemoryAPI):
             validate_length(value, length=size)
             validate_lte(start_position + size, maximum=len(self))
 
-            for idx, v in enumerate(value):
-                self._bytes[start_position + idx] = v
+            self._bytes[start_position : start_position + len(value)] = value
 
     def read(self, start_position: int, size: int) -> memoryview:
         return memoryview(self._bytes)[start_position : start_position + size]

--- a/eth/vm/memory.py
+++ b/eth/vm/memory.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 
 from eth._utils.numeric import (
@@ -32,7 +31,7 @@ class Memory(MemoryAPI):
 
         size_to_extend = new_size - len(self)
         try:
-            self._bytes.extend(itertools.repeat(0, size_to_extend))
+            self._bytes.extend(bytearray(size_to_extend))
         except BufferError:
             # we can't extend the buffer (which might involve relocating it) if a
             # memoryview (which stores a pointer into the buffer) has been created by

--- a/eth/vm/opcode.py
+++ b/eth/vm/opcode.py
@@ -63,7 +63,7 @@ class Opcode(Configurable, OpcodeAPI):
             "gas_cost": gas_cost,
         }
         opcode_cls = type(f"opcode:{mnemonic}", (cls,), props)
-        return opcode_cls()
+        return wrapped_logic_fn
 
     def __copy__(self) -> "Opcode":
         return type(self)()

--- a/eth/vm/stack.py
+++ b/eth/vm/stack.py
@@ -1,5 +1,6 @@
 import logging
 from typing import (
+    Any,
     Iterable,
     List,
     Tuple,
@@ -49,7 +50,7 @@ class Stack(StackAPI):
     #
 
     def __init__(self) -> None:
-        values: List[Tuple[type, Union[int, bytes]]] = []
+        values: List[Union[int, bytes]] = []
         self.values = values
         # caching optimizations to avoid an attribute lookup on self.values
         # This doesn't use `cached_property`, because it doesn't play nice with slots
@@ -136,28 +137,29 @@ class Stack(StackAPI):
             raise InsufficientStack(f"Insufficient stack items for DUP{position}")
 
     def _stack_items_str(self) -> Iterable[str]:
-        for item_type, val in self.values:
+        for val in self.values:
             if isinstance(val, int):
                 yield hex(val)
             elif isinstance(val, bytes):
                 yield "0x" + val.hex()
             else:
                 raise RuntimeError(
-                    f"Stack items can only be int or bytes, not {val!r}:{item_type}"
+                    f"Stack items can only be int or bytes, not {val!r}:{type(val)}"
                 )
 
     def __str__(self) -> str:
         return str(list(self._stack_items_str()))
 
 
-def to_int(x):
+def to_int(x: Any) -> int:
     if isinstance(x, int):
         return x
     if isinstance(x, bytes):
         return big_endian_to_int(x)
     raise _busted_type(x)
 
-def to_bytes(x):
+
+def to_bytes(x: Any) -> bytes:
     if isinstance(x, bytes):
         return x
     if isinstance(x, int):

--- a/newsfragments/2076.performance.rst
+++ b/newsfragments/2076.performance.rst
@@ -1,0 +1,1 @@
+Performance improvements; code refactor; some cleanup.


### PR DESCRIPTION
### What was wrong?


### How was it fixed?
grab bag of optimizations. profiling (using pypy as the runtime) showed that hotspots included
- `functools.__call__` (presumably from `functools.partial` and `functools.wraps`)
- `apply_computation`
- `expand_memory`
- stack operations

to that end, I applied the following optimizations
- write more inlineable wrappers for DUP/SWAP/PUSH instructions
- write more inlineable ceil_XX implementations, replace with branchless implementation
- optimize the Stack data structure. instead of using List[type, value], simply use List[value] (as the type is tagged in the python runtime anyways)
- optimize apply_computation event loop
  - remove usage of CodeStream iterator, inline pc logic
  - remove `__enter__` and `__exit__`, replace with inlined try/finally
- a minor peephole optimization in expand_memory, not sure if it helped much.

some of these optimizations are simple rewrites (e.g. ceil32 rewrite and stack data structure), but others (e.g. inlining `CodeStream.__iter__`) may break some abstractions.

execution time came down 25% in local timings, will try to make some reproductions

```
$ pypy3 --version
Python 3.8.13 (7.3.9+dfsg-1, Apr 01 2022, 21:41:47)
[PyPy 7.3.9 with GCC 11.2.0]
```

final thoughts -- according to profiling, this is most of the low hanging fruit. better performance would probably need to come from some deeper redesigns, including how opcodes are constructed / get looked up and analyzed (analysis of opcodes for runtime hotspots could be very fruitful, for instance)

### Todo:

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] reproduce timings
- [x] record profiling results

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

```
  \ /
(. )=========-
   /\ /\ /\ /\
```
