### PR TITLE
[1/3] Added isort to setup, makefile and tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,11 @@ clean-pyc:
 	find . -name '__pycache__' -exec rm -rf {} +
 
 lint:
-	tox -e lint
+	tox run -e lint
+
+lint-roll:
+	isort eth tests
+	$(MAKE) lint
 
 test:
 	py.test --tb native tests

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ deps = {
         "pydocstyle>=6.0.0",
         "types-setuptools",
         "importlib-metadata<5.0;python_version<'3.8'",
+        "isort==5.11.4"
     ],
     'benchmark': [
         "termcolor>=1.1.0,<2.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,22 @@ envlist=
     py{37,38,39}-lint
     py39-docs
 
+[isort]
+profile=black
+force_grid_wrap=1
+multi_line_output=3
+honor_noqa=true
+float_to_top=true
+combine_as_imports=true
+force_sort_within_sections=true
+include_trailing_comma=true
+extra_standard_library=pytest
+known_first_party=eth
+line_length=88
+use_parentheses=true
+# skip `__init__.py` files because sometimes order of initialization is important
+skip=__init__.py
+
 [flake8]
 max-line-length= 100
 exclude=


### PR DESCRIPTION
### What was wrong?

Imports are not sorted.

Related to Issue https://github.com/ethereum/py-evm/issues/2094

### How was it fixed?

Added `isort`, a tool to sort imports, in the linting process.

Adding lint setup + linting files would be a large PR to review. I've decided to split it up into two parts. 

```mermaid
flowchart LR
    pr1[Added isort to setup, makefile and tox - This PR] --> pr2[Linted file with isort in eth and tests directory]
    pr2 --> pr3[Add isort check to tox]
```

In this PR, I've added `isort` and related commands to `setup.py`, `Makefile` and `tox`. 
In the follow up PR, I will be running `make lint-roll`. It will be easier for repo maintainers to checksum the changes and review the lint changes. 

Let me know if I missed anything in the contribution process.

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![white-rabbit-24093391](https://user-images.githubusercontent.com/3950603/233183169-c2013af8-fb73-4992-861a-abd2f5300f5c.jpg)
