### PR TITLE
fix: make KeyMapDB deep-copiable

### DIFF
--- a/eth/db/keymap.py
+++ b/eth/db/keymap.py
@@ -44,7 +44,7 @@ class KeyMapDB(BaseDB):
         return mapped_key in self._db
 
     def __getattr__(self, attr: Any) -> Any:
-        return getattr(self._db, attr)
+        return getattr(super().__getattribute__("_db"), attr)
 
     def __setattr__(self, attr: Any, val: Any) -> None:
         if attr in ("_db", "keymap"):

--- a/newsfragments/2116.bugfix.rst
+++ b/newsfragments/2116.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``__getattr__()`` for ``KeyMapDB`` and thus allow it to be copied / deep copied.

--- a/tests/core/db/test_keymap_db.py
+++ b/tests/core/db/test_keymap_db.py
@@ -1,0 +1,22 @@
+import copy
+
+from eth.db.backends.memory import (
+    MemoryDB,
+)
+from eth.db.hash_trie import (
+    HashTrie,
+)
+
+
+def test_keymap_db_can_be_copied_and_deep_copied():
+    hash_trie = HashTrie(MemoryDB({b"a": b"1", b"b": b"2"}))
+
+    copied_hash_trie = copy.copy(hash_trie)
+    deep_copied_hash_trie = copy.deepcopy(hash_trie)
+
+    assert hash_trie._db == copied_hash_trie._db
+    assert hash_trie._db == deep_copied_hash_trie._db
+
+    hash_trie[b"c"] = b"3"
+    assert b"c" in hash_trie
+    assert b"c" not in deep_copied_hash_trie


### PR DESCRIPTION
### What was wrong?
KeyMapDB would segfault on deepcopy, due to recursion in `__getattr__`

### How was it fixed?

### Todo:
- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

`0_o`