### PR TITLE
Invoke tox differently in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ common: &common
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox
+        command: python -m tox -r
     - save_cache:
         paths:
           - .hypothesis

--- a/newsfragments/2082.misc.rst
+++ b/newsfragments/2082.misc.rst
@@ -1,0 +1,1 @@
+Invoke tox with ``python -m tox``


### PR DESCRIPTION
### What was wrong?

The updated circleci images can't find tox under `~/.local/bin/tox`

### How was it fixed?
Changed invocation to: `python -m tox -r`


### Todo:

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/7d/5e/d3/7d5ed3f95b1b888c79d94243c85409db.jpg)
