### PR TITLE
fix: msg.data mutability

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -2058,14 +2058,6 @@ class ComputationAPI(
         ...
 
     @abstractmethod
-    def memory_read(self, start_position: int, size: int) -> memoryview:
-        """
-        Read and return a view of ``size`` bytes from memory starting at
-        ``start_position``.
-        """
-        ...
-
-    @abstractmethod
     def memory_read_bytes(self, start_position: int, size: int) -> bytes:
         """
         Read and return ``size`` bytes from memory starting at ``start_position``.

--- a/eth/vm/computation.py
+++ b/eth/vm/computation.py
@@ -437,9 +437,6 @@ class BaseComputation(ComputationAPI, Configurable):
     def memory_write(self, start_position: int, size: int, value: bytes) -> None:
         return self._memory.write(start_position, size, value)
 
-    def memory_read(self, start_position: int, size: int) -> memoryview:
-        return self._memory.read(start_position, size)
-
     def memory_read_bytes(self, start_position: int, size: int) -> bytes:
         return self._memory.read_bytes(start_position, size)
 

--- a/eth/vm/logic/call.py
+++ b/eth/vm/logic/call.py
@@ -83,7 +83,7 @@ class BaseCall(Opcode, ABC):
         computation.extend_memory(memory_input_start_position, memory_input_size)
         computation.extend_memory(memory_output_start_position, memory_output_size)
 
-        call_data = computation.memory_read(
+        call_data = computation.memory_read_bytes(
             memory_input_start_position, memory_input_size
         )
 

--- a/newsfragments/2140.breaking.rst
+++ b/newsfragments/2140.breaking.rst
@@ -1,0 +1,1 @@
+Remove ``memory_read`` from ``ComputationAPI`` interface and ``Computation`` implementation. Use ``memory_read_bytes`` in its place for call data read.


### PR DESCRIPTION
this commit modifies `msg.data` so that it is an immutable `bytes` copy of the input. the issue is that right now it is a view of memory, which means the caller can trample the msg.data buffer after the call returns (and `msg.data` gets mutated). this is not necessarily a problem for the VM correctness, but it is an issue for integrators that inspect `msg.data` after a call, because `msg.data` will not retain its original value.

as a refactor, since `Computation.memory_read()` is completely dead (and more importantly, probably a footgun), this commit also removes `memory_read()` from the `ComputationAPI` interface as well as the `Computation` implementation.

### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.ZDa4AjSs1jUDBSFArKT-qwAAAA%26pid%3DApi&f=1&ipt=8f01d5fe6123a74a35c45c70e7364d24db2f2255e67654a395d575486dbe6643&ipo=images)