### PR TITLE
Update OpenSSL Config for ripemd160

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,26 @@ common: &common
   steps:
     - checkout
     - run:
+        # this is necessary until circleci images begin using openssl>=3.0.7
+        name: update openssl.cnf for ripemd160
+        command: |
+          sudo tee -a /etc/ssl/openssl.cnf >/dev/null <<'EOF'
+
+          [openssl_init]
+          providers = provider_sect
+
+          [provider_sect]
+          default = default_sect
+          legacy = legacy_sect
+
+          [default_sect]
+          activate = 1
+
+          [legacy_sect]
+          activate = 1
+
+          EOF
+    - run:
         name: checkout fixtures submodule
         command: git submodule update --init --recursive
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ common: &common
   steps:
     - checkout
     - run:
+        name: check openssl version
+        command: dpkg -l | grep " openssl "
+    - run:
         # this is necessary until circleci images begin using openssl>=3.0.7
         name: update openssl.cnf for ripemd160
         command: |

--- a/newsfragments/2087.internal.rst
+++ b/newsfragments/2087.internal.rst
@@ -1,0 +1,1 @@
+Update openssl config on circleci builds to re-introduce ``ripemd160`` function by default.


### PR DESCRIPTION
### What was wrong?

- OpenSSL 3 removed ripemd160 functions from the default behavior. Instead they now have to be locally configured. This broke a lot of blockchain related logic and they decided to add it back in in version 3.0.7, see blog post [here](https://www.openssl.org/blog/blog/2022/10/18/rmd160-and-the-legacy-provider/).

- CircleCI is using openssl3 but not (yet?) the latest version. Since this breaks tests even on `master`, which were previously passing, we need to update the config for now until the newer open ssl version is used in the circleci images.

### How was it fixed?

- For now, updating the openssl config just works™ and we can ideally remove it when the images are updated.
- Config changes suggested, among other places, [here](https://github.com/openssl/openssl/issues/16994#issuecomment-963669325)

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![IMG_2333](https://user-images.githubusercontent.com/3532824/200391164-c892ae4b-487b-4e1d-8465-04c537886713.jpg)
