### PR TITLE
Address failing tests from ethereum/tests ``v11.1``

### DIFF
--- a/docs/guides/understanding_the_mining_process.rst
+++ b/docs/guides/understanding_the_mining_process.rst
@@ -376,8 +376,8 @@ zero value transfer transaction.
   >>> nonce, mix_hash = mine_pow_nonce(
   ...     block.number,
   ...     block.header.mining_hash,
-  ...     block.header.difficulty
-  ... )
+  ...     block.header.difficulty,
+  ... )  # doctest: +SKIP (takes too long for doctest to process)
 
-  >>> chain.mine_block(mix_hash=mix_hash, nonce=nonce)
+  >>> chain.mine_block(mix_hash=mix_hash, nonce=nonce)  # doctest: +SKIP
   <ByzantiumBlock(#Block #1-0xe372..385c)>

--- a/eth/vm/forks/byzantium/headers.py
+++ b/eth/vm/forks/byzantium/headers.py
@@ -60,7 +60,7 @@ def compute_difficulty(
     )
     difficulty = max(
         parent_difficulty + offset * adj_factor,
-        min(parent_header.difficulty, DIFFICULTY_MINIMUM)
+        DIFFICULTY_MINIMUM
     )
     num_bomb_periods = (
         max(

--- a/eth/vm/forks/homestead/headers.py
+++ b/eth/vm/forks/homestead/headers.py
@@ -46,13 +46,16 @@ def compute_homestead_difficulty(parent_header: BlockHeaderAPI, timestamp: int) 
     offset = parent_header.difficulty // DIFFICULTY_ADJUSTMENT_DENOMINATOR
     sign = max(
         1 - (timestamp - parent_tstamp) // HOMESTEAD_DIFFICULTY_ADJUSTMENT_CUTOFF,
-        -99)
-    difficulty = int(max(
+        -99,
+    )
+    difficulty = max(
         parent_header.difficulty + offset * sign,
-        min(parent_header.difficulty, DIFFICULTY_MINIMUM)))
+        DIFFICULTY_MINIMUM
+    )
     num_bomb_periods = (
         (parent_header.block_number + 1) // BOMB_EXPONENTIAL_PERIOD
     ) - BOMB_EXPONENTIAL_FREE_PERIODS
+
     if num_bomb_periods >= 0:
         return max(difficulty + 2**num_bomb_periods, DIFFICULTY_MINIMUM)
     else:

--- a/newsfragments/2084.bugfix.rst
+++ b/newsfragments/2084.bugfix.rst
@@ -1,0 +1,1 @@
+Use the ``DIFFICULTY_MINIMUM`` more appropriately as the lower limit in all difficulty calculations.

--- a/tests/core/consensus/test_pow_mining.py
+++ b/tests/core/consensus/test_pow_mining.py
@@ -77,7 +77,7 @@ def test_mining_tools_proof_of_work_mining(base_vm_class):
 
     chain = genesis(ChainClass)
 
-    block = chain.mine_block()
+    block = chain.mine_block(difficulty=1)
     check_pow(
         block.number,
         block.header.mining_hash,

--- a/tests/json-fixtures/blockchain/test_blockchain.py
+++ b/tests/json-fixtures/blockchain/test_blockchain.py
@@ -317,15 +317,6 @@ def blockchain_fixture_mark_fn(fixture_path, fixture_name, fixture_fork):
         return pytest.mark.skip(
             "EIP-2681 update not implemented. HighNonce tests turned off for now."
         )
-    elif any(_ in fixture_name for _ in (
-            "CreateAddressWarmAfterFailureEF", "doubleSelfdestructTouch",
-            "delegatecall09Undefined_d0g0v0", "senderBalance_d0g0v0",
-            "touchAndGo_d0g0v0",
-    )):
-        return pytest.mark.skip(
-            "Skipped failing tests in v11.1 update to get Merge-related changes in. "
-            "Turn these back on and fix after the Merge is implemented."
-        )
     elif "Merge" in fixture_name:
         # TODO: Implement changes for the Merge and turn these tests on
         return pytest.mark.skip("The Merge has not yet been implemented.")


### PR DESCRIPTION
### What was wrong?

Related to #2075 

- Difficulty calculation was taking into account the parent ``difficulty`` which would slip below the ``DIFFICULTY_MINIMUM`` value if the parent ``difficulty`` was less than the allowed minimum. 

### How was it fixed?

- Take the max only between the difficulty calculation and the _actual_ minimum allowed value.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="631" alt="Screen Shot 2022-10-20 at 13 27 26" src="https://user-images.githubusercontent.com/3532824/197040130-beb8ef91-bd0c-4ae6-9ec9-4bb0382e5173.png">
