### PR TITLE
bump version for flake8, flake8-bugbear, mypy

### DIFF
--- a/newsfragments/2112.internal.rst
+++ b/newsfragments/2112.internal.rst
@@ -1,0 +1,1 @@
+bump version for flake8, flake8-bugbear, and mypy

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,10 @@ deps = {
         "importlib-metadata<5.0;python_version<'3.8'",
     ],
     "lint": [
-        "flake8==3.8.2",
-        "flake8-bugbear==20.1.4",
+        "flake8==6.0.0",  # flake8 claims semver but adds new warnings at minor releases, leave it pinned.
+        "flake8-bugbear==23.3.23",  # flake8-bugbear does not follow semver, leave it pinned.
         "isort>=5.10.1",
-        "mypy==0.910",
+        "mypy==0.971",  # mypy does not follow semver, leave it pinned.
         "pydocstyle>=6.0.0",
         "black>=23",
         "types-setuptools",


### PR DESCRIPTION
### What was wrong?

Lint dependencies were not bumped in the template update

### How was it fixed?

bumped

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-evm/assets/5199899/bbaa7ff7-1475-4cfb-9160-f461a813b6be)