### PR TITLE
fix eth_now()

### DIFF
--- a/eth/_utils/headers.py
+++ b/eth/_utils/headers.py
@@ -34,7 +34,7 @@ def eth_now() -> int:
     """
     The timestamp is in UTC.
     """
-    return int(datetime.datetime.utcnow().timestamp())
+    return int(datetime.datetime.now(datetime.timezone.utc).timestamp())
 
 
 def new_timestamp_from_parent(parent: Optional[BlockHeaderAPI]) -> int:

--- a/newsfragments/2119.bugfix.rst
+++ b/newsfragments/2119.bugfix.rst
@@ -1,0 +1,1 @@
+``eth_now`` now returns a utc timestamp instead of a local timestamp


### PR DESCRIPTION
utcnow() returns a local time, which for computers in any time zone besides utc will result in an eth_now() value being shifted forwards or backwards by the distance from utc.

### What was wrong?

Related to Issue #
Closes Issue #

### How was it fixed?

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()