### PR TITLE
Create CI-only docs builds for additional formats, update docs Makefile, add deletion of unused autogen docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,9 +90,19 @@ windows_steps: &windows_steps
           - .tox
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
+docs: &docs
+  docker:
+    - image: common
+  steps:
+    - run:
+        name: install latexpdf dependencies
+        command: |
+          sudo apt-get update
+          sudo apt-get install latexmk tex-gyre texlive-fonts-extra
+
 jobs:
   docs:
-    <<: *common
+    <<: *docs
     docker:
       - image: cimg/python:3.8
         environment:

--- a/2137.internal.rst
+++ b/2137.internal.rst
@@ -1,0 +1,1 @@
+Fix epub docs build issue, add pdf and epub docs builds to CI

--- a/Makefile
+++ b/Makefile
@@ -42,16 +42,19 @@ build-docs:
 	sphinx-apidoc -o docs/ . setup.py "*conftest*"
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
-	$(MAKE) -C docs latexpdf
-	$(MAKE) -C docs epub
 	$(MAKE) -C docs doctest
 
-doctest:
-	cd docs/; sphinx-build -T -b doctest . _build/doctest
+build-docs-ci:
+	$(MAKE) -C docs latexpdf
+	$(MAKE) -C docs epub
 
-validate-docs: build-docs doctest
+validate-newsfragments:
 	./newsfragments/validate_files.py
 	towncrier build --draft
+
+validate-docs: build-docs validate-newsfragments
+
+validate-docs-ci: build-docs build-docs-ci validate-newsfragments
 
 docs: build-docs
 	open docs/_build/html/index.html

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ build-docs:
 	sphinx-apidoc -o docs/ . setup.py "*conftest*"
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
+	$(MAKE) -C docs latexpdf
+	$(MAKE) -C docs epub
 	$(MAKE) -C docs doctest
 
 doctest:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-# Minimal makefile for Sphinx documentation
+# Makefile for Sphinx documentation
 #
 
 # You can set these variables from the command line.
@@ -6,15 +6,175 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = py-evm
 SOURCEDIR     = .
+PAPER         =
 BUILDDIR      = _build
 
-# Put it first so that "make" without argument is like "make help".
+# User-friendly check for sphinx-build
+ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+endif
+
+# Internal variables.
+PAPEROPT_a4     = -D latex_paper_size=a4
+PAPEROPT_letter = -D latex_paper_size=letter
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+# the i18n builder cannot share the environment and doctrees with the others
+I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  html       to make standalone HTML files"
+	@echo "  dirhtml    to make HTML files named index.html in directories"
+	@echo "  singlehtml to make a single large HTML file"
+	@echo "  pickle     to make pickle files"
+	@echo "  json       to make JSON files"
+	@echo "  htmlhelp   to make HTML files and a HTML help project"
+	@echo "  qthelp     to make HTML files and a qthelp project"
+	@echo "  devhelp    to make HTML files and a Devhelp project"
+	@echo "  epub       to make an epub"
+	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
+	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
+	@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
+	@echo "  text       to make text files"
+	@echo "  man        to make manual pages"
+	@echo "  texinfo    to make Texinfo files"
+	@echo "  info       to make Texinfo files and run them through makeinfo"
+	@echo "  gettext    to make PO message catalogs"
+	@echo "  changes    to make an overview of all changed/added/deprecated items"
+	@echo "  xml        to make Docutils-native XML files"
+	@echo "  pseudoxml  to make pseudoxml-XML files for display purposes"
+	@echo "  linkcheck  to check all external links for integrity"
+	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
-.PHONY: help Makefile
+clean:
+	rm -rf $(BUILDDIR)/*
+	rm eth.* scripts.* tests.*
 
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+html:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+dirhtml:
+	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+
+singlehtml:
+	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
+	@echo
+	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
+
+pickle:
+	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
+	@echo
+	@echo "Build finished; now you can process the pickle files."
+
+json:
+	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
+	@echo
+	@echo "Build finished; now you can process the JSON files."
+
+htmlhelp:
+	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
+	@echo
+	@echo "Build finished; now you can run HTML Help Workshop with the" \
+	      ".hhp project file in $(BUILDDIR)/htmlhelp."
+
+qthelp:
+	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
+	@echo
+	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
+	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/<MODULE_NAME>.qhcp"
+	@echo "To view the help file:"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/<MODULE_NAME>.qhc"
+
+devhelp:
+	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
+	@echo
+	@echo "Build finished."
+	@echo "To view the help file:"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/<MODULE_NAME>"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/<MODULE_NAME>"
+	@echo "# devhelp"
+
+epub:
+	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+	@echo
+	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
+
+latex:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo
+	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
+	@echo "Run \`make' in that directory to run these through (pdf)latex" \
+	      "(use \`make latexpdf' here to do that automatically)."
+
+latexpdf:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo "Running LaTeX files through pdflatex..."
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+
+latexpdfja:
+	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	@echo "Running LaTeX files through platex and dvipdfmx..."
+	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
+	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+
+text:
+	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
+	@echo
+	@echo "Build finished. The text files are in $(BUILDDIR)/text."
+
+man:
+	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	@echo
+	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
+
+texinfo:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	@echo
+	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
+	@echo "Run \`make' in that directory to run these through makeinfo" \
+	      "(use \`make info' here to do that automatically)."
+
+info:
+	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	@echo "Running Texinfo files through makeinfo..."
+	make -C $(BUILDDIR)/texinfo info
+	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
+
+gettext:
+	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
+	@echo
+	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
+
+changes:
+	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
+	@echo
+	@echo "The overview file is in $(BUILDDIR)/changes."
+
+linkcheck:
+	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	@echo
+	@echo "Link check complete; look for any errors in the above output " \
+	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
+doctest:
+	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
+	@echo "Testing of doctests in the sources finished, look at the " \
+	      "results in $(BUILDDIR)/doctest/output.txt."
+
+xml:
+	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
+	@echo
+	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
+
+pseudoxml:
+	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
+	@echo
+	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -7,7 +7,7 @@ This section aims to provide hands-on guides to demonstrate how to use Py-EVM. I
    :maxdepth: 2
    :name: toc-eth-guides
 
-   quickstart
+   installation
    building_an_app_that_uses_pyevm
    architecture
    understanding_the_mining_process

--- a/docs/guides/installation.rst
+++ b/docs/guides/installation.rst
@@ -1,8 +1,6 @@
-Quickstart
-==========
-
 Installation
-~~~~~~~~~~~~
+============
+
 
 This guide teaches how to use Py-EVM as a library. For contributors, please check out the
 :doc:`Contributing Guide </contributing>` which explains how to set everything up for development.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,6 @@ Table of contents
    :caption: General
 
    introduction
-   guides/quickstart
    release_notes
 
 .. toctree::

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -26,6 +26,11 @@ The main focus is to enrich the Ethereum ecosystem with a Python implementation 
   * Consortium chains
   * Advanced research
 
+Usage
+-----
+
+Check out our :doc:`guides </guides/installation>` to get started using
+the ``py-evm`` library.
 
 Further reading
 ---------------

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ per-file-ignores=__init__.py:F401
 [testenv]
 commands=
     core: pytest {posargs:tests/core/}
-    docs: make validate-docs
+    docs: make validate-docs-ci
     database: pytest {posargs:tests/database}
     difficulty: pytest {posargs:tests/json-fixtures/test_difficulty.py}
     transactions: pytest {posargs:tests/json-fixtures/test_transactions.py}


### PR DESCRIPTION
### What was wrong?

Build on RTD has been failing, but only when a PR is merged into `main`. In our own docs testing, we only test building the html version of the docs, but for several months now we've had RTD building html, pdf, and epub versions for almost all our libs. It seems like there hasn't been an issue, but in this case the html docs build fine but the epub build fails.

### How was it fixed?

Created a new `validate-docs-ci` make command, which will build pdf and epub only as part of CI. Tried changing it so all docs building builds all 3 formats, but the local reqs for building `latexpdf` are hefty. 

Fix issues with epub build by restructuring the introduction and guides so that the `quickstart.rst` (now `installation.rst` is only included once.

Updated `docs/Makefile` to template version(not sure why that didn't happen in the recent general update) and added to the docs Makefile `clean` directive to specifically delete the autogenerated docs we don't use.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-evm/assets/5199899/a617887a-5811-41a1-93f2-f5f40c262cd3)
