### PR TITLE
Turn on pyspec generated tests

### DIFF
--- a/eth/tools/_utils/normalization.py
+++ b/eth/tools/_utils/normalization.py
@@ -508,7 +508,7 @@ def normalize_signed_transaction(transaction: Dict[str, Any]) -> Dict[str, Any]:
     }
     if "type" in transaction:
         type_id = to_int(transaction["type"])
-        if type_id == 1:
+        if type_id in (0, 1):
             custom_fields = {
                 "type": type_id,
                 "gasPrice": to_int(transaction["gasPrice"]),

--- a/newsfragments/2136.bugfix.rst
+++ b/newsfragments/2136.bugfix.rst
@@ -1,0 +1,1 @@
+Accept ``type==0`` as legacy a transaction.

--- a/newsfragments/2136.internal.rst
+++ b/newsfragments/2136.internal.rst
@@ -1,0 +1,1 @@
+Update `ethereum/tests` test fixture to use ``v13``.

--- a/tests/json-fixtures/blockchain/test_blockchain.py
+++ b/tests/json-fixtures/blockchain/test_blockchain.py
@@ -1145,10 +1145,6 @@ INCORRECT_UPSTREAM_TESTS = {
 def blockchain_fixture_mark_fn(fixture_path, fixture_name, fixture_fork):
     fixture_id = (fixture_path, fixture_name)
 
-    if "Pyspecs" in fixture_path:
-        # TODO: Turn on Pyspecs tests when we restructure the test suite
-        return pytest.mark.skip("Turn off Pyspecs tests for now.")
-
     # -- expected skips and failures -- #
     if "bcExploitTest/" in fixture_path:
         return pytest.mark.skip("Exploit tests are slow")

--- a/tests/json-fixtures/blockchain/test_blockchain.py
+++ b/tests/json-fixtures/blockchain/test_blockchain.py
@@ -10,6 +10,10 @@ from eth_utils import (
 import pytest
 import rlp
 
+from eth.exceptions import (
+    OutOfGas,
+    UnrecognizedTransactionType,
+)
 from eth.tools._utils.normalization import (
     normalize_blockchain_fixtures,
 )
@@ -1227,6 +1231,8 @@ EXPECTED_BAD_BLOCK_EXCEPTIONS = (
     rlp.DeserializationError,
     ValidationError,
     AssertionError,
+    UnrecognizedTransactionType,
+    OutOfGas,
 )
 
 


### PR DESCRIPTION
### What was wrong?

- There are some new tests under the PySpecs directory that we should turn on.

### How was it fixed?

- Update test fixture to use the latest, `v13`
- Turn on the pyspec tests and address failing tests:
  - We can accept `type==0` as legacy transactions
  - Handle expected failures based on transaction type
  
These changes are better addressed separately but they are necessary for passing the cancun branch

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![WhatsApp Image 2024-01-23 at 14 46 07](https://github.com/ethereum/py-evm/assets/3532824/25135f90-fb00-42af-8204-739287be734b)

