### PR TITLE
Added isort for reorganizing imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ version: 2.0
 
 common: &common
   working_directory: ~/repo
+  resource_class: xlarge
   steps:
     - checkout
     - run:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ clean-pyc:
 lint:
 	tox -e lint
 
+lint-roll:
+	$(MAKE) lint
+
 test:
 	py.test --tb native tests
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ deps = {
         "pydocstyle>=6.0.0",
         "types-setuptools",
         "importlib-metadata<5.0;python_version<'3.8'",
+        "isort>=5.12.0"
     ],
     'benchmark': [
         "termcolor>=1.1.0,<2.0.0",
@@ -72,7 +73,7 @@ deps = {
         "idna==2.7",
         # idna 2.7 is not supported by requests 2.18
         "requests>=2.20,<3",
-        "tox==2.7.0",
+        "tox>=4.4.12",
         "twine",
     ],
 }


### PR DESCRIPTION
### What was wrong?

Imports are not sorted.

Related to Issue https://github.com/ethereum/py-evm/issues/2094

### How was it fixed?

Added `isort`, a tool to sort imports, in the linting process.

Adding lint setup + linting files would be a large PR to review. I've decided to split it up into two parts. 
This is first PR. 
In this PR, I've added `isort` and related commands to `setup.py`, `Makefile` and `tox`. 
In the follow up PR, I will be running `make lint-roll`. It will be easier for repo maintainers to checksum the changes and review the lint changes. 

Let me know if I missed anything in the contribution process.

### Todo:
- [x] Clean up commit history

- [ ] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![white-rabbit-24093391](https://user-images.githubusercontent.com/3950603/233183169-c2013af8-fb73-4992-861a-abd2f5300f5c.jpg)
