### PR TITLE
Update ``ethereum/tests`` and turn on all Shanghai tests

### DIFF
--- a/newsfragments/2108.internal.rst
+++ b/newsfragments/2108.internal.rst
@@ -1,0 +1,1 @@
+Update ``fixtures`` (ethereum/tests) version to ``v12.2`` and turn on all Shanghai fork tests since EOF is no longer in Shanghai.

--- a/tests/json-fixtures/blockchain/test_blockchain.py
+++ b/tests/json-fixtures/blockchain/test_blockchain.py
@@ -1145,20 +1145,8 @@ INCORRECT_UPSTREAM_TESTS = {
 def blockchain_fixture_mark_fn(fixture_path, fixture_name, fixture_fork):
     fixture_id = (fixture_path, fixture_name)
 
-    if "bcExploitTest/" in fixture_path:
-        return pytest.mark.skip("Exploit tests are slow")
-    elif fixture_path.startswith("bcForkStressTest/ForkStressTest.json"):
-        return pytest.mark.skip("Fork stress tests are slow.")
-    elif fixture_path == "bcWalletTest/walletReorganizeOwners.json":
-        return pytest.mark.skip("Wallet owner reorganization tests are slow")
-    elif fixture_id in INCORRECT_UPSTREAM_TESTS:
-        return pytest.mark.xfail(
-            reason="Listed in INCORRECT_UPSTREAM_TESTS.",
-            strict=False,
-        )
-    elif "stTransactionTest/zeroSigTransa" in fixture_path:
-        return pytest.mark.skip("EIP-86 not supported.")
-    elif "HighNonce" in fixture_name:
+    # -- not expected to fail, need to be addressed -- #
+    if "HighNonce" in fixture_name:
         # TODO: Turn these tests on and implement the relevant changes to pass them
         #  https://github.com/ethereum/EIPs/pull/4784
         return pytest.mark.skip(
@@ -1172,6 +1160,22 @@ def blockchain_fixture_mark_fn(fixture_path, fixture_name, fixture_fork):
         #  Address these issues and turn these tests back on.
         #  https://github.com/ethereum/tests/blob/develop/BlockchainTests/GeneralStateTests/stCreateTest/CreateAddressWarmAfterFail.json#L4  # noqa: E501
         return pytest.mark.skip("Need support for EIP-2929 edge cases.")
+    elif "Pyspecs" in fixture_path:
+        # TODO: Turn on Pyspecs tests when we restructure the test suite
+        return pytest.mark.skip("Turn off Pyspecs tests for now.")
+
+    # -- expected skips and failures -- #
+    if "bcExploitTest/" in fixture_path:
+        return pytest.mark.skip("Exploit tests are slow")
+    elif fixture_path.startswith("bcForkStressTest/ForkStressTest.json"):
+        return pytest.mark.skip("Fork stress tests are slow.")
+    elif fixture_path == "bcWalletTest/walletReorganizeOwners.json":
+        return pytest.mark.skip("Wallet owner reorganization tests are slow")
+    elif fixture_id in INCORRECT_UPSTREAM_TESTS:
+        return pytest.mark.xfail(
+            reason="Listed in INCORRECT_UPSTREAM_TESTS.",
+            strict=False,
+        )
     elif fixture_id in SLOWEST_TESTS:
         if should_run_slow_tests():
             return
@@ -1179,6 +1183,9 @@ def blockchain_fixture_mark_fn(fixture_path, fixture_name, fixture_fork):
             return pytest.mark.skip("Skipping slow test")
     elif "stQuadraticComplexityTest" in fixture_path:
         return pytest.mark.skip("Skipping slow test")
+
+    elif "stTransactionTest/zeroSigTransa" in fixture_path:
+        return pytest.mark.skip("EIP-86 not supported.")
 
 
 def generate_ignore_fn_for_fork(passed_fork):

--- a/tox.ini
+++ b/tox.ini
@@ -54,8 +54,7 @@ commands=
     native-blockchain-berlin: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Berlin}
     native-blockchain-london: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork London}
     native-blockchain-merge: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Merge}
-    # TODO: Add EOF support and remove the `-k "not EOF"` filter
-    native-blockchain-shanghai: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Shanghai -k "not EOF"}
+    native-blockchain-shanghai: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Shanghai}
 
 
 deps =


### PR DESCRIPTION
- The latest release of ``ethereum/tests`` moves EOF to Cancun, which will be moved again to Prague since 4844 took precedence in Cacun. Either way, Shanghai tests no longer have EOF so we can remove the ``-k "not EOF"`` flag from the Shanghai tests

### Todo:
- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![IMG_5776](https://github.com/ethereum/py-evm/assets/3532824/01753fad-d508-410f-8ed5-c049a9b820d6)
