### PR TITLE
[2/3] Linted file with isort in eth and tests directory

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# ignore SHA that added isort
+2f421ce6049dc74a1520280adf8c350c1c567e9f

--- a/eth/_utils/address.py
+++ b/eth/_utils/address.py
@@ -1,7 +1,10 @@
+from eth_hash.auto import (
+    keccak,
+)
+from eth_typing import (
+    Address,
+)
 import rlp
-
-from eth_hash.auto import keccak
-from eth_typing import Address
 
 from eth._utils.numeric import (
     int_to_bytes32,

--- a/eth/_utils/blake2/coders.py
+++ b/eth/_utils/blake2/coders.py
@@ -1,13 +1,13 @@
 from typing import (
-    cast,
     Iterable,
     Tuple,
+    cast,
 )
 
 from eth_utils import (
+    ValidationError,
     to_int,
     to_tuple,
-    ValidationError,
 )
 
 from .compression import (

--- a/eth/_utils/bn128.py
+++ b/eth/_utils/bn128.py
@@ -1,16 +1,17 @@
-from py_ecc import (
-    optimized_bn128 as bn128,
-)
-from py_ecc.optimized_bn128 import (
-    FQP,
-    FQ2,
+from typing import (
+    Tuple,
 )
 
 from eth_utils import (
     ValidationError,
 )
-
-from typing import Tuple
+from py_ecc import (
+    optimized_bn128 as bn128,
+)
+from py_ecc.optimized_bn128 import (
+    FQ2,
+    FQP,
+)
 
 
 def validate_point(x: int, y: int) -> Tuple[bn128.FQ, bn128.FQ, bn128.FQ]:

--- a/eth/_utils/datatypes.py
+++ b/eth/_utils/datatypes.py
@@ -1,17 +1,25 @@
-from eth_utils.toolz import (
-    assoc,
-    groupby,
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Tuple,
+    Type,
+    TypeVar,
 )
 
 from eth_utils import (
     to_dict,
     to_set,
 )
+from eth_utils.toolz import (
+    assoc,
+    groupby,
+)
 
-
-from typing import Any, Dict, Tuple, Type, TypeVar, Iterator, List
-
-from eth.abc import ConfigurableAPI
+from eth.abc import (
+    ConfigurableAPI,
+)
 
 
 def _is_local_prop(prop: str) -> bool:

--- a/eth/_utils/env.py
+++ b/eth/_utils/env.py
@@ -4,7 +4,6 @@ extracting environment variables.
 """
 
 import os
-
 from typing import (
     Any,
     Callable,
@@ -15,7 +14,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
 
 # No set literals because we support Python 2.6.
 TRUE_VALUES = {

--- a/eth/_utils/generator.py
+++ b/eth/_utils/generator.py
@@ -7,7 +7,6 @@ from typing import (
     TypeVar,
 )
 
-
 TItem = TypeVar('TItem')
 
 

--- a/eth/_utils/headers.py
+++ b/eth/_utils/headers.py
@@ -9,17 +9,19 @@ from eth_typing import (
     Address,
 )
 
-from eth.abc import BlockHeaderAPI
+from eth.abc import (
+    BlockHeaderAPI,
+)
 from eth.constants import (
     BLANK_ROOT_HASH,
-    GENESIS_BLOCK_NUMBER,
-    GENESIS_PARENT_HASH,
-    GAS_LIMIT_EMA_DENOMINATOR,
     GAS_LIMIT_ADJUSTMENT_FACTOR,
+    GAS_LIMIT_EMA_DENOMINATOR,
     GAS_LIMIT_MAXIMUM,
     GAS_LIMIT_MINIMUM,
-    GAS_LIMIT_USAGE_ADJUSTMENT_NUMERATOR,
     GAS_LIMIT_USAGE_ADJUSTMENT_DENOMINATOR,
+    GAS_LIMIT_USAGE_ADJUSTMENT_NUMERATOR,
+    GENESIS_BLOCK_NUMBER,
+    GENESIS_PARENT_HASH,
     ZERO_ADDRESS,
 )
 from eth.typing import (

--- a/eth/_utils/module_loading.py
+++ b/eth/_utils/module_loading.py
@@ -1,6 +1,7 @@
+from importlib import (
+    import_module,
+)
 import operator
-from importlib import import_module
-
 from types import (
     ModuleType,
 )

--- a/eth/_utils/numeric.py
+++ b/eth/_utils/numeric.py
@@ -5,17 +5,17 @@ from typing import (
     Union,
 )
 
-from eth_utils.toolz import (
-    curry,
-)
 from eth_typing import (
     Hash32,
+)
+from eth_utils.toolz import (
+    curry,
 )
 
 from eth.constants import (
     UINT_255_MAX,
-    UINT_256_MAX,
     UINT_256_CEILING,
+    UINT_256_MAX,
 )
 
 

--- a/eth/_utils/padding.py
+++ b/eth/_utils/padding.py
@@ -2,7 +2,6 @@ from eth_utils.toolz import (
     curry,
 )
 
-
 ZERO_BYTE = b'\x00'
 
 

--- a/eth/_utils/rlp.py
+++ b/eth/_utils/rlp.py
@@ -1,18 +1,17 @@
-import rlp
 from typing import (
     Iterable,
     Optional,
     Tuple,
 )
 
+from eth_utils import (
+    ValidationError,
+    to_tuple,
+)
 from eth_utils.toolz import (
     curry,
 )
-
-from eth_utils import (
-    to_tuple,
-    ValidationError,
-)
+import rlp
 
 from eth.rlp.blocks import (
     BaseBlock,

--- a/eth/_utils/spoof.py
+++ b/eth/_utils/spoof.py
@@ -8,15 +8,14 @@ from eth_utils.toolz import (
     merge,
 )
 
-from eth.constants import (
-    DEFAULT_SPOOF_Y_PARITY,
-    DEFAULT_SPOOF_R,
-    DEFAULT_SPOOF_S,
-)
-
 from eth.abc import (
     SignedTransactionAPI,
     UnsignedTransactionAPI,
+)
+from eth.constants import (
+    DEFAULT_SPOOF_R,
+    DEFAULT_SPOOF_S,
+    DEFAULT_SPOOF_Y_PARITY,
 )
 
 SPOOF_ATTRIBUTES_DEFAULTS = {

--- a/eth/_utils/state.py
+++ b/eth/_utils/state.py
@@ -6,7 +6,9 @@ from eth.typing import (
     AccountDiff,
     AccountState,
 )
-from eth.vm.state import BaseState
+from eth.vm.state import (
+    BaseState,
+)
 
 
 @to_tuple

--- a/eth/_utils/transactions.py
+++ b/eth/_utils/transactions.py
@@ -1,18 +1,23 @@
-from typing import NamedTuple
+from typing import (
+    NamedTuple,
+)
 
-import rlp
-
-from eth_keys import keys
-from eth_keys import datatypes
+from eth_keys import (
+    datatypes,
+    keys,
+)
 from eth_keys.exceptions import (
     BadSignature,
 )
-
 from eth_utils import (
-    int_to_big_endian,
     ValidationError,
+    int_to_big_endian,
 )
+import rlp
 
+from eth._utils.numeric import (
+    is_even,
+)
 from eth.abc import (
     SignedTransactionAPI,
     UnsignedTransactionAPI,
@@ -20,16 +25,13 @@ from eth.abc import (
 from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
 )
+from eth.rlp.transactions import (
+    BaseTransaction,
+)
 from eth.typing import (
-    Address,
     VRS,
+    Address,
 )
-from eth._utils.numeric import (
-    is_even,
-)
-
-from eth.rlp.transactions import BaseTransaction
-
 
 EIP155_CHAIN_ID_OFFSET = 35
 # Add this offset to y_parity to get "v" for legacy transactions, from Frontier

--- a/eth/_utils/version.py
+++ b/eth/_utils/version.py
@@ -1,6 +1,8 @@
 import sys
 
-from eth import __version__
+from eth import (
+    __version__,
+)
 
 
 def construct_evm_runtime_identifier() -> str:

--- a/eth/_warnings.py
+++ b/eth/_warnings.py
@@ -1,5 +1,9 @@
-from contextlib import contextmanager
-from typing import Iterator
+from contextlib import (
+    contextmanager,
+)
+from typing import (
+    Iterator,
+)
 import warnings
 
 

--- a/eth/abc.py
+++ b/eth/abc.py
@@ -1,6 +1,6 @@
 from abc import (
     ABC,
-    abstractmethod
+    abstractmethod,
 )
 from typing import (
     Any,
@@ -9,6 +9,7 @@ from typing import (
     ContextManager,
     Dict,
     FrozenSet,
+    Hashable,
     Iterable,
     Iterator,
     List,
@@ -20,35 +21,37 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    Hashable,
 )
 
-from eth_bloom import BloomFilter
-
+from eth_bloom import (
+    BloomFilter,
+)
+from eth_keys.datatypes import (
+    PrivateKey,
+)
 from eth_typing import (
     Address,
     BlockNumber,
     Hash32,
 )
-
-from eth_utils import ExtendedDebugLogger
-
-from eth_keys.datatypes import PrivateKey
+from eth_utils import (
+    ExtendedDebugLogger,
+)
 
 from eth.constants import (
     BLANK_ROOT_HASH,
 )
-
-from eth.exceptions import VMError
+from eth.exceptions import (
+    VMError,
+)
 from eth.typing import (
+    AccountState,
     BytesOrView,
     ChainGaps,
-    JournalDBCheckpoint,
-    AccountState,
     HeaderParams,
+    JournalDBCheckpoint,
     VMConfiguration,
 )
-
 
 T = TypeVar('T')
 

--- a/eth/chains/base.py
+++ b/eth/chains/base.py
@@ -1,3 +1,4 @@
+import logging
 import operator
 import random
 from typing import (
@@ -9,8 +10,6 @@ from typing import (
     Tuple,
     Type,
 )
-
-import logging
 
 from eth_typing import (
     Address,
@@ -25,32 +24,35 @@ from eth_utils.toolz import (
     sliding_window,
 )
 
-from eth._utils.db import (
-    apply_state_dict,
-)
 from eth._utils.datatypes import (
     Configurable,
+)
+from eth._utils.db import (
+    apply_state_dict,
 )
 from eth._utils.rlp import (
     validate_imported_block_unchanged,
 )
+from eth._warnings import (
+    catch_and_ignore_import_warning,
+)
 from eth.abc import (
-    BlockAPI,
-    BlockAndMetaWitness,
-    MiningChainAPI,
     AtomicDatabaseAPI,
+    BlockAndMetaWitness,
+    BlockAPI,
     BlockHeaderAPI,
     BlockImportResult,
     BlockPersistResult,
     ChainAPI,
     ChainDatabaseAPI,
-    ConsensusContextAPI,
-    VirtualMachineAPI,
-    ReceiptAPI,
     ComputationAPI,
-    StateAPI,
+    ConsensusContextAPI,
+    MiningChainAPI,
+    ReceiptAPI,
     SignedTransactionAPI,
+    StateAPI,
     UnsignedTransactionAPI,
+    VirtualMachineAPI,
     WithdrawalAPI,
 )
 from eth.consensus import (
@@ -60,14 +62,12 @@ from eth.constants import (
     EMPTY_UNCLE_HASH,
     MAX_UNCLE_DEPTH,
 )
-
 from eth.db.chain import (
     ChainDB,
 )
 from eth.db.header import (
     HeaderDB,
 )
-
 from eth.estimators import (
     get_gas_estimator,
 )
@@ -76,30 +76,28 @@ from eth.exceptions import (
     TransactionNotFound,
     VMNotFound,
 )
-
 from eth.rlp.headers import (
     BlockHeader,
 )
-
 from eth.typing import (
     AccountState,
     HeaderParams,
     StaticMethod,
 )
-
 from eth.validation import (
     validate_block_number,
     validate_uint256,
-    validate_word,
     validate_vm_configuration,
+    validate_word,
 )
-from eth.vm.chain_context import ChainContext
+from eth.vm.chain_context import (
+    ChainContext,
+)
 
-from eth._warnings import catch_and_ignore_import_warning
 with catch_and_ignore_import_warning():
     from eth_utils import (
-        to_set,
         ValidationError,
+        to_set,
     )
     from eth_utils.toolz import (
         assoc,

--- a/eth/chains/goerli/constants.py
+++ b/eth/chains/goerli/constants.py
@@ -1,5 +1,6 @@
-from eth_typing import BlockNumber
-
+from eth_typing import (
+    BlockNumber,
+)
 
 GOERLI_CHAIN_ID = 5
 

--- a/eth/chains/header.py
+++ b/eth/chains/header.py
@@ -1,7 +1,7 @@
 from typing import (
-    cast,
     Tuple,
     Type,
+    cast,
 )
 
 from eth_typing import (
@@ -9,6 +9,9 @@ from eth_typing import (
     Hash32,
 )
 
+from eth._utils.datatypes import (
+    Configurable,
+)
 from eth.abc import (
     AtomicDatabaseAPI,
     BlockHeaderAPI,
@@ -20,9 +23,6 @@ from eth.db.backends.base import (
 )
 from eth.db.header import (
     HeaderDB,
-)
-from eth._utils.datatypes import (
-    Configurable,
 )
 
 

--- a/eth/chains/mainnet/constants.py
+++ b/eth/chains/mainnet/constants.py
@@ -1,5 +1,6 @@
-from eth_typing import BlockNumber
-
+from eth_typing import (
+    BlockNumber,
+)
 
 # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
 MAINNET_CHAIN_ID = 1

--- a/eth/chains/ropsten/constants.py
+++ b/eth/chains/ropsten/constants.py
@@ -1,5 +1,6 @@
-from eth_typing import BlockNumber
-
+from eth_typing import (
+    BlockNumber,
+)
 
 # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md
 ROPSTEN_CHAIN_ID = 3

--- a/eth/consensus/clique/_utils.py
+++ b/eth/consensus/clique/_utils.py
@@ -2,19 +2,25 @@ from typing import (
     Iterable,
 )
 
-from eth_keys import keys
-from eth_keys.datatypes import PrivateKey
+from eth_keys import (
+    keys,
+)
+from eth_keys.datatypes import (
+    PrivateKey,
+)
 from eth_typing import (
     Address,
     Hash32,
 )
 from eth_utils import (
+    ValidationError,
     encode_hex,
     to_tuple,
-    ValidationError,
 )
 
-from eth._utils.headers import eth_now
+from eth._utils.headers import (
+    eth_now,
+)
 from eth.abc import (
     BlockHeaderAPI,
 )

--- a/eth/consensus/clique/clique.py
+++ b/eth/consensus/clique/clique.py
@@ -4,26 +4,25 @@ from typing import (
     Sequence,
 )
 
-from eth.abc import (
-    AtomicDatabaseAPI,
-    BlockHeaderAPI,
-    VirtualMachineAPI,
-    VirtualMachineModifierAPI,
-)
-from eth.db.chain import ChainDB
-
 from eth_typing import (
     Address,
 )
 from eth_utils import (
+    ValidationError,
     encode_hex,
     to_tuple,
-    ValidationError,
 )
 
 from eth.abc import (
+    AtomicDatabaseAPI,
+    BlockHeaderAPI,
     ConsensusAPI,
     ConsensusContextAPI,
+    VirtualMachineAPI,
+    VirtualMachineModifierAPI,
+)
+from eth.db.chain import (
+    ChainDB,
 )
 from eth.typing import (
     HeaderParams,
@@ -31,17 +30,19 @@ from eth.typing import (
     VMFork,
 )
 
+from ._utils import (
+    get_block_signer,
+    is_in_turn,
+    validate_header_integrity,
+)
 from .constants import (
     EPOCH_LENGTH,
 )
 from .datatypes import (
     Snapshot,
 )
-from .snapshot_manager import SnapshotManager
-from ._utils import (
-    get_block_signer,
-    is_in_turn,
-    validate_header_integrity,
+from .snapshot_manager import (
+    SnapshotManager,
 )
 
 

--- a/eth/consensus/clique/constants.py
+++ b/eth/consensus/clique/constants.py
@@ -1,4 +1,6 @@
-from eth_utils import decode_hex
+from eth_utils import (
+    decode_hex,
+)
 
 ALLOWED_CLIQUE_DIFFICULTIES = {1, 2}
 

--- a/eth/consensus/clique/datatypes.py
+++ b/eth/consensus/clique/datatypes.py
@@ -1,5 +1,5 @@
 from enum import (
-    Enum
+    Enum,
 )
 from typing import (
     Dict,
@@ -11,7 +11,7 @@ from typing import (
 
 from eth_typing import (
     Address,
-    Hash32
+    Hash32,
 )
 from eth_utils import (
     ValidationError,
@@ -19,7 +19,7 @@ from eth_utils import (
 
 from .constants import (
     NONCE_AUTH,
-    NONCE_DROP
+    NONCE_DROP,
 )
 
 

--- a/eth/consensus/clique/encoding.py
+++ b/eth/consensus/clique/encoding.py
@@ -1,4 +1,3 @@
-import rlp
 from typing import (
     Tuple,
 )
@@ -6,15 +5,16 @@ from typing import (
 from eth_typing import (
     Address,
 )
+import rlp
 
-from eth.rlp.sedes import (
-    uint256,
-)
 from eth.consensus.clique.datatypes import (
     Snapshot,
     Tally,
     Vote,
     VoteAction,
+)
+from eth.rlp.sedes import (
+    uint256,
 )
 
 ADDRESS_TALLY_SEDES = rlp.sedes.List((rlp.sedes.binary, rlp.sedes.binary))

--- a/eth/consensus/clique/exceptions.py
+++ b/eth/consensus/clique/exceptions.py
@@ -1,4 +1,6 @@
-from eth.exceptions import PyEVMError
+from eth.exceptions import (
+    PyEVMError,
+)
 
 
 class SnapshotNotFound(PyEVMError):

--- a/eth/consensus/clique/snapshot_manager.py
+++ b/eth/consensus/clique/snapshot_manager.py
@@ -1,5 +1,17 @@
+from typing import (
+    Iterable,
+)
+
+from eth_typing import (
+    Address,
+    Hash32,
+)
+from eth_utils import (
+    ValidationError,
+    encode_hex,
+    get_extended_debug_logger,
+)
 import lru
-from typing import Iterable
 
 from eth.abc import (
     BlockHeaderAPI,
@@ -9,22 +21,10 @@ from eth.exceptions import (
     HeaderNotFound,
 )
 
-from eth_typing import (
-    Address,
-    Hash32,
-)
-from eth_utils import (
-    encode_hex,
-    get_extended_debug_logger,
-    ValidationError,
-)
-
-from .encoding import (
-    decode_snapshot,
-    encode_snapshot,
-)
-from .exceptions import (
-    SnapshotNotFound,
+from ._utils import (
+    get_block_signer,
+    get_signers_at_checkpoint,
+    is_checkpoint,
 )
 from .constants import (
     IN_MEMORY_SNAPSHOTS,
@@ -38,11 +38,12 @@ from .datatypes import (
     Vote,
     VoteAction,
 )
-
-from ._utils import (
-    get_signers_at_checkpoint,
-    get_block_signer,
-    is_checkpoint,
+from .encoding import (
+    decode_snapshot,
+    encode_snapshot,
+)
+from .exceptions import (
+    SnapshotNotFound,
 )
 
 

--- a/eth/consensus/noproof.py
+++ b/eth/consensus/noproof.py
@@ -1,6 +1,7 @@
 from typing import (
     Iterable,
 )
+
 from eth.abc import (
     AtomicDatabaseAPI,
     BlockHeaderAPI,

--- a/eth/consensus/pos.py
+++ b/eth/consensus/pos.py
@@ -1,6 +1,7 @@
 from typing import (
     Iterable,
 )
+
 from eth.abc import (
     AtomicDatabaseAPI,
     BlockHeaderAPI,

--- a/eth/consensus/pow.py
+++ b/eth/consensus/pow.py
@@ -1,28 +1,28 @@
-from collections import OrderedDict
+from collections import (
+    OrderedDict,
+)
 from typing import (
     Iterable,
     Tuple,
 )
 
+from eth_hash.auto import (
+    keccak,
+)
 from eth_typing import (
     Address,
     Hash32,
 )
-
 from eth_utils import (
-    big_endian_to_int,
     ValidationError,
+    big_endian_to_int,
     encode_hex,
 )
-
-from eth_hash.auto import keccak
-
 from pyethash import (
     EPOCH_LENGTH,
     hashimoto_light,
     mkcache_bytes,
 )
-
 
 from eth.abc import (
     AtomicDatabaseAPI,
@@ -33,7 +33,6 @@ from eth.validation import (
     validate_length,
     validate_lte,
 )
-
 
 # Type annotation here is to ensure we don't accidentally use strings instead of bytes.
 cache_by_epoch: 'OrderedDict[int, bytearray]' = OrderedDict()

--- a/eth/constants.py
+++ b/eth/constants.py
@@ -1,16 +1,22 @@
-from eth_typing import (
-    Address,
-    BlockNumber,
-    Hash32,
-)
 from typing import (
     List,
     Optional,
 )
 
-from eth._warnings import catch_and_ignore_import_warning
+from eth_typing import (
+    Address,
+    BlockNumber,
+    Hash32,
+)
+
+from eth._warnings import (
+    catch_and_ignore_import_warning,
+)
+
 with catch_and_ignore_import_warning():
-    from eth_utils import denoms
+    from eth_utils import (
+        denoms,
+    )
 
 
 ANY = 'any'

--- a/eth/db/accesslog.py
+++ b/eth/db/accesslog.py
@@ -1,21 +1,23 @@
-from contextlib import contextmanager
+from contextlib import (
+    contextmanager,
+)
 import logging
 from typing import (
-    Iterator,
     FrozenSet,
+    Iterator,
     Set,
 )
 
 from eth.abc import (
-    AtomicWriteBatchAPI,
     AtomicDatabaseAPI,
+    AtomicWriteBatchAPI,
     DatabaseAPI,
-)
-from eth.db.backends.base import (
-    BaseDB,
 )
 from eth.db.atomic import (
     BaseAtomicDB,
+)
+from eth.db.backends.base import (
+    BaseDB,
 )
 
 

--- a/eth/db/account.py
+++ b/eth/db/account.py
@@ -1,26 +1,29 @@
-from lru import LRU
 from typing import (
-    cast,
     Dict,
     Iterable,
     Set,
     Tuple,
+    cast,
 )
 
-from eth_hash.auto import keccak
+from eth_hash.auto import (
+    keccak,
+)
 from eth_typing import (
     Address,
-    Hash32
+    Hash32,
 )
-
 from eth_utils import (
+    ValidationError,
     encode_hex,
     get_extended_debug_logger,
     int_to_big_endian,
     to_checksum_address,
     to_dict,
     to_tuple,
-    ValidationError,
+)
+from lru import (
+    LRU,
 )
 import rlp
 from trie import (
@@ -43,6 +46,9 @@ from eth.db.accesslog import (
     KeyAccessLoggerAtomicDB,
     KeyAccessLoggerDB,
 )
+from eth.db.backends.memory import (
+    MemoryDB,
+)
 from eth.db.batch import (
     BatchDB,
 )
@@ -55,9 +61,6 @@ from eth.db.diff import (
 from eth.db.journal import (
     JournalDB,
 )
-from eth.db.backends.memory import (
-    MemoryDB,
-)
 from eth.db.storage import (
     AccountStorageDB,
 )
@@ -65,23 +68,25 @@ from eth.db.witness import (
     AccountQueryTracker,
     MetaWitness,
 )
+from eth.rlp.accounts import (
+    Account,
+)
 from eth.typing import (
     JournalDBCheckpoint,
+)
+from eth.validation import (
+    validate_canonical_address,
+    validate_is_bytes,
+    validate_uint256,
 )
 from eth.vm.interrupt import (
     MissingAccountTrieNode,
     MissingBytecode,
 )
-from eth.rlp.accounts import (
-    Account,
-)
-from eth.validation import (
-    validate_is_bytes,
-    validate_uint256,
-    validate_canonical_address,
-)
 
-from .hash_trie import HashTrie
+from .hash_trie import (
+    HashTrie,
+)
 
 IS_PRESENT_VALUE = b''
 

--- a/eth/db/atomic.py
+++ b/eth/db/atomic.py
@@ -1,4 +1,6 @@
-from contextlib import contextmanager
+from contextlib import (
+    contextmanager,
+)
 import logging
 from typing import (
     Iterator,
@@ -12,14 +14,18 @@ from eth.abc import (
     AtomicWriteBatchAPI,
     DatabaseAPI,
 )
-
+from eth.db.backends.base import (
+    BaseAtomicDB,
+    BaseDB,
+)
+from eth.db.backends.memory import (
+    MemoryDB,
+)
 from eth.db.diff import (
     DBDiff,
     DBDiffTracker,
     DiffMissingError,
 )
-from eth.db.backends.base import BaseAtomicDB, BaseDB
-from eth.db.backends.memory import MemoryDB
 
 
 class AtomicDB(BaseAtomicDB):

--- a/eth/db/backends/level.py
+++ b/eth/db/backends/level.py
@@ -1,13 +1,22 @@
-from contextlib import contextmanager
+from contextlib import (
+    contextmanager,
+)
 import logging
-from pathlib import Path
+from pathlib import (
+    Path,
+)
 from typing import (
-    Iterator,
     TYPE_CHECKING,
+    Iterator,
 )
 
-from eth_utils import ValidationError
+from eth_utils import (
+    ValidationError,
+)
 
+from eth._warnings import (
+    catch_and_ignore_import_warning,
+)
 from eth.abc import (
     AtomicWriteBatchAPI,
     DatabaseAPI,
@@ -16,12 +25,11 @@ from eth.db.diff import (
     DBDiffTracker,
     DiffMissingError,
 )
+
 from .base import (
     BaseAtomicDB,
     BaseDB,
 )
-
-from eth._warnings import catch_and_ignore_import_warning
 
 if TYPE_CHECKING:
     with catch_and_ignore_import_warning():

--- a/eth/db/batch.py
+++ b/eth/db/batch.py
@@ -4,13 +4,17 @@ from eth_utils import (
     ValidationError,
 )
 
-from eth.abc import DatabaseAPI
+from eth.abc import (
+    DatabaseAPI,
+)
+from eth.db.backends.base import (
+    BaseDB,
+)
 from eth.db.diff import (
     DBDiff,
     DBDiffTracker,
     DiffMissingError,
 )
-from eth.db.backends.base import BaseDB
 
 
 class BatchDB(BaseDB):

--- a/eth/db/cache.py
+++ b/eth/db/cache.py
@@ -1,7 +1,13 @@
-from lru import LRU
+from lru import (
+    LRU,
+)
 
-from eth.abc import DatabaseAPI
-from eth.db.backends.base import BaseDB
+from eth.abc import (
+    DatabaseAPI,
+)
+from eth.db.backends.base import (
+    BaseDB,
+)
 
 
 class CacheDB(BaseDB):

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -1,6 +1,5 @@
 import functools
 import itertools
-
 from typing import (
     Dict,
     Iterable,
@@ -10,28 +9,29 @@ from typing import (
     cast,
 )
 
-from eth.vm.forks.shanghai.withdrawals import (
-    Withdrawal,
+from eth_hash.auto import (
+    keccak,
 )
 from eth_typing import (
     BlockNumber,
-    Hash32
+    Hash32,
 )
 from eth_utils import (
     encode_hex,
 )
-
-from eth_hash.auto import keccak
 from trie.exceptions import (
     MissingTrieNode,
 )
 
+from eth._warnings import (
+    catch_and_ignore_import_warning,
+)
 from eth.abc import (
+    AtomicDatabaseAPI,
     BlockAPI,
     BlockHeaderAPI,
     ChainDatabaseAPI,
     DatabaseAPI,
-    AtomicDatabaseAPI,
     ReceiptAPI,
     ReceiptDecoderAPI,
     SignedTransactionAPI,
@@ -43,36 +43,51 @@ from eth.constants import (
     GENESIS_PARENT_HASH,
 )
 from eth.db.chain_gaps import (
-    fill_gap,
+    GENESIS_CHAIN_GAPS,
     GapChange,
     GapInfo,
-    GENESIS_CHAIN_GAPS,
+    fill_gap,
     is_block_number_in_gap,
     reopen_gap,
 )
-from eth.db.trie import make_trie_root_and_nodes
+from eth.db.header import (
+    HeaderDB,
+)
+from eth.db.schema import (
+    SchemaV1,
+)
+from eth.db.trie import (
+    make_trie_root_and_nodes,
+)
 from eth.exceptions import (
     HeaderNotFound,
     ReceiptNotFound,
     TransactionNotFound,
 )
-from eth.db.header import HeaderDB
-from eth.db.schema import SchemaV1
-from eth.rlp.sedes import chain_gaps
-from eth.typing import ChainGaps
+from eth.rlp.sedes import (
+    chain_gaps,
+)
+from eth.typing import (
+    ChainGaps,
+)
 from eth.validation import (
     validate_word,
 )
-from eth.vm.header import HeaderSedes
-from eth._warnings import catch_and_ignore_import_warning
+from eth.vm.forks.shanghai.withdrawals import (
+    Withdrawal,
+)
+from eth.vm.header import (
+    HeaderSedes,
+)
+
 with catch_and_ignore_import_warning():
+    from eth_utils import (
+        ValidationError,
+        to_tuple,
+    )
     import rlp
     from trie import (
         HexaryTrie,
-    )
-    from eth_utils import (
-        to_tuple,
-        ValidationError,
     )
 
 

--- a/eth/db/chain_gaps.py
+++ b/eth/db/chain_gaps.py
@@ -1,14 +1,24 @@
 import enum
-from typing import Iterable, Tuple
+from typing import (
+    Iterable,
+    Tuple,
+)
 
-from eth_typing import BlockNumber
+from eth_typing import (
+    BlockNumber,
+)
 from eth_utils import (
     ValidationError,
     to_tuple,
 )
 
-from eth.exceptions import GapTrackingCorrupted
-from eth.typing import BlockRange, ChainGaps
+from eth.exceptions import (
+    GapTrackingCorrupted,
+)
+from eth.typing import (
+    BlockRange,
+    ChainGaps,
+)
 
 
 class GapChange(enum.Enum):

--- a/eth/db/diff.py
+++ b/eth/db/diff.py
@@ -3,12 +3,12 @@ from collections.abc import (
     MutableMapping,
 )
 from typing import (
-    cast,
+    TYPE_CHECKING,
     Dict,
     Iterable,
-    Union,
     Tuple,
-    TYPE_CHECKING,
+    Union,
+    cast,
 )
 
 from eth_utils import (
@@ -16,8 +16,12 @@ from eth_utils import (
     to_tuple,
 )
 
-from eth.abc import DatabaseAPI
-from eth.vm.interrupt import EVMMissingData
+from eth.abc import (
+    DatabaseAPI,
+)
+from eth.vm.interrupt import (
+    EVMMissingData,
+)
 
 if TYPE_CHECKING:
     ABC_Mutable_Mapping = MutableMapping[bytes, Union[bytes, 'MissingReason']]

--- a/eth/db/hash_trie.py
+++ b/eth/db/hash_trie.py
@@ -1,11 +1,15 @@
 import contextlib
 from typing import (
-    cast,
     Iterator,
+    cast,
 )
 
-from eth_hash.auto import keccak
-from trie import HexaryTrie
+from eth_hash.auto import (
+    keccak,
+)
+from trie import (
+    HexaryTrie,
+)
 
 from eth.db.keymap import (
     KeyMapDB,

--- a/eth/db/header.py
+++ b/eth/db/header.py
@@ -1,29 +1,26 @@
 import functools
 from typing import (
-    cast,
     Iterable,
     Sequence,
     Tuple,
+    cast,
 )
 
-import rlp
-
+from eth_typing import (
+    BlockNumber,
+    Hash32,
+)
+from eth_utils import (
+    ValidationError,
+    encode_hex,
+    to_tuple,
+)
 from eth_utils.toolz import (
     concat,
     first,
     sliding_window,
 )
-
-from eth_utils import (
-    encode_hex,
-    to_tuple,
-    ValidationError,
-)
-
-from eth_typing import (
-    Hash32,
-    BlockNumber,
-)
+import rlp
 
 from eth.abc import (
     AtomicDatabaseAPI,
@@ -35,12 +32,15 @@ from eth.constants import (
     GENESIS_PARENT_HASH,
 )
 from eth.db.chain_gaps import (
-    GapChange,
-    GapInfo,
     GAP_WRITES,
     GENESIS_CHAIN_GAPS,
+    GapChange,
+    GapInfo,
     fill_gap,
     reopen_gap,
+)
+from eth.db.schema import (
+    SchemaV1,
 )
 from eth.exceptions import (
     CanonicalHeadNotFound,
@@ -48,14 +48,19 @@ from eth.exceptions import (
     HeaderNotFound,
     ParentNotFound,
 )
-from eth.db.schema import SchemaV1
-from eth.rlp.sedes import chain_gaps
-from eth.typing import ChainGaps
+from eth.rlp.sedes import (
+    chain_gaps,
+)
+from eth.typing import (
+    ChainGaps,
+)
 from eth.validation import (
     validate_block_number,
     validate_word,
 )
-from eth.vm.header import HeaderSedes
+from eth.vm.header import (
+    HeaderSedes,
+)
 
 
 class HeaderDB(HeaderDatabaseAPI):

--- a/eth/db/journal.py
+++ b/eth/db/journal.py
@@ -2,21 +2,37 @@ import collections
 from itertools import (
     count,
 )
-from typing import Callable, cast, Dict, List, Set, Union
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Set,
+    Union,
+    cast,
+)
 
+from eth_utils import (
+    ValidationError,
+)
 from eth_utils.toolz import (
     first,
     nth,
 )
-from eth_utils import (
-    ValidationError,
+
+from eth.abc import (
+    DatabaseAPI,
+)
+from eth.typing import (
+    JournalDBCheckpoint,
 )
 
-from eth.abc import DatabaseAPI
-from eth.typing import JournalDBCheckpoint
-
-from .backends.base import BaseDB
-from .diff import DBDiff, DBDiffTracker
+from .backends.base import (
+    BaseDB,
+)
+from .diff import (
+    DBDiff,
+    DBDiffTracker,
+)
 
 
 class DeletedEntry:

--- a/eth/db/keymap.py
+++ b/eth/db/keymap.py
@@ -1,13 +1,16 @@
 from abc import (
     abstractmethod,
 )
-
 from typing import (
     Any,
 )
 
-from eth.abc import DatabaseAPI
-from eth.db.backends.base import BaseDB
+from eth.abc import (
+    DatabaseAPI,
+)
+from eth.db.backends.base import (
+    BaseDB,
+)
 
 
 class KeyMapDB(BaseDB):

--- a/eth/db/schema.py
+++ b/eth/db/schema.py
@@ -3,7 +3,9 @@ from eth_typing import (
     Hash32,
 )
 
-from eth.abc import SchemaAPI
+from eth.abc import (
+    SchemaAPI,
+)
 
 
 class SchemaV1(SchemaAPI):

--- a/eth/db/slow_journal.py
+++ b/eth/db/slow_journal.py
@@ -1,19 +1,31 @@
 import collections
-from typing import cast, Dict, Set, Union
+from typing import (
+    Dict,
+    Set,
+    Union,
+    cast,
+)
 import uuid
 
+from eth_utils import (
+    ValidationError,
+)
 from eth_utils.toolz import (
     first,
     merge,
     nth,
 )
-from eth_utils import (
-    ValidationError,
-)
 
-from eth.abc import DatabaseAPI
-from eth.db.backends.base import BaseDB
-from eth.db.diff import DBDiff, DBDiffTracker
+from eth.abc import (
+    DatabaseAPI,
+)
+from eth.db.backends.base import (
+    BaseDB,
+)
+from eth.db.diff import (
+    DBDiff,
+    DBDiffTracker,
+)
 
 
 class DeletedEntry:

--- a/eth/db/storage.py
+++ b/eth/db/storage.py
@@ -5,7 +5,9 @@ from typing import (
     Set,
 )
 
-from eth_hash.auto import keccak
+from eth_hash.auto import (
+    keccak,
+)
 from eth_typing import (
     Address,
     Hash32,
@@ -50,11 +52,11 @@ from eth.db.cache import (
 from eth.db.journal import (
     JournalDB,
 )
-from eth.vm.interrupt import (
-    MissingStorageTrieNode,
-)
 from eth.typing import (
     JournalDBCheckpoint,
+)
+from eth.vm.interrupt import (
+    MissingStorageTrieNode,
 )
 
 

--- a/eth/db/trie.py
+++ b/eth/db/trie.py
@@ -1,12 +1,18 @@
 import functools
-from typing import Dict, Sequence, Tuple, Union
+from typing import (
+    Dict,
+    Sequence,
+    Tuple,
+    Union,
+)
 
+from eth_typing import (
+    Hash32,
+)
 import rlp
 from trie import (
     HexaryTrie,
 )
-
-from eth_typing import Hash32
 
 from eth.abc import (
     ReceiptAPI,

--- a/eth/estimators/gas.py
+++ b/eth/estimators/gas.py
@@ -1,14 +1,22 @@
-from typing import cast, Optional
+from typing import (
+    Optional,
+    cast,
+)
 
-from eth_utils.toolz import curry
-
-from eth.exceptions import VMError
+from eth_utils.toolz import (
+    curry,
+)
 
 from eth.abc import (
     SignedTransactionAPI,
     StateAPI,
 )
-from eth.vm.spoof import SpoofTransaction
+from eth.exceptions import (
+    VMError,
+)
+from eth.vm.spoof import (
+    SpoofTransaction,
+)
 
 
 def _get_computation_error(state: StateAPI, transaction: SignedTransactionAPI) -> Optional[VMError]:

--- a/eth/exceptions.py
+++ b/eth/exceptions.py
@@ -1,4 +1,6 @@
-from eth_typing import Hash32
+from eth_typing import (
+    Hash32,
+)
 
 
 class PyEVMError(Exception):

--- a/eth/precompiles/blake2.py
+++ b/eth/precompiles/blake2.py
@@ -2,18 +2,24 @@ from eth_utils import (
     ValidationError,
 )
 
-from eth._utils.blake2.coders import extract_blake2b_parameters
-from eth.exceptions import (
-    VMError,
+from eth._utils.blake2.coders import (
+    extract_blake2b_parameters,
 )
 from eth.abc import (
     ComputationAPI,
 )
+from eth.exceptions import (
+    VMError,
+)
 
 try:
-    from blake2b import compress as blake2b_compress
+    from blake2b import (
+        compress as blake2b_compress,
+    )
 except ImportError:
-    from eth._utils.blake2.compression import blake2b_compress
+    from eth._utils.blake2.compression import (
+        blake2b_compress,
+    )
 
 GAS_COST_PER_ROUND = 1
 

--- a/eth/precompiles/ecadd.py
+++ b/eth/precompiles/ecadd.py
@@ -1,7 +1,5 @@
-from typing import Tuple
-
-from py_ecc import (
-    optimized_bn128 as bn128,
+from typing import (
+    Tuple,
 )
 
 from eth_utils import (
@@ -12,14 +10,12 @@ from eth_utils import (
 from eth_utils.toolz import (
     curry,
 )
-
-from eth import constants
-
-from eth.abc import (
-    ComputationAPI,
+from py_ecc import (
+    optimized_bn128 as bn128,
 )
-from eth.exceptions import (
-    VMError,
+
+from eth import (
+    constants,
 )
 from eth._utils.bn128 import (
     validate_point,
@@ -27,6 +23,12 @@ from eth._utils.bn128 import (
 from eth._utils.padding import (
     pad32,
     pad32r,
+)
+from eth.abc import (
+    ComputationAPI,
+)
+from eth.exceptions import (
+    VMError,
 )
 
 

--- a/eth/precompiles/ecmul.py
+++ b/eth/precompiles/ecmul.py
@@ -1,25 +1,21 @@
-from typing import Tuple
-
-from py_ecc import (
-    optimized_bn128 as bn128,
+from typing import (
+    Tuple,
 )
 
 from eth_utils import (
+    ValidationError,
     big_endian_to_int,
     int_to_big_endian,
-    ValidationError,
 )
 from eth_utils.toolz import (
     curry,
 )
-
-from eth import constants
-
-from eth.abc import (
-    ComputationAPI,
+from py_ecc import (
+    optimized_bn128 as bn128,
 )
-from eth.exceptions import (
-    VMError,
+
+from eth import (
+    constants,
 )
 from eth._utils.bn128 import (
     validate_point,
@@ -27,6 +23,12 @@ from eth._utils.bn128 import (
 from eth._utils.padding import (
     pad32,
     pad32r,
+)
+from eth.abc import (
+    ComputationAPI,
+)
+from eth.exceptions import (
+    VMError,
 )
 
 

--- a/eth/precompiles/ecpairing.py
+++ b/eth/precompiles/ecpairing.py
@@ -1,8 +1,10 @@
-from typing import Tuple
+from typing import (
+    Tuple,
+)
 
 from eth_utils import (
-    big_endian_to_int,
     ValidationError,
+    big_endian_to_int,
 )
 from eth_utils.toolz import (
     curry,
@@ -12,28 +14,25 @@ from py_ecc import (
     optimized_bn128 as bn128,
 )
 
-from eth import constants
-
-from eth.exceptions import (
-    VMError,
+from eth import (
+    constants,
 )
-
-from eth.typing import (
-    BytesOrView,
-)
-
 from eth._utils.bn128 import (
-    validate_point,
     FQP_point_to_FQ2_point,
+    validate_point,
 )
 from eth._utils.padding import (
     pad32,
 )
-
 from eth.abc import (
     ComputationAPI,
 )
-
+from eth.exceptions import (
+    VMError,
+)
+from eth.typing import (
+    BytesOrView,
+)
 
 ZERO = bn128.Z2
 EXPONENT = bn128.FQ12.one()

--- a/eth/precompiles/ecrecover.py
+++ b/eth/precompiles/ecrecover.py
@@ -1,26 +1,27 @@
-from eth_keys import keys
+from eth_keys import (
+    keys,
+)
 from eth_keys.exceptions import (
     BadSignature,
 )
-
 from eth_utils import (
-    big_endian_to_int,
     ValidationError,
+    big_endian_to_int,
 )
 
-from eth import constants
-
+from eth import (
+    constants,
+)
 from eth._utils.padding import (
     pad32,
     pad32r,
 )
-
 from eth.abc import (
     ComputationAPI,
 )
 from eth.validation import (
-    validate_lt_secpk1n,
     validate_gte,
+    validate_lt_secpk1n,
     validate_lte,
 )
 

--- a/eth/precompiles/identity.py
+++ b/eth/precompiles/identity.py
@@ -1,8 +1,9 @@
-from eth import constants
+from eth import (
+    constants,
+)
 from eth._utils.numeric import (
     ceil32,
 )
-
 from eth.abc import (
     ComputationAPI,
 )

--- a/eth/precompiles/modexp.py
+++ b/eth/precompiles/modexp.py
@@ -11,15 +11,16 @@ from eth_utils.toolz import (
     curry,
 )
 
-from eth import constants
-
+from eth import (
+    constants,
+)
 from eth._utils.numeric import (
     get_highest_bit_index,
 )
 from eth._utils.padding import (
     pad32r,
-    zpad_right,
     zpad_left,
+    zpad_right,
 )
 from eth.abc import (
     ComputationAPI,

--- a/eth/precompiles/ripemd160.py
+++ b/eth/precompiles/ripemd160.py
@@ -1,7 +1,8 @@
 import hashlib
 
-from eth import constants
-
+from eth import (
+    constants,
+)
 from eth._utils.numeric import (
     ceil32,
 )

--- a/eth/precompiles/sha256.py
+++ b/eth/precompiles/sha256.py
@@ -1,11 +1,11 @@
 import hashlib
 
-from eth import constants
-
+from eth import (
+    constants,
+)
 from eth._utils.numeric import (
     ceil32,
 )
-
 from eth.abc import (
     ComputationAPI,
 )

--- a/eth/rlp/accounts.py
+++ b/eth/rlp/accounts.py
@@ -1,20 +1,24 @@
+from typing import (
+    Any,
+)
+
 import rlp
 from rlp.sedes import (
     big_endian_int,
 )
 
-from eth.abc import AccountAPI
+from eth.abc import (
+    AccountAPI,
+)
 from eth.constants import (
-    EMPTY_SHA3,
     BLANK_ROOT_HASH,
+    EMPTY_SHA3,
 )
 
 from .sedes import (
-    trie_root,
     hash32,
+    trie_root,
 )
-
-from typing import Any
 
 
 class Account(rlp.Serializable, AccountAPI):

--- a/eth/rlp/headers.py
+++ b/eth/rlp/headers.py
@@ -4,23 +4,22 @@ from typing import (
     overload,
 )
 
-import rlp
-from rlp.sedes import (
-    big_endian_int,
-    Binary,
-    binary,
+from eth_hash.auto import (
+    keccak,
 )
-
 from eth_typing import (
     Address,
     BlockNumber,
     Hash32,
 )
-
-from eth_hash.auto import keccak
-
 from eth_utils import (
     encode_hex,
+)
+import rlp
+from rlp.sedes import (
+    Binary,
+    big_endian_int,
+    binary,
 )
 
 from eth._utils.headers import (
@@ -31,20 +30,22 @@ from eth.abc import (
     MiningHeaderAPI,
 )
 from eth.constants import (
-    ZERO_ADDRESS,
-    ZERO_HASH32,
+    BLANK_ROOT_HASH,
     EMPTY_UNCLE_HASH,
     GENESIS_NONCE,
     GENESIS_PARENT_HASH,
-    BLANK_ROOT_HASH,
+    ZERO_ADDRESS,
+    ZERO_HASH32,
 )
-from eth.typing import HeaderParams
+from eth.typing import (
+    HeaderParams,
+)
 
 from .sedes import (
     address,
     hash32,
-    uint256,
     trie_root,
+    uint256,
 )
 
 

--- a/eth/rlp/logs.py
+++ b/eth/rlp/logs.py
@@ -1,15 +1,16 @@
-from rlp.sedes import (
-    CountableList,
-    binary,
-)
-
 from typing import (
     Tuple,
 )
 
 import rlp
+from rlp.sedes import (
+    CountableList,
+    binary,
+)
 
-from eth.abc import LogAPI
+from eth.abc import (
+    LogAPI,
+)
 
 from .sedes import (
     address,

--- a/eth/rlp/receipts.py
+++ b/eth/rlp/receipts.py
@@ -1,11 +1,15 @@
 import itertools
-from typing import Iterable
+from typing import (
+    Iterable,
+)
 
-from eth_bloom import BloomFilter
+from eth_bloom import (
+    BloomFilter,
+)
 import rlp
 from rlp.sedes import (
-    big_endian_int,
     CountableList,
+    big_endian_int,
     binary,
 )
 
@@ -14,7 +18,9 @@ from eth.abc import (
     ReceiptBuilderAPI,
 )
 
-from .logs import Log
+from .logs import (
+    Log,
+)
 from .sedes import (
     uint256,
 )

--- a/eth/rlp/sedes.py
+++ b/eth/rlp/sedes.py
@@ -4,7 +4,6 @@ from rlp.sedes import (
     Binary,
 )
 
-
 address = Binary.fixed_length(20, allow_empty=True)
 hash32 = Binary.fixed_length(32)
 uint32 = BigEndianInt(32)

--- a/eth/rlp/transactions.py
+++ b/eth/rlp/transactions.py
@@ -5,21 +5,23 @@ from typing import (
     cast,
 )
 
-from cached_property import cached_property
-import rlp
-from rlp.sedes import (
-    big_endian_int,
-    binary,
+from cached_property import (
+    cached_property,
 )
-
+from eth_hash.auto import (
+    keccak,
+)
 from eth_typing import (
     Address,
     Hash32,
 )
-
-from eth_hash.auto import keccak
 from eth_utils import (
     ValidationError,
+)
+import rlp
+from rlp.sedes import (
+    big_endian_int,
+    binary,
 )
 
 from eth.abc import (
@@ -32,7 +34,9 @@ from eth.abc import (
     UnsignedTransactionAPI,
 )
 
-from .sedes import address
+from .sedes import (
+    address,
+)
 
 
 class BaseTransactionMethods(BaseTransactionAPI):

--- a/eth/tools/_utils/deprecation.py
+++ b/eth/tools/_utils/deprecation.py
@@ -1,12 +1,11 @@
 import functools
-import warnings
 from typing import (
     Any,
     Callable,
     TypeVar,
     cast,
 )
-
+import warnings
 
 TFunc = TypeVar("TFunc", bound=Callable[..., Any])
 

--- a/eth/tools/_utils/git.py
+++ b/eth/tools/_utils/git.py
@@ -1,6 +1,8 @@
 import subprocess
 
-from eth_utils import to_text
+from eth_utils import (
+    to_text,
+)
 
 
 def get_version_from_git() -> str:

--- a/eth/tools/_utils/hashing.py
+++ b/eth/tools/_utils/hashing.py
@@ -4,13 +4,17 @@ from typing import (
     cast,
 )
 
-from eth_hash.auto import keccak
+from eth_hash.auto import (
+    keccak,
+)
 from eth_typing import (
     Hash32,
 )
 import rlp
 
-from eth.rlp.logs import Log
+from eth.rlp.logs import (
+    Log,
+)
 
 
 def hash_log_entries(log_entries: Iterable[Tuple[bytes, Tuple[int, ...], bytes]]) -> Hash32:

--- a/eth/tools/_utils/mappings.py
+++ b/eth/tools/_utils/mappings.py
@@ -1,13 +1,16 @@
-from collections.abc import Mapping
+from collections.abc import (
+    Mapping,
+)
 import itertools
-
 from typing import (
     Any,
     Dict,
     Sequence,
 )
 
-from eth_utils.toolz import merge_with
+from eth_utils.toolz import (
+    merge_with,
+)
 
 
 def merge_if_dicts(values: Sequence[Dict[Any, Any]]) -> Any:

--- a/eth/tools/_utils/normalization.py
+++ b/eth/tools/_utils/normalization.py
@@ -4,7 +4,6 @@ from typing import (
     Any,
     AnyStr,
     Callable,
-    cast,
     Dict,
     Iterable,
     List,
@@ -12,28 +11,15 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    cast,
 )
-
-from mypy_extensions import (
-    TypedDict,
-)
-
-from eth_utils.toolz import (
-    assoc_in,
-    compose,
-    concat,
-    curry,
-    identity,
-    merge,
-)
-from eth_utils.toolz import curried
 
 from eth_typing import (
     Address,
     HexStr,
 )
-
 from eth_utils.curried import (
+    ValidationError,
     apply_formatter_if,
     apply_formatter_to_array,
     apply_formatters_to_dict,
@@ -49,18 +35,27 @@ from eth_utils.curried import (
     to_bytes,
     to_canonical_address,
     to_dict,
-    ValidationError,
+)
+from eth_utils.toolz import (
+    assoc_in,
+    compose,
+    concat,
+    curried,
+    curry,
+    identity,
+    merge,
+)
+from mypy_extensions import (
+    TypedDict,
 )
 
 from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
 )
-
 from eth.tools._utils.mappings import (
     deep_merge,
     is_cleanly_mergable,
 )
-
 from eth.typing import (
     AccountState,
     GeneralState,

--- a/eth/tools/_utils/slow_code_stream.py
+++ b/eth/tools/_utils/slow_code_stream.py
@@ -3,13 +3,15 @@ import io
 import logging
 from typing import (
     Iterator,
-    Set
+    Set,
 )
 
 from eth.validation import (
     validate_is_bytes,
 )
-from eth.vm import opcode_values
+from eth.vm import (
+    opcode_values,
+)
 
 PUSH1, PUSH32, STOP = opcode_values.PUSH1, opcode_values.PUSH32, opcode_values.STOP
 

--- a/eth/tools/_utils/vyper.py
+++ b/eth/tools/_utils/vyper.py
@@ -1,5 +1,4 @@
 import functools
-
 from typing import (
     Any,
     Callable,
@@ -10,10 +9,12 @@ from typing import (
 
 try:
     from vyper.compile_lll import (
-        compile_to_assembly,
         assembly_to_evm,
+        compile_to_assembly,
     )
-    from vyper.parser.parser_utils import LLLnode
+    from vyper.parser.parser_utils import (
+        LLLnode,
+    )
 except ImportError:
     vyper_available = False
 else:

--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -1,7 +1,6 @@
 import functools
 import time
 from typing import (
-    cast,
     Any,
     Callable,
     Dict,
@@ -9,12 +8,7 @@ from typing import (
     Tuple,
     Type,
     Union,
-)
-
-from eth_utils.toolz import (
-    curry,
-    merge,
-    pipe,
+    cast,
 )
 
 from eth_typing import (
@@ -22,14 +16,20 @@ from eth_typing import (
     BlockNumber,
     Hash32,
 )
-
 from eth_utils import (
+    ValidationError,
     to_dict,
     to_tuple,
-    ValidationError,
+)
+from eth_utils.toolz import (
+    curry,
+    merge,
+    pipe,
 )
 
-from eth import constants
+from eth import (
+    constants,
+)
 from eth.abc import (
     AtomicDatabaseAPI,
     BlockAPI,
@@ -37,47 +37,55 @@ from eth.abc import (
     MiningChainAPI,
     VirtualMachineAPI,
 )
-from eth.consensus.applier import ConsensusApplier
-from eth.consensus.noproof import NoProofConsensus
-from eth.db.atomic import AtomicDB
+from eth.consensus.applier import (
+    ConsensusApplier,
+)
+from eth.consensus.noproof import (
+    NoProofConsensus,
+)
+from eth.db.atomic import (
+    AtomicDB,
+)
 from eth.db.backends.memory import (
     MemoryDB,
 )
 from eth.rlp.headers import (
     HeaderParams,
 )
-from eth.tools.mining import POWMiningMixin
 from eth.tools._utils.mappings import (
     deep_merge,
 )
 from eth.tools._utils.normalization import (
     normalize_state,
 )
+from eth.tools.mining import (
+    POWMiningMixin,
+)
 from eth.typing import (
     AccountState,
     GeneralState,
-    VMFork,
     VMConfiguration,
+    VMFork,
 )
 from eth.validation import (
     validate_vm_configuration,
 )
 from eth.vm.forks import (
-    FrontierVM,
-    HomesteadVM,
-    TangerineWhistleVM,
-    SpuriousDragonVM,
+    ArrowGlacierVM,
+    BerlinVM,
     ByzantiumVM,
     ConstantinopleVM,
-    PetersburgVM,
-    IstanbulVM,
-    MuirGlacierVM,
-    BerlinVM,
-    LondonVM,
-    ArrowGlacierVM,
+    FrontierVM,
     GrayGlacierVM,
+    HomesteadVM,
+    IstanbulVM,
+    LondonVM,
+    MuirGlacierVM,
     ParisVM,
+    PetersburgVM,
     ShanghaiVM,
+    SpuriousDragonVM,
+    TangerineWhistleVM,
 )
 
 

--- a/eth/tools/db/atomic.py
+++ b/eth/tools/db/atomic.py
@@ -1,8 +1,12 @@
 import pytest
 
-from eth_utils import ValidationError
+from eth_utils import (
+    ValidationError,
+)
 
-from eth.abc import AtomicDatabaseAPI
+from eth.abc import (
+    AtomicDatabaseAPI,
+)
 
 
 class AtomicDatabaseBatchAPITestSuite:

--- a/eth/tools/db/base.py
+++ b/eth/tools/db/base.py
@@ -1,6 +1,8 @@
 import pytest
 
-from eth.abc import DatabaseAPI
+from eth.abc import (
+    DatabaseAPI,
+)
 
 
 class DatabaseAPITestSuite:

--- a/eth/tools/factories/keys.py
+++ b/eth/tools/factories/keys.py
@@ -1,14 +1,17 @@
 import secrets
-try:
-    import factory
-except ImportError:
-    raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
 
+from eth_keys import (
+    keys,
+)
 from eth_utils import (
     int_to_big_endian,
 )
 
-from eth_keys import keys
+try:
+    import factory
+except ImportError:
+    raise ImportError(
+        "The p2p.tools.factories module requires the `factory_boy` library.")
 
 
 def _mk_private_key_bytes() -> bytes:

--- a/eth/tools/factories/transaction.py
+++ b/eth/tools/factories/transaction.py
@@ -1,4 +1,6 @@
-from eth_utils.toolz import curry
+from eth_utils.toolz import (
+    curry,
+)
 
 from eth.vm.spoof import (
     SpoofTransaction,

--- a/eth/tools/fixtures/_utils.py
+++ b/eth/tools/fixtures/_utils.py
@@ -1,14 +1,15 @@
 import fnmatch
 import functools
 import os
-
 from typing import (
     Any,
     Callable,
     Iterable,
 )
 
-from eth_utils import to_tuple
+from eth_utils import (
+    to_tuple,
+)
 
 
 @to_tuple

--- a/eth/tools/fixtures/fillers/_utils.py
+++ b/eth/tools/fixtures/fillers/_utils.py
@@ -8,7 +8,9 @@ from typing import (
     Type,
 )
 
-from eth_keys import keys
+from eth_keys import (
+    keys,
+)
 from eth_typing import (
     Address,
 )
@@ -22,8 +24,12 @@ from eth._utils.db import (
 from eth._utils.padding import (
     pad32,
 )
-from eth.constants import BLANK_ROOT_HASH
-from eth.db.atomic import AtomicDB
+from eth.constants import (
+    BLANK_ROOT_HASH,
+)
+from eth.db.atomic import (
+    AtomicDB,
+)
 from eth.typing import (
     AccountState,
     TransactionDict,

--- a/eth/tools/fixtures/fillers/common.py
+++ b/eth/tools/fixtures/fillers/common.py
@@ -10,35 +10,35 @@ from typing import (
     Callable,
     Dict,
 )
+
+from eth_utils import (
+    apply_formatters_to_dict,
+    decode_hex,
+    to_canonical_address,
+)
 from eth_utils.toolz import (
     assoc,
     assoc_in,
     curry,
     merge,
 )
-from eth_utils import (
-    apply_formatters_to_dict,
-    decode_hex,
-    to_canonical_address,
-)
 
-from eth.tools.fixtures.helpers import (
-    get_test_name,
+from eth.tools._utils.mappings import (
+    deep_merge,
 )
 from eth.tools._utils.normalization import (
     normalize_environment,
     normalize_execution,
+    normalize_networks,
     normalize_state,
     normalize_transaction,
-    normalize_networks,
-)
-from eth.tools._utils.mappings import (
-    deep_merge,
 )
 from eth.tools._utils.vyper import (
     compile_vyper_lll,
 )
-
+from eth.tools.fixtures.helpers import (
+    get_test_name,
+)
 from eth.typing import (
     GeneralState,
     TransactionDict,
@@ -48,7 +48,6 @@ from ._utils import (
     add_transaction_to_group,
     wrap_in_list,
 )
-
 
 #
 # Defaults

--- a/eth/tools/fixtures/fillers/formatters.py
+++ b/eth/tools/fixtures/fillers/formatters.py
@@ -12,9 +12,9 @@ from eth_utils.curried import (
     to_checksum_address,
     to_hex,
 )
-
-from eth_utils.toolz import curried
-
+from eth_utils.toolz import (
+    curried,
+)
 
 environment_formatter = apply_formatters_to_dict({
     "currentCoinbase": to_checksum_address,

--- a/eth/tools/fixtures/fillers/main.py
+++ b/eth/tools/fixtures/fillers/main.py
@@ -8,18 +8,23 @@ from eth_utils.toolz import (
     merge,
 )
 
+from eth.tools._utils.git import (
+    get_version_from_git,
+)
 from eth.tools.fixtures.helpers import (
     get_test_name,
 )
-from eth.tools._utils.git import get_version_from_git
 
 from .formatters import (
     filled_state_test_formatter,
     filled_vm_test_formatter,
 )
-from .state import fill_state_test
-from .vm import fill_vm_test
-
+from .state import (
+    fill_state_test,
+)
+from .vm import (
+    fill_vm_test,
+)
 
 FILLED_WITH_TEMPLATE = "py-evm-{version}"
 

--- a/eth/tools/fixtures/fillers/state.py
+++ b/eth/tools/fixtures/fillers/state.py
@@ -1,14 +1,18 @@
-from collections import defaultdict
+from collections import (
+    defaultdict,
+)
 from typing import (
     Any,
     Dict,
     List,
 )
 
-from eth_utils import encode_hex
+from eth_utils import (
+    encode_hex,
+)
 
-from eth.tools.fixtures.helpers import (
-    get_test_name,
+from eth.tools._utils.mappings import (
+    deep_merge,
 )
 from eth.tools._utils.normalization import (
     normalize_environment,
@@ -16,20 +20,37 @@ from eth.tools._utils.normalization import (
     normalize_state,
     normalize_transaction_group,
 )
-from eth.tools._utils.mappings import deep_merge
-from eth.vm.forks.byzantium.state import ByzantiumState
-from eth.vm.forks.constantinople.state import ConstantinopleState
-from eth.vm.forks.frontier.state import FrontierState
-from eth.vm.forks.homestead.state import HomesteadState
-from eth.vm.forks.istanbul.state import IstanbulState
-from eth.vm.forks.petersburg.state import PetersburgState
-from eth.vm.forks.spurious_dragon.state import SpuriousDragonState
-from eth.vm.forks.tangerine_whistle.state import TangerineWhistleState
+from eth.tools.fixtures.helpers import (
+    get_test_name,
+)
+from eth.vm.forks.byzantium.state import (
+    ByzantiumState,
+)
+from eth.vm.forks.constantinople.state import (
+    ConstantinopleState,
+)
+from eth.vm.forks.frontier.state import (
+    FrontierState,
+)
+from eth.vm.forks.homestead.state import (
+    HomesteadState,
+)
+from eth.vm.forks.istanbul.state import (
+    IstanbulState,
+)
+from eth.vm.forks.petersburg.state import (
+    PetersburgState,
+)
+from eth.vm.forks.spurious_dragon.state import (
+    SpuriousDragonState,
+)
+from eth.vm.forks.tangerine_whistle.state import (
+    TangerineWhistleState,
+)
 
 from ._utils import (
     calc_state_root,
 )
-
 
 ALL_NETWORKS = [
     "Frontier",

--- a/eth/tools/fixtures/fillers/vm.py
+++ b/eth/tools/fixtures/fillers/vm.py
@@ -6,8 +6,11 @@ from typing import (
     Union,
 )
 
-from eth.tools.fixtures.helpers import (
-    get_test_name,
+from eth.tools._utils.hashing import (
+    hash_log_entries,
+)
+from eth.tools._utils.mappings import (
+    deep_merge,
 )
 from eth.tools._utils.normalization import (
     normalize_bytes,
@@ -18,8 +21,9 @@ from eth.tools._utils.normalization import (
     normalize_logs,
     normalize_state,
 )
-from eth.tools._utils.hashing import hash_log_entries
-from eth.tools._utils.mappings import deep_merge
+from eth.tools.fixtures.helpers import (
+    get_test_name,
+)
 
 
 def fill_vm_test(

--- a/eth/tools/fixtures/generation.py
+++ b/eth/tools/fixtures/generation.py
@@ -1,5 +1,4 @@
 import hashlib
-
 from typing import (
     Any,
     Callable,

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -1,36 +1,40 @@
 import os
-
-import rlp
-
 from typing import (
-    cast,
     Any,
     Dict,
     Iterable,
     Tuple,
     Type,
-)
-
-from eth_utils.toolz import (
-    assoc,
-    first,
+    cast,
 )
 
 from eth_utils import (
     to_normalized_address,
 )
+from eth_utils.toolz import (
+    assoc,
+    first,
+)
+import rlp
 
-from eth import MainnetChain
+from eth import (
+    MainnetChain,
+    constants,
+)
+from eth._utils.state import (
+    diff_state,
+)
 from eth.abc import (
     BlockAPI,
     ChainAPI,
     StateAPI,
     VirtualMachineAPI,
 )
-from eth import constants
-from eth.db.atomic import AtomicDB
 from eth.chains.mainnet import (
     MainnetDAOValidatorVM,
+)
+from eth.db.atomic import (
+    AtomicDB,
 )
 from eth.tools.builder.chain import (
     disable_pow_check,
@@ -38,23 +42,20 @@ from eth.tools.builder.chain import (
 from eth.typing import (
     AccountState,
 )
-from eth._utils.state import (
-    diff_state,
-)
 from eth.vm.forks import (
-    PetersburgVM,
-    ConstantinopleVM,
-    ByzantiumVM,
-    TangerineWhistleVM,
-    FrontierVM,
-    HomesteadVM as BaseHomesteadVM,
-    SpuriousDragonVM,
-    IstanbulVM,
     BerlinVM,
-    LondonVM,
+    ByzantiumVM,
+    ConstantinopleVM,
+    FrontierVM,
     GrayGlacierVM,
+    HomesteadVM as BaseHomesteadVM,
+    IstanbulVM,
+    LondonVM,
     ParisVM,
+    PetersburgVM,
     ShanghaiVM,
+    SpuriousDragonVM,
+    TangerineWhistleVM,
 )
 
 

--- a/eth/tools/fixtures/loading.py
+++ b/eth/tools/fixtures/loading.py
@@ -1,7 +1,6 @@
 import functools
 import json
 import os
-
 from typing import (
     Any,
     Callable,
@@ -10,12 +9,13 @@ from typing import (
     Tuple,
 )
 
+from eth_utils import (
+    to_tuple,
+)
 from eth_utils.toolz import (
     curry,
     identity,
 )
-
-from eth_utils import to_tuple
 
 from ._utils import (
     recursive_find_files,

--- a/eth/tools/mining.py
+++ b/eth/tools/mining.py
@@ -1,6 +1,6 @@
 from eth.abc import (
-    BlockAPI,
     BlockAndMetaWitness,
+    BlockAPI,
     VirtualMachineAPI,
 )
 from eth.consensus import (

--- a/eth/tools/rlp.py
+++ b/eth/tools/rlp.py
@@ -1,12 +1,11 @@
 from eth_utils import (
-    replace_exceptions,
     ValidationError,
+    replace_exceptions,
 )
 
 from eth._utils.rlp import (
     validate_rlp_equal,
 )
-
 
 assert_imported_block_unchanged = replace_exceptions({
     ValidationError: AssertionError,

--- a/eth/typing.py
+++ b/eth/typing.py
@@ -1,17 +1,17 @@
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     Generic,
     Iterable,
     List,
-    Optional,
     NewType,
+    Optional,
     Sequence,
     Tuple,
     Type,
     TypeVar,
-    TYPE_CHECKING,
     Union,
 )
 

--- a/eth/validation.py
+++ b/eth/validation.py
@@ -1,41 +1,40 @@
 import functools
-
 from typing import (
     Any,
-    cast,
     Dict,
     Iterable,
     Sequence,
     Tuple,
     Type,
     Union,
+    cast,
 )
 
 from eth_typing import (
     Address,
     Hash32,
 )
-
 from eth_utils import (
-    is_list_like,
     ValidationError,
+    is_list_like,
 )
-from eth_utils.toolz import dicttoolz
-
-from eth_utils.toolz import functoolz
-
-from eth_utils.toolz import itertoolz
+from eth_utils.toolz import (
+    dicttoolz,
+    functoolz,
+    itertoolz,
+)
 
 from eth._utils.headers import (
     compute_gas_limit_bounds,
 )
-from eth.abc import VirtualMachineAPI
+from eth.abc import (
+    VirtualMachineAPI,
+)
 from eth.constants import (
     SECPK1_N,
-    UINT_256_MAX,
     UINT_64_MAX,
+    UINT_256_MAX,
 )
-
 from eth.typing import (
     BytesOrView,
 )

--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -16,8 +16,12 @@ from typing import (
     Union,
 )
 
-from cached_property import cached_property
-from eth_hash.auto import keccak
+from cached_property import (
+    cached_property,
+)
+from eth_hash.auto import (
+    keccak,
+)
 from eth_typing import (
     Address,
     Hash32,
@@ -28,10 +32,17 @@ from eth_utils import (
 )
 import rlp
 
+from eth._utils.datatypes import (
+    Configurable,
+)
+from eth._utils.db import (
+    get_block_header_by_hash,
+    get_parent_header,
+)
 from eth.abc import (
     AtomicDatabaseAPI,
-    BlockAPI,
     BlockAndMetaWitness,
+    BlockAPI,
     BlockHeaderAPI,
     ChainContextAPI,
     ChainDatabaseAPI,
@@ -56,7 +67,9 @@ from eth.constants import (
     MAX_PREV_HEADER_DEPTH,
     MAX_UNCLES,
 )
-from eth.db.trie import make_trie_root_and_nodes
+from eth.db.trie import (
+    make_trie_root_and_nodes,
+)
 from eth.exceptions import (
     HeaderNotFound,
 )
@@ -66,16 +79,9 @@ from eth.rlp.headers import (
 from eth.rlp.sedes import (
     uint32,
 )
-from eth._utils.datatypes import (
-    Configurable,
-)
-from eth._utils.db import (
-    get_parent_header,
-    get_block_header_by_hash,
-)
 from eth.validation import (
-    validate_length_lte,
     validate_gas_limit,
+    validate_length_lte,
 )
 from eth.vm.execution_context import (
     ExecutionContext,

--- a/eth/vm/chain_context.py
+++ b/eth/vm/chain_context.py
@@ -1,6 +1,10 @@
-from typing import Optional
+from typing import (
+    Optional,
+)
 
-from eth.abc import ChainContextAPI
+from eth.abc import (
+    ChainContextAPI,
+)
 from eth.validation import (
     validate_uint256,
 )

--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -2,10 +2,12 @@ import contextlib
 import logging
 from typing import (
     Iterator,
-    Set
+    Set,
 )
 
-from eth.abc import CodeStreamAPI
+from eth.abc import (
+    CodeStreamAPI,
+)
 from eth.validation import (
     validate_is_bytes,
 )

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -1,5 +1,7 @@
 import itertools
-from types import TracebackType
+from types import (
+    TracebackType,
+)
 from typing import (
     Any,
     Callable,
@@ -12,12 +14,9 @@ from typing import (
     cast,
 )
 
-from cached_property import cached_property
-
-from eth.typing import BytesOrView
-from eth.vm.code_stream import CodeStream
-from eth.vm.gas_meter import GasMeter
-from eth.vm.message import Message
+from cached_property import (
+    cached_property,
+)
 from eth_typing import (
     Address,
 )
@@ -35,9 +34,9 @@ from eth._utils.numeric import (
 from eth.abc import (
     CodeStreamAPI,
     ComputationAPI,
+    GasMeterAPI,
     MemoryAPI,
     MessageAPI,
-    GasMeterAPI,
     OpcodeAPI,
     StackAPI,
     StateAPI,
@@ -51,16 +50,28 @@ from eth.exceptions import (
     Halt,
     VMError,
 )
+from eth.typing import (
+    BytesOrView,
+)
 from eth.validation import (
     validate_canonical_address,
     validate_is_bytes,
     validate_uint256,
+)
+from eth.vm.code_stream import (
+    CodeStream,
+)
+from eth.vm.gas_meter import (
+    GasMeter,
 )
 from eth.vm.logic.invalid import (
     InvalidOpcode,
 )
 from eth.vm.memory import (
     Memory,
+)
+from eth.vm.message import (
+    Message,
 )
 from eth.vm.stack import (
     Stack,

--- a/eth/vm/execution_context.py
+++ b/eth/vm/execution_context.py
@@ -9,8 +9,12 @@ from eth_typing import (
     Hash32,
 )
 
-from eth.abc import ExecutionContextAPI
-from eth._utils.generator import CachedIterable
+from eth._utils.generator import (
+    CachedIterable,
+)
+from eth.abc import (
+    ExecutionContextAPI,
+)
 
 
 class ExecutionContext(ExecutionContextAPI):

--- a/eth/vm/forks/arrow_glacier/blocks.py
+++ b/eth/vm/forks/arrow_glacier/blocks.py
@@ -1,18 +1,21 @@
-from abc import ABC
-from typing import Type
+from abc import (
+    ABC,
+)
+from typing import (
+    Type,
+)
 
-from eth.abc import TransactionBuilderAPI
 from eth_utils import (
     encode_hex,
 )
-
 from rlp.sedes import (
     CountableList,
 )
 
-from .transactions import (
-    ArrowGlacierTransactionBuilder,
+from eth.abc import (
+    TransactionBuilderAPI,
 )
+
 from ..london import (
     LondonBlock,
 )
@@ -20,6 +23,9 @@ from ..london.blocks import (
     LondonBackwardsHeader,
     LondonBlockHeader,
     LondonMiningHeader,
+)
+from .transactions import (
+    ArrowGlacierTransactionBuilder,
 )
 
 

--- a/eth/vm/forks/arrow_glacier/computation.py
+++ b/eth/vm/forks/arrow_glacier/computation.py
@@ -1,4 +1,6 @@
-from ..london.computation import LondonComputation
+from ..london.computation import (
+    LondonComputation,
+)
 
 
 class ArrowGlacierComputation(LondonComputation):

--- a/eth/vm/forks/arrow_glacier/headers.py
+++ b/eth/vm/forks/arrow_glacier/headers.py
@@ -1,19 +1,26 @@
-from typing import Any, Callable, Optional
+from typing import (
+    Any,
+    Callable,
+    Optional,
+)
 
-from toolz import curry
+from toolz import (
+    curry,
+)
 
-from eth.abc import BlockHeaderAPI
-from .blocks import (
-    ArrowGlacierBlockHeader,
+from eth.abc import (
+    BlockHeaderAPI,
+)
+from eth.vm.forks.byzantium.headers import (
+    compute_difficulty,
+    configure_header,
 )
 from eth.vm.forks.london.headers import (
     create_london_header_from_parent,
 )
-from eth.vm.forks.byzantium.headers import (
-    compute_difficulty,
-)
-from eth.vm.forks.byzantium.headers import (
-    configure_header,
+
+from .blocks import (
+    ArrowGlacierBlockHeader,
 )
 
 compute_arrow_glacier_difficulty = compute_difficulty(10_700_000)

--- a/eth/vm/forks/arrow_glacier/state.py
+++ b/eth/vm/forks/arrow_glacier/state.py
@@ -1,9 +1,20 @@
-from typing import Type
+from typing import (
+    Type,
+)
 
-from eth.abc import TransactionExecutorAPI
-from .computation import ArrowGlacierComputation
-from ..london import LondonState
-from ..london.state import LondonTransactionExecutor
+from eth.abc import (
+    TransactionExecutorAPI,
+)
+
+from ..london import (
+    LondonState,
+)
+from ..london.state import (
+    LondonTransactionExecutor,
+)
+from .computation import (
+    ArrowGlacierComputation,
+)
 
 
 class ArrowGlacierTransactionExecutor(LondonTransactionExecutor):

--- a/eth/vm/forks/arrow_glacier/transactions.py
+++ b/eth/vm/forks/arrow_glacier/transactions.py
@@ -1,6 +1,10 @@
-from abc import ABC
+from abc import (
+    ABC,
+)
 
-from eth_keys.datatypes import PrivateKey
+from eth_keys.datatypes import (
+    PrivateKey,
+)
 
 from eth._utils.transactions import (
     create_transaction_signature,

--- a/eth/vm/forks/berlin/blocks.py
+++ b/eth/vm/forks/berlin/blocks.py
@@ -1,4 +1,6 @@
-from typing import Type
+from typing import (
+    Type,
+)
 
 from rlp.sedes import (
     CountableList,

--- a/eth/vm/forks/berlin/computation.py
+++ b/eth/vm/forks/berlin/computation.py
@@ -7,10 +7,6 @@ from eth_utils.toolz import (
     merge,
 )
 
-from eth.precompiles.modexp import (
-    extract_lengths,
-    modexp,
-)
 from eth._utils.address import (
     force_bytes_to_address,
 )
@@ -20,17 +16,21 @@ from eth._utils.numeric import (
 from eth._utils.padding import (
     zpad_right,
 )
-
-from eth.vm.forks.berlin import constants
-
-from eth.vm.forks.muir_glacier.computation import (
-    MUIR_GLACIER_PRECOMPILES
+from eth.precompiles.modexp import (
+    extract_lengths,
+    modexp,
+)
+from eth.vm.forks.berlin import (
+    constants,
 )
 from eth.vm.forks.muir_glacier.computation import (
+    MUIR_GLACIER_PRECOMPILES,
     MuirGlacierComputation,
 )
 
-from .opcodes import BERLIN_OPCODES
+from .opcodes import (
+    BERLIN_OPCODES,
+)
 
 
 def _calculate_multiplication_complexity(base_length: int, modulus_length: int) -> int:

--- a/eth/vm/forks/berlin/headers.py
+++ b/eth/vm/forks/berlin/headers.py
@@ -1,9 +1,8 @@
 from eth.vm.forks.muir_glacier.headers import (
+    compute_muir_glacier_difficulty,
     configure_header,
     create_header_from_parent,
-    compute_muir_glacier_difficulty,
 )
-
 
 compute_berlin_difficulty = compute_muir_glacier_difficulty
 

--- a/eth/vm/forks/berlin/logic.py
+++ b/eth/vm/forks/berlin/logic.py
@@ -1,16 +1,22 @@
 from eth_typing import (
     Address,
 )
-from eth_utils.toolz import curry
+from eth_utils.toolz import (
+    curry,
+)
 
-from eth import constants
+from eth import (
+    constants,
+)
 from eth._utils.address import (
     force_bytes_to_address,
 )
 from eth.abc import (
     ComputationAPI,
 )
-from eth.vm import mnemonics
+from eth.vm import (
+    mnemonics,
+)
 from eth.vm.forks.istanbul.storage import (
     GAS_SCHEDULE_EIP2200,
     sstore_eip2200_generic,
@@ -23,8 +29,8 @@ from eth.vm.logic.call import (
 )
 from eth.vm.logic.context import (
     consume_extcodecopy_word_cost,
-    push_balance_of_address,
     extcodecopy_execute,
+    push_balance_of_address,
 )
 from eth.vm.logic.storage import (
     NetSStoreGasSchedule,
@@ -36,7 +42,9 @@ from eth.vm.logic.system import (
     selfdestruct_eip161_on_address,
 )
 
-from . import constants as berlin_constants
+from . import (
+    constants as berlin_constants,
+)
 
 
 def _mark_address_warm(computation: ComputationAPI, address: Address) -> bool:

--- a/eth/vm/forks/berlin/opcodes.py
+++ b/eth/vm/forks/berlin/opcodes.py
@@ -1,20 +1,18 @@
 import copy
-from typing import Dict
+from typing import (
+    Dict,
+)
 
-from eth_utils.toolz import merge
+from eth_utils.toolz import (
+    merge,
+)
 
+from eth import (
+    constants,
+)
 from eth.vm import (
     mnemonics,
     opcode_values,
-)
-from eth.vm.opcode import (
-    Opcode,
-    as_opcode,
-)
-from eth import constants
-
-from eth.vm.forks.tangerine_whistle.constants import (
-    GAS_SELFDESTRUCT_EIP150,
 )
 from eth.vm.forks.byzantium.opcodes import (
     ensure_no_static,
@@ -22,9 +20,17 @@ from eth.vm.forks.byzantium.opcodes import (
 from eth.vm.forks.muir_glacier.opcodes import (
     MUIR_GLACIER_OPCODES,
 )
+from eth.vm.forks.tangerine_whistle.constants import (
+    GAS_SELFDESTRUCT_EIP150,
+)
+from eth.vm.opcode import (
+    Opcode,
+    as_opcode,
+)
 
-from . import logic
-
+from . import (
+    logic,
+)
 
 UPDATED_OPCODES: Dict[int, Opcode] = {
     opcode_values.BALANCE: as_opcode(

--- a/eth/vm/forks/berlin/receipts.py
+++ b/eth/vm/forks/berlin/receipts.py
@@ -4,8 +4,12 @@ from typing import (
     Type,
 )
 
-from cached_property import cached_property
-from eth_bloom import BloomFilter
+from cached_property import (
+    cached_property,
+)
+from eth_bloom import (
+    BloomFilter,
+)
 from eth_utils import (
     ValidationError,
     to_bytes,
@@ -23,14 +27,17 @@ from eth.abc import (
     ReceiptBuilderAPI,
     ReceiptDecoderAPI,
 )
-from eth.exceptions import UnrecognizedTransactionType
-from eth.rlp.receipts import Receipt
+from eth.exceptions import (
+    UnrecognizedTransactionType,
+)
+from eth.rlp.receipts import (
+    Receipt,
+)
 
 from .constants import (
     ACCESS_LIST_TRANSACTION_TYPE,
     VALID_TRANSACTION_TYPES,
 )
-
 
 TYPED_RECEIPT_BODY_CODECS = {
     # Note that the body of a "type 1" receipt uses exactly the same codec as a

--- a/eth/vm/forks/berlin/state.py
+++ b/eth/vm/forks/berlin/state.py
@@ -1,4 +1,6 @@
-from typing import Type
+from typing import (
+    Type,
+)
 
 from eth.abc import (
     ComputationAPI,
@@ -7,13 +9,15 @@ from eth.abc import (
     TransactionExecutorAPI,
 )
 from eth.vm.forks.muir_glacier.state import (
-    MuirGlacierState
+    MuirGlacierState,
 )
 from eth.vm.forks.spurious_dragon.state import (
     SpuriousDragonTransactionExecutor,
 )
 
-from .computation import BerlinComputation
+from .computation import (
+    BerlinComputation,
+)
 
 
 class BerlinTransactionExecutor(SpuriousDragonTransactionExecutor):

--- a/eth/vm/forks/berlin/transactions.py
+++ b/eth/vm/forks/berlin/transactions.py
@@ -4,13 +4,19 @@ from typing import (
     Sequence,
     Tuple,
     Type,
-    cast,
     Union,
+    cast,
 )
 
-from cached_property import cached_property
-from eth_keys.datatypes import PrivateKey
-from eth_hash.auto import keccak
+from cached_property import (
+    cached_property,
+)
+from eth_hash.auto import (
+    keccak,
+)
+from eth_keys.datatypes import (
+    PrivateKey,
+)
 from eth_typing import (
     Address,
     Hash32,
@@ -29,6 +35,12 @@ from rlp.sedes import (
     binary,
 )
 
+from eth._utils.transactions import (
+    calculate_intrinsic_gas,
+    create_transaction_signature,
+    extract_transaction_sender,
+    validate_transaction_signature,
+)
 from eth.abc import (
     DecodedZeroOrOneLayerRLP,
     ReceiptAPI,
@@ -37,12 +49,24 @@ from eth.abc import (
     TransactionDecoderAPI,
     UnsignedTransactionAPI,
 )
-from eth.constants import CREATE_CONTRACT_ADDRESS
-from eth.exceptions import UnrecognizedTransactionType
-from eth.rlp.logs import Log
-from eth.rlp.receipts import Receipt
-from eth.rlp.sedes import address
-from eth.rlp.transactions import SignedTransactionMethods
+from eth.constants import (
+    CREATE_CONTRACT_ADDRESS,
+)
+from eth.exceptions import (
+    UnrecognizedTransactionType,
+)
+from eth.rlp.logs import (
+    Log,
+)
+from eth.rlp.receipts import (
+    Receipt,
+)
+from eth.rlp.sedes import (
+    address,
+)
+from eth.rlp.transactions import (
+    SignedTransactionMethods,
+)
 from eth.validation import (
     validate_canonical_address,
     validate_is_bytes,
@@ -55,13 +79,6 @@ from eth.vm.forks.istanbul.transactions import (
 from eth.vm.forks.muir_glacier.transactions import (
     MuirGlacierTransaction,
     MuirGlacierUnsignedTransaction,
-)
-
-from eth._utils.transactions import (
-    calculate_intrinsic_gas,
-    create_transaction_signature,
-    extract_transaction_sender,
-    validate_transaction_signature,
 )
 
 from .constants import (

--- a/eth/vm/forks/byzantium/blocks.py
+++ b/eth/vm/forks/byzantium/blocks.py
@@ -1,6 +1,7 @@
 from rlp.sedes import (
     CountableList,
 )
+
 from eth.rlp.headers import (
     BlockHeader,
 )

--- a/eth/vm/forks/byzantium/computation.py
+++ b/eth/vm/forks/byzantium/computation.py
@@ -2,14 +2,22 @@ from eth_utils.toolz import (
     merge,
 )
 
-from eth import precompiles
+from eth import (
+    precompiles,
+)
 from eth._utils.address import (
     force_bytes_to_address,
 )
-from eth.vm.forks.frontier.computation import FRONTIER_PRECOMPILES
-from eth.vm.forks.spurious_dragon.computation import SpuriousDragonComputation
+from eth.vm.forks.frontier.computation import (
+    FRONTIER_PRECOMPILES,
+)
+from eth.vm.forks.spurious_dragon.computation import (
+    SpuriousDragonComputation,
+)
 
-from .opcodes import BYZANTIUM_OPCODES
+from .opcodes import (
+    BYZANTIUM_OPCODES,
+)
 
 BYZANTIUM_PRECOMPILES = merge(
     FRONTIER_PRECOMPILES,

--- a/eth/vm/forks/byzantium/constants.py
+++ b/eth/vm/forks/byzantium/constants.py
@@ -1,4 +1,6 @@
-from eth_utils import denoms
+from eth_utils import (
+    denoms,
+)
 
 #
 # Difficulty

--- a/eth/vm/forks/byzantium/headers.py
+++ b/eth/vm/forks/byzantium/headers.py
@@ -2,26 +2,27 @@ from typing import (
     Any,
     Callable,
 )
+
 from eth_utils.toolz import (
     curry,
 )
 
-from eth.abc import (
-    BlockHeaderAPI,
-    VirtualMachineAPI,
-)
-from eth.constants import (
-    EMPTY_UNCLE_HASH,
-    DIFFICULTY_ADJUSTMENT_DENOMINATOR,
-    DIFFICULTY_MINIMUM,
-    BOMB_EXPONENTIAL_PERIOD,
-    BOMB_EXPONENTIAL_FREE_PERIODS,
-)
 from eth._utils.db import (
     get_parent_header,
 )
 from eth._utils.headers import (
     new_timestamp_from_parent,
+)
+from eth.abc import (
+    BlockHeaderAPI,
+    VirtualMachineAPI,
+)
+from eth.constants import (
+    BOMB_EXPONENTIAL_FREE_PERIODS,
+    BOMB_EXPONENTIAL_PERIOD,
+    DIFFICULTY_ADJUSTMENT_DENOMINATOR,
+    DIFFICULTY_MINIMUM,
+    EMPTY_UNCLE_HASH,
 )
 from eth.validation import (
     validate_gt,
@@ -32,7 +33,7 @@ from eth.vm.forks.frontier.headers import (
 )
 
 from .constants import (
-    BYZANTIUM_DIFFICULTY_ADJUSTMENT_CUTOFF
+    BYZANTIUM_DIFFICULTY_ADJUSTMENT_CUTOFF,
 )
 
 

--- a/eth/vm/forks/byzantium/opcodes.py
+++ b/eth/vm/forks/byzantium/opcodes.py
@@ -1,25 +1,35 @@
 import copy
 import functools
-from typing import Dict
-
-from eth_utils.toolz import merge
-
 from typing import (
     Any,
     Callable,
+    Dict,
 )
 
-from eth import constants
+from eth_utils.toolz import (
+    merge,
+)
 
-from eth.abc import ComputationAPI, OpcodeAPI
+from eth import (
+    constants,
+)
+from eth.abc import (
+    ComputationAPI,
+    OpcodeAPI,
+)
 from eth.exceptions import (
     WriteProtection,
 )
-from eth.vm import mnemonics
-from eth.vm import opcode_values
+from eth.vm import (
+    mnemonics,
+    opcode_values,
+)
+from eth.vm.forks.spurious_dragon.opcodes import (
+    SPURIOUS_DRAGON_OPCODES,
+)
 from eth.vm.forks.tangerine_whistle.constants import (
     GAS_CALL_EIP150,
-    GAS_SELFDESTRUCT_EIP150
+    GAS_SELFDESTRUCT_EIP150,
 )
 from eth.vm.logic import (
     call,
@@ -28,9 +38,9 @@ from eth.vm.logic import (
     storage,
     system,
 )
-from eth.vm.opcode import as_opcode
-
-from eth.vm.forks.spurious_dragon.opcodes import SPURIOUS_DRAGON_OPCODES
+from eth.vm.opcode import (
+    as_opcode,
+)
 
 
 def ensure_no_static(opcode_fn: Callable[..., Any]) -> Callable[..., Any]:

--- a/eth/vm/forks/byzantium/state.py
+++ b/eth/vm/forks/byzantium/state.py
@@ -1,6 +1,10 @@
-from eth.vm.forks.spurious_dragon.state import SpuriousDragonState
+from eth.vm.forks.spurious_dragon.state import (
+    SpuriousDragonState,
+)
 
-from .computation import ByzantiumComputation
+from .computation import (
+    ByzantiumComputation,
+)
 
 
 class ByzantiumState(SpuriousDragonState):

--- a/eth/vm/forks/byzantium/transactions.py
+++ b/eth/vm/forks/byzantium/transactions.py
@@ -1,10 +1,13 @@
-from eth_keys.datatypes import PrivateKey
-from eth_typing import Address
+from eth_keys.datatypes import (
+    PrivateKey,
+)
+from eth_typing import (
+    Address,
+)
 
 from eth._utils.transactions import (
     create_transaction_signature,
 )
-
 from eth.vm.forks.spurious_dragon.transactions import (
     SpuriousDragonTransaction,
     SpuriousDragonUnsignedTransaction,

--- a/eth/vm/forks/constantinople/blocks.py
+++ b/eth/vm/forks/constantinople/blocks.py
@@ -1,6 +1,7 @@
 from rlp.sedes import (
     CountableList,
 )
+
 from eth.rlp.headers import (
     BlockHeader,
 )

--- a/eth/vm/forks/constantinople/computation.py
+++ b/eth/vm/forks/constantinople/computation.py
@@ -1,15 +1,15 @@
 from eth.vm.forks.byzantium.computation import (
-    BYZANTIUM_PRECOMPILES
-)
-from eth.vm.forks.byzantium.computation import (
-    ByzantiumComputation
+    BYZANTIUM_PRECOMPILES,
+    ByzantiumComputation,
 )
 from eth.vm.gas_meter import (
-    allow_negative_refund_strategy,
     GasMeter,
+    allow_negative_refund_strategy,
 )
 
-from .opcodes import CONSTANTINOPLE_OPCODES
+from .opcodes import (
+    CONSTANTINOPLE_OPCODES,
+)
 
 CONSTANTINOPLE_PRECOMPILES = BYZANTIUM_PRECOMPILES
 

--- a/eth/vm/forks/constantinople/constants.py
+++ b/eth/vm/forks/constantinople/constants.py
@@ -1,5 +1,6 @@
-from eth_utils import denoms
-
+from eth_utils import (
+    denoms,
+)
 
 GAS_EXTCODEHASH_EIP1052 = 400
 GAS_SSTORE_EIP1283_NOOP = 200

--- a/eth/vm/forks/constantinople/headers.py
+++ b/eth/vm/forks/constantinople/headers.py
@@ -1,9 +1,8 @@
 from eth.vm.forks.byzantium.headers import (
+    compute_difficulty,
     configure_header,
     create_header_from_parent,
-    compute_difficulty,
 )
-
 
 compute_constantinople_difficulty = compute_difficulty(5000000)
 

--- a/eth/vm/forks/constantinople/opcodes.py
+++ b/eth/vm/forks/constantinople/opcodes.py
@@ -1,10 +1,11 @@
 import copy
+
 from eth_utils.toolz import (
-    merge
+    merge,
 )
 
 from eth import (
-    constants
+    constants,
 )
 from eth.vm import (
     mnemonics,
@@ -12,10 +13,10 @@ from eth.vm import (
 )
 from eth.vm.forks.byzantium.opcodes import (
     BYZANTIUM_OPCODES,
-    ensure_no_static
+    ensure_no_static,
 )
 from eth.vm.forks.constantinople.constants import (
-    GAS_EXTCODEHASH_EIP1052
+    GAS_EXTCODEHASH_EIP1052,
 )
 from eth.vm.forks.constantinople.storage import (
     sstore_eip1283,
@@ -26,9 +27,8 @@ from eth.vm.logic import (
     system,
 )
 from eth.vm.opcode import (
-    as_opcode
+    as_opcode,
 )
-
 
 UPDATED_OPCODES = {
     opcode_values.SHL: as_opcode(

--- a/eth/vm/forks/constantinople/state.py
+++ b/eth/vm/forks/constantinople/state.py
@@ -1,8 +1,10 @@
 from eth.vm.forks.byzantium.state import (
-    ByzantiumState
+    ByzantiumState,
 )
 
-from .computation import ConstantinopleComputation
+from .computation import (
+    ConstantinopleComputation,
+)
 
 
 class ConstantinopleState(ByzantiumState):

--- a/eth/vm/forks/constantinople/storage.py
+++ b/eth/vm/forks/constantinople/storage.py
@@ -1,8 +1,10 @@
-from functools import partial
+from functools import (
+    partial,
+)
 
 from eth.vm.logic.storage import (
-    net_sstore,
     NetSStoreGasSchedule,
+    net_sstore,
 )
 
 GAS_SCHEDULE_EIP1283 = NetSStoreGasSchedule(

--- a/eth/vm/forks/constantinople/transactions.py
+++ b/eth/vm/forks/constantinople/transactions.py
@@ -1,13 +1,16 @@
-from eth_keys.datatypes import PrivateKey
-from eth_typing import Address
-
-from eth.vm.forks.byzantium.transactions import (
-    ByzantiumTransaction,
-    ByzantiumUnsignedTransaction,
+from eth_keys.datatypes import (
+    PrivateKey,
+)
+from eth_typing import (
+    Address,
 )
 
 from eth._utils.transactions import (
     create_transaction_signature,
+)
+from eth.vm.forks.byzantium.transactions import (
+    ByzantiumTransaction,
+    ByzantiumUnsignedTransaction,
 )
 
 

--- a/eth/vm/forks/frontier/blocks.py
+++ b/eth/vm/forks/frontier/blocks.py
@@ -4,19 +4,16 @@ from typing import (
     Type,
 )
 
-from rlp.sedes import (
-    CountableList,
-)
-
 from eth_bloom import (
     BloomFilter,
 )
-
 from eth_typing import (
     BlockNumber,
     Hash32,
 )
-
+from rlp.sedes import (
+    CountableList,
+)
 from trie.exceptions import (
     MissingTrieNode,
 )

--- a/eth/vm/forks/frontier/computation.py
+++ b/eth/vm/forks/frontier/computation.py
@@ -1,15 +1,13 @@
-from eth import precompiles
-
-from eth_hash.auto import keccak
+from eth_hash.auto import (
+    keccak,
+)
 from eth_utils import (
     encode_hex,
 )
 
-from eth.constants import (
-    GAS_CODEDEPOSIT,
-    STACK_DEPTH_LIMIT,
+from eth import (
+    precompiles,
 )
-
 from eth._utils.address import (
     force_bytes_to_address,
 )
@@ -19,17 +17,22 @@ from eth.abc import (
     StateAPI,
     TransactionContextAPI,
 )
+from eth.constants import (
+    GAS_CODEDEPOSIT,
+    STACK_DEPTH_LIMIT,
+)
 from eth.exceptions import (
-    OutOfGas,
     InsufficientFunds,
+    OutOfGas,
     StackDepthLimit,
 )
 from eth.vm.computation import (
     BaseComputation,
 )
 
-from .opcodes import FRONTIER_OPCODES
-
+from .opcodes import (
+    FRONTIER_OPCODES,
+)
 
 FRONTIER_PRECOMPILES = {
     force_bytes_to_address(b'\x01'): precompiles.ecrecover,

--- a/eth/vm/forks/frontier/headers.py
+++ b/eth/vm/forks/frontier/headers.py
@@ -1,21 +1,8 @@
 from typing import (
-    Any,
     TYPE_CHECKING,
+    Any,
 )
 
-from eth.abc import BlockHeaderAPI
-from eth.validation import (
-    validate_gt,
-    validate_header_params_for_configuration,
-)
-
-from eth.constants import (
-    GENESIS_GAS_LIMIT,
-    DIFFICULTY_ADJUSTMENT_DENOMINATOR,
-    DIFFICULTY_MINIMUM,
-    BOMB_EXPONENTIAL_PERIOD,
-    BOMB_EXPONENTIAL_FREE_PERIODS,
-)
 from eth._utils.db import (
     get_parent_header,
 )
@@ -24,14 +11,30 @@ from eth._utils.headers import (
     fill_header_params_from_parent,
     new_timestamp_from_parent,
 )
-from eth.rlp.headers import BlockHeader
+from eth.abc import (
+    BlockHeaderAPI,
+)
+from eth.constants import (
+    BOMB_EXPONENTIAL_FREE_PERIODS,
+    BOMB_EXPONENTIAL_PERIOD,
+    DIFFICULTY_ADJUSTMENT_DENOMINATOR,
+    DIFFICULTY_MINIMUM,
+    GENESIS_GAS_LIMIT,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
+from eth.validation import (
+    validate_gt,
+    validate_header_params_for_configuration,
+)
 
 from .constants import (
-    FRONTIER_DIFFICULTY_ADJUSTMENT_CUTOFF
+    FRONTIER_DIFFICULTY_ADJUSTMENT_CUTOFF,
 )
 
 if TYPE_CHECKING:
-    from eth.vm.forks.frontier import FrontierVM    # noqa: F401
+    from eth.vm.forks.frontier import FrontierVM  # noqa: F401
 
 
 def compute_frontier_difficulty(parent_header: BlockHeaderAPI, timestamp: int) -> int:

--- a/eth/vm/forks/frontier/opcodes.py
+++ b/eth/vm/forks/frontier/opcodes.py
@@ -1,10 +1,17 @@
-from typing import Dict
+from typing import (
+    Dict,
+)
 
-from eth import constants
-
-from eth.abc import OpcodeAPI
-from eth.vm import mnemonics
-from eth.vm import opcode_values
+from eth import (
+    constants,
+)
+from eth.abc import (
+    OpcodeAPI,
+)
+from eth.vm import (
+    mnemonics,
+    opcode_values,
+)
 from eth.vm.logic import (
     arithmetic,
     block,
@@ -24,7 +31,6 @@ from eth.vm.logic import (
 from eth.vm.opcode import (
     as_opcode,
 )
-
 
 FRONTIER_OPCODES: Dict[int, OpcodeAPI] = {
     #

--- a/eth/vm/forks/frontier/state.py
+++ b/eth/vm/forks/frontier/state.py
@@ -1,30 +1,34 @@
-from typing import Type
+from typing import (
+    Type,
+)
 
-from eth_hash.auto import keccak
+from eth_hash.auto import (
+    keccak,
+)
 from eth_utils import (
     encode_hex,
 )
 
+from eth._utils.address import (
+    generate_contract_address,
+)
 from eth.abc import (
     AccountDatabaseAPI,
     ComputationAPI,
-    SignedTransactionAPI,
     MessageAPI,
+    SignedTransactionAPI,
     TransactionContextAPI,
     TransactionExecutorAPI,
 )
-from eth.constants import CREATE_CONTRACT_ADDRESS
+from eth.constants import (
+    CREATE_CONTRACT_ADDRESS,
+)
 from eth.db.account import (
     AccountDB,
 )
 from eth.exceptions import (
     ContractCreationCollision,
 )
-
-from eth._utils.address import (
-    generate_contract_address,
-)
-
 from eth.vm.message import (
     Message,
 )
@@ -33,16 +37,19 @@ from eth.vm.state import (
     BaseTransactionExecutor,
 )
 
-
-from .computation import FrontierComputation
+from .computation import (
+    FrontierComputation,
+)
 from .constants import (
-    REFUND_SELFDESTRUCT,
     MAX_REFUND_QUOTIENT,
+    REFUND_SELFDESTRUCT,
 )
 from .transaction_context import (
-    FrontierTransactionContext
+    FrontierTransactionContext,
 )
-from .validation import validate_frontier_transaction
+from .validation import (
+    validate_frontier_transaction,
+)
 
 
 class FrontierTransactionExecutor(BaseTransactionExecutor):

--- a/eth/vm/forks/frontier/transaction_context.py
+++ b/eth/vm/forks/frontier/transaction_context.py
@@ -1,4 +1,6 @@
-from eth.vm.transaction_context import BaseTransactionContext
+from eth.vm.transaction_context import (
+    BaseTransactionContext,
+)
 
 
 class FrontierTransactionContext(BaseTransactionContext):

--- a/eth/vm/forks/frontier/transactions.py
+++ b/eth/vm/forks/frontier/transactions.py
@@ -1,14 +1,26 @@
-from functools import partial
+from functools import (
+    partial,
+)
 from typing import (
     Tuple,
 )
 
-from eth_keys.datatypes import PrivateKey
+from eth_keys.datatypes import (
+    PrivateKey,
+)
 from eth_typing import (
     Address,
 )
 import rlp
 
+from eth._utils.transactions import (
+    V_OFFSET,
+    IntrinsicGasSchedule,
+    calculate_intrinsic_gas,
+    create_transaction_signature,
+    extract_transaction_sender,
+    validate_transaction_signature,
+)
 from eth.abc import (
     ReceiptAPI,
     SignedTransactionAPI,
@@ -16,35 +28,28 @@ from eth.abc import (
 from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
     GAS_TX,
-    GAS_TXDATAZERO,
     GAS_TXDATANONZERO,
+    GAS_TXDATAZERO,
 )
-from eth.validation import (
-    validate_uint256,
-    validate_is_integer,
-    validate_is_bytes,
-    validate_lt_secpk1n,
-    validate_lte,
-    validate_gte,
-    validate_canonical_address,
+from eth.rlp.logs import (
+    Log,
 )
-
-from eth.rlp.logs import Log
-from eth.rlp.receipts import Receipt
+from eth.rlp.receipts import (
+    Receipt,
+)
 from eth.rlp.transactions import (
     BaseTransaction,
     BaseUnsignedTransaction,
 )
-
-from eth._utils.transactions import (
-    V_OFFSET,
-    create_transaction_signature,
-    extract_transaction_sender,
-    validate_transaction_signature,
-    IntrinsicGasSchedule,
-    calculate_intrinsic_gas,
+from eth.validation import (
+    validate_canonical_address,
+    validate_gte,
+    validate_is_bytes,
+    validate_is_integer,
+    validate_lt_secpk1n,
+    validate_lte,
+    validate_uint256,
 )
-
 
 FRONTIER_TX_GAS_SCHEDULE = IntrinsicGasSchedule(
     gas_tx=GAS_TX,

--- a/eth/vm/forks/gray_glacier/blocks.py
+++ b/eth/vm/forks/gray_glacier/blocks.py
@@ -1,18 +1,21 @@
-from abc import ABC
-from typing import Type
+from abc import (
+    ABC,
+)
+from typing import (
+    Type,
+)
 
-from eth.abc import TransactionBuilderAPI
 from eth_utils import (
     encode_hex,
 )
-
 from rlp.sedes import (
     CountableList,
 )
 
-from .transactions import (
-    GrayGlacierTransactionBuilder,
+from eth.abc import (
+    TransactionBuilderAPI,
 )
+
 from ..arrow_glacier import (
     ArrowGlacierBlock,
 )
@@ -20,7 +23,12 @@ from ..arrow_glacier.blocks import (
     ArrowGlacierBlockHeader,
     ArrowGlacierMiningHeader,
 )
-from ..london.blocks import LondonBackwardsHeader
+from ..london.blocks import (
+    LondonBackwardsHeader,
+)
+from .transactions import (
+    GrayGlacierTransactionBuilder,
+)
 
 
 class GrayGlacierMiningHeader(ArrowGlacierMiningHeader, ABC):

--- a/eth/vm/forks/gray_glacier/computation.py
+++ b/eth/vm/forks/gray_glacier/computation.py
@@ -1,4 +1,6 @@
-from ..arrow_glacier.computation import ArrowGlacierComputation
+from ..arrow_glacier.computation import (
+    ArrowGlacierComputation,
+)
 
 
 class GrayGlacierComputation(ArrowGlacierComputation):

--- a/eth/vm/forks/gray_glacier/headers.py
+++ b/eth/vm/forks/gray_glacier/headers.py
@@ -1,10 +1,13 @@
-from typing import Any, Callable, Optional
-
-from toolz import curry
-
-from .blocks import (
-    GrayGlacierBlockHeader,
+from typing import (
+    Any,
+    Callable,
+    Optional,
 )
+
+from toolz import (
+    curry,
+)
+
 from eth.abc import (
     BlockHeaderAPI,
 )
@@ -13,9 +16,11 @@ from eth.vm.forks.arrow_glacier.headers import (
 )
 from eth.vm.forks.byzantium.headers import (
     compute_difficulty,
-)
-from eth.vm.forks.byzantium.headers import (
     configure_header,
+)
+
+from .blocks import (
+    GrayGlacierBlockHeader,
 )
 
 compute_gray_glacier_difficulty = compute_difficulty(11_400_000)

--- a/eth/vm/forks/gray_glacier/state.py
+++ b/eth/vm/forks/gray_glacier/state.py
@@ -1,9 +1,20 @@
-from typing import Type
+from typing import (
+    Type,
+)
 
-from eth.abc import TransactionExecutorAPI
-from .computation import GrayGlacierComputation
-from ..arrow_glacier import ArrowGlacierState
-from ..arrow_glacier.state import ArrowGlacierTransactionExecutor
+from eth.abc import (
+    TransactionExecutorAPI,
+)
+
+from ..arrow_glacier import (
+    ArrowGlacierState,
+)
+from ..arrow_glacier.state import (
+    ArrowGlacierTransactionExecutor,
+)
+from .computation import (
+    GrayGlacierComputation,
+)
 
 
 class GrayGlacierTransactionExecutor(ArrowGlacierTransactionExecutor):

--- a/eth/vm/forks/gray_glacier/transactions.py
+++ b/eth/vm/forks/gray_glacier/transactions.py
@@ -1,6 +1,10 @@
-from abc import ABC
+from abc import (
+    ABC,
+)
 
-from eth_keys.datatypes import PrivateKey
+from eth_keys.datatypes import (
+    PrivateKey,
+)
 
 from eth._utils.transactions import (
     create_transaction_signature,

--- a/eth/vm/forks/homestead/blocks.py
+++ b/eth/vm/forks/homestead/blocks.py
@@ -1,12 +1,14 @@
 from rlp.sedes import (
     CountableList,
 )
+
 from eth.rlp.headers import (
     BlockHeader,
 )
 from eth.vm.forks.frontier.blocks import (
     FrontierBlock,
 )
+
 from .transactions import (
     HomesteadTransaction,
 )

--- a/eth/vm/forks/homestead/computation.py
+++ b/eth/vm/forks/homestead/computation.py
@@ -1,24 +1,29 @@
-from eth_hash.auto import keccak
-
-from eth import constants
-from eth.exceptions import (
-    OutOfGas,
+from eth_hash.auto import (
+    keccak,
 )
 from eth_utils import (
     encode_hex,
 )
 
+from eth import (
+    constants,
+)
 from eth.abc import (
     ComputationAPI,
     MessageAPI,
     StateAPI,
     TransactionContextAPI,
 )
+from eth.exceptions import (
+    OutOfGas,
+)
 from eth.vm.forks.frontier.computation import (
     FrontierComputation,
 )
 
-from .opcodes import HOMESTEAD_OPCODES
+from .opcodes import (
+    HOMESTEAD_OPCODES,
+)
 
 
 class HomesteadComputation(FrontierComputation):

--- a/eth/vm/forks/homestead/headers.py
+++ b/eth/vm/forks/homestead/headers.py
@@ -1,6 +1,6 @@
 from typing import (
-    Any,
     TYPE_CHECKING,
+    Any,
 )
 
 from eth_typing import (
@@ -10,16 +10,20 @@ from eth_utils import (
     decode_hex,
 )
 
-from eth.abc import BlockHeaderAPI
-from eth.constants import (
-    DIFFICULTY_ADJUSTMENT_DENOMINATOR,
-    DIFFICULTY_MINIMUM,
-    BOMB_EXPONENTIAL_PERIOD,
-    BOMB_EXPONENTIAL_FREE_PERIODS,
-)
-from eth.rlp.headers import BlockHeader
 from eth._utils.db import (
     get_parent_header,
+)
+from eth.abc import (
+    BlockHeaderAPI,
+)
+from eth.constants import (
+    BOMB_EXPONENTIAL_FREE_PERIODS,
+    BOMB_EXPONENTIAL_PERIOD,
+    DIFFICULTY_ADJUSTMENT_DENOMINATOR,
+    DIFFICULTY_MINIMUM,
+)
+from eth.rlp.headers import (
+    BlockHeader,
 )
 from eth.validation import (
     validate_gt,
@@ -30,11 +34,11 @@ from eth.vm.forks.frontier.headers import (
 )
 
 from .constants import (
-    HOMESTEAD_DIFFICULTY_ADJUSTMENT_CUTOFF
+    HOMESTEAD_DIFFICULTY_ADJUSTMENT_CUTOFF,
 )
 
 if TYPE_CHECKING:
-    from eth.vm.forks.homestead import HomesteadVM      # noqa: F401
+    from eth.vm.forks.homestead import HomesteadVM  # noqa: F401
 
 
 def compute_homestead_difficulty(parent_header: BlockHeaderAPI, timestamp: int) -> int:

--- a/eth/vm/forks/homestead/opcodes.py
+++ b/eth/vm/forks/homestead/opcodes.py
@@ -1,18 +1,28 @@
 import copy
-from typing import Dict
+from typing import (
+    Dict,
+)
 
-from eth_utils.toolz import merge
+from eth_utils.toolz import (
+    merge,
+)
 
-from eth import constants
-from eth.abc import OpcodeAPI
-from eth.vm import mnemonics
-from eth.vm import opcode_values
+from eth import (
+    constants,
+)
+from eth.abc import (
+    OpcodeAPI,
+)
+from eth.vm import (
+    mnemonics,
+    opcode_values,
+)
+from eth.vm.forks.frontier.opcodes import (
+    FRONTIER_OPCODES,
+)
 from eth.vm.logic import (
     call,
 )
-
-from eth.vm.forks.frontier.opcodes import FRONTIER_OPCODES
-
 
 NEW_OPCODES = {
     opcode_values.DELEGATECALL: call.DelegateCall.configure(

--- a/eth/vm/forks/homestead/state.py
+++ b/eth/vm/forks/homestead/state.py
@@ -1,4 +1,6 @@
-from typing import Type
+from typing import (
+    Type,
+)
 
 from eth.abc import (
     ComputationAPI,
@@ -9,8 +11,12 @@ from eth.vm.forks.frontier.state import (
     FrontierTransactionExecutor,
 )
 
-from .computation import HomesteadComputation
-from .validation import validate_homestead_transaction
+from .computation import (
+    HomesteadComputation,
+)
+from .validation import (
+    validate_homestead_transaction,
+)
 
 
 class HomesteadState(FrontierState):

--- a/eth/vm/forks/homestead/transactions.py
+++ b/eth/vm/forks/homestead/transactions.py
@@ -1,26 +1,29 @@
-from functools import partial
+from functools import (
+    partial,
+)
 
+from eth_keys.datatypes import (
+    PrivateKey,
+)
+from eth_typing import (
+    Address,
+)
 import rlp
 
-from eth_keys.datatypes import PrivateKey
-
-from eth_typing import Address
-
-from eth.constants import GAS_TXCREATE
-
+from eth._utils.transactions import (
+    calculate_intrinsic_gas,
+    create_transaction_signature,
+)
+from eth.constants import (
+    GAS_TXCREATE,
+)
 from eth.validation import (
     validate_lt_secpk1n2,
 )
-
 from eth.vm.forks.frontier.transactions import (
+    FRONTIER_TX_GAS_SCHEDULE,
     FrontierTransaction,
     FrontierUnsignedTransaction,
-    FRONTIER_TX_GAS_SCHEDULE,
-)
-
-from eth._utils.transactions import (
-    create_transaction_signature,
-    calculate_intrinsic_gas,
 )
 
 HOMESTEAD_TX_GAS_SCHEDULE = FRONTIER_TX_GAS_SCHEDULE._replace(

--- a/eth/vm/forks/homestead/validation.py
+++ b/eth/vm/forks/homestead/validation.py
@@ -2,13 +2,12 @@ from eth_utils import (
     ValidationError,
 )
 
-from eth.constants import (
-    SECPK1_N,
-)
-
 from eth.abc import (
     SignedTransactionAPI,
     StateAPI,
+)
+from eth.constants import (
+    SECPK1_N,
 )
 from eth.vm.forks.frontier.validation import (
     validate_frontier_transaction,

--- a/eth/vm/forks/istanbul/blocks.py
+++ b/eth/vm/forks/istanbul/blocks.py
@@ -1,6 +1,7 @@
 from rlp.sedes import (
     CountableList,
 )
+
 from eth.rlp.headers import (
     BlockHeader,
 )

--- a/eth/vm/forks/istanbul/computation.py
+++ b/eth/vm/forks/istanbul/computation.py
@@ -2,19 +2,19 @@ from eth_utils.toolz import (
     merge,
 )
 
-from eth import precompiles
+from eth import (
+    precompiles,
+)
 from eth._utils.address import (
     force_bytes_to_address,
 )
 from eth.vm.forks.petersburg.computation import (
-    PETERSBURG_PRECOMPILES
-)
-from eth.vm.forks.petersburg.computation import (
+    PETERSBURG_PRECOMPILES,
     PetersburgComputation,
 )
 from eth.vm.gas_meter import (
-    allow_negative_refund_strategy,
     GasMeter,
+    allow_negative_refund_strategy,
 )
 
 from .constants import (
@@ -23,7 +23,9 @@ from .constants import (
     GAS_ECPAIRING_BASE,
     GAS_ECPAIRING_PER_POINT,
 )
-from .opcodes import ISTANBUL_OPCODES
+from .opcodes import (
+    ISTANBUL_OPCODES,
+)
 
 ISTANBUL_PRECOMPILES = merge(
     PETERSBURG_PRECOMPILES,

--- a/eth/vm/forks/istanbul/headers.py
+++ b/eth/vm/forks/istanbul/headers.py
@@ -1,9 +1,8 @@
 from eth.vm.forks.petersburg.headers import (
+    compute_petersburg_difficulty,
     configure_header,
     create_header_from_parent,
-    compute_petersburg_difficulty,
 )
-
 
 compute_istanbul_difficulty = compute_petersburg_difficulty
 

--- a/eth/vm/forks/istanbul/opcodes.py
+++ b/eth/vm/forks/istanbul/opcodes.py
@@ -1,32 +1,38 @@
 import copy
 
-from eth_utils.toolz import merge
+from eth_utils.toolz import (
+    merge,
+)
 
-from eth import constants
+from eth import (
+    constants,
+)
 from eth.vm import (
     mnemonics,
     opcode_values,
 )
 from eth.vm.forks.byzantium.opcodes import (
-    ensure_no_static
-)
-from eth.vm.forks.petersburg.opcodes import (
-    PETERSBURG_OPCODES,
+    ensure_no_static,
 )
 from eth.vm.forks.istanbul.constants import (
     GAS_BALANCE_EIP1884,
-    GAS_SLOAD_EIP1884,
     GAS_EXTCODEHASH_EIP1884,
+    GAS_SLOAD_EIP1884,
+)
+from eth.vm.forks.petersburg.opcodes import (
+    PETERSBURG_OPCODES,
 )
 from eth.vm.logic import (
     context,
     storage,
 )
-from eth.vm.opcode import as_opcode
+from eth.vm.opcode import (
+    as_opcode,
+)
+
 from .storage import (
     sstore_eip2200,
 )
-
 
 UPDATED_OPCODES = {
     # New opcodes

--- a/eth/vm/forks/istanbul/state.py
+++ b/eth/vm/forks/istanbul/state.py
@@ -1,8 +1,10 @@
 from eth.vm.forks.petersburg.state import (
-    PetersburgState
+    PetersburgState,
 )
 
-from .computation import IstanbulComputation
+from .computation import (
+    IstanbulComputation,
+)
 
 
 class IstanbulState(PetersburgState):

--- a/eth/vm/forks/istanbul/storage.py
+++ b/eth/vm/forks/istanbul/storage.py
@@ -1,12 +1,18 @@
-from eth_utils.toolz import curry
+from eth_utils.toolz import (
+    curry,
+)
 
-from eth.abc import ComputationAPI
-from eth.exceptions import OutOfGas
+from eth.abc import (
+    ComputationAPI,
+)
+from eth.exceptions import (
+    OutOfGas,
+)
 from eth.vm.forks.constantinople.storage import (
     GAS_SCHEDULE_EIP1283,
 )
 from eth.vm.forks.istanbul import (
-    constants
+    constants,
 )
 from eth.vm.logic.storage import (
     NetSStoreGasSchedule,

--- a/eth/vm/forks/istanbul/transactions.py
+++ b/eth/vm/forks/istanbul/transactions.py
@@ -1,19 +1,24 @@
-from functools import partial
+from functools import (
+    partial,
+)
 
-from eth_keys.datatypes import PrivateKey
-from eth_typing import Address
-
-from eth.vm.forks.petersburg.transactions import (
-    PetersburgTransaction,
-    PetersburgUnsignedTransaction,
+from eth_keys.datatypes import (
+    PrivateKey,
+)
+from eth_typing import (
+    Address,
 )
 
 from eth._utils.transactions import (
-    create_transaction_signature,
     calculate_intrinsic_gas,
+    create_transaction_signature,
 )
 from eth.vm.forks.homestead.transactions import (
     HOMESTEAD_TX_GAS_SCHEDULE,
+)
+from eth.vm.forks.petersburg.transactions import (
+    PetersburgTransaction,
+    PetersburgUnsignedTransaction,
 )
 
 from .constants import (

--- a/eth/vm/forks/london/blocks.py
+++ b/eth/vm/forks/london/blocks.py
@@ -5,13 +5,15 @@ from typing import (
     cast,
 )
 
-from eth_hash.auto import keccak
+from eth_hash.auto import (
+    keccak,
+)
 from eth_typing import (
     BlockNumber,
 )
 from eth_typing.evm import (
     Address,
-    Hash32
+    Hash32,
 )
 from eth_utils import (
     encode_hex,
@@ -21,7 +23,7 @@ from rlp.sedes import (
     Binary,
     CountableList,
     big_endian_int,
-    binary
+    binary,
 )
 
 from eth._utils.headers import (
@@ -35,12 +37,12 @@ from eth.abc import (
     TransactionBuilderAPI,
 )
 from eth.constants import (
-    ZERO_ADDRESS,
-    ZERO_HASH32,
+    BLANK_ROOT_HASH,
     EMPTY_UNCLE_HASH,
     GENESIS_NONCE,
     GENESIS_PARENT_HASH,
-    BLANK_ROOT_HASH,
+    ZERO_ADDRESS,
+    ZERO_HASH32,
 )
 from eth.rlp.headers import (
     BlockHeader,

--- a/eth/vm/forks/london/computation.py
+++ b/eth/vm/forks/london/computation.py
@@ -1,10 +1,16 @@
-from eth.exceptions import ReservedBytesInCode
+from eth.exceptions import (
+    ReservedBytesInCode,
+)
 from eth.vm.forks.berlin.computation import (
     BerlinComputation,
 )
 
-from .opcodes import LONDON_OPCODES
-from ..london.constants import EIP3541_RESERVED_STARTING_BYTE
+from ..london.constants import (
+    EIP3541_RESERVED_STARTING_BYTE,
+)
+from .opcodes import (
+    LONDON_OPCODES,
+)
 
 
 class LondonComputation(BerlinComputation):

--- a/eth/vm/forks/london/headers.py
+++ b/eth/vm/forks/london/headers.py
@@ -8,7 +8,9 @@ from typing import (
 from eth_utils import (
     ValidationError,
 )
-from toolz.functoolz import curry
+from toolz.functoolz import (
+    curry,
+)
 
 from eth._utils.headers import (
     compute_gas_limit,
@@ -19,8 +21,12 @@ from eth.abc import (
     BlockHeaderAPI,
     BlockHeaderSedesAPI,
 )
-from eth.constants import GENESIS_GAS_LIMIT
-from eth.rlp.headers import BlockHeader
+from eth.constants import (
+    GENESIS_GAS_LIMIT,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
 from eth.vm.forks.berlin.headers import (
     configure_header,
 )
@@ -28,8 +34,9 @@ from eth.vm.forks.muir_glacier.headers import (
     compute_difficulty,
 )
 
-
-from .blocks import LondonBlockHeader
+from .blocks import (
+    LondonBlockHeader,
+)
 from .constants import (
     BASE_FEE_MAX_CHANGE_DENOMINATOR,
     ELASTICITY_MULTIPLIER,

--- a/eth/vm/forks/london/opcodes.py
+++ b/eth/vm/forks/london/opcodes.py
@@ -1,29 +1,36 @@
 import copy
-from typing import Dict
+from typing import (
+    Dict,
+)
 
-from eth_utils.toolz import merge
+from eth_utils.toolz import (
+    merge,
+)
 
-from eth.vm.logic import (
-    block,
+from eth import (
+    constants,
 )
 from eth.vm import (
     mnemonics,
     opcode_values,
 )
-from eth.vm.opcode import (
-    Opcode,
-    as_opcode,
-)
-from eth import constants
-
 from eth.vm.forks.berlin.opcodes import (
     BERLIN_OPCODES,
 )
 from eth.vm.forks.byzantium.opcodes import (
     ensure_no_static,
 )
+from eth.vm.logic import (
+    block,
+)
+from eth.vm.opcode import (
+    Opcode,
+    as_opcode,
+)
 
-from . import storage
+from . import (
+    storage,
+)
 
 UPDATED_OPCODES: Dict[int, Opcode] = {
     opcode_values.BASEFEE: as_opcode(

--- a/eth/vm/forks/london/receipts.py
+++ b/eth/vm/forks/london/receipts.py
@@ -6,15 +6,17 @@ from typing import (
 from eth.rlp.receipts import (
     Receipt,
 )
+from eth.vm.forks.berlin.constants import (
+    ACCESS_LIST_TRANSACTION_TYPE,
+)
 from eth.vm.forks.berlin.receipts import (
     BerlinReceiptBuilder,
     TypedReceipt as BerlinTypedReceipt,
 )
-from eth.vm.forks.berlin.constants import (
-    ACCESS_LIST_TRANSACTION_TYPE,
-)
 
-from .constants import DYNAMIC_FEE_TRANSACTION_TYPE
+from .constants import (
+    DYNAMIC_FEE_TRANSACTION_TYPE,
+)
 
 
 class LondonTypedReceipt(BerlinTypedReceipt):

--- a/eth/vm/forks/london/state.py
+++ b/eth/vm/forks/london/state.py
@@ -1,10 +1,17 @@
-from typing import Type
+from typing import (
+    Type,
+)
 
-from eth_hash.auto import keccak
+from eth_hash.auto import (
+    keccak,
+)
 from eth_utils import (
     encode_hex,
 )
 
+from eth._utils.address import (
+    generate_contract_address,
+)
 from eth.abc import (
     ComputationAPI,
     MessageAPI,
@@ -16,20 +23,23 @@ from eth.abc import (
 from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
 )
-from eth.vm.message import (
-    Message,
-)
 from eth.vm.forks.berlin.state import (
     BerlinState,
     BerlinTransactionExecutor,
 )
-from eth._utils.address import (
-    generate_contract_address,
+from eth.vm.message import (
+    Message,
 )
 
-from .computation import LondonComputation
-from .validation import validate_london_normalized_transaction
-from .constants import EIP3529_MAX_REFUND_QUOTIENT
+from .computation import (
+    LondonComputation,
+)
+from .constants import (
+    EIP3529_MAX_REFUND_QUOTIENT,
+)
+from .validation import (
+    validate_london_normalized_transaction,
+)
 
 
 class LondonTransactionExecutor(BerlinTransactionExecutor):

--- a/eth/vm/forks/london/storage.py
+++ b/eth/vm/forks/london/storage.py
@@ -1,11 +1,14 @@
-from eth_utils.toolz import partial
+from eth_utils.toolz import (
+    partial,
+)
 
-from eth.vm.forks.berlin import constants as berlin_constants
+from eth.vm.forks.berlin import (
+    constants as berlin_constants,
+)
 from eth.vm.forks.berlin.logic import (
     GAS_SCHEDULE_EIP2929,
     sstore_eip2929_generic,
 )
-
 
 SSTORE_CLEARS_SCHEDULE_EIP_3529 = (
     GAS_SCHEDULE_EIP2929.sstore_reset_gas

--- a/eth/vm/forks/london/transactions.py
+++ b/eth/vm/forks/london/transactions.py
@@ -1,4 +1,3 @@
-from cached_property import cached_property
 from typing import (
     Dict,
     Sequence,
@@ -7,7 +6,12 @@ from typing import (
     Union,
 )
 
-from eth_keys.datatypes import PrivateKey
+from cached_property import (
+    cached_property,
+)
+from eth_keys.datatypes import (
+    PrivateKey,
+)
 from eth_typing import (
     Address,
     Hash32,
@@ -33,11 +37,21 @@ from eth.abc import (
     SignedTransactionAPI,
     TransactionDecoderAPI,
 )
-from eth.constants import CREATE_CONTRACT_ADDRESS
-from eth.rlp.logs import Log
-from eth.rlp.receipts import Receipt
-from eth.rlp.transactions import SignedTransactionMethods
-from eth.rlp.sedes import address
+from eth.constants import (
+    CREATE_CONTRACT_ADDRESS,
+)
+from eth.rlp.logs import (
+    Log,
+)
+from eth.rlp.receipts import (
+    Receipt,
+)
+from eth.rlp.sedes import (
+    address,
+)
+from eth.rlp.transactions import (
+    SignedTransactionMethods,
+)
 from eth.validation import (
     validate_canonical_address,
     validate_is_bytes,
@@ -61,8 +75,12 @@ from eth.vm.forks.istanbul.transactions import (
     ISTANBUL_TX_GAS_SCHEDULE,
 )
 
-from .constants import DYNAMIC_FEE_TRANSACTION_TYPE
-from .receipts import LondonReceiptBuilder
+from .constants import (
+    DYNAMIC_FEE_TRANSACTION_TYPE,
+)
+from .receipts import (
+    LondonReceiptBuilder,
+)
 
 
 class LondonLegacyTransaction(BerlinLegacyTransaction):

--- a/eth/vm/forks/london/validation.py
+++ b/eth/vm/forks/london/validation.py
@@ -1,8 +1,10 @@
-from eth_utils.exceptions import ValidationError
+from eth_utils.exceptions import (
+    ValidationError,
+)
 
 from eth.abc import (
     SignedTransactionAPI,
-    StateAPI
+    StateAPI,
 )
 from eth.vm.forks.homestead.validation import (
     validate_homestead_transaction,

--- a/eth/vm/forks/muir_glacier/blocks.py
+++ b/eth/vm/forks/muir_glacier/blocks.py
@@ -1,6 +1,7 @@
 from rlp.sedes import (
     CountableList,
 )
+
 from eth.rlp.headers import (
     BlockHeader,
 )

--- a/eth/vm/forks/muir_glacier/computation.py
+++ b/eth/vm/forks/muir_glacier/computation.py
@@ -1,11 +1,11 @@
 from eth.vm.forks.istanbul.computation import (
-    ISTANBUL_PRECOMPILES
-)
-from eth.vm.forks.istanbul.computation import (
+    ISTANBUL_PRECOMPILES,
     IstanbulComputation,
 )
 
-from .opcodes import MUIR_GLACIER_OPCODES
+from .opcodes import (
+    MUIR_GLACIER_OPCODES,
+)
 
 MUIR_GLACIER_PRECOMPILES = ISTANBUL_PRECOMPILES
 

--- a/eth/vm/forks/muir_glacier/headers.py
+++ b/eth/vm/forks/muir_glacier/headers.py
@@ -1,11 +1,10 @@
-from eth.vm.forks.petersburg.headers import (
-    compute_difficulty,
-)
 from eth.vm.forks.istanbul.headers import (
     configure_header,
     create_header_from_parent,
 )
-
+from eth.vm.forks.petersburg.headers import (
+    compute_difficulty,
+)
 
 compute_muir_glacier_difficulty = compute_difficulty(9000000)
 

--- a/eth/vm/forks/muir_glacier/opcodes.py
+++ b/eth/vm/forks/muir_glacier/opcodes.py
@@ -1,7 +1,7 @@
 import copy
+
 from eth.vm.forks.istanbul.opcodes import (
     ISTANBUL_OPCODES,
 )
-
 
 MUIR_GLACIER_OPCODES = copy.deepcopy(ISTANBUL_OPCODES)

--- a/eth/vm/forks/muir_glacier/state.py
+++ b/eth/vm/forks/muir_glacier/state.py
@@ -1,8 +1,10 @@
 from eth.vm.forks.istanbul.state import (
-    IstanbulState
+    IstanbulState,
 )
 
-from .computation import MuirGlacierComputation
+from .computation import (
+    MuirGlacierComputation,
+)
 
 
 class MuirGlacierState(IstanbulState):

--- a/eth/vm/forks/muir_glacier/transactions.py
+++ b/eth/vm/forks/muir_glacier/transactions.py
@@ -1,13 +1,16 @@
-from eth_keys.datatypes import PrivateKey
-from eth_typing import Address
-
-from eth.vm.forks.istanbul.transactions import (
-    IstanbulTransaction,
-    IstanbulUnsignedTransaction,
+from eth_keys.datatypes import (
+    PrivateKey,
+)
+from eth_typing import (
+    Address,
 )
 
 from eth._utils.transactions import (
     create_transaction_signature,
+)
+from eth.vm.forks.istanbul.transactions import (
+    IstanbulTransaction,
+    IstanbulUnsignedTransaction,
 )
 
 

--- a/eth/vm/forks/paris/blocks.py
+++ b/eth/vm/forks/paris/blocks.py
@@ -1,26 +1,31 @@
-from abc import ABC
-from typing import Type
-
-from eth.abc import TransactionBuilderAPI
+from abc import (
+    ABC,
+)
+from typing import (
+    Type,
+)
 
 from eth_utils import (
     encode_hex,
 )
-
 from rlp.sedes import (
     CountableList,
 )
 
-from .transactions import (
-    ParisTransactionBuilder,
+from eth.abc import (
+    TransactionBuilderAPI,
 )
 from eth.vm.forks.gray_glacier.blocks import (
     GrayGlacierBlock,
     GrayGlacierBlockHeader,
     GrayGlacierMiningHeader,
 )
+
 from ..london.blocks import (
     LondonBackwardsHeader,
+)
+from .transactions import (
+    ParisTransactionBuilder,
 )
 
 

--- a/eth/vm/forks/paris/computation.py
+++ b/eth/vm/forks/paris/computation.py
@@ -1,5 +1,10 @@
-from .opcodes import PARIS_OPCODES
-from eth.vm.forks.gray_glacier.computation import GrayGlacierComputation
+from eth.vm.forks.gray_glacier.computation import (
+    GrayGlacierComputation,
+)
+
+from .opcodes import (
+    PARIS_OPCODES,
+)
 
 
 class ParisComputation(GrayGlacierComputation):

--- a/eth/vm/forks/paris/headers.py
+++ b/eth/vm/forks/paris/headers.py
@@ -1,22 +1,34 @@
-from typing import Any, Optional
+from typing import (
+    Any,
+    Optional,
+)
 
-from toolz import curry
+from eth_utils import (
+    ValidationError,
+)
+from toolz import (
+    curry,
+)
 
-from eth.abc import BlockHeaderAPI
+from eth.abc import (
+    BlockHeaderAPI,
+)
 from eth.constants import (
     POST_MERGE_DIFFICULTY,
     POST_MERGE_MIX_HASH,
     POST_MERGE_NONCE,
 )
+from eth.vm.forks.byzantium.headers import (
+    configure_header,
+)
 from eth.vm.forks.gray_glacier.headers import (
     compute_gray_glacier_difficulty,
     create_gray_glacier_header_from_parent,
 )
-from eth.vm.forks.byzantium.headers import (
-    configure_header,
+
+from .blocks import (
+    ParisBlockHeader,
 )
-from eth_utils import ValidationError
-from .blocks import ParisBlockHeader
 
 
 def _validate_and_return_paris_header_param(

--- a/eth/vm/forks/paris/opcodes.py
+++ b/eth/vm/forks/paris/opcodes.py
@@ -1,19 +1,31 @@
 import copy
-from typing import Dict
+from typing import (
+    Dict,
+)
 
-from eth.vm.opcode import as_opcode
-from eth_utils.toolz import merge
+from eth_utils.toolz import (
+    merge,
+)
 
-from eth import constants
-from eth.abc import OpcodeAPI
-from eth.vm import mnemonics
-from eth.vm import opcode_values
+from eth import (
+    constants,
+)
+from eth.abc import (
+    OpcodeAPI,
+)
+from eth.vm import (
+    mnemonics,
+    opcode_values,
+)
+from eth.vm.forks.london.opcodes import (
+    LONDON_OPCODES,
+)
 from eth.vm.logic import (
     block,
 )
-
-from eth.vm.forks.london.opcodes import LONDON_OPCODES
-
+from eth.vm.opcode import (
+    as_opcode,
+)
 
 NEW_OPCODES = {
     # EIP-4399: supplant DIFFICULTY with PREVRANDAO

--- a/eth/vm/forks/paris/state.py
+++ b/eth/vm/forks/paris/state.py
@@ -1,13 +1,25 @@
-from typing import Type
+from typing import (
+    Type,
+)
+
+from eth_typing import (
+    Hash32,
+)
 
 from eth.abc import (
     StateAPI,
     TransactionExecutorAPI,
 )
-from eth_typing import Hash32
-from .computation import ParisComputation
-from ..gray_glacier import GrayGlacierState
-from ..gray_glacier.state import GrayGlacierTransactionExecutor
+
+from ..gray_glacier import (
+    GrayGlacierState,
+)
+from ..gray_glacier.state import (
+    GrayGlacierTransactionExecutor,
+)
+from .computation import (
+    ParisComputation,
+)
 
 
 class ParisTransactionExecutor(GrayGlacierTransactionExecutor):

--- a/eth/vm/forks/paris/transactions.py
+++ b/eth/vm/forks/paris/transactions.py
@@ -1,6 +1,10 @@
-from abc import ABC
+from abc import (
+    ABC,
+)
 
-from eth_keys.datatypes import PrivateKey
+from eth_keys.datatypes import (
+    PrivateKey,
+)
 
 from eth._utils.transactions import (
     create_transaction_signature,

--- a/eth/vm/forks/petersburg/blocks.py
+++ b/eth/vm/forks/petersburg/blocks.py
@@ -1,6 +1,7 @@
 from rlp.sedes import (
     CountableList,
 )
+
 from eth.rlp.headers import (
     BlockHeader,
 )

--- a/eth/vm/forks/petersburg/computation.py
+++ b/eth/vm/forks/petersburg/computation.py
@@ -1,11 +1,11 @@
 from eth.vm.forks.byzantium.computation import (
-    BYZANTIUM_PRECOMPILES
-)
-from eth.vm.forks.byzantium.computation import (
-    ByzantiumComputation
+    BYZANTIUM_PRECOMPILES,
+    ByzantiumComputation,
 )
 
-from .opcodes import PETERSBURG_OPCODES
+from .opcodes import (
+    PETERSBURG_OPCODES,
+)
 
 PETERSBURG_PRECOMPILES = BYZANTIUM_PRECOMPILES
 

--- a/eth/vm/forks/petersburg/constants.py
+++ b/eth/vm/forks/petersburg/constants.py
@@ -1,5 +1,6 @@
-from eth_utils import denoms
-
+from eth_utils import (
+    denoms,
+)
 
 GAS_EXTCODEHASH_EIP1052 = 400
 

--- a/eth/vm/forks/petersburg/headers.py
+++ b/eth/vm/forks/petersburg/headers.py
@@ -1,9 +1,8 @@
 from eth.vm.forks.byzantium.headers import (
+    compute_difficulty,
     configure_header,
     create_header_from_parent,
-    compute_difficulty,
 )
-
 
 compute_petersburg_difficulty = compute_difficulty(5000000)
 

--- a/eth/vm/forks/petersburg/opcodes.py
+++ b/eth/vm/forks/petersburg/opcodes.py
@@ -1,14 +1,18 @@
 import copy
-from typing import Dict
+from typing import (
+    Dict,
+)
 
 from eth_utils.toolz import (
-    merge
+    merge,
 )
 
 from eth import (
-    constants
+    constants,
 )
-from eth.abc import OpcodeAPI
+from eth.abc import (
+    OpcodeAPI,
+)
 from eth.vm import (
     mnemonics,
     opcode_values,
@@ -17,7 +21,7 @@ from eth.vm.forks.byzantium.opcodes import (
     BYZANTIUM_OPCODES,
 )
 from eth.vm.forks.petersburg.constants import (
-    GAS_EXTCODEHASH_EIP1052
+    GAS_EXTCODEHASH_EIP1052,
 )
 from eth.vm.logic import (
     arithmetic,
@@ -25,9 +29,8 @@ from eth.vm.logic import (
     system,
 )
 from eth.vm.opcode import (
-    as_opcode
+    as_opcode,
 )
-
 
 UPDATED_OPCODES = {
     opcode_values.SHL: as_opcode(

--- a/eth/vm/forks/petersburg/state.py
+++ b/eth/vm/forks/petersburg/state.py
@@ -1,8 +1,10 @@
 from eth.vm.forks.byzantium.state import (
-    ByzantiumState
+    ByzantiumState,
 )
 
-from .computation import PetersburgComputation
+from .computation import (
+    PetersburgComputation,
+)
 
 
 class PetersburgState(ByzantiumState):

--- a/eth/vm/forks/petersburg/transactions.py
+++ b/eth/vm/forks/petersburg/transactions.py
@@ -1,13 +1,16 @@
-from eth_keys.datatypes import PrivateKey
-from eth_typing import Address
-
-from eth.vm.forks.byzantium.transactions import (
-    ByzantiumTransaction,
-    ByzantiumUnsignedTransaction,
+from eth_keys.datatypes import (
+    PrivateKey,
+)
+from eth_typing import (
+    Address,
 )
 
 from eth._utils.transactions import (
     create_transaction_signature,
+)
+from eth.vm.forks.byzantium.transactions import (
+    ByzantiumTransaction,
+    ByzantiumUnsignedTransaction,
 )
 
 

--- a/eth/vm/forks/shanghai/blocks.py
+++ b/eth/vm/forks/shanghai/blocks.py
@@ -1,52 +1,88 @@
-from abc import ABC
-from typing import List, Sequence, Tuple, Type, cast
-
-import rlp
-from eth.exceptions import BlockNotFound, HeaderNotFound
-from eth.rlp.blocks import BaseBlock
-from eth.rlp.headers import BlockHeader
-from eth.rlp.sedes import address, hash32, trie_root, uint256
-from eth_bloom import BloomFilter
-from eth_typing import Address, BlockNumber, Hash32
-
-from eth._utils.headers import new_timestamp_from_parent
-from eth.abc import (
-    BlockHeaderAPI, BlockHeaderSedesAPI, ChainDatabaseAPI, MiningHeaderAPI,
-    ReceiptAPI, ReceiptBuilderAPI, SignedTransactionAPI, TransactionBuilderAPI,
-    WithdrawalAPI,
+from abc import (
+    ABC,
 )
-from eth.constants import (
-    ZERO_ADDRESS,
-    ZERO_HASH32,
-    EMPTY_UNCLE_HASH,
-    GENESIS_NONCE,
-    GENESIS_PARENT_HASH,
-    BLANK_ROOT_HASH,
+from typing import (
+    List,
+    Sequence,
+    Tuple,
+    Type,
+    cast,
 )
 
+from eth_bloom import (
+    BloomFilter,
+)
+from eth_typing import (
+    Address,
+    BlockNumber,
+    Hash32,
+)
 from eth_utils import (
-    encode_hex, keccak,
+    encode_hex,
+    keccak,
 )
-
+import rlp
 from rlp.sedes import (
     Binary,
     CountableList,
     big_endian_int,
     binary,
 )
-from trie.exceptions import MissingTrieNode
-
-from .transactions import (
-    ShanghaiTransactionBuilder,
+from trie.exceptions import (
+    MissingTrieNode,
 )
-from .withdrawals import Withdrawal
+
+from eth._utils.headers import (
+    new_timestamp_from_parent,
+)
+from eth.abc import (
+    BlockHeaderAPI,
+    BlockHeaderSedesAPI,
+    ChainDatabaseAPI,
+    MiningHeaderAPI,
+    ReceiptAPI,
+    ReceiptBuilderAPI,
+    SignedTransactionAPI,
+    TransactionBuilderAPI,
+    WithdrawalAPI,
+)
+from eth.constants import (
+    BLANK_ROOT_HASH,
+    EMPTY_UNCLE_HASH,
+    GENESIS_NONCE,
+    GENESIS_PARENT_HASH,
+    ZERO_ADDRESS,
+    ZERO_HASH32,
+)
+from eth.exceptions import (
+    BlockNotFound,
+    HeaderNotFound,
+)
+from eth.rlp.blocks import (
+    BaseBlock,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
+from eth.rlp.sedes import (
+    address,
+    hash32,
+    trie_root,
+    uint256,
+)
+
 from ..london.blocks import (
     LondonBlockHeader,
 )
 from ..london.receipts import (
     LondonReceiptBuilder,
 )
-
+from .transactions import (
+    ShanghaiTransactionBuilder,
+)
+from .withdrawals import (
+    Withdrawal,
+)
 
 UNMINED_SHANGHAI_HEADER_FIELDS = [
     ('parent_hash', hash32),

--- a/eth/vm/forks/shanghai/computation.py
+++ b/eth/vm/forks/shanghai/computation.py
@@ -1,19 +1,26 @@
-from eth._utils.numeric import ceil32
+from eth._utils.numeric import (
+    ceil32,
+)
 from eth.abc import (
     ComputationAPI,
     MessageAPI,
     StateAPI,
     TransactionContextAPI,
 )
+from eth.exceptions import (
+    OutOfGas,
+)
+from eth.vm.forks.paris.computation import (
+    ParisComputation,
+)
+
 from .constants import (
     INITCODE_WORD_COST,
     MAX_INITCODE_SIZE,
 )
-from .opcodes import SHANGHAI_OPCODES
-from eth.exceptions import (
-    OutOfGas,
+from .opcodes import (
+    SHANGHAI_OPCODES,
 )
-from eth.vm.forks.paris.computation import ParisComputation
 
 
 class ShanghaiComputation(ParisComputation):

--- a/eth/vm/forks/shanghai/constants.py
+++ b/eth/vm/forks/shanghai/constants.py
@@ -1,4 +1,6 @@
-from eth.vm.forks.spurious_dragon.constants import EIP170_CODE_SIZE_LIMIT
+from eth.vm.forks.spurious_dragon.constants import (
+    EIP170_CODE_SIZE_LIMIT,
+)
 
 # https://eips.ethereum.org/EIPS/eip-3860
 INITCODE_WORD_COST = 2

--- a/eth/vm/forks/shanghai/headers.py
+++ b/eth/vm/forks/shanghai/headers.py
@@ -1,15 +1,25 @@
-from typing import Any, Optional
+from typing import (
+    Any,
+    Optional,
+)
 
-from toolz import curry
+from toolz import (
+    curry,
+)
 
-from eth.abc import BlockHeaderAPI
-from eth.vm.forks.paris.headers import (
-    create_paris_header_from_parent,
+from eth.abc import (
+    BlockHeaderAPI,
 )
 from eth.vm.forks.byzantium.headers import (
     configure_header,
 )
-from .blocks import ShanghaiBlockHeader
+from eth.vm.forks.paris.headers import (
+    create_paris_header_from_parent,
+)
+
+from .blocks import (
+    ShanghaiBlockHeader,
+)
 
 
 @curry

--- a/eth/vm/forks/shanghai/logic.py
+++ b/eth/vm/forks/shanghai/logic.py
@@ -1,15 +1,16 @@
-from .constants import (
-    INITCODE_WORD_COST,
-)
 from eth._utils.numeric import (
     ceil32,
 )
 from eth.vm.forks.berlin.logic import (
-    CreateEIP2929,
     Create2EIP2929,
+    CreateEIP2929,
 )
 from eth.vm.logic.system import (
     CreateOpcodeStackData,
+)
+
+from .constants import (
+    INITCODE_WORD_COST,
 )
 
 

--- a/eth/vm/forks/shanghai/opcodes.py
+++ b/eth/vm/forks/shanghai/opcodes.py
@@ -1,24 +1,39 @@
 import copy
-from typing import Dict
-
-from .logic import (
-    CreateEIP3860,
-    Create2EIP3860,
+from typing import (
+    Dict,
 )
-from eth.tools._utils.deprecation import deprecate_method
-from eth.vm.opcode import as_opcode
-from eth_utils.toolz import merge
 
-from eth import constants
-from eth.abc import OpcodeAPI
-from eth.vm import mnemonics
-from eth.vm import opcode_values
+from eth_utils.toolz import (
+    merge,
+)
+
+from eth import (
+    constants,
+)
+from eth.abc import (
+    OpcodeAPI,
+)
+from eth.tools._utils.deprecation import (
+    deprecate_method,
+)
+from eth.vm import (
+    mnemonics,
+    opcode_values,
+)
+from eth.vm.forks.paris.opcodes import (
+    PARIS_OPCODES,
+)
 from eth.vm.logic import (
     stack,
 )
+from eth.vm.opcode import (
+    as_opcode,
+)
 
-from eth.vm.forks.paris.opcodes import PARIS_OPCODES
-
+from .logic import (
+    Create2EIP3860,
+    CreateEIP3860,
+)
 
 UPDATED_OPCODES: Dict[int, OpcodeAPI] = {
     opcode_values.CREATE: CreateEIP3860.configure(

--- a/eth/vm/forks/shanghai/state.py
+++ b/eth/vm/forks/shanghai/state.py
@@ -1,12 +1,21 @@
-from typing import Type
+from typing import (
+    Type,
+)
 
 from eth.abc import (
     TransactionExecutorAPI,
     WithdrawalAPI,
 )
-from .computation import ShanghaiComputation
-from ..paris import ParisState
-from ..paris.state import ParisTransactionExecutor
+
+from ..paris import (
+    ParisState,
+)
+from ..paris.state import (
+    ParisTransactionExecutor,
+)
+from .computation import (
+    ShanghaiComputation,
+)
 
 
 class ShanghaiTransactionExecutor(ParisTransactionExecutor):

--- a/eth/vm/forks/shanghai/transactions.py
+++ b/eth/vm/forks/shanghai/transactions.py
@@ -1,6 +1,10 @@
-from abc import ABC
+from abc import (
+    ABC,
+)
 
-from eth_keys.datatypes import PrivateKey
+from eth_keys.datatypes import (
+    PrivateKey,
+)
 
 from eth._utils.transactions import (
     create_transaction_signature,

--- a/eth/vm/forks/shanghai/withdrawals.py
+++ b/eth/vm/forks/shanghai/withdrawals.py
@@ -1,20 +1,32 @@
-from cached_property import cached_property
-from typing import cast
+from typing import (
+    cast,
+)
 
-from eth.abc import WithdrawalAPI
-from eth.validation import (
-    validate_canonical_address,
-    validate_uint64,
+from cached_property import (
+    cached_property,
 )
 from eth_typing import (
     Address,
     Hash32,
 )
-
+from eth_utils import (
+    keccak,
+)
 import rlp
-from eth.rlp.sedes import address
-from eth_utils import keccak
-from rlp.sedes import big_endian_int
+from rlp.sedes import (
+    big_endian_int,
+)
+
+from eth.abc import (
+    WithdrawalAPI,
+)
+from eth.rlp.sedes import (
+    address,
+)
+from eth.validation import (
+    validate_canonical_address,
+    validate_uint64,
+)
 
 
 class Withdrawal(rlp.Serializable):

--- a/eth/vm/forks/spurious_dragon/_utils.py
+++ b/eth/vm/forks/spurious_dragon/_utils.py
@@ -1,16 +1,22 @@
-from typing import Iterable
+from typing import (
+    Iterable,
+)
 
-from eth_typing import Address
+from eth_typing import (
+    Address,
+)
+from eth_utils import (
+    to_set,
+)
 
-from eth_utils import to_set
-
-from eth import constants
-
-from eth.abc import (
-    ComputationAPI,
+from eth import (
+    constants,
 )
 from eth._utils.address import (
     force_bytes_to_address,
+)
+from eth.abc import (
+    ComputationAPI,
 )
 
 THREE = force_bytes_to_address(b'\x03')

--- a/eth/vm/forks/spurious_dragon/blocks.py
+++ b/eth/vm/forks/spurious_dragon/blocks.py
@@ -1,12 +1,14 @@
 from rlp.sedes import (
     CountableList,
 )
+
 from eth.rlp.headers import (
     BlockHeader,
 )
 from eth.vm.forks.homestead.blocks import (
     HomesteadBlock,
 )
+
 from .transactions import (
     SpuriousDragonTransaction,
 )

--- a/eth/vm/forks/spurious_dragon/computation.py
+++ b/eth/vm/forks/spurious_dragon/computation.py
@@ -1,10 +1,13 @@
-from eth_hash.auto import keccak
-
+from eth_hash.auto import (
+    keccak,
+)
 from eth_utils import (
     encode_hex,
 )
 
-from eth import constants
+from eth import (
+    constants,
+)
 from eth.abc import (
     ComputationAPI,
     MessageAPI,
@@ -19,8 +22,12 @@ from eth.vm.forks.homestead.computation import (
     HomesteadComputation,
 )
 
-from ..spurious_dragon.constants import EIP170_CODE_SIZE_LIMIT
-from .opcodes import SPURIOUS_DRAGON_OPCODES
+from ..spurious_dragon.constants import (
+    EIP170_CODE_SIZE_LIMIT,
+)
+from .opcodes import (
+    SPURIOUS_DRAGON_OPCODES,
+)
 
 
 class SpuriousDragonComputation(HomesteadComputation):

--- a/eth/vm/forks/spurious_dragon/opcodes.py
+++ b/eth/vm/forks/spurious_dragon/opcodes.py
@@ -1,28 +1,39 @@
 import copy
-from typing import Dict
-
-from eth_utils.toolz import merge
-
-from eth.abc import OpcodeAPI
-from eth.vm.forks.tangerine_whistle.constants import (
-    GAS_SELFDESTRUCT_EIP150,
-    GAS_CALL_EIP150
+from typing import (
+    Dict,
 )
-from eth.vm import mnemonics
-from eth.vm import opcode_values
-from eth.vm.forks.tangerine_whistle.opcodes import TANGERINE_WHISTLE_OPCODES
+
+from eth_utils.toolz import (
+    merge,
+)
+
+from eth.abc import (
+    OpcodeAPI,
+)
+from eth.vm import (
+    mnemonics,
+    opcode_values,
+)
+from eth.vm.forks.tangerine_whistle.constants import (
+    GAS_CALL_EIP150,
+    GAS_SELFDESTRUCT_EIP150,
+)
+from eth.vm.forks.tangerine_whistle.opcodes import (
+    TANGERINE_WHISTLE_OPCODES,
+)
 from eth.vm.logic import (
     arithmetic,
-    system,
     call,
+    system,
 )
-from eth.vm.opcode import as_opcode
+from eth.vm.opcode import (
+    as_opcode,
+)
 
 from .constants import (
     GAS_EXP_EIP160,
-    GAS_EXPBYTE_EIP160
+    GAS_EXPBYTE_EIP160,
 )
-
 
 UPDATED_OPCODES = {
     opcode_values.EXP: as_opcode(

--- a/eth/vm/forks/spurious_dragon/state.py
+++ b/eth/vm/forks/spurious_dragon/state.py
@@ -1,4 +1,6 @@
-from typing import Type
+from typing import (
+    Type,
+)
 
 from eth_utils import (
     encode_hex,
@@ -14,8 +16,12 @@ from eth.vm.forks.homestead.state import (
     HomesteadTransactionExecutor,
 )
 
-from .computation import SpuriousDragonComputation
-from ._utils import collect_touched_accounts
+from ._utils import (
+    collect_touched_accounts,
+)
+from .computation import (
+    SpuriousDragonComputation,
+)
 
 
 class SpuriousDragonTransactionExecutor(HomesteadTransactionExecutor):

--- a/eth/vm/forks/spurious_dragon/transactions.py
+++ b/eth/vm/forks/spurious_dragon/transactions.py
@@ -1,27 +1,29 @@
-from typing import Optional
+from typing import (
+    Optional,
+)
 
-from eth_keys.datatypes import PrivateKey
-
+from eth_keys.datatypes import (
+    PrivateKey,
+)
 from eth_typing import (
     Address,
 )
-
 from eth_utils import (
     int_to_big_endian,
 )
-
 import rlp
 
-from eth.vm.forks.homestead.transactions import (
-    HomesteadTransaction,
-    HomesteadUnsignedTransaction,
+from eth._utils.numeric import (
+    is_even,
 )
-
-from eth._utils.numeric import is_even
 from eth._utils.transactions import (
     create_transaction_signature,
     extract_chain_id,
     is_eip_155_signed_transaction,
+)
+from eth.vm.forks.homestead.transactions import (
+    HomesteadTransaction,
+    HomesteadUnsignedTransaction,
 )
 
 

--- a/eth/vm/forks/tangerine_whistle/computation.py
+++ b/eth/vm/forks/tangerine_whistle/computation.py
@@ -1,6 +1,9 @@
-from ..homestead.computation import HomesteadComputation
-
-from .opcodes import TANGERINE_WHISTLE_OPCODES
+from ..homestead.computation import (
+    HomesteadComputation,
+)
+from .opcodes import (
+    TANGERINE_WHISTLE_OPCODES,
+)
 
 
 class TangerineWhistleComputation(HomesteadComputation):

--- a/eth/vm/forks/tangerine_whistle/opcodes.py
+++ b/eth/vm/forks/tangerine_whistle/opcodes.py
@@ -1,20 +1,31 @@
 import copy
 
-from eth_utils.toolz import merge
+from eth_utils.toolz import (
+    merge,
+)
 
-from eth.vm.forks.tangerine_whistle import constants
-from eth.constants import GAS_CREATE
-from eth.vm import opcode_values
-from eth.vm import mnemonics
-from eth.vm.forks.homestead.opcodes import HOMESTEAD_OPCODES
+from eth.constants import (
+    GAS_CREATE,
+)
+from eth.vm import (
+    mnemonics,
+    opcode_values,
+)
+from eth.vm.forks.homestead.opcodes import (
+    HOMESTEAD_OPCODES,
+)
+from eth.vm.forks.tangerine_whistle import (
+    constants,
+)
 from eth.vm.logic import (
     call,
     context,
     storage,
     system,
 )
-from eth.vm.opcode import as_opcode
-
+from eth.vm.opcode import (
+    as_opcode,
+)
 
 UPDATED_OPCODES = {
     opcode_values.EXTCODESIZE: as_opcode(

--- a/eth/vm/forks/tangerine_whistle/state.py
+++ b/eth/vm/forks/tangerine_whistle/state.py
@@ -1,6 +1,10 @@
-from eth.vm.forks.homestead.state import HomesteadState
+from eth.vm.forks.homestead.state import (
+    HomesteadState,
+)
 
-from .computation import TangerineWhistleComputation
+from .computation import (
+    TangerineWhistleComputation,
+)
 
 
 class TangerineWhistleState(HomesteadState):

--- a/eth/vm/gas_meter.py
+++ b/eth/vm/gas_meter.py
@@ -1,12 +1,15 @@
 from typing import (
     Callable,
 )
+
 from eth_utils import (
     ValidationError,
     get_extended_debug_logger,
 )
 
-from eth.abc import GasMeterAPI
+from eth.abc import (
+    GasMeterAPI,
+)
 from eth.exceptions import (
     OutOfGas,
 )

--- a/eth/vm/header.py
+++ b/eth/vm/header.py
@@ -1,4 +1,6 @@
-from eth.vm.forks.shanghai.blocks import ShanghaiBackwardsHeader
+from eth.vm.forks.shanghai.blocks import (
+    ShanghaiBackwardsHeader,
+)
 
 HeaderSedes = ShanghaiBackwardsHeader
 """

--- a/eth/vm/logic/arithmetic.py
+++ b/eth/vm/logic/arithmetic.py
@@ -1,14 +1,17 @@
-from eth.abc import ComputationAPI
 from eth_utils.toolz import (
     curry,
 )
 
-from eth import constants
-
+from eth import (
+    constants,
+)
 from eth._utils.numeric import (
-    unsigned_to_signed,
-    signed_to_unsigned,
     ceil8,
+    signed_to_unsigned,
+    unsigned_to_signed,
+)
+from eth.abc import (
+    ComputationAPI,
 )
 
 

--- a/eth/vm/logic/block.py
+++ b/eth/vm/logic/block.py
@@ -1,6 +1,10 @@
-from eth_typing import BlockNumber
+from eth_typing import (
+    BlockNumber,
+)
 
-from eth.abc import ComputationAPI
+from eth.abc import (
+    ComputationAPI,
+)
 
 
 def blockhash(computation: ComputationAPI) -> None:

--- a/eth/vm/logic/call.py
+++ b/eth/vm/logic/call.py
@@ -1,18 +1,21 @@
 from abc import (
     ABC,
-    abstractmethod
+    abstractmethod,
 )
-
 from typing import (
     Tuple,
 )
-
-from eth import constants
 
 from eth_typing import (
     Address,
 )
 
+from eth import (
+    constants,
+)
+from eth._utils.address import (
+    force_bytes_to_address,
+)
 from eth.abc import (
     ComputationAPI,
 )
@@ -23,11 +26,6 @@ from eth.exceptions import (
 from eth.vm.opcode import (
     Opcode,
 )
-
-from eth._utils.address import (
-    force_bytes_to_address,
-)
-
 
 CallParams = Tuple[int, int, Address, Address, Address, int, int, int, int, bool, bool]
 

--- a/eth/vm/logic/comparison.py
+++ b/eth/vm/logic/comparison.py
@@ -1,10 +1,13 @@
-from eth import constants
-
+from eth import (
+    constants,
+)
 from eth._utils.numeric import (
     signed_to_unsigned,
     unsigned_to_signed,
 )
-from eth.abc import ComputationAPI
+from eth.abc import (
+    ComputationAPI,
+)
 
 
 def lt(computation: ComputationAPI) -> None:

--- a/eth/vm/logic/context.py
+++ b/eth/vm/logic/context.py
@@ -1,23 +1,25 @@
-from typing import Tuple
+from typing import (
+    Tuple,
+)
 
 from eth_typing import (
     Address,
 )
 
-from eth import constants
-
-from eth.abc import (
-    ComputationAPI,
+from eth import (
+    constants,
 )
-from eth.exceptions import (
-    OutOfBoundsRead,
-)
-
 from eth._utils.address import (
     force_bytes_to_address,
 )
 from eth._utils.numeric import (
     ceil32,
+)
+from eth.abc import (
+    ComputationAPI,
+)
+from eth.exceptions import (
+    OutOfBoundsRead,
 )
 
 

--- a/eth/vm/logic/duplication.py
+++ b/eth/vm/logic/duplication.py
@@ -1,6 +1,8 @@
 import functools
 
-from eth.abc import ComputationAPI
+from eth.abc import (
+    ComputationAPI,
+)
 
 
 def dup_XX(computation: ComputationAPI, position: int) -> None:

--- a/eth/vm/logic/flow.py
+++ b/eth/vm/logic/flow.py
@@ -1,10 +1,11 @@
-from eth.abc import ComputationAPI
-from eth.exceptions import (
-    InvalidJumpDestination,
-    InvalidInstruction,
-    Halt,
+from eth.abc import (
+    ComputationAPI,
 )
-
+from eth.exceptions import (
+    Halt,
+    InvalidInstruction,
+    InvalidJumpDestination,
+)
 from eth.vm.opcode_values import (
     JUMPDEST,
 )

--- a/eth/vm/logic/invalid.py
+++ b/eth/vm/logic/invalid.py
@@ -1,6 +1,12 @@
-from eth.abc import ComputationAPI
-from eth.exceptions import InvalidInstruction
-from eth.vm.opcode import Opcode
+from eth.abc import (
+    ComputationAPI,
+)
+from eth.exceptions import (
+    InvalidInstruction,
+)
+from eth.vm.opcode import (
+    Opcode,
+)
 
 
 class InvalidOpcode(Opcode):

--- a/eth/vm/logic/logging.py
+++ b/eth/vm/logic/logging.py
@@ -1,7 +1,14 @@
 import functools
-from typing import Tuple
-from eth import constants
-from eth.abc import ComputationAPI
+from typing import (
+    Tuple,
+)
+
+from eth import (
+    constants,
+)
+from eth.abc import (
+    ComputationAPI,
+)
 
 
 def log_XX(computation: ComputationAPI, topic_count: int) -> None:

--- a/eth/vm/logic/memory.py
+++ b/eth/vm/logic/memory.py
@@ -1,4 +1,6 @@
-from eth.abc import ComputationAPI
+from eth.abc import (
+    ComputationAPI,
+)
 
 
 def mstore(computation: ComputationAPI) -> None:

--- a/eth/vm/logic/sha3.py
+++ b/eth/vm/logic/sha3.py
@@ -1,10 +1,16 @@
-from eth_hash.auto import keccak
+from eth_hash.auto import (
+    keccak,
+)
 
-from eth import constants
+from eth import (
+    constants,
+)
 from eth._utils.numeric import (
     ceil32,
 )
-from eth.abc import ComputationAPI
+from eth.abc import (
+    ComputationAPI,
+)
 
 
 def sha3(computation: ComputationAPI) -> None:

--- a/eth/vm/logic/stack.py
+++ b/eth/vm/logic/stack.py
@@ -1,6 +1,8 @@
 import functools
 
-from eth.abc import ComputationAPI
+from eth.abc import (
+    ComputationAPI,
+)
 
 
 def pop(computation: ComputationAPI) -> None:

--- a/eth/vm/logic/storage.py
+++ b/eth/vm/logic/storage.py
@@ -1,10 +1,17 @@
-from typing import NamedTuple
+from typing import (
+    NamedTuple,
+)
 
-from eth.abc import ComputationAPI
 from eth_utils import (
     encode_hex,
 )
-from eth import constants
+
+from eth import (
+    constants,
+)
+from eth.abc import (
+    ComputationAPI,
+)
 
 
 def sstore(computation: ComputationAPI) -> None:

--- a/eth/vm/logic/swap.py
+++ b/eth/vm/logic/swap.py
@@ -1,6 +1,8 @@
 import functools
 
-from eth.abc import ComputationAPI
+from eth.abc import (
+    ComputationAPI,
+)
 
 
 def swap_XX(computation: ComputationAPI, position: int) -> None:

--- a/eth/vm/logic/system.py
+++ b/eth/vm/logic/system.py
@@ -4,13 +4,10 @@ from eth_typing import (
 from eth_utils import (
     encode_hex,
 )
-from eth import constants
-from eth.exceptions import (
-    Halt,
-    Revert,
-    WriteProtection,
-)
 
+from eth import (
+    constants,
+)
 from eth._utils.address import (
     force_bytes_to_address,
     generate_contract_address,
@@ -23,10 +20,21 @@ from eth.abc import (
     ComputationAPI,
     MessageAPI,
 )
-from eth.vm import mnemonics
-from eth.vm.opcode import Opcode
+from eth.exceptions import (
+    Halt,
+    Revert,
+    WriteProtection,
+)
+from eth.vm import (
+    mnemonics,
+)
+from eth.vm.opcode import (
+    Opcode,
+)
 
-from .call import max_child_gas_eip150
+from .call import (
+    max_child_gas_eip150,
+)
 
 
 def return_op(computation: ComputationAPI) -> None:

--- a/eth/vm/memory.py
+++ b/eth/vm/memory.py
@@ -1,17 +1,18 @@
 import itertools
 import logging
 
+from eth._utils.numeric import (
+    ceil32,
+)
+from eth.abc import (
+    MemoryAPI,
+)
 from eth.validation import (
     validate_is_bytes,
     validate_length,
     validate_lte,
     validate_uint256,
 )
-
-from eth._utils.numeric import (
-    ceil32,
-)
-from eth.abc import MemoryAPI
 
 
 class Memory(MemoryAPI):

--- a/eth/vm/message.py
+++ b/eth/vm/message.py
@@ -1,8 +1,12 @@
 import logging
 
-from eth_typing import Address
+from eth_typing import (
+    Address,
+)
 
-from eth.abc import MessageAPI
+from eth.abc import (
+    MessageAPI,
+)
 from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
 )
@@ -11,12 +15,12 @@ from eth.typing import (
 )
 from eth.validation import (
     validate_canonical_address,
+    validate_gte,
+    validate_is_boolean,
     validate_is_bytes,
     validate_is_bytes_or_view,
     validate_is_integer,
-    validate_gte,
     validate_uint256,
-    validate_is_boolean,
 )
 
 

--- a/eth/vm/opcode.py
+++ b/eth/vm/opcode.py
@@ -1,5 +1,4 @@
 import functools
-
 from typing import (
     Any,
     Callable,
@@ -12,12 +11,13 @@ from eth_utils import (
     get_extended_debug_logger,
 )
 
-from eth._utils.datatypes import Configurable
+from eth._utils.datatypes import (
+    Configurable,
+)
 from eth.abc import (
     ComputationAPI,
     OpcodeAPI,
 )
-
 
 T = TypeVar('T')
 

--- a/eth/vm/spoof.py
+++ b/eth/vm/spoof.py
@@ -1,7 +1,15 @@
-from typing import Any, Union
+from typing import (
+    Any,
+    Union,
+)
 
-from eth.abc import SignedTransactionAPI, UnsignedTransactionAPI
-from eth._utils.spoof import SpoofAttributes
+from eth._utils.spoof import (
+    SpoofAttributes,
+)
+from eth.abc import (
+    SignedTransactionAPI,
+    UnsignedTransactionAPI,
+)
 
 
 class SpoofTransaction(SpoofAttributes):

--- a/eth/vm/stack.py
+++ b/eth/vm/stack.py
@@ -3,7 +3,7 @@ from typing import (
     Iterable,
     List,
     Tuple,
-    Union
+    Union,
 )
 
 from eth_utils import (
@@ -11,16 +11,18 @@ from eth_utils import (
     big_endian_to_int,
     int_to_big_endian,
 )
+
+from eth.abc import (
+    StackAPI,
+)
 from eth.exceptions import (
-    InsufficientStack,
     FullStack,
+    InsufficientStack,
 )
 from eth.validation import (
     validate_stack_bytes,
     validate_stack_int,
 )
-
-from eth.abc import StackAPI
 
 
 def _busted_type(item_type: type, value: Union[int, bytes]) -> ValidationError:

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -15,27 +15,31 @@ from eth_utils import (
     ExtendedDebugLogger,
     get_extended_debug_logger,
 )
-from eth_utils.toolz import nth
+from eth_utils.toolz import (
+    nth,
+)
 
+from eth._utils.datatypes import (
+    Configurable,
+)
 from eth.abc import (
     AccountDatabaseAPI,
     AtomicDatabaseAPI,
     ComputationAPI,
     ExecutionContextAPI,
     MessageAPI,
+    MetaWitnessAPI,
     SignedTransactionAPI,
     StateAPI,
     TransactionContextAPI,
     TransactionExecutorAPI,
-    MetaWitnessAPI,
     WithdrawalAPI,
 )
 from eth.constants import (
     MAX_PREV_HEADER_DEPTH,
 )
-from eth.typing import JournalDBCheckpoint
-from eth._utils.datatypes import (
-    Configurable,
+from eth.typing import (
+    JournalDBCheckpoint,
 )
 
 

--- a/eth/vm/transaction_context.py
+++ b/eth/vm/transaction_context.py
@@ -1,8 +1,12 @@
 import itertools
 
-from eth_typing import Address
+from eth_typing import (
+    Address,
+)
 
-from eth.abc import TransactionContextAPI
+from eth.abc import (
+    TransactionContextAPI,
+)
 from eth.validation import (
     validate_canonical_address,
     validate_uint256,

--- a/newsfragments/2094.internal.rst
+++ b/newsfragments/2094.internal.rst
@@ -1,0 +1,1 @@
+Added [isort](https://pycqa.github.io/isort/) for automatically sorting python imports.

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,11 @@ deps = {
     'lint': [
         "flake8==3.8.2",
         "flake8-bugbear==20.1.4",
+        "isort>=5.10.1",
         "mypy==0.910",
         "pydocstyle>=6.0.0",
         "types-setuptools",
         "importlib-metadata<5.0;python_version<'3.8'",
-        "isort==5.11.4"
     ],
     'benchmark': [
         "termcolor>=1.1.0,<2.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,40 +1,52 @@
-from pathlib import Path
-
+from pathlib import (
+    Path,
+)
 import pytest
 
+from eth_keys import (
+    keys,
+)
 from eth_utils import (
     decode_hex,
+    setup_DEBUG2_logging,
     to_tuple,
     to_wei,
-    setup_DEBUG2_logging,
 )
-
-from eth_keys import keys
 import rlp
 
-from eth import constants
+from eth import (
+    constants,
+)
 from eth.chains.base import (
     Chain,
     MiningChain,
 )
-from eth.consensus import PowConsensus
-from eth.consensus.noproof import NoProofConsensus
-from eth.db.atomic import AtomicDB
-from eth.rlp.headers import BlockHeader
+from eth.consensus import (
+    PowConsensus,
+)
+from eth.consensus.noproof import (
+    NoProofConsensus,
+)
+from eth.db.atomic import (
+    AtomicDB,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
 from eth.vm.forks import (
-    FrontierVM,
-    HomesteadVM,
-    TangerineWhistleVM,
-    SpuriousDragonVM,
+    ArrowGlacierVM,
+    BerlinVM,
     ByzantiumVM,
     ConstantinopleVM,
-    PetersburgVM,
-    IstanbulVM,
-    MuirGlacierVM,
-    BerlinVM,
-    LondonVM,
-    ArrowGlacierVM,
+    FrontierVM,
     GrayGlacierVM,
+    HomesteadVM,
+    IstanbulVM,
+    LondonVM,
+    MuirGlacierVM,
+    PetersburgVM,
+    SpuriousDragonVM,
+    TangerineWhistleVM,
 )
 
 #

--- a/tests/core/address-utils/test_address_generation.py
+++ b/tests/core/address-utils/test_address_generation.py
@@ -1,10 +1,11 @@
 import pytest
 
 from eth_utils import (
-    decode_hex,
     big_endian_to_int,
+    decode_hex,
     is_same_address,
 )
+
 from eth._utils.address import (
     generate_safe_contract_address,
 )

--- a/tests/core/builder-tools/test_chain_builder.py
+++ b/tests/core/builder-tools/test_chain_builder.py
@@ -1,12 +1,17 @@
 import pytest
 
-from eth_utils import ValidationError, to_wei
+from eth_utils import (
+    ValidationError,
+    to_wei,
+)
 
 from eth.chains.base import (
     Chain,
     MiningChain,
 )
-from eth.constants import ZERO_ADDRESS
+from eth.constants import (
+    ZERO_ADDRESS,
+)
 from eth.tools.builder.chain import (
     at_block_number,
     build,
@@ -20,7 +25,9 @@ from eth.tools.builder.chain import (
     mine_block,
     mine_blocks,
 )
-from eth.tools.factories.transaction import new_transaction
+from eth.tools.factories.transaction import (
+    new_transaction,
+)
 
 
 @pytest.fixture

--- a/tests/core/builder-tools/test_chain_construction.py
+++ b/tests/core/builder-tools/test_chain_construction.py
@@ -1,9 +1,15 @@
 import pytest
 
-from eth_utils import ValidationError
+from eth_utils import (
+    ValidationError,
+)
 
-from eth.chains.base import MiningChain
-from eth.consensus.pow import check_pow
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.consensus.pow import (
+    check_pow,
+)
 from eth.tools.builder.chain import (
     arrow_glacier_at,
     berlin_at,
@@ -30,21 +36,21 @@ from eth.tools.builder.chain import (
     tangerine_whistle_at,
 )
 from eth.vm.forks import (
-    FrontierVM,
-    HomesteadVM,
-    TangerineWhistleVM,
-    SpuriousDragonVM,
+    ArrowGlacierVM,
+    BerlinVM,
     ByzantiumVM,
     ConstantinopleVM,
-    PetersburgVM,
-    IstanbulVM,
-    MuirGlacierVM,
-    BerlinVM,
-    LondonVM,
-    ArrowGlacierVM,
+    FrontierVM,
     GrayGlacierVM,
+    HomesteadVM,
+    IstanbulVM,
+    LondonVM,
+    MuirGlacierVM,
     ParisVM,
+    PetersburgVM,
     ShanghaiVM,
+    SpuriousDragonVM,
+    TangerineWhistleVM,
 )
 
 

--- a/tests/core/builder-tools/test_chain_initializer.py
+++ b/tests/core/builder-tools/test_chain_initializer.py
@@ -1,11 +1,16 @@
+import pytest
 import time
 
-import pytest
+from eth_utils.toolz import (
+    pipe,
+)
 
-from eth_utils.toolz import pipe
-
-from eth import constants
-from eth.chains.base import Chain
+from eth import (
+    constants,
+)
+from eth.chains.base import (
+    Chain,
+)
 from eth.tools.builder.chain import (
     frontier_at,
     genesis,

--- a/tests/core/chain-object/test_build_block_incrementally.py
+++ b/tests/core/chain-object/test_build_block_incrementally.py
@@ -1,11 +1,14 @@
 import pytest
 
-from eth.chains.base import MiningChain
-from eth.tools.factories.transaction import (
-    new_transaction
+from eth._utils.address import (
+    force_bytes_to_address,
 )
-from eth._utils.address import force_bytes_to_address
-
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.tools.factories.transaction import (
+    new_transaction,
+)
 
 ADDRESS_1010 = force_bytes_to_address(b'\x10\x10')
 

--- a/tests/core/chain-object/test_chain.py
+++ b/tests/core/chain-object/test_chain.py
@@ -1,26 +1,41 @@
 import pytest
+
+from eth_utils import (
+    decode_hex,
+)
+from eth_utils.toolz import (
+    sliding_window,
+)
 import rlp
 
-from eth_utils import decode_hex
-from eth_utils.toolz import sliding_window
-
-from eth import constants
-from eth.abc import MiningChainAPI
-from eth.chains.base import MiningChain
+from eth import (
+    constants,
+)
+from eth.abc import (
+    MiningChainAPI,
+)
+from eth.chains.base import (
+    MiningChain,
+)
 from eth.chains.mainnet import (
     MAINNET_GENESIS_HEADER,
     MINING_MAINNET_VMS,
 )
-from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER
-from eth.consensus.noproof import NoProofConsensus
+from eth.chains.ropsten import (
+    ROPSTEN_GENESIS_HEADER,
+)
+from eth.consensus.noproof import (
+    NoProofConsensus,
+)
 from eth.exceptions import (
     TransactionNotFound,
 )
 from eth.tools.factories.transaction import (
-    new_transaction
+    new_transaction,
 )
-from eth.vm.forks.frontier.blocks import FrontierBlock
-
+from eth.vm.forks.frontier.blocks import (
+    FrontierBlock,
+)
 from tests.core.fixtures import (
     valid_block_rlp,
 )

--- a/tests/core/chain-object/test_chain_get_ancestors.py
+++ b/tests/core/chain-object/test_chain_get_ancestors.py
@@ -1,8 +1,14 @@
 import pytest
 
-from eth.chains.base import MiningChain
-from eth.db.backends.memory import MemoryDB
-from eth.db.atomic import AtomicDB
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.db.atomic import (
+    AtomicDB,
+)
+from eth.db.backends.memory import (
+    MemoryDB,
+)
 
 
 @pytest.fixture

--- a/tests/core/chain-object/test_chain_reorganization.py
+++ b/tests/core/chain-object/test_chain_reorganization.py
@@ -1,8 +1,11 @@
 import pytest
 
-from eth.chains.base import MiningChain
-
-from eth.tools.builder.chain import api
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.tools.builder.chain import (
+    api,
+)
 
 
 @pytest.fixture(params=api.mining_mainnet_fork_at_fns)

--- a/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
+++ b/tests/core/chain-object/test_chain_retrieval_of_vm_class.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 from eth.chains.base import (
     Chain,
     MiningChain,
@@ -10,14 +9,18 @@ from eth.constants import (
     GENESIS_DIFFICULTY,
     GENESIS_GAS_LIMIT,
 )
-from eth.db.chain import ChainDB
+from eth.db.chain import (
+    ChainDB,
+)
 from eth.exceptions import (
     VMNotFound,
 )
 from eth.rlp.headers import (
     BlockHeader,
 )
-from eth.vm.base import VM
+from eth.vm.base import (
+    VM,
+)
 
 
 @pytest.fixture

--- a/tests/core/chain-object/test_contract_call.py
+++ b/tests/core/chain-object/test_contract_call.py
@@ -1,14 +1,13 @@
-from eth_utils.toolz import (
-    assoc,
-)
-
+import pytest
 
 from eth_utils import (
     decode_hex,
     function_signature_to_4byte_selector,
     to_bytes,
 )
-import pytest
+from eth_utils.toolz import (
+    assoc,
+)
 
 from eth.exceptions import (
     InvalidInstruction,
@@ -16,22 +15,22 @@ from eth.exceptions import (
     Revert,
 )
 from eth.tools.factories.transaction import (
-    new_transaction
+    new_transaction,
 )
 from eth.vm.forks import (
-    FrontierVM,
-    HomesteadVM,
-    TangerineWhistleVM,
-    SpuriousDragonVM,
+    ArrowGlacierVM,
+    BerlinVM,
     ByzantiumVM,
     ConstantinopleVM,
-    PetersburgVM,
-    IstanbulVM,
-    MuirGlacierVM,
-    BerlinVM,
-    LondonVM,
-    ArrowGlacierVM,
+    FrontierVM,
     GrayGlacierVM,
+    HomesteadVM,
+    IstanbulVM,
+    LondonVM,
+    MuirGlacierVM,
+    PetersburgVM,
+    SpuriousDragonVM,
+    TangerineWhistleVM,
 )
 
 

--- a/tests/core/chain-object/test_create_transaction.py
+++ b/tests/core/chain-object/test_create_transaction.py
@@ -1,10 +1,18 @@
 import pytest
 
-from eth_keys import keys
+from eth_keys import (
+    keys,
+)
 
-from eth.chains.base import MiningChain
-from eth.chains.mainnet import MINING_MAINNET_VMS
-from eth.tools.builder.chain import api
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.chains.mainnet import (
+    MINING_MAINNET_VMS,
+)
+from eth.tools.builder.chain import (
+    api,
+)
 
 
 @pytest.fixture(params=MINING_MAINNET_VMS)

--- a/tests/core/chain-object/test_gas_estimation.py
+++ b/tests/core/chain-object/test_gas_estimation.py
@@ -1,29 +1,31 @@
 import pytest
 
-from eth.estimators.gas import binary_gas_search_1000_tolerance
+from eth._utils.address import (
+    force_bytes_to_address,
+)
+from eth.estimators.gas import (
+    binary_gas_search_1000_tolerance,
+)
 from eth.tools.factories.transaction import (
-    new_transaction
+    new_transaction,
 )
 from eth.vm.forks import (
-    FrontierVM,
-    HomesteadVM,
-    TangerineWhistleVM,
-    SpuriousDragonVM,
+    ArrowGlacierVM,
+    BerlinVM,
     ByzantiumVM,
     ConstantinopleVM,
-    PetersburgVM,
+    FrontierVM,
+    HomesteadVM,
     IstanbulVM,
-    MuirGlacierVM,
-    BerlinVM,
     LondonVM,
-    ArrowGlacierVM,
+    MuirGlacierVM,
+    PetersburgVM,
+    SpuriousDragonVM,
+    TangerineWhistleVM,
 )
-from eth._utils.address import force_bytes_to_address
-
 from tests.core.helpers import (
     fill_block,
 )
-
 
 ADDRESS_2 = b'\0' * 19 + b'\x02'
 

--- a/tests/core/code-stream/test_code_stream.py
+++ b/tests/core/code-stream/test_code_stream.py
@@ -1,20 +1,27 @@
 import itertools
+import pytest
 import sys
 
-import pytest
-
+from eth_utils import (
+    ValidationError,
+)
+from eth_utils.toolz import (
+    drop,
+)
 from hypothesis import (
     given,
     strategies as st,
 )
 
-from eth_utils import ValidationError
-
-from eth_utils.toolz import drop
-
-from eth.vm import opcode_values
-from eth.vm.code_stream import CodeStream
-from eth.tools._utils.slow_code_stream import SlowCodeStream
+from eth.tools._utils.slow_code_stream import (
+    SlowCodeStream,
+)
+from eth.vm import (
+    opcode_values,
+)
+from eth.vm.code_stream import (
+    CodeStream,
+)
 
 
 def test_code_stream_accepts_bytes():

--- a/tests/core/consensus/test_clique_consensus.py
+++ b/tests/core/consensus/test_clique_consensus.py
@@ -1,43 +1,54 @@
 import pytest
 
+from eth_keys import (
+    keys,
+)
 from eth_utils import (
+    ValidationError,
     decode_hex,
     to_tuple,
 )
 
-from eth_keys import keys
-
-from eth_utils import ValidationError
-
-from eth.chains.base import MiningChain
+from eth.chains.base import (
+    MiningChain,
+)
 from eth.chains.goerli import (
     GOERLI_GENESIS_HEADER,
 )
 from eth.consensus.clique import (
+    NONCE_AUTH,
+    NONCE_DROP,
     CliqueApplier,
     CliqueConsensus,
     CliqueConsensusContext,
-    NONCE_AUTH,
-    NONCE_DROP,
     VoteAction,
-)
-from eth.consensus.clique.constants import (
-    VANITY_LENGTH,
-    SIGNATURE_LENGTH,
 )
 from eth.consensus.clique._utils import (
     get_block_signer,
     sign_block_header,
 )
-from eth.constants import (
-    ZERO_ADDRESS
+from eth.consensus.clique.constants import (
+    SIGNATURE_LENGTH,
+    VANITY_LENGTH,
 )
-from eth.rlp.headers import BlockHeader
-from eth.tools.factories.keys import PublicKeyFactory
-from eth.tools.factories.transaction import new_transaction
-from eth.vm.forks.istanbul import IstanbulVM
-from eth.vm.forks.petersburg import PetersburgVM
-
+from eth.constants import (
+    ZERO_ADDRESS,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
+from eth.tools.factories.keys import (
+    PublicKeyFactory,
+)
+from eth.tools.factories.transaction import (
+    new_transaction,
+)
+from eth.vm.forks.istanbul import (
+    IstanbulVM,
+)
+from eth.vm.forks.petersburg import (
+    PetersburgVM,
+)
 
 ALICE_PK = keys.PrivateKey(
     decode_hex('0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8')

--- a/tests/core/consensus/test_clique_encoding.py
+++ b/tests/core/consensus/test_clique_encoding.py
@@ -1,27 +1,25 @@
 import pytest
 
-from eth.constants import (
-    GENESIS_PARENT_HASH,
-    ZERO_ADDRESS,
-)
 from eth.consensus.clique.datatypes import (
     Snapshot,
     Tally,
     Vote,
-    VoteAction
+    VoteAction,
 )
 from eth.consensus.clique.encoding import (
     decode_address_tally_pair,
-    encode_address_tally_pair,
-
     decode_snapshot,
     decode_tally,
     decode_vote,
+    encode_address_tally_pair,
     encode_snapshot,
     encode_tally,
     encode_vote,
 )
-
+from eth.constants import (
+    GENESIS_PARENT_HASH,
+    ZERO_ADDRESS,
+)
 
 SOME_ADDRESS = b'\x85\x82\xa2\x89V\xb9%\x93M\x03\xdd\xb4Xu\xe1\x8e\x85\x93\x12\xc1'
 

--- a/tests/core/consensus/test_clique_utils.py
+++ b/tests/core/consensus/test_clique_utils.py
@@ -1,26 +1,30 @@
 import pytest
 
+from eth_keys import (
+    keys,
+)
+from eth_typing import (
+    Address,
+)
 from eth_utils import (
     decode_hex,
 )
 
-from eth_keys import keys
-
-from eth_typing import Address
-
 from eth.chains.goerli import (
     GOERLI_GENESIS_HEADER,
-)
-from eth.consensus.clique.constants import (
-    VANITY_LENGTH,
-    SIGNATURE_LENGTH,
 )
 from eth.consensus.clique._utils import (
     get_block_signer,
     get_signers_at_checkpoint,
     sign_block_header,
 )
-from eth.rlp.headers import BlockHeader
+from eth.consensus.clique.constants import (
+    SIGNATURE_LENGTH,
+    VANITY_LENGTH,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
 
 ALICE_PK = keys.PrivateKey(
     decode_hex('0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8')

--- a/tests/core/consensus/test_consensus_engine.py
+++ b/tests/core/consensus/test_consensus_engine.py
@@ -1,22 +1,24 @@
 import pytest
 
-from eth.abc import (
-    ConsensusAPI,
-)
-from eth.consensus import (
-    ConsensusContext,
-)
-
-from eth.chains.base import MiningChain
-from eth.tools.builder.chain import (
-    genesis,
-)
-from eth.vm.forks.istanbul import IstanbulVM
-
 from eth_utils import (
     ValidationError,
 )
 
+from eth.abc import (
+    ConsensusAPI,
+)
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.consensus import (
+    ConsensusContext,
+)
+from eth.tools.builder.chain import (
+    genesis,
+)
+from eth.vm.forks.istanbul import (
+    IstanbulVM,
+)
 
 CONSENSUS_DATA_LENGH = 9
 

--- a/tests/core/consensus/test_pow_mining.py
+++ b/tests/core/consensus/test_pow_mining.py
@@ -3,17 +3,23 @@ import random
 import threading
 import time
 
-from eth.chains.base import MiningChain
-from eth.chains.mainnet import MINING_MAINNET_VMS
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.chains.mainnet import (
+    MINING_MAINNET_VMS,
+)
 from eth.consensus.pow import (
     CACHE_MAX_ITEMS,
     EPOCH_LENGTH,
     check_pow,
     get_cache,
 )
-from eth.tools.mining import POWMiningMixin
 from eth.tools.builder.chain import (
     genesis,
+)
+from eth.tools.mining import (
+    POWMiningMixin,
 )
 
 

--- a/tests/core/fixture-tools/test_normalize_state.py
+++ b/tests/core/fixture-tools/test_normalize_state.py
@@ -1,12 +1,13 @@
 import pytest
 
 from eth_utils import (
-    big_endian_to_int,
     ValidationError,
+    big_endian_to_int,
 )
 
-from eth.tools._utils.normalization import normalize_state
-
+from eth.tools._utils.normalization import (
+    normalize_state,
+)
 
 ADDRESS_A = b'a' + b'\0' * 19
 ADDRESS_B = b'b' + b'\0' * 19

--- a/tests/core/fixtures.py
+++ b/tests/core/fixtures.py
@@ -2,7 +2,6 @@ from eth_utils import (
     decode_hex,
 )
 
-
 # This block is a child of the genesis defined in the chain fixture above and contains a single tx
 # that transfers 10 wei from 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b to
 # 0x095e7baea6a6c7c4c2dfeb977efac326af552d87.

--- a/tests/core/gas_meter/test_gas_meter.py
+++ b/tests/core/gas_meter/test_gas_meter.py
@@ -1,12 +1,14 @@
 import pytest
+
 from eth_utils import (
     ValidationError,
 )
-from eth.vm.gas_meter import (
-    GasMeter,
-)
+
 from eth.exceptions import (
     OutOfGas,
+)
+from eth.vm.gas_meter import (
+    GasMeter,
 )
 
 

--- a/tests/core/generator-utils/test_cached_iterable.py
+++ b/tests/core/generator-utils/test_cached_iterable.py
@@ -1,10 +1,13 @@
-from eth._utils.generator import CachedIterable
+import itertools
 
 from eth_utils.toolz import (
     first,
     nth,
 )
-import itertools
+
+from eth._utils.generator import (
+    CachedIterable,
+)
 
 
 def test_cached_generator():

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -1,12 +1,16 @@
 import pytest
 
 from eth_utils import (
-    decode_hex,
     ValidationError,
+    decode_hex,
 )
 
-from eth.chains.base import MiningChain
-from eth.tools.factories.transaction import new_transaction
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.tools.factories.transaction import (
+    new_transaction,
+)
 
 
 def fill_block(chain, from_, key, gas, data):

--- a/tests/core/hexadecimal-utils/test_encode_and_decode.py
+++ b/tests/core/hexadecimal-utils/test_encode_and_decode.py
@@ -1,10 +1,9 @@
 import pytest
 
 from eth_utils import (
-    encode_hex,
     decode_hex,
+    encode_hex,
 )
-
 from hypothesis import (
     given,
     strategies as st,

--- a/tests/core/message-object/test_message_object.py
+++ b/tests/core/message-object/test_message_object.py
@@ -1,17 +1,16 @@
 import pytest
 
 from eth_utils import (
-    to_normalized_address,
     ValidationError,
+    to_normalized_address,
 )
 
-from eth.vm.message import (
-    Message,
-)
 from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
 )
-
+from eth.vm.message import (
+    Message,
+)
 
 ADDRESS_A = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0"
 ADDRESS_B = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xf1"

--- a/tests/core/numeric-utils/test_int_to_bytes32.py
+++ b/tests/core/numeric-utils/test_int_to_bytes32.py
@@ -1,12 +1,11 @@
 import pytest
 
+from eth._utils.numeric import (
+    int_to_bytes32,
+)
 from eth.constants import (
     NULL_BYTE,
     UINT_256_MAX,
-)
-
-from eth._utils.numeric import (
-    int_to_bytes32,
 )
 
 

--- a/tests/core/numeric-utils/test_integer_squareroot.py
+++ b/tests/core/numeric-utils/test_integer_squareroot.py
@@ -1,4 +1,5 @@
 import pytest
+
 from hypothesis import (
     given,
     strategies as st,

--- a/tests/core/opcodes/test_opcodes.py
+++ b/tests/core/opcodes/test_opcodes.py
@@ -1,66 +1,71 @@
+import pytest
 import warnings
 
-import pytest
-
-from eth.chains.mainnet import (
-    MAINNET_VMS,
-    POS_MAINNET_VMS,
-)
-from eth.vm.forks.shanghai.computation import (
-    ShanghaiComputation,
-)
 from eth_utils import (
+    ValidationError,
     decode_hex,
     encode_hex,
     hexstr_if_str,
     int_to_big_endian,
     to_bytes,
     to_canonical_address,
-    ValidationError,
 )
+
 from eth import (
-    constants
+    constants,
 )
 from eth._utils.address import (
     force_bytes_to_address,
 )
-from eth.consensus import ConsensusContext
+from eth._utils.padding import (
+    pad32,
+)
+from eth.chains.mainnet import (
+    MAINNET_VMS,
+    POS_MAINNET_VMS,
+)
+from eth.consensus import (
+    ConsensusContext,
+)
 from eth.db.atomic import (
-    AtomicDB
+    AtomicDB,
 )
 from eth.db.chain import (
-    ChainDB
+    ChainDB,
 )
 from eth.exceptions import (
     InvalidInstruction,
     VMError,
 )
-from eth._utils.padding import (
-    pad32
-)
 from eth.vm import (
-    opcode_values
+    opcode_values,
 )
-from eth.vm.chain_context import ChainContext
+from eth.vm.chain_context import (
+    ChainContext,
+)
 from eth.vm.forks import (
-    FrontierVM,
-    HomesteadVM,
-    TangerineWhistleVM,
-    SpuriousDragonVM,
+    BerlinVM,
     ByzantiumVM,
     ConstantinopleVM,
-    PetersburgVM,
+    FrontierVM,
+    HomesteadVM,
     IstanbulVM,
-    MuirGlacierVM,
-    BerlinVM,
     LondonVM,
+    MuirGlacierVM,
+    PetersburgVM,
     ShanghaiVM,
+    SpuriousDragonVM,
+    TangerineWhistleVM,
+)
+from eth.vm.forks.shanghai.computation import (
+    ShanghaiComputation,
 )
 from eth.vm.message import (
     Message,
 )
-from eth.vm.spoof import SpoofTransaction
-
+from eth.vm.spoof import (
+    SpoofTransaction,
+)
 
 NORMALIZED_ADDRESS_A = "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6"
 NORMALIZED_ADDRESS_B = "0xcd1722f3947def4cf144679da39c4c32bdc35681"

--- a/tests/core/padding-utils/test_padding.py
+++ b/tests/core/padding-utils/test_padding.py
@@ -2,7 +2,7 @@ import pytest
 
 from eth._utils.padding import (
     pad32,
-    pad32r
+    pad32r,
 )
 
 padding_byte = b"\x00"

--- a/tests/core/precompiles/test_blake2.py
+++ b/tests/core/precompiles/test_blake2.py
@@ -1,12 +1,16 @@
 import pytest
 
 from eth_utils import (
-    to_bytes,
     ValidationError,
+    to_bytes,
 )
 
-from eth._utils.blake2.coders import extract_blake2b_parameters
-from eth._utils.blake2.compression import blake2b_compress
+from eth._utils.blake2.coders import (
+    extract_blake2b_parameters,
+)
+from eth._utils.blake2.compression import (
+    blake2b_compress,
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/core/stack/test_stack.py
+++ b/tests/core/stack/test_stack.py
@@ -4,12 +4,12 @@ from eth_utils import (
     ValidationError,
 )
 
-from eth.vm.stack import (
-    Stack,
-)
 from eth.exceptions import (
     FullStack,
     InsufficientStack,
+)
+from eth.vm.stack import (
+    Stack,
 )
 
 

--- a/tests/core/tester/test_generate_vm_configuration.py
+++ b/tests/core/tester/test_generate_vm_configuration.py
@@ -1,10 +1,11 @@
+import enum
 import pytest
 
-import enum
-
-from eth.vm.forks.frontier import FrontierVM
 from eth.chains.tester import (
     _generate_vm_configuration,
+)
+from eth.vm.forks.frontier import (
+    FrontierVM,
 )
 
 

--- a/tests/core/transaction-utils/conftest.py
+++ b/tests/core/transaction-utils/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 # from https://github.com/ethereum/tests/blob/c951a3c105d600ccd8f1c3fc87856b2bcca3df0a/BasicTests/txtest.json  # noqa: E501
 TRANSACTION_FIXTURES = [
     {

--- a/tests/core/transaction-utils/test_receipt_encoding.py
+++ b/tests/core/transaction-utils/test_receipt_encoding.py
@@ -1,13 +1,18 @@
+import pytest
+
 from eth_utils import (
     ValidationError,
     decode_hex,
     to_bytes,
 )
-import pytest
 import rlp
 
-from eth.exceptions import UnrecognizedTransactionType
-from eth.rlp.receipts import Receipt
+from eth.exceptions import (
+    UnrecognizedTransactionType,
+)
+from eth.rlp.receipts import (
+    Receipt,
+)
 from eth.vm.forks import (
     BerlinVM,
     LondonVM,

--- a/tests/core/transaction-utils/test_transaction_encoding.py
+++ b/tests/core/transaction-utils/test_transaction_encoding.py
@@ -1,13 +1,16 @@
+import pytest
+
 from eth_utils import (
     ValidationError,
     decode_hex,
     to_bytes,
     to_int,
 )
-import pytest
 import rlp
 
-from eth.exceptions import UnrecognizedTransactionType
+from eth.exceptions import (
+    UnrecognizedTransactionType,
+)
 from eth.vm.forks import (
     BerlinVM,
     LondonVM,

--- a/tests/core/transaction-utils/test_transaction_signature_validation.py
+++ b/tests/core/transaction-utils/test_transaction_signature_validation.py
@@ -1,15 +1,22 @@
 import pytest
 
-import rlp
-
+from eth_keys import (
+    keys,
+)
 from eth_utils import (
     decode_hex,
     is_same_address,
     to_canonical_address,
 )
+import rlp
 
-from eth_keys import keys
-
+from eth._utils.transactions import (
+    extract_transaction_sender,
+    validate_transaction_signature,
+)
+from eth.vm.forks.berlin.transactions import (
+    BerlinTransactionBuilder,
+)
 from eth.vm.forks.frontier.transactions import (
     FrontierTransaction,
 )
@@ -18,14 +25,6 @@ from eth.vm.forks.homestead.transactions import (
 )
 from eth.vm.forks.spurious_dragon.transactions import (
     SpuriousDragonTransaction,
-)
-from eth.vm.forks.berlin.transactions import (
-    BerlinTransactionBuilder,
-)
-
-from eth._utils.transactions import (
-    extract_transaction_sender,
-    validate_transaction_signature,
 )
 
 

--- a/tests/core/validation/test_eth1_validation.py
+++ b/tests/core/validation/test_eth1_validation.py
@@ -3,6 +3,7 @@ import pytest
 from eth_utils import (
     ValidationError,
 )
+
 from eth.constants import (
     SECPK1_N,
 )
@@ -19,9 +20,9 @@ from eth.validation import (
     validate_length,
     validate_length_lte,
     validate_lt,
-    validate_lte,
     validate_lt_secpk1n,
     validate_lt_secpk1n2,
+    validate_lte,
     validate_multiple_of,
     validate_stack_bytes,
     validate_stack_int,
@@ -31,7 +32,6 @@ from eth.validation import (
     validate_vm_configuration,
     validate_word,
 )
-
 
 byte = b"\x00"
 

--- a/tests/core/validation/test_transaction_validation.py
+++ b/tests/core/validation/test_transaction_validation.py
@@ -1,9 +1,15 @@
 import pytest
-from eth.vm.forks.london.transactions import UnsignedDynamicFeeTransaction
 
-from eth.vm.forks.berlin.transactions import UnsignedAccessListTransaction
+from eth_utils import (
+    ValidationError,
+)
 
-from eth_utils import ValidationError
+from eth.vm.forks.berlin.transactions import (
+    UnsignedAccessListTransaction,
+)
+from eth.vm.forks.london.transactions import (
+    UnsignedDynamicFeeTransaction,
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/core/validation/test_withdrawal_validation.py
+++ b/tests/core/validation/test_withdrawal_validation.py
@@ -1,11 +1,18 @@
 import pytest
-from eth_typing import Address
 
-from eth.vm.forks.shanghai.withdrawals import Withdrawal
-from eth.validation import UINT_64_MAX
+from eth_typing import (
+    Address,
+)
 from eth_utils import (
     ValidationError,
     to_hex,
+)
+
+from eth.validation import (
+    UINT_64_MAX,
+)
+from eth.vm.forks.shanghai.withdrawals import (
+    Withdrawal,
 )
 
 

--- a/tests/core/vm/conftest.py
+++ b/tests/core/vm/conftest.py
@@ -1,7 +1,12 @@
 import pytest
-from eth_utils import to_canonical_address
 
-from eth.vm.transaction_context import BaseTransactionContext
+from eth_utils import (
+    to_canonical_address,
+)
+
+from eth.vm.transaction_context import (
+    BaseTransactionContext,
+)
 
 
 @pytest.fixture

--- a/tests/core/vm/test_base_computation.py
+++ b/tests/core/vm/test_base_computation.py
@@ -5,14 +5,14 @@ from eth_utils import (
 )
 
 from eth.exceptions import (
-    VMError,
     Revert,
-)
-from eth.vm.message import (
-    Message,
+    VMError,
 )
 from eth.vm.computation import (
     BaseComputation,
+)
+from eth.vm.message import (
+    Message,
 )
 from eth.vm.transaction_context import (
     BaseTransactionContext,

--- a/tests/core/vm/test_clique_validation.py
+++ b/tests/core/vm/test_clique_validation.py
@@ -1,11 +1,13 @@
 import pytest
 
 from eth_utils import (
-    decode_hex,
     ValidationError,
+    decode_hex,
 )
 
-from eth.chains.base import MiningChain
+from eth.chains.base import (
+    MiningChain,
+)
 from eth.chains.goerli import (
     GOERLI_GENESIS_HEADER,
 )
@@ -13,13 +15,12 @@ from eth.consensus.clique import (
     CliqueApplier,
     CliqueConsensusContext,
 )
-
-from eth.rlp.headers import BlockHeader
-
+from eth.rlp.headers import (
+    BlockHeader,
+)
 from eth.vm.forks.petersburg import (
     PetersburgVM,
 )
-
 
 GOERLI_HEADER_ONE = BlockHeader(
     difficulty=2,

--- a/tests/core/vm/test_computation.py
+++ b/tests/core/vm/test_computation.py
@@ -1,14 +1,25 @@
 # test computation class behavior across VMs
 import pytest
-from eth_typing import Address
 
-from eth_utils import decode_hex
+from eth_typing import (
+    Address,
+)
+from eth_utils import (
+    decode_hex,
+)
 
-from eth.chains.base import MiningChain
-from eth.chains.mainnet import MINING_MAINNET_VMS
-
-from eth import constants
-from eth.consensus import NoProofConsensus
+from eth import (
+    constants,
+)
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.chains.mainnet import (
+    MINING_MAINNET_VMS,
+)
+from eth.consensus import (
+    NoProofConsensus,
+)
 from eth.exceptions import (
     InvalidInstruction,
 )

--- a/tests/core/vm/test_contract_code_size_limit.py
+++ b/tests/core/vm/test_contract_code_size_limit.py
@@ -1,14 +1,35 @@
 import pytest
 
-from eth_utils import hexstr_if_str, to_wei, to_bytes
-from eth.constants import CREATE_CONTRACT_ADDRESS
-from eth.vm import opcode_values
-from eth.vm.forks.spurious_dragon.computation import SpuriousDragonComputation
-from eth.vm.forks.spurious_dragon.constants import EIP170_CODE_SIZE_LIMIT
-from eth.vm.message import Message
-from eth._utils.address import generate_contract_address
-from eth.exceptions import OutOfGas
-from eth.tools.factories.transaction import new_transaction
+from eth_utils import (
+    hexstr_if_str,
+    to_bytes,
+    to_wei,
+)
+
+from eth._utils.address import (
+    generate_contract_address,
+)
+from eth.constants import (
+    CREATE_CONTRACT_ADDRESS,
+)
+from eth.exceptions import (
+    OutOfGas,
+)
+from eth.tools.factories.transaction import (
+    new_transaction,
+)
+from eth.vm import (
+    opcode_values,
+)
+from eth.vm.forks.spurious_dragon.computation import (
+    SpuriousDragonComputation,
+)
+from eth.vm.forks.spurious_dragon.constants import (
+    EIP170_CODE_SIZE_LIMIT,
+)
+from eth.vm.message import (
+    Message,
+)
 
 
 def assemble(*codes):

--- a/tests/core/vm/test_frontier_computation.py
+++ b/tests/core/vm/test_frontier_computation.py
@@ -1,10 +1,10 @@
 import pytest
 
-from eth.vm.message import (
-    Message,
-)
 from eth.vm.forks.frontier.computation import (
     FrontierComputation,
+)
+from eth.vm.message import (
+    Message,
 )
 
 

--- a/tests/core/vm/test_interrupt.py
+++ b/tests/core/vm/test_interrupt.py
@@ -1,6 +1,8 @@
 import pytest
 
-from eth_hash.auto import keccak
+from eth_hash.auto import (
+    keccak,
+)
 from eth_utils import (
     int_to_big_endian,
 )

--- a/tests/core/vm/test_london.py
+++ b/tests/core/vm/test_london.py
@@ -1,18 +1,33 @@
 import pytest
-from eth_typing import Address
 
-from eth_utils import decode_hex
+from eth_typing import (
+    Address,
+)
+from eth_utils import (
+    decode_hex,
+)
 
-from eth import constants
-from eth.consensus.noproof import NoProofConsensus
-from eth.chains.base import MiningChain
+from eth import (
+    constants,
+)
+from eth.chains.base import (
+    MiningChain,
+)
 from eth.chains.mainnet import (
     MINING_MAINNET_VMS,
 )
-from eth.exceptions import InvalidInstruction
-from eth.vm.forks import BerlinVM
+from eth.consensus.noproof import (
+    NoProofConsensus,
+)
+from eth.exceptions import (
+    InvalidInstruction,
+)
 from eth.tools.factories.transaction import (
-    new_dynamic_fee_transaction, new_transaction,
+    new_dynamic_fee_transaction,
+    new_transaction,
+)
+from eth.vm.forks import (
+    BerlinVM,
 )
 
 FOUR_TXN_GAS_LIMIT = 21000 * 4

--- a/tests/core/vm/test_mainnet_dao_fork.py
+++ b/tests/core/vm/test_mainnet_dao_fork.py
@@ -1,16 +1,19 @@
 import pytest
 
 from eth_utils import (
-    to_tuple,
     ValidationError,
+    to_tuple,
 )
-
-from eth_utils.toolz import sliding_window
+from eth_utils.toolz import (
+    sliding_window,
+)
 
 from eth.chains.mainnet import (
     MainnetHomesteadVM,
 )
-from eth.rlp.headers import BlockHeader
+from eth.rlp.headers import (
+    BlockHeader,
+)
 
 
 class ETC_VM(MainnetHomesteadVM):

--- a/tests/core/vm/test_modexp_precompile.py
+++ b/tests/core/vm/test_modexp_precompile.py
@@ -7,8 +7,8 @@ from eth_utils import (
 )
 
 from eth.precompiles.modexp import (
-    _modexp,
     _compute_modexp_gas_fee_eip_198,
+    _modexp,
 )
 from eth.vm.forks.berlin.computation import (
     _compute_modexp_gas_fee_eip_2565,

--- a/tests/core/vm/test_rewards.py
+++ b/tests/core/vm/test_rewards.py
@@ -1,31 +1,33 @@
 import pytest
 
 from eth_utils import (
-    to_wei,
     ValidationError,
+    to_wei,
 )
 
 from eth.chains.base import (
-    MiningChain
+    MiningChain,
 )
 from eth.tools.builder.chain import (
     at_block_number,
+    berlin_at,
     build,
+    byzantium_at,
+    constantinople_at,
     disable_pow_check,
+    frontier_at,
+    genesis,
+    homestead_at,
+    london_at,
     mine_block,
     mine_blocks,
-    byzantium_at,
-    frontier_at,
-    homestead_at,
+    petersburg_at,
     spurious_dragon_at,
     tangerine_whistle_at,
-    constantinople_at,
-    petersburg_at,
-    berlin_at,
-    london_at,
-    genesis,
 )
-from eth.tools.factories.transaction import new_dynamic_fee_transaction
+from eth.tools.factories.transaction import (
+    new_dynamic_fee_transaction,
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/core/vm/test_shanghai.py
+++ b/tests/core/vm/test_shanghai.py
@@ -1,9 +1,17 @@
 import pytest
 
-from eth.chains.base import MiningChain
-from eth.consensus import NoProofConsensus
-from eth.vm.forks import ShanghaiVM
-from eth.vm.forks.shanghai.withdrawals import Withdrawal
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.consensus import (
+    NoProofConsensus,
+)
+from eth.vm.forks import (
+    ShanghaiVM,
+)
+from eth.vm.forks.shanghai.withdrawals import (
+    Withdrawal,
+)
 
 
 @pytest.fixture

--- a/tests/core/vm/test_validate_transaction.py
+++ b/tests/core/vm/test_validate_transaction.py
@@ -1,11 +1,24 @@
-from eth_utils import ValidationError
 import pytest
 
-from eth._utils.address import force_bytes_to_address
-from eth.chains.base import MiningChain
-from eth.constants import GAS_TX
-from eth.tools.factories.transaction import new_dynamic_fee_transaction
-from eth.vm.forks import LondonVM
+from eth_utils import (
+    ValidationError,
+)
+
+from eth._utils.address import (
+    force_bytes_to_address,
+)
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.constants import (
+    GAS_TX,
+)
+from eth.tools.factories.transaction import (
+    new_dynamic_fee_transaction,
+)
+from eth.vm.forks import (
+    LondonVM,
+)
 
 
 @pytest.fixture

--- a/tests/core/vm/test_vm.py
+++ b/tests/core/vm/test_vm.py
@@ -1,12 +1,14 @@
 import pytest
 
-import rlp
 from eth_utils import (
-    decode_hex,
     ValidationError,
+    decode_hex,
 )
+import rlp
 
-from eth import constants
+from eth import (
+    constants,
+)
 from eth.chains.base import (
     MiningChain,
 )
@@ -14,9 +16,11 @@ from eth.chains.mainnet import (
     MAINNET_VMS,
     MINING_MAINNET_VMS,
 )
-from eth.tools.builder.chain import api
+from eth.tools.builder.chain import (
+    api,
+)
 from eth.tools.factories.transaction import (
-    new_transaction
+    new_transaction,
 )
 
 

--- a/tests/core/vm/test_vm_class_configurations.py
+++ b/tests/core/vm/test_vm_class_configurations.py
@@ -1,13 +1,19 @@
 import pytest
 
+from eth_bloom import (
+    BloomFilter,
+)
+
 from eth.abc import (
     ReceiptBuilderAPI,
     TransactionBuilderAPI,
 )
-from eth.chains.mainnet import MAINNET_VMS
-from eth.rlp.headers import BlockHeader
-
-from eth_bloom import BloomFilter
+from eth.chains.mainnet import (
+    MAINNET_VMS,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
 
 
 @pytest.fixture(scope="module")

--- a/tests/core/vm/test_vm_state.py
+++ b/tests/core/vm/test_vm_state.py
@@ -1,12 +1,15 @@
 import pytest
 
-from eth_utils import ValidationError
+from eth_utils import (
+    ValidationError,
+)
 
 from eth.tools.factories.transaction import (
-    new_transaction
+    new_transaction,
 )
-from eth.vm.interrupt import MissingAccountTrieNode
-
+from eth.vm.interrupt import (
+    MissingAccountTrieNode,
+)
 
 ADDRESS = b'\xaa' * 20
 OTHER_ADDRESS = b'\xbb' * 20

--- a/tests/database/test_accesslog.py
+++ b/tests/database/test_accesslog.py
@@ -1,14 +1,17 @@
+import pytest
+
 from hypothesis import (
     given,
     strategies as st,
 )
-import pytest
 
 from eth.db.accesslog import (
-    KeyAccessLoggerDB,
     KeyAccessLoggerAtomicDB,
+    KeyAccessLoggerDB,
 )
-from eth.db.backends.memory import MemoryDB
+from eth.db.backends.memory import (
+    MemoryDB,
+)
 
 
 @given(st.lists(st.binary()))

--- a/tests/database/test_account_db.py
+++ b/tests/database/test_account_db.py
@@ -1,21 +1,24 @@
 import pytest
 
-from eth_hash.auto import keccak
-
+from eth_hash.auto import (
+    keccak,
+)
 from eth_utils import (
     ValidationError,
-)
-
-from eth.db.atomic import AtomicDB
-from eth.db.backends.memory import MemoryDB
-from eth.db.account import (
-    AccountDB,
 )
 
 from eth.constants import (
     EMPTY_SHA3,
 )
-
+from eth.db.account import (
+    AccountDB,
+)
+from eth.db.atomic import (
+    AtomicDB,
+)
+from eth.db.backends.memory import (
+    MemoryDB,
+)
 
 ADDRESS = b'\xaa' * 20
 OTHER_ADDRESS = b'\xbb' * 20

--- a/tests/database/test_atomic_database_api.py
+++ b/tests/database/test_atomic_database_api.py
@@ -1,10 +1,17 @@
 import pytest
 
-from eth.db.atomic import AtomicDB
-from eth.db.backends.level import LevelDB
-
-from eth.tools.db.base import DatabaseAPITestSuite
-from eth.tools.db.atomic import AtomicDatabaseBatchAPITestSuite
+from eth.db.atomic import (
+    AtomicDB,
+)
+from eth.db.backends.level import (
+    LevelDB,
+)
+from eth.tools.db.atomic import (
+    AtomicDatabaseBatchAPITestSuite,
+)
+from eth.tools.db.base import (
+    DatabaseAPITestSuite,
+)
 
 
 @pytest.fixture(params=['atomic', 'level'])

--- a/tests/database/test_batch_db.py
+++ b/tests/database/test_batch_db.py
@@ -1,10 +1,15 @@
 import pytest
+
 from eth_utils import (
     ValidationError,
 )
 
-from eth.db.backends.memory import MemoryDB
-from eth.db.batch import BatchDB
+from eth.db.backends.memory import (
+    MemoryDB,
+)
+from eth.db.batch import (
+    BatchDB,
+)
 
 
 @pytest.fixture

--- a/tests/database/test_database_api.py
+++ b/tests/database/test_database_api.py
@@ -1,15 +1,27 @@
 import pytest
+
 from eth.db.accesslog import (
     KeyAccessLoggerAtomicDB,
     KeyAccessLoggerDB,
 )
-from eth.db.backends.memory import MemoryDB
-from eth.db.journal import JournalDB
-from eth.db.batch import BatchDB
-from eth.db.atomic import AtomicDB
-from eth.db.cache import CacheDB
-
-from eth.tools.db.base import DatabaseAPITestSuite
+from eth.db.atomic import (
+    AtomicDB,
+)
+from eth.db.backends.memory import (
+    MemoryDB,
+)
+from eth.db.batch import (
+    BatchDB,
+)
+from eth.db.cache import (
+    CacheDB,
+)
+from eth.db.journal import (
+    JournalDB,
+)
+from eth.tools.db.base import (
+    DatabaseAPITestSuite,
+)
 
 
 @pytest.fixture(params=[

--- a/tests/database/test_eth1_chaindb.py
+++ b/tests/database/test_eth1_chaindb.py
@@ -1,43 +1,55 @@
 import pytest
 
+from eth_hash.auto import (
+    keccak,
+)
 from hypothesis import (
     given,
     strategies as st,
 )
-
 import rlp
 
-from eth_hash.auto import keccak
-
-from eth.constants import (
-    BLANK_ROOT_HASH,
-    ZERO_ADDRESS,
+from eth._utils.address import (
+    force_bytes_to_address,
 )
 from eth.chains.base import (
     MiningChain,
 )
-from eth.db.atomic import AtomicDB
+from eth.constants import (
+    BLANK_ROOT_HASH,
+    ZERO_ADDRESS,
+)
+from eth.db.atomic import (
+    AtomicDB,
+)
 from eth.db.chain import (
     ChainDB,
 )
-from eth.db.chain_gaps import GENESIS_CHAIN_GAPS
-from eth.db.schema import SchemaV1
+from eth.db.chain_gaps import (
+    GENESIS_CHAIN_GAPS,
+)
+from eth.db.schema import (
+    SchemaV1,
+)
 from eth.exceptions import (
     BlockNotFound,
+    CheckpointsMustBeCanonical,
     HeaderNotFound,
     ParentNotFound,
     ReceiptNotFound,
-    CheckpointsMustBeCanonical,
 )
 from eth.rlp.headers import (
     BlockHeader,
 )
-from eth.tools.builder.chain import api
+from eth.tools.builder.chain import (
+    api,
+)
+from eth.tools.factories.transaction import (
+    new_access_list_transaction,
+    new_transaction,
+)
 from eth.tools.rlp import (
     assert_headers_eq,
-)
-from eth._utils.address import (
-    force_bytes_to_address,
 )
 from eth.vm.forks import (
     BerlinVM,
@@ -49,11 +61,6 @@ from eth.vm.forks.frontier.blocks import (
 from eth.vm.forks.homestead.blocks import (
     HomesteadBlock,
 )
-from eth.tools.factories.transaction import (
-    new_access_list_transaction,
-    new_transaction,
-)
-
 
 A_ADDRESS = b"\xaa" * 20
 B_ADDRESS = b"\xbb" * 20

--- a/tests/database/test_hash_trie.py
+++ b/tests/database/test_hash_trie.py
@@ -1,10 +1,13 @@
+from eth_hash.auto import (
+    keccak,
+)
 from hypothesis import (
     given,
     strategies as st,
 )
-
-from eth_hash.auto import keccak
-from trie import HexaryTrie
+from trie import (
+    HexaryTrie,
+)
 
 from eth.db.hash_trie import (
     HashTrie,

--- a/tests/database/test_header_db.py
+++ b/tests/database/test_header_db.py
@@ -1,27 +1,27 @@
 import enum
-from functools import partial
+from functools import (
+    partial,
+)
 import operator
+import pytest
 import random
 
-from hypothesis import (
-    example,
-    given,
-    settings,
-    strategies as st,
+from eth_utils import (
+    ValidationError,
+    keccak,
+    to_set,
+    to_tuple,
 )
-import pytest
-
 from eth_utils.toolz import (
     accumulate,
     compose,
     sliding_window,
 )
-
-from eth_utils import (
-    to_set,
-    to_tuple,
-    keccak,
-    ValidationError,
+from hypothesis import (
+    example,
+    given,
+    settings,
+    strategies as st,
 )
 
 from eth.constants import (
@@ -29,13 +29,18 @@ from eth.constants import (
     GENESIS_DIFFICULTY,
     GENESIS_GAS_LIMIT,
 )
-from eth.db.atomic import AtomicDB
+from eth.db.atomic import (
+    AtomicDB,
+)
 from eth.db.chain_gaps import (
-    GapChange,
     GENESIS_CHAIN_GAPS,
+    GapChange,
     fill_gap,
-    reopen_gap,
     is_block_number_in_gap,
+    reopen_gap,
+)
+from eth.db.header import (
+    HeaderDB,
 )
 from eth.exceptions import (
     CanonicalHeadNotFound,
@@ -44,15 +49,14 @@ from eth.exceptions import (
     HeaderNotFound,
     ParentNotFound,
 )
-from eth.db.header import HeaderDB
+from eth.tools.rlp import (
+    assert_headers_eq,
+)
 from eth.vm.forks.gray_glacier import (
     GrayGlacierVM,
 )
 from eth.vm.forks.gray_glacier.blocks import (
     GrayGlacierBlockHeader as BlockHeader,
-)
-from eth.tools.rlp import (
-    assert_headers_eq,
 )
 
 

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -1,16 +1,31 @@
-from eth_utils import ValidationError
+import pytest
+
+from eth_utils import (
+    ValidationError,
+)
 from hypothesis import (
     given,
     settings,
     strategies as st,
 )
-from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
-import pytest
+from hypothesis.stateful import (
+    Bundle,
+    RuleBasedStateMachine,
+    rule,
+)
 
-from eth.db.backends.memory import MemoryDB
-from eth.db.journal import JournalDB
-from eth.db.slow_journal import JournalDB as SlowJournalDB
-from eth.vm.interrupt import EVMMissingData
+from eth.db.backends.memory import (
+    MemoryDB,
+)
+from eth.db.journal import (
+    JournalDB,
+)
+from eth.db.slow_journal import (
+    JournalDB as SlowJournalDB,
+)
+from eth.vm.interrupt import (
+    EVMMissingData,
+)
 
 
 @pytest.fixture

--- a/tests/database/test_leveldb_db_backend.py
+++ b/tests/database/test_leveldb_db_backend.py
@@ -1,11 +1,14 @@
 import pytest
 
-from eth.db.backends.memory import MemoryDB
-from eth.db.atomic import AtomicDB
 from eth.db import (
     get_db_backend,
 )
-
+from eth.db.atomic import (
+    AtomicDB,
+)
+from eth.db.backends.memory import (
+    MemoryDB,
+)
 
 pytest.importorskip('leveldb')
 

--- a/tests/fillers/build_json.py
+++ b/tests/fillers/build_json.py
@@ -1,21 +1,22 @@
-import os
 import json
+import os
 
-from eth_hash.auto import keccak
-
+from eth_hash.auto import (
+    keccak,
+)
 from eth_utils import (
     encode_hex,
 )
-from eth.tools.fixtures.helpers import (
-    get_test_name,
-)
+
 from eth.tools.fixtures.fillers import (
     fill_test,
 )
 from eth.tools.fixtures.fillers.formatters import (
     filler_formatter,
 )
-
+from eth.tools.fixtures.helpers import (
+    get_test_name,
+)
 
 PARENT_DIR = os.path.dirname(os.path.abspath(__file__))
 OUTPUT_DIR = os.path.join(PARENT_DIR, "json")

--- a/tests/json-fixtures/blockchain/test_blockchain.py
+++ b/tests/json-fixtures/blockchain/test_blockchain.py
@@ -1,17 +1,15 @@
 import os
-from pathlib import Path
+from pathlib import (
+    Path,
+)
 import pytest
-import rlp
 
 from eth_utils import (
-    to_tuple,
     ValidationError,
+    to_tuple,
 )
+import rlp
 
-from eth.tools.rlp import (
-    assert_imported_block_unchanged,
-    assert_headers_eq,
-)
 from eth.tools._utils.normalization import (
     normalize_blockchain_fixtures,
 )
@@ -25,8 +23,13 @@ from eth.tools.fixtures import (
     should_run_slow_tests,
     verify_state,
 )
-from eth.vm.header import HeaderSedes
-
+from eth.tools.rlp import (
+    assert_headers_eq,
+    assert_imported_block_unchanged,
+)
+from eth.vm.header import (
+    HeaderSedes,
+)
 
 ROOT_PROJECT_DIR = Path(__file__).parents[3]
 

--- a/tests/json-fixtures/test_difficulty.py
+++ b/tests/json-fixtures/test_difficulty.py
@@ -1,26 +1,33 @@
 import os
-
 import pytest
-from eth_utils import to_int
 
-from eth.constants import EMPTY_UNCLE_HASH
-from eth.rlp.headers import BlockHeader
+from eth_typing.enums import (
+    ForkName,
+)
+from eth_utils import (
+    to_int,
+)
+
+from eth.constants import (
+    EMPTY_UNCLE_HASH,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
 from eth.tools.fixtures import (
     filter_fixtures,
     generate_fixture_tests,
     load_fixture,
 )
 from eth.vm.forks import (
-    FrontierVM,
-    HomesteadVM,
+    ArrowGlacierVM,
+    BerlinVM,
     ByzantiumVM,
     ConstantinopleVM,
-    BerlinVM,
-    ArrowGlacierVM,
+    FrontierVM,
     GrayGlacierVM,
+    HomesteadVM,
 )
-from eth_typing.enums import ForkName
-
 
 ROOT_PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 

--- a/tests/json-fixtures/test_transactions.py
+++ b/tests/json-fixtures/test_transactions.py
@@ -1,61 +1,62 @@
 import os
-
 import pytest
 
-import rlp
-
-from eth.exceptions import UnrecognizedTransactionType
-from eth.vm.forks.shanghai.transactions import ShanghaiTransactionBuilder
+from eth_typing.enums import (
+    ForkName,
+)
 from eth_utils import (
+    ValidationError,
     is_same_address,
     to_tuple,
-    ValidationError,
+)
+import rlp
+
+from eth.exceptions import (
+    UnrecognizedTransactionType,
+)
+from eth.tools._utils.normalization import (
+    normalize_transactiontest_fixture,
 )
 from eth.tools.fixtures import (
     generate_fixture_tests,
     load_fixture,
 )
-from eth.tools._utils.normalization import (
-    normalize_transactiontest_fixture,
-)
-from eth.vm.forks.frontier.transactions import (
-    FrontierTransaction
-)
-from eth.vm.forks.homestead.transactions import (
-    HomesteadTransaction
-)
-from eth.vm.forks.spurious_dragon.transactions import (
-    SpuriousDragonTransaction
-)
-from eth.vm.forks.byzantium.transactions import (
-    ByzantiumTransaction
-)
-from eth.vm.forks.constantinople.transactions import (
-    ConstantinopleTransaction
-)
-from eth.vm.forks.petersburg.transactions import (
-    PetersburgTransaction
-)
-from eth.vm.forks.istanbul.transactions import (
-    IstanbulTransaction
-)
 from eth.vm.forks.berlin.constants import (
     VALID_TRANSACTION_TYPES,
 )
 from eth.vm.forks.berlin.transactions import (
-    BerlinTransactionBuilder
+    BerlinTransactionBuilder,
+)
+from eth.vm.forks.byzantium.transactions import (
+    ByzantiumTransaction,
+)
+from eth.vm.forks.constantinople.transactions import (
+    ConstantinopleTransaction,
+)
+from eth.vm.forks.frontier.transactions import (
+    FrontierTransaction,
+)
+from eth.vm.forks.homestead.transactions import (
+    HomesteadTransaction,
+)
+from eth.vm.forks.istanbul.transactions import (
+    IstanbulTransaction,
 )
 from eth.vm.forks.london.transactions import (
-    LondonTransactionBuilder
+    LondonTransactionBuilder,
 )
 from eth.vm.forks.paris.transactions import (
-    ParisTransactionBuilder
+    ParisTransactionBuilder,
 )
-
-from eth_typing.enums import (
-    ForkName
+from eth.vm.forks.petersburg.transactions import (
+    PetersburgTransaction,
 )
-
+from eth.vm.forks.shanghai.transactions import (
+    ShanghaiTransactionBuilder,
+)
+from eth.vm.forks.spurious_dragon.transactions import (
+    SpuriousDragonTransaction,
+)
 
 ROOT_PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 

--- a/tests/json-fixtures/test_virtual_machine.py
+++ b/tests/json-fixtures/test_virtual_machine.py
@@ -1,24 +1,33 @@
 import os
-
 import pytest
 
+from eth_hash.auto import (
+    keccak,
+)
 from eth_utils import (
     to_bytes,
 )
 
-from eth.consensus import ConsensusContext
+from eth.consensus import (
+    ConsensusContext,
+)
 from eth.db import (
     get_db_backend,
 )
-from eth.db.chain import ChainDB
-
-from eth_hash.auto import keccak
-
+from eth.db.chain import (
+    ChainDB,
+)
 from eth.exceptions import (
     VMError,
 )
 from eth.rlp.headers import (
     BlockHeader,
+)
+from eth.tools._utils.hashing import (
+    hash_log_entries,
+)
+from eth.tools._utils.normalization import (
+    normalize_vmtest_fixture,
 )
 from eth.tools.fixtures import (
     filter_fixtures,
@@ -27,20 +36,18 @@ from eth.tools.fixtures import (
     setup_state,
     verify_state,
 )
-from eth.tools._utils.normalization import (
-    normalize_vmtest_fixture,
+from eth.vm.chain_context import (
+    ChainContext,
 )
-from eth.tools._utils.hashing import (
-    hash_log_entries,
-)
-from eth.vm.chain_context import ChainContext
 from eth.vm.forks import (
     HomesteadVM,
 )
 from eth.vm.forks.homestead.computation import (
     HomesteadComputation,
 )
-from eth.vm.forks.homestead.state import HomesteadState
+from eth.vm.forks.homestead.state import (
+    HomesteadState,
+)
 from eth.vm.message import (
     Message,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -76,6 +76,7 @@ deps: .[eth,lint]
 commands:
     flake8 {toxinidir}/eth {toxinidir}/tests {toxinidir}/scripts
     mypy -p eth --config-file {toxinidir}/mypy.ini
+    isort --check-only --diff {toxinidir}/eth/ {toxinidir}/tests/
 
 [testenv:lint]
 basepython: python

--- a/tox.ini
+++ b/tox.ini
@@ -10,18 +10,13 @@ envlist=
     py39-docs
 
 [isort]
-profile=black
-force_grid_wrap=1
-multi_line_output=3
-honor_noqa=true
-float_to_top=true
-combine_as_imports=true
-force_sort_within_sections=true
-include_trailing_comma=true
+combine_as_imports=True
 extra_standard_library=pytest
+force_grid_wrap=1
+force_sort_within_sections=True
 known_first_party=eth
-line_length=88
-use_parentheses=true
+multi_line_output=3
+profile=black
 # skip `__init__.py` files because sometimes order of initialization is important
 skip=__init__.py
 


### PR DESCRIPTION
### What was wrong?

Imports are not sorted.

Closes Issue #2094 

### How was it fixed?

Added `isort`, a tool to sort imports, in the linting process.

Adding lint setup + linting files would be a large PR to review. I've decided to split it up into 3 parts. 
[First PR](https://github.com/ethereum/py-evm/pull/2098)

```mermaid
flowchart LR
    pr1[Added isort to setup, makefile and tox] --> pr2[Linted file with isort in eth and tests directory - This PR]
    pr2 --> pr3[Add isort check to tox]
```

This is second PR of a two part linting rollout. In this PR, I ran `make lint-roll`. 
In order to validate and review the PR quickly, you can checksum `eth` and `tests` directory.

Let me know if I missed anything in the contribution process.

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![images](https://user-images.githubusercontent.com/3950603/233185340-5ee14010-5ca3-403e-8b94-2411963a1ca2.jpeg)