### PR TITLE
Drop the concept of pre-mining header post merge

### DIFF
--- a/eth/vm/forks/paris/blocks.py
+++ b/eth/vm/forks/paris/blocks.py
@@ -5,6 +5,9 @@ from typing import (
     Type,
 )
 
+from eth_typing import (
+    Hash32,
+)
 from eth_utils import (
     encode_hex,
 )
@@ -18,7 +21,6 @@ from eth.abc import (
 from eth.vm.forks.gray_glacier.blocks import (
     GrayGlacierBlock,
     GrayGlacierBlockHeader,
-    GrayGlacierMiningHeader,
 )
 
 from ..london.blocks import (
@@ -29,13 +31,13 @@ from .transactions import (
 )
 
 
-class ParisMiningHeader(GrayGlacierMiningHeader, ABC):
-    pass
-
-
 class ParisBlockHeader(GrayGlacierBlockHeader, ABC):
     def __str__(self) -> str:
         return f"<ParisBlockHeader #{self.block_number} {encode_hex(self.hash)[2:10]}>"
+
+    @property
+    def mining_hash(self) -> Hash32:
+        raise ValueError("Mining hash is not available post merge.")
 
 
 class ParisBlock(GrayGlacierBlock):

--- a/eth/vm/forks/shanghai/blocks.py
+++ b/eth/vm/forks/shanghai/blocks.py
@@ -39,7 +39,6 @@ from eth.abc import (
     BlockHeaderAPI,
     BlockHeaderSedesAPI,
     ChainDatabaseAPI,
-    MiningHeaderAPI,
     ReceiptAPI,
     ReceiptBuilderAPI,
     SignedTransactionAPI,
@@ -84,40 +83,27 @@ from .withdrawals import (
     Withdrawal,
 )
 
-UNMINED_SHANGHAI_HEADER_FIELDS = [
-    ("parent_hash", hash32),
-    ("uncles_hash", hash32),
-    ("coinbase", address),
-    ("state_root", trie_root),
-    ("transaction_root", trie_root),
-    ("receipt_root", trie_root),
-    ("bloom", uint256),
-    ("difficulty", big_endian_int),
-    ("block_number", big_endian_int),
-    ("gas_limit", big_endian_int),
-    ("gas_used", big_endian_int),
-    ("timestamp", big_endian_int),
-    ("extra_data", binary),
-    ("base_fee_per_gas", big_endian_int),
-    ("withdrawals_root", trie_root),
-]
-
-
-class ShanghaiMiningHeader(rlp.Serializable, MiningHeaderAPI, ABC):
-    fields = UNMINED_SHANGHAI_HEADER_FIELDS
-
 
 class ShanghaiBlockHeader(rlp.Serializable, BlockHeaderAPI, ABC):
-    # `mix_hash` and `nonce` were fields before `base_fee_per_gas` and
-    # `withdrawals_root` and, thus, appear in the block header before them.
-    fields = (
-        UNMINED_SHANGHAI_HEADER_FIELDS[:13]
-        + [
-            ("mix_hash", binary),
-            ("nonce", Binary(8, allow_empty=True)),
-        ]
-        + UNMINED_SHANGHAI_HEADER_FIELDS[13:]
-    )
+    fields = [
+        ("parent_hash", hash32),
+        ("uncles_hash", hash32),
+        ("coinbase", address),
+        ("state_root", trie_root),
+        ("transaction_root", trie_root),
+        ("receipt_root", trie_root),
+        ("bloom", uint256),
+        ("difficulty", big_endian_int),
+        ("block_number", big_endian_int),
+        ("gas_limit", big_endian_int),
+        ("gas_used", big_endian_int),
+        ("timestamp", big_endian_int),
+        ("extra_data", binary),
+        ("mix_hash", binary),
+        ("nonce", Binary(8, allow_empty=True)),
+        ("base_fee_per_gas", big_endian_int),
+        ("withdrawals_root", trie_root),
+    ]
 
     def __init__(
         self,
@@ -185,9 +171,7 @@ class ShanghaiBlockHeader(rlp.Serializable, BlockHeaderAPI, ABC):
 
     @property
     def mining_hash(self) -> Hash32:
-        non_pow_fields = self[:-3] + self[-1:]
-        result = keccak(rlp.encode(non_pow_fields, ShanghaiMiningHeader))
-        return cast(Hash32, result)
+        raise ValueError("Mining hash is not available post merge.")
 
     @property
     def hex_hash(self) -> str:


### PR DESCRIPTION
### What was wrong?

- `Paris` network and above still defined a `MiningHeader` class which isn't necessary.

### How was it fixed?

- Remove the concept of a pre-mining header post-merge by removing the `MiningHeader` class beginning with the `Paris` network upgrade.
- Raise when trying to call `block.mining_hash`, post `Paris` network upgrade.

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![1000021254](https://github.com/ethereum/py-evm/assets/3532824/9f11faba-a46a-4842-8726-478e2e9d766e)

