### PR TITLE
update CodeStream slot name pc to program_counter

### DIFF
--- a/eth/vm/code_stream.py
+++ b/eth/vm/code_stream.py
@@ -24,17 +24,17 @@ class CodeStream(CodeStreamAPI):
         "_raw_code_bytes",
         "invalid_positions",
         "valid_positions",
-        "pc",
+        "program_counter",
     ]
 
     logger = logging.getLogger("eth.vm.CodeStream")
 
     def __init__(self, code_bytes: bytes) -> None:
         validate_is_bytes(code_bytes, title="CodeStream bytes")
-        # in order to avoid method overhead when setting/accessing pc, we no longer
-        # fence the pc (Program Counter) into 0 <= pc <= len(code_bytes).
+        # in order to avoid method overhead when setting/accessing program_counter,
+        # we no longer fence it into 0 <= program_counter <= len(code_bytes).
         # We now let it float free.
-        # NOTE: Setting pc to a negative value has undefined behavior.
+        # NOTE: Setting program_counter to a negative value has undefined behavior.
         self.program_counter = 0
         self._raw_code_bytes = code_bytes
         self._length_cache = len(code_bytes)

--- a/newsfragments/2109.bugfix.rst
+++ b/newsfragments/2109.bugfix.rst
@@ -1,0 +1,1 @@
+Updated `CodeStream` slot name `pc` to `program_counter` to match the attribute name


### PR DESCRIPTION
### What was wrong?

`pc` was used in the `__slots__` list, but `program_counter` was used throughout the rest of the `CodeStream` class.
Closes #2109 

### How was it fixed?
Changed slot `pc` to `program_counter`.
Quick `timeit` tests showed ~25% faster access to `program_counter` :tada: 

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-evm/assets/5199899/7e00cb49-d3e9-4643-8b1f-9887f3b48d02)
