### PR TITLE
Remove upper pin on eth-bloom

### DIFF
--- a/newsfragments/2090.misc.rst
+++ b/newsfragments/2090.misc.rst
@@ -1,0 +1,1 @@
+Remove upper pin on eth-bloom, minor updates to get tox running

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 deps = {
     'eth': [
         "cached-property>=1.5.1,<2",
-        "eth-bloom>=1.0.3,<2.0.0",
+        "eth-bloom>=1.0.3",
         "eth-keys>=0.4.0,<0.5.0",
         "eth-typing>=3.2.0,<4.0.0",
         "eth-utils>=2.0.0,<3.0.0",
@@ -52,7 +52,7 @@ deps = {
         "web3>=4.1.0,<5.0.0",
     ],
     'doc': [
-        "py-evm>=0.2.0-alpha.14",
+        "py-evm>=0.2.0-a.14",
         # We need to have pysha for autodoc to be able to extract API docs
         "pysha3>=1.0.0,<2.0.0",
         "Sphinx>=1.5.5,<2",

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ deps: {[common-lint]deps}
 commands: {[common-lint]commands}
 
 [testenv:py39-docs]
-whitelist_externals=
+allowlist_externals=
     make
 deps = .[doc,eth-extra]
 passenv =


### PR DESCRIPTION
### What was wrong?
To get dependencies to resolve, we need to remove the upper pin on eth-bloom.

### How was it fixed?
Removed pin per our current philosophy. I will remove other pins in a separate PR. 

### Todo:

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (See: https://py-evm.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://lazypenguins.com/wp-content/uploads/2016/02/Adorable-Platypus-Babies.jpg)
