### PR TITLE
fix doc typo for `validate_block` function

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -3769,7 +3769,7 @@ class VirtualMachineAPI(ConfigurableAPI):
     @abstractmethod
     def validate_block(self, block: BlockAPI) -> None:
         """
-        Validate the the given block.
+        Validate the given block.
         """
         ...
 


### PR DESCRIPTION
### What was wrong?

Simple typo fix.