### PR TITLE
bump versions for lint, cleanup setup.py and tox.ini, docs ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,13 @@ common: &common
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
+  docs:
+    <<: *common
+    docker:
+      - image: cimg/python:3.8
+        environment:
+          TOXENV: docs
+
   py39-native-blockchain-berlin:
     <<: *common
     docker:
@@ -144,13 +151,6 @@ jobs:
         environment:
           TOXENV: py39-native-blockchain-shanghai
 
-  py39-docs:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-        environment:
-          TOXENV: py39-docs
-
   py37-core:
     <<: *common
     docker:
@@ -181,12 +181,6 @@ jobs:
       - image: cimg/python:3.7
         environment:
           TOXENV: py37-vm
-  py37-lint:
-    <<: *common
-    docker:
-      - image: cimg/python:3.7
-        environment:
-          TOXENV: py37-lint
 
   py38-core:
     <<: *common
@@ -266,6 +260,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - docs
       - py39-native-blockchain-berlin
       - py39-native-blockchain-byzantium
       - py39-native-blockchain-constantinople
@@ -294,7 +289,5 @@ workflows:
       - py37-database
       - py38-database
       - py39-database
-      - py39-docs
-      - py37-lint
       - py38-lint
       - py39-lint

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,16 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+   configuration: docs/conf.py
+
 python:
   install:
     - method: pip
       path: .
       extra_requirements:
-        - doc
+        - docs

--- a/eth/abc.py
+++ b/eth/abc.py
@@ -241,7 +241,7 @@ class ReceiptAPI(ABC):
         ...
 
     # We can remove this API and inherit from rlp.Serializable when it becomes typesafe
-    def copy(self, *args: Any, **kwargs: Any) -> "ReceiptAPI":
+    def copy(self, *args: Any, **kwargs: Any) -> "ReceiptAPI":  # noqa: B027
         """
         Return a copy of the receipt, optionally overwriting any of its properties.
         """
@@ -876,7 +876,7 @@ class BlockAPI(ABC):
         ...
 
     # We can remove this API and inherit from rlp.Serializable when it becomes typesafe
-    def copy(self, *args: Any, **kwargs: Any) -> "BlockAPI":
+    def copy(self, *args: Any, **kwargs: Any) -> "BlockAPI":  # noqa: B027
         """
         Return a copy of the block, optionally overwriting any of its properties.
         """
@@ -3902,7 +3902,9 @@ class HeaderChainAPI(ABC):
     #
     # Canonical Chain API
     #
-    def get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
+    def get_canonical_block_hash(  # noqa: B027
+        self, block_number: BlockNumber
+    ) -> Hash32:
         """
         Direct passthrough to `headerdb`
         """

--- a/eth/db/__init__.py
+++ b/eth/db/__init__.py
@@ -21,4 +21,4 @@ def get_db_backend_class(import_path: str = None) -> Type[AtomicDatabaseAPI]:
 def get_db_backend(import_path: str = None, **init_kwargs: Any) -> AtomicDatabaseAPI:
     backend_class = get_db_backend_class(import_path)
     # mypy doesn't understand the constructor  of AtomicDatabaseAPI
-    return backend_class(**init_kwargs)  # type: ignore
+    return backend_class(**init_kwargs)

--- a/eth/db/chain.py
+++ b/eth/db/chain.py
@@ -461,7 +461,7 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
                 f"Receipt with index {receipt_index} not found in block"
             )
 
-    @functools.lru_cache(maxsize=32)
+    @functools.lru_cache(maxsize=32)  # noqa: B019
     @to_tuple
     def _get_block_transactions(
         self, transaction_root: Hash32, transaction_decoder: Type[TransactionDecoderAPI]
@@ -515,7 +515,7 @@ class ChainDB(HeaderDB, ChainDatabaseAPI):
     ) -> Tuple[WithdrawalAPI, ...]:
         return self._get_block_withdrawals(header.withdrawals_root)
 
-    @functools.lru_cache(maxsize=32)
+    @functools.lru_cache(maxsize=32)  # noqa: B019
     @to_tuple
     def _get_block_withdrawals(
         self,

--- a/eth/tools/_utils/deprecation.py
+++ b/eth/tools/_utils/deprecation.py
@@ -20,6 +20,7 @@ def deprecate_method(func: TFunc, message: str = None) -> TFunc:
                 or f"{func.__name__} is deprecated. "
                 "A breaking change is expected in a future release."
             ),
+            stacklevel=2,
         )
         func(*args, **kwargs)
 

--- a/eth/tools/db/atomic.py
+++ b/eth/tools/db/atomic.py
@@ -105,7 +105,7 @@ class AtomicDatabaseBatchAPITestSuite:
 
         # exists
         with pytest.raises(ValidationError):
-            b"1" in batch
+            assert b"1" in batch
 
         with pytest.raises(ValidationError):
             batch.exists(b"1")

--- a/eth/tools/fixtures/fillers/common.py
+++ b/eth/tools/fixtures/fillers/common.py
@@ -97,7 +97,7 @@ DEFAULT_EXECUTION = {
 
 Test = namedtuple("Test", ["filler", "fill_kwargs"])
 # make `None` default for fill_kwargs
-Test.__new__.__defaults__ = (None,)  # type: ignore
+Test.__new__.__defaults__ = (None,)
 
 
 #

--- a/newsfragments/2113.internal.rst
+++ b/newsfragments/2113.internal.rst
@@ -1,0 +1,1 @@
+bump version for flake8, flake8-bugbear, and mypy, and cleanup `tox.ini`

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -11,7 +11,7 @@ Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 * `feature`
 * `bugfix`
 * `performance`
-* `doc`
+* `docs`
 * `internal`
 * `removal`
 * `misc`

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -9,7 +9,7 @@ import sys
 ALLOWED_EXTENSIONS = {
     ".breaking.rst",
     ".bugfix.rst",
-    ".doc.rst",
+    ".docs.rst",
     ".feature.rst",
     ".internal.rst",
     ".misc.rst",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ name = "Performance improvements"
 showcontent = true
 
 [[tool.towncrier.type]]
-directory = "doc"
+directory = "docs"
 name = "Improved Documentation"
 showcontent = true
 

--- a/scripts/benchmark/checks/deploy_dos.py
+++ b/scripts/benchmark/checks/deploy_dos.py
@@ -86,7 +86,9 @@ class BaseDOSContractBenchmark(BaseBenchmark):
             self._setup_benchmark(chain)
 
             value = self.as_timed_result(
-                lambda: self.mine_blocks(chain, self.num_blocks, self.num_tx)
+                lambda chain=chain: self.mine_blocks(
+                    chain, self.num_blocks, self.num_tx
+                )
             )
 
             total_gas_used, total_num_tx = value.wrapped_value

--- a/scripts/benchmark/checks/erc20_interact.py
+++ b/scripts/benchmark/checks/erc20_interact.py
@@ -88,7 +88,9 @@ class BaseERC20Benchmark(BaseBenchmark):
 
             # Perform the actual work that is measured
             value = self.as_timed_result(
-                lambda: self.mine_blocks(chain, self.num_blocks, self.num_tx)
+                lambda chain=chain: self.mine_blocks(
+                    chain, self.num_blocks, self.num_tx
+                )
             )
             total_gas_used, total_num_tx = value.wrapped_value
             stat = DefaultStat(

--- a/scripts/benchmark/checks/import_empty_blocks.py
+++ b/scripts/benchmark/checks/import_empty_blocks.py
@@ -32,7 +32,7 @@ class ImportEmptyBlocksBenchmark(BaseBenchmark):
 
         for chain in get_all_chains():
             val = self.as_timed_result(
-                lambda: self.import_empty_blocks(chain, self.num_blocks)
+                lambda chain=chain: self.import_empty_blocks(chain, self.num_blocks)
             )
             stat = DefaultStat(
                 caption=chain.get_vm().fork,

--- a/scripts/benchmark/checks/mine_empty_blocks.py
+++ b/scripts/benchmark/checks/mine_empty_blocks.py
@@ -32,7 +32,7 @@ class MineEmptyBlocksBenchmark(BaseBenchmark):
 
         for chain in get_all_chains():
             value = self.as_timed_result(
-                lambda: self.mine_empty_blocks(chain, self.num_blocks)
+                lambda chain=chain: self.mine_empty_blocks(chain, self.num_blocks)
             )
 
             stat = DefaultStat(

--- a/scripts/benchmark/checks/simple_value_transfers.py
+++ b/scripts/benchmark/checks/simple_value_transfers.py
@@ -77,7 +77,9 @@ class SimpleValueTransferBenchmark(BaseBenchmark):
         for chain in get_all_chains():
             self._next_nonce = None
 
-            value = self.as_timed_result(lambda: self.mine_blocks(chain, num_blocks))
+            value = self.as_timed_result(
+                lambda chain=chain: self.mine_blocks(chain, num_blocks)
+            )
 
             total_gas_used, total_num_tx = value.wrapped_value
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import setup, find_packages
+from setuptools import (
+    setup,
+    find_packages,
+)
 
 
-deps = {
+extras_require = {
     "eth": [
         "cached-property>=1.5.1,<2",
         "eth-bloom>=1.0.3",
@@ -41,10 +44,10 @@ deps = {
         "importlib-metadata<5.0;python_version<'3.8'",
     ],
     "lint": [
-        "flake8==3.8.2",
-        "flake8-bugbear==20.1.4",
+        "flake8==6.0.0",  # flake8 claims semver but adds new warnings at minor releases, leave it pinned.
+        "flake8-bugbear==23.3.23",  # flake8-bugbear does not follow semver, leave it pinned.
         "isort>=5.10.1",
-        "mypy==0.910",
+        "mypy==0.971",  # mypy does not follow semver, leave it pinned.
         "pydocstyle>=6.0.0",
         "black>=23",
         "types-setuptools",
@@ -54,7 +57,7 @@ deps = {
         "termcolor>=1.1.0,<2.0.0",
         "web3>=4.1.0,<5.0.0",
     ],
-    "doc": [
+    "docs": [
         "py-evm>=0.2.0-a.14",
         # We need to have pysha for autodoc to be able to extract API docs
         "pysha3>=1.0.0,<2.0.0",
@@ -73,16 +76,21 @@ deps = {
         "idna==2.7",
         # idna 2.7 is not supported by requests 2.18
         "requests>=2.20,<3",
-        "tox==2.7.0",
+        "tox>=4.0.0",
         "twine",
     ],
 }
 
 
-deps["dev"] = deps["dev"] + deps["eth"] + deps["test"] + deps["doc"] + deps["lint"]
+extras_require["dev"] = (
+    extras_require["dev"]
+    + extras_require["eth"]
+    + extras_require["test"]
+    + extras_require["lint"]
+    + extras_require["docs"]
+)
 
-
-install_requires = deps["eth"]
+install_requires = extras_require["eth"]
 
 with open("README.md") as readme_file:
     long_description = readme_file.read()
@@ -100,7 +108,7 @@ setup(
     include_package_data=True,
     py_modules=["eth"],
     install_requires=install_requires,
-    extras_require=deps,
+    extras_require=extras_require,
     license="MIT",
     zip_safe=False,
     keywords="ethereum blockchain evm",

--- a/tests/core/consensus/test_clique_utils.py
+++ b/tests/core/consensus/test_clique_utils.py
@@ -193,7 +193,7 @@ UNSIGNED_HEADER = GOERLI_HEADER_ONE.copy(
 )
 def test_get_signer(header, expected_signer):
     signer = get_block_signer(header)
-    signer is expected_signer
+    assert signer == expected_signer
 
 
 @pytest.mark.parametrize(

--- a/tests/database/test_leveldb_db_backend.py
+++ b/tests/database/test_leveldb_db_backend.py
@@ -57,7 +57,7 @@ def test_set_on_existing_value(level_db, memory_db):
 def test_exists(level_db, memory_db):
     level_db.set(b"1", b"2")
     memory_db.set(b"1", b"1")
-    level_db.exists(b"1") == memory_db.exists(b"1")
+    assert level_db.exists(b"1") == memory_db.exists(b"1")
 
 
 def test_delete(level_db, memory_db):

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ envlist=
         spurious_dragon, byzantium, constantinople, petersburg, istanbul, \
         berlin, london, merge, shanghai \
     }
-    py{37,38,39}-lint
-    py39-docs
+    py{38,39}-lint
+    docs
 
 [isort]
 combine_as_imports=True
@@ -37,6 +37,7 @@ passenv =
     TRAVIS_EVENT_TYPE
 commands=
     core: pytest {posargs:tests/core/}
+    docs: make validate-docs
     database: pytest {posargs:tests/database}
     difficulty: pytest {posargs:tests/json-fixtures/test_difficulty.py}
     transactions: pytest {posargs:tests/json-fixtures/test_transactions.py}
@@ -55,15 +56,16 @@ commands=
     native-blockchain-london: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork London}
     native-blockchain-merge: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Merge}
     native-blockchain-shanghai: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Shanghai}
-
-
-deps =
-    .[eth-extra,test]
-
 basepython =
+    docs: python
     py37: python3.7
     py38: python3.8
     py39: python3.9
+extras=
+    docs
+    eth-extra
+    test
+allowlist_externals=make
 
 [common-lint]
 deps: .[eth,lint]
@@ -78,16 +80,6 @@ basepython: python
 deps: {[common-lint]deps}
 commands: {[common-lint]commands}
 
-[testenv:py{36,37,38,39}-lint]
-deps: {[common-lint]deps}
+[testenv:py{38,39}-lint]
+extras: {[common-lint]extras}
 commands: {[common-lint]commands}
-
-[testenv:py39-docs]
-allowlist_externals=
-    make
-deps = .[doc,eth-extra]
-passenv =
-    PYTEST_ADDOPTS
-    TRAVIS_EVENT_TYPE
-commands=
-    make validate-docs

--- a/tox.ini
+++ b/tox.ini
@@ -23,12 +23,7 @@ skip=__init__.py
 [flake8]
 max-line-length= 88
 exclude=venv*,.tox,docs,build
-ignore =
-    # W503 line break before binary operator
-    # It's either this or W504 (line break _after_ binary operator), pick your poison.
-    # W503 gets enabled when any "ignore =" config is added (even the empty one), see:
-    # https://github.com/ethereum/py-evm/pull/1940#discussion_r432606845
-    W503,E203
+extend-ignore= E203,W503
 
 [testenv]
 usedevelop=True
@@ -68,8 +63,10 @@ extras=
 allowlist_externals=make
 
 [common-lint]
-deps: .[eth,lint]
-commands:
+basepython=python
+extras=lint
+allowlist_externals=black
+commands=
     flake8 {toxinidir}/eth {toxinidir}/tests {toxinidir}/scripts
     mypy -p eth --config-file {toxinidir}/mypy.ini
     isort --check-only --diff {toxinidir}/eth/ {toxinidir}/tests/ {toxinidir}/scripts/
@@ -77,7 +74,7 @@ commands:
 
 [testenv:lint]
 basepython: python
-deps: {[common-lint]deps}
+extras: {[common-lint]extras}
 commands: {[common-lint]commands}
 
 [testenv:py{38,39}-lint]


### PR DESCRIPTION
### What was wrong?

Lint dependencies were not bumped in the template update
`tox.ini` and `setup.py`could use some cleanup

### How was it fixed?

bumped version for flake8, flake8-bugbear, mypy
bumped tox version and cleaned up `tox.ini` and 'setup.py`
set docs build to template standard

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-evm/assets/5199899/bbaa7ff7-1475-4cfb-9160-f461a813b6be)