### PR TITLE
Add ``c-kzg-4844`` dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ common: &common
 
           EOF
     - run:
-        name: checkout fixtures submodule
+        name: checkout submodules
         command: git submodule update --init --recursive
     - run:
         name: merge pull request base
@@ -52,6 +52,15 @@ common: &common
         command: |
           python -m pip install --upgrade pip
           python -m pip install tox
+    - run:
+        name: Install clang for ckzg
+        command: sudo apt-get update && sudo apt-get install -y clang
+    - run:
+        name: install blst, ckzg, and python bindings
+        command: |
+          make -C ./c-kzg-4844/src blst
+          make -C ./c-kzg-4844/src
+          make -C ./c-kzg-4844/bindings/python install
     - run:
         name: run tox
         command: python -m tox run -r
@@ -82,6 +91,12 @@ windows_steps: &windows_steps
         command: |
           python -m pip install --upgrade pip
           python -m pip install tox
+    - run:
+        name: install blst, ckzg, and python bindings
+        command: |
+          make -C ./c-kzg-4844/src blst
+          make -C ./c-kzg-4844/src
+          make -C ./c-kzg-4844/bindings/python install
     - run:
         name: run tox
         command: python -m tox run -r

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,11 @@ windows_steps: &windows_steps
           python -m pip install --upgrade pip
           python -m pip install tox
     - run:
+        name: Install make and clang via chocolatey
+        command: |
+          choco install make
+          choco install llvm
+    - run:
         name: install blst, ckzg, and python bindings
         command: |
           make -C ./c-kzg-4844/src blst

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "fixtures"]
 	path = fixtures
 	url = https://github.com/ethereum/tests.git
+[submodule "c-kzg-4844"]
+	path = c-kzg-4844
+	url = https://www.github.com/ethereum/c-kzg-4844

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,8 @@ recursive-include tests *
 
 global-include *.pyi
 
+recursive-include c-kzg-4844 *.c *.h *.o *.a
+
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 prune .tox

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,25 @@
 #!/usr/bin/env python
 from setuptools import (
+    Extension,
     find_packages,
     setup,
 )
+
+# build c-kzg-4844 from source since no pypi distribution exists
+ckzg_dir = "c-kzg-4844"
+ckzg = Extension(
+    "ckzg",
+    sources=[f"{ckzg_dir}/bindings/python/ckzg.c", f"{ckzg_dir}/src/c_kzg_4844.c"],
+    include_dirs=[
+        f"{ckzg_dir}/inc",
+        f"{ckzg_dir}/src",
+        f"{ckzg_dir}/blst/src",
+        f"{ckzg_dir}/blst/bindings",
+    ],
+    library_dirs=[f"{ckzg_dir}/lib"],
+    libraries=["blst"],
+)
+
 
 extras_require = {
     "benchmark": [
@@ -80,6 +97,7 @@ setup(
     url="https://github.com/ethereum/py-evm",
     include_package_data=True,
     py_modules=["eth"],
+    ext_modules=[ckzg],
     install_requires=install_requires,
     python_requires=">=3.8, <4",
     extras_require=extras_require,

--- a/tests/core/test_import.py
+++ b/tests/core/test_import.py
@@ -1,2 +1,6 @@
 def test_import():
     import eth  # noqa: F401
+
+
+def test_ckzg_import():
+    import ckzg  # noqa: F401

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ commands=
     python -m pip install --upgrade pip
     /bin/rm -rf build dist
     python -m build
-    /bin/bash -c 'python -m pip install --upgrade "$(ls dist/py_evm-*-py3-none-any.whl)" --progress-bar off'
+    /bin/bash -c 'python -m pip install --upgrade "$(ls dist/py_evm-*.whl)" --progress-bar off'
     python -c "import eth"
 skip_install=true
 
@@ -87,6 +87,6 @@ commands=
     python -m pip install --upgrade pip
     bash.exe -c "rm -rf build dist"
     python -m build
-    bash.exe -c 'python -m pip install --upgrade "$(ls dist/py_evm-*-py3-none-any.whl)" --progress-bar off'
+    bash.exe -c 'python -m pip install --upgrade "$(ls dist/py_evm-*.whl)" --progress-bar off'
     python -c "import eth"
 skip_install=true


### PR DESCRIPTION
### What was wrong?

We are missing a kzg 4844 library to implement EIP-4844

### How was it fixed?

Add the [c-kzg-4844](https://github.com/ethereum/c-kzg-4844) library as a dependency.

### Todo:

- [ ] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
