### PR TITLE
Add cancun tests; silence for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,12 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-native-blockchain-byzantium
+  py311-native-blockchain-cancun:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-native-blockchain-cancun
   py311-native-blockchain-constantinople:
     <<: *common
     docker:
@@ -360,6 +366,7 @@ workflows:
       - docs
       - py311-native-blockchain-berlin
       - py311-native-blockchain-byzantium
+#      - py311-native-blockchain-cancun  # TODO: re-enable when we have tests passing
       - py311-native-blockchain-constantinople
       - py311-native-blockchain-frontier
       - py311-native-blockchain-homestead

--- a/tests/json-fixtures/blockchain/test_blockchain.py
+++ b/tests/json-fixtures/blockchain/test_blockchain.py
@@ -10,6 +10,10 @@ from eth_utils import (
 import pytest
 import rlp
 
+from eth.exceptions import (
+    OutOfGas,
+    UnrecognizedTransactionType,
+)
 from eth.tools._utils.normalization import (
     normalize_blockchain_fixtures,
 )
@@ -1231,6 +1235,8 @@ EXPECTED_BAD_BLOCK_EXCEPTIONS = (
     rlp.DeserializationError,
     ValidationError,
     AssertionError,
+    UnrecognizedTransactionType,
+    OutOfGas,
 )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist=
     py311-native-blockchain-{ \
         metropolis, transition, frontier, homestead, tangerine_whistle, \
         spurious_dragon, byzantium, constantinople, petersburg, istanbul, \
-        berlin, london, merge, shanghai \
+        berlin, london, merge, shanghai, cancun \
     }
 
 [flake8]
@@ -43,6 +43,7 @@ commands=
     native-blockchain-london: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork London}
     native-blockchain-merge: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Merge}
     native-blockchain-shanghai: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Shanghai}
+    native-blockchain-cancun: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Cancun}
 basepython =
     docs: python
     py38: python3.8


### PR DESCRIPTION
### What was wrong?

- Update `ethereum/tests` (fixtures submodule) to latest release, `v13`
- Add cancun test run to `tox.ini` but silence it in circleci config for now since everything will be failing

This PR is meant to be tested as a test run but we should be able to merge into the base branch before starting implementation on separate EIP PRs