### PR TITLE
Bugfix: Add receipt builder to ShanghaiBlock

### DIFF
--- a/eth/vm/forks/shanghai/blocks.py
+++ b/eth/vm/forks/shanghai/blocks.py
@@ -29,7 +29,10 @@ from eth_utils import (
 )
 
 from rlp.sedes import (
-    Binary, CountableList, big_endian_int, binary,
+    Binary,
+    CountableList,
+    big_endian_int,
+    binary,
 )
 from trie.exceptions import MissingTrieNode
 
@@ -39,6 +42,9 @@ from .transactions import (
 from .withdrawals import Withdrawal
 from ..london.blocks import (
     LondonBlockHeader,
+)
+from ..london.receipts import (
+    LondonReceiptBuilder,
 )
 
 
@@ -182,6 +188,8 @@ class ShanghaiBlock(BaseBlock):
     # re-defined from `BaseBlock`, as `FrontierBlock` was, to include withdrawals
 
     transaction_builder: Type[TransactionBuilderAPI] = ShanghaiTransactionBuilder
+    # London was the last fork where the receipt builder was updated
+    receipt_builder: Type[ReceiptBuilderAPI] = LondonReceiptBuilder
     fields = [
         ('header', ShanghaiBlockHeader),
         ('transactions', CountableList(transaction_builder)),

--- a/newsfragments/2105.bugfix.rst
+++ b/newsfragments/2105.bugfix.rst
@@ -1,0 +1,1 @@
+Add missing receipt builder for the `ShanghaiBlock` class.

--- a/tests/core/vm/test_vm_class_configurations.py
+++ b/tests/core/vm/test_vm_class_configurations.py
@@ -1,0 +1,42 @@
+import pytest
+
+from eth.abc import (
+    ReceiptBuilderAPI,
+    TransactionBuilderAPI,
+)
+from eth.chains.mainnet import MAINNET_VMS
+from eth.rlp.headers import BlockHeader
+
+from eth_bloom import BloomFilter
+
+
+@pytest.fixture(scope="module")
+def genesis_header():
+    return BlockHeader(
+        difficulty=0,
+        block_number=0,
+        gas_limit=10000,
+    )
+
+
+@pytest.mark.parametrize("vm_class", MAINNET_VMS)
+def test_vm_block_class_is_properly_configured(
+    vm_class,
+    genesis_header,
+):
+    vm_block_instance = vm_class.get_block_class()(genesis_header)
+
+    txn_builder = vm_block_instance.get_transaction_builder()
+    assert txn_builder is not None
+    assert issubclass(txn_builder, TransactionBuilderAPI)
+
+    receipt_builder = vm_block_instance.get_receipt_builder()
+    assert receipt_builder is not None
+    assert issubclass(receipt_builder, ReceiptBuilderAPI)
+
+    bloom_filter = vm_block_instance.bloom_filter
+    assert bloom_filter is not None
+    assert isinstance(bloom_filter, BloomFilter)
+
+    assert vm_block_instance.number == genesis_header.block_number == 0
+    assert vm_block_instance.hash == genesis_header.hash


### PR DESCRIPTION
### What was wrong?

- `ShanghaiBlock` class was missing a receipt builder. This is not directly used in PyEVM but is used by `eth-tester`. Since `ShanghaiBlock` is the first time we've had to re-build from `BaseBlock` since the `__init__()` adds a new field, this was the first time in a while we were vulnerable to missing a configuration on the class. Since it wasn't directly tested here, we missed it.

### How was it fixed?

- Add the `LondonReceiptBuilder` to the `ShanghaiBlock` class since that's the latest version of the receipt builder (the last time a typed transaction was introduced was the type=2 transaction via EIP-1559, London).
- Add basic testing around Block class configuration to make sure each is wired up with the expected configuration classes.

### Todo:
- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20230328_091531](https://user-images.githubusercontent.com/3532824/235732066-d4d872bf-d47d-4230-a659-6a6a0607f9cb.jpg)
