### PR TITLE
Turn on Cancun transition tests and address issues

### DIFF
--- a/eth/tools/builder/chain/builders.py
+++ b/eth/tools/builder/chain/builders.py
@@ -164,6 +164,9 @@ def fork_at(
     * :func:`~eth.tools.builder.chain.london_at`
     * :func:`~eth.tools.builder.chain.arrow_glacier_at`
     * :func:`~eth.tools.builder.chain.gray_glacier_at`
+    * :func:`~eth.tools.builder.chain.paris_at`
+    * :func:`~eth.tools.builder.chain.shanghai_at`
+    * :func:`~eth.tools.builder.chain.cancun_at`
     * :func:`~eth.tools.builder.chain.latest_mainnet_at` - whatever latest mainnet VM is
     """
     if chain_class.vm_configuration is not None:

--- a/eth/tools/fixtures/helpers.py
+++ b/eth/tools/fixtures/helpers.py
@@ -135,7 +135,7 @@ def transition_test_at_timestamp(
             return ((0, initial_vm),)
 
         raise ValidationError(
-            "Not a known transition test format - transition_block is ``None``."
+            "Not a known transition test format: transition_block==None."
         )
 
     return (

--- a/eth/vm/forks/cancun/headers.py
+++ b/eth/vm/forks/cancun/headers.py
@@ -27,17 +27,21 @@ from .blocks import (
 
 
 def calc_excess_blob_gas(parent_header: BlockHeaderAPI) -> int:
-    if (
-        parent_header.excess_blob_gas + parent_header.blob_gas_used
-        < TARGET_BLOB_GAS_PER_BLOCK
-    ):
+    try:
+        if (
+            parent_header.excess_blob_gas + parent_header.blob_gas_used
+            < TARGET_BLOB_GAS_PER_BLOCK
+        ):
+            return 0
+        else:
+            return (
+                parent_header.excess_blob_gas
+                + parent_header.blob_gas_used
+                - TARGET_BLOB_GAS_PER_BLOCK
+            )
+    except AttributeError:
+        # parent is a non-Cancun header
         return 0
-    else:
-        return (
-            parent_header.excess_blob_gas
-            + parent_header.blob_gas_used
-            - TARGET_BLOB_GAS_PER_BLOCK
-        )
 
 
 @curry

--- a/newsfragments/2156.bugfix.rst
+++ b/newsfragments/2156.bugfix.rst
@@ -1,0 +1,1 @@
+bugfix: Address issues instantiating VM at Cancun transition.

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands=
     transactions: pytest {posargs:tests/json-fixtures/test_transactions.py}
     vm: pytest {posargs:tests/json-fixtures/test_virtual_machine.py}
     native-blockchain-metropolis: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Metropolis}
-    native-blockchain-transition: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py -k TransitionTests --tx '2*popen//execmodel=eventlet'}
+    native-blockchain-transition: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py -k "At5 or AtTime15k or AtDiff" --tx '2*popen//execmodel=eventlet'}
     native-blockchain-frontier: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Frontier}
     native-blockchain-homestead: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork Homestead}
     native-blockchain-tangerine_whistle: pytest {posargs:tests/json-fixtures/blockchain/test_blockchain.py --fork EIP150}


### PR DESCRIPTION
New transition tests no longer live under `/BlockchainTests/TransitionTests/...` and so we didn't catch any Shanghai to Cancun tests. This PR turns those on and more properly addresses transition test setup dealing with a timestamp by introducing helper functions to set them up properly.

- Address issues at Shanghai -> Cancun transition.
- Add helpers for testing transition tests at timestamp.
- Fix the keywords for CI transition tests since they no longer live in ``/TransitionTests``.

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

prompt: `snakes transitioning from the Shanghai city life to a life in Cancun with a sign that says "Cancun"`

<img width="1081" alt="Screenshot 2024-03-15 at 13 23 18" src="https://github.com/ethereum/py-evm/assets/3532824/3439df1f-5efe-49a0-a72e-0eee229e2e5c">
