### PR TITLE
Update pip and virtualenv for CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,9 @@ common: &common
           - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
-        command: pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: run tox
         command: python -m tox -r

--- a/newsfragments/2102.internal.rst
+++ b/newsfragments/2102.internal.rst
@@ -1,0 +1,1 @@
+Update ``pip`` version sitting in the circleci image before installing and running ``tox``. Install ``tox`` at the sys level to help avoid ``virtualenv`` version conflicts.


### PR DESCRIPTION
### What was wrong?

- `virtualenv` versions seem to be clashing across sys and user libraries. CircleCI images come with `virtualenv` installed at the sys level and when we did `pip install --user tox` we installed `tox` and a different `virtualenv` version there at the user package level. I believe the `--user` flag was causing issues with the different `virtualenv` installs. By installing `tox` at the sys level, it allows us to work with the existing `virtualenv` version already in the image. Whether the `tox` version chooses to update it or not is left to its dependency setup.

- Also, ``--upgrade`` the ``pip`` version sitting in the image python install before any of the above steps.

### Todo:
- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20230403_170554](https://user-images.githubusercontent.com/3532824/233731673-8e6d4408-b80d-4c2f-a93d-bd3f580d72a9.jpg)

