### PR TITLE
Properly decode all transaction test cases

### DIFF
--- a/newsfragments/2111.internal.rst
+++ b/newsfragments/2111.internal.rst
@@ -1,0 +1,1 @@
+Fix some failing tests by properly decoding the tx bytes provided by the Transaction test fixtures.

--- a/tests/json-fixtures/test_transactions.py
+++ b/tests/json-fixtures/test_transactions.py
@@ -106,13 +106,6 @@ def fixture(fixture_data):
 def fixture_transaction_class(fixture_data):
     _, test_name, fork_name = fixture_data
 
-    # TODO: Address these test issues in London, Berlin, and Paris / Merge
-    if test_name in (
-        "GasLimitPriceProductOverflowtMinusOne",
-        "accessListStorage32Bytes",
-    ):
-        pytest.skip("Failing tests that need to be addressed.")
-
     if fork_name == ForkName.Frontier:
         return FrontierTransaction
     elif fork_name == ForkName.Homestead:
@@ -148,7 +141,7 @@ def test_transaction_fixtures(fixture, fixture_transaction_class):
     TransactionClass = fixture_transaction_class
 
     try:
-        txn = rlp.decode(fixture["txbytes"], sedes=TransactionClass)
+        txn = TransactionClass.decode(fixture["txbytes"])
     except (rlp.DeserializationError, rlp.exceptions.DecodingError):
         assert "hash" not in fixture, "Transaction was supposed to be valid"
     except TypeError as err:


### PR DESCRIPTION
Since Berlin, the way we handle decoding isn't as straightforward as passing the encoded bytes object to rlp.decode using the class as the sedes. Properly handling decoding by directly calling the ``decode()`` method of the transaction builder classes (Berlin and above) is the best way to decode from bytes in a way that accounts for similar behavior across all fork Transaction / TransactionBuilder classes.

Closes #2075 

### Todo:
- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![IMG_20230517_133810](https://github.com/ethereum/py-evm/assets/3532824/5547624f-c619-4c18-82d0-639fe2c2c3c1)
