### PR TITLE
Pin ``importlib-metadata`` dependency to ``<5`` to allow py37 builds to run

### DIFF
--- a/newsfragments/2085.misc.rst
+++ b/newsfragments/2085.misc.rst
@@ -1,0 +1,1 @@
+Pin ``importlib-metadata`` dependency to ``<5`` to allow py37 builds to run

--- a/setup.py
+++ b/setup.py
@@ -38,12 +38,14 @@ deps = {
         "pytest-timeout>=1.4.2,<2",
         "pytest-watch>=4.1.0,<5",
         "pytest-xdist==2.3.0",
+        "importlib-metadata<5.0;python_version<'3.8'",
     ],
     'lint': [
         "flake8==3.8.2",
         "flake8-bugbear==20.1.4",
         "mypy==0.910",
-        "types-setuptools"
+        "types-setuptools",
+        "importlib-metadata<5.0;python_version<'3.8'",
     ],
     'benchmark': [
         "termcolor>=1.1.0,<2.0.0",


### PR DESCRIPTION
### What was wrong?

- Breaking ``importlib-metadata`` dependency issues with python version below ``3.8``

### How was it fixed?

- Pin version to ``<5`` for python versions below ``3.8``

### Todo:


- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20221006_210324](https://user-images.githubusercontent.com/3532824/194640732-2e1446e0-eed9-460b-833f-20a80fabd005.jpg)
