### PR TITLE
Use some general state tests as transaction tests; Ensure txn `type_id`

### DIFF
--- a/eth/_utils/spoof.py
+++ b/eth/_utils/spoof.py
@@ -19,6 +19,7 @@ from eth.constants import (
 )
 
 SPOOF_ATTRIBUTES_DEFAULTS = {
+    "type_id": None,
     "y_parity": DEFAULT_SPOOF_Y_PARITY,
     "r": DEFAULT_SPOOF_R,
     "s": DEFAULT_SPOOF_S,
@@ -46,8 +47,12 @@ class SpoofAttributes:
 
             overrides["sender"] = overrides["from_"]
             overrides["get_sender"] = lambda: overrides["from_"]
+
+            if hasattr(self.spoof_target, "_type_id"):
+                overrides["type_id"] = self.spoof_target._type_id
+
             for attr, value in SPOOF_ATTRIBUTES_DEFAULTS.items():
-                if not hasattr(spoof_target, attr):
+                if not hasattr(spoof_target, attr) and attr not in overrides:
                     overrides[attr] = value
 
     def __getattr__(self, attr: str) -> Any:

--- a/eth/tools/_utils/normalization.py
+++ b/eth/tools/_utils/normalization.py
@@ -542,18 +542,29 @@ def normalize_transactiontest_fixture(
 ) -> Dict[str, Any]:
     normalized_fixture = {}
 
-    fork_data = fixture["result"][fork]
+    if "result" in fixture:
+        # old transaction tests
+        fork_data = fixture["result"][fork]
+        if "sender" in fork_data:
+            normalized_fixture["sender"] = fork_data["sender"]
+
+        if "hash" in fork_data:
+            normalized_fixture["hash"] = fork_data["hash"]
+    else:
+        # transaction tests from pyspec general state tests
+        fork_data = fixture["post"][fork]
+        fixture = fork_data[0]
+        if "expectException" in fixture:
+            normalized_fixture["expectException"] = fixture["expectException"]
+        if "transaction" in fixture:
+            normalized_fixture["sender"] = fixture["transaction"]["sender"]
+        if "hash" in fixture:
+            normalized_fixture["hash"] = fixture["hash"]
 
     try:
         normalized_fixture["txbytes"] = decode_hex(fixture["txbytes"])
     except binascii.Error:
         normalized_fixture["rlpHex"] = fixture["txbytes"]
-
-    if "sender" in fork_data:
-        normalized_fixture["sender"] = fork_data["sender"]
-
-    if "hash" in fork_data:
-        normalized_fixture["hash"] = fork_data["hash"]
 
     return normalized_fixture
 

--- a/eth/tools/fixtures/generation.py
+++ b/eth/tools/fixtures/generation.py
@@ -46,6 +46,7 @@ def generate_fixture_tests(
     base_fixture_path: str,
     filter_fn: Callable[..., Any] = identity,
     preprocess_fn: Callable[..., Any] = identity,
+    postprocess_fn: Callable[..., Any] = identity,
 ) -> None:
     """
     Helper function for use with `pytest_generate_tests` which will use the
@@ -58,6 +59,8 @@ def generate_fixture_tests(
     - `preprocess_fn` handles any preprocessing that should be done on the raw
        fixtures (such as expanding the statetest fixtures to be multiple tests for
        each fork.
+    - `postprocess_fn` handles any postprocessing that should be done on the fixtures
+       after they have been preprocessed (optional) and filtered (optional).
     """
     if "fixture_data" in metafunc.fixturenames:
         all_fixtures = find_fixtures(base_fixture_path)
@@ -67,6 +70,6 @@ def generate_fixture_tests(
                 f"Suspiciously found zero fixtures: {base_fixture_path}"
             )
 
-        filtered_fixtures = filter_fn(preprocess_fn(all_fixtures))
+        filtered_fixtures = postprocess_fn(filter_fn(preprocess_fn(all_fixtures)))
 
         metafunc.parametrize("fixture_data", filtered_fixtures, ids=idfn)

--- a/eth/tools/fixtures/loading.py
+++ b/eth/tools/fixtures/loading.py
@@ -43,8 +43,12 @@ def find_fixtures(fixtures_base_dir: str) -> Iterable[Tuple[str, str]]:
         with open(fixture_path) as fixture_file:
             fixtures = json.load(fixture_file)
 
-        for fixture_key in sorted(fixtures.keys()):
-            yield (fixture_path, fixture_key)
+        try:
+            for fixture_key in sorted(fixtures.keys()):
+                yield (fixture_path, fixture_key)
+        except AttributeError:
+            # If the fixture is not a dictionary, it's not a valid fixture file.
+            continue
 
 
 # we use an LRU cache on this function so that we can sort the tests such that

--- a/eth/vm/forks/__init__.py
+++ b/eth/vm/forks/__init__.py
@@ -43,6 +43,8 @@ from .paris import (
 from .shanghai import (
     ShanghaiVM,
 )
-from .cancun import (  # noqa: F401
+from .cancun import (
     CancunVM,
 )
+
+LATEST_VM = CancunVM

--- a/eth/vm/forks/cancun/state.py
+++ b/eth/vm/forks/cancun/state.py
@@ -205,7 +205,7 @@ class CancunState(ShanghaiState):
         max_total_fee = transaction.gas * transaction.max_fee_per_gas
         if transaction.type_id == BLOB_TX_TYPE:
             max_total_fee += (
-                get_total_blob_gas(transaction) * transaction.max_fee_per_blob_gas  # type: ignore  # noqa: E501
+                get_total_blob_gas(transaction) * transaction.max_fee_per_blob_gas
             )
         if self.get_balance(transaction.sender) < max_total_fee:
             raise ValidationError("Sender has insufficient funds for blob fee.")
@@ -213,13 +213,13 @@ class CancunState(ShanghaiState):
         # add validity logic specific to blob txs
         if transaction.type_id == BLOB_TX_TYPE:
             # there must be at least one blob
-            if len(transaction.blob_versioned_hashes) == 0:  # type: ignore  # noqa: E501
+            if len(transaction.blob_versioned_hashes) == 0:
                 raise ValidationError(
                     "Blob transaction must contain at least one blob."
                 )
 
             # all versioned blob hashes must start with VERSIONED_HASH_VERSION_KZG
-            for h in transaction.blob_versioned_hashes:  # type: ignore  # noqa: E501
+            for h in transaction.blob_versioned_hashes:
                 if h[0].to_bytes() != VERSIONED_HASH_VERSION_KZG:
                     raise ValidationError(
                         "Blob versioned hash does not start with expected "
@@ -228,7 +228,7 @@ class CancunState(ShanghaiState):
 
             # ensure that the user was willing to at least pay the current
             # blob base fee
-            if transaction.max_fee_per_blob_gas < self.blob_base_fee:  # type: ignore  # noqa: E501
+            if transaction.max_fee_per_blob_gas < self.blob_base_fee:
                 raise ValidationError(
                     "Blob transaction must pay at least the current blob base fee."
                 )

--- a/newsfragments/2157.bugfix.rst
+++ b/newsfragments/2157.bugfix.rst
@@ -1,0 +1,1 @@
+bugfix: Ensure a ``type_id`` for  ``SpoofTransaction`` when unsigned -> signed spoofing. This defaults to ``None`` for legacy and uses the ``_type_id`` for unsigned typed txns.

--- a/newsfragments/2157.internal.rst
+++ b/newsfragments/2157.internal.rst
@@ -1,0 +1,1 @@
+Use some general state tests for transaction tests since they have similar formats. This yielded a decent amount of new transaction tests.

--- a/tests/core/transaction-utils/test_spoof_transaction.py
+++ b/tests/core/transaction-utils/test_spoof_transaction.py
@@ -1,0 +1,112 @@
+from eth_typing import (
+    Address,
+)
+from toolz import (
+    merge,
+)
+
+from eth.constants import (
+    DEFAULT_SPOOF_R,
+    DEFAULT_SPOOF_S,
+    DEFAULT_SPOOF_Y_PARITY,
+)
+from eth.vm.forks import (
+    LATEST_VM,
+)
+from eth.vm.spoof import (
+    SpoofTransaction,
+)
+
+
+def test_spoof_transaction_with_from_spoofs_a_signed_transaction_with_default_fields():
+    latest_txn_builder = LATEST_VM.get_transaction_builder()
+
+    legacy_tx_values = {
+        "nonce": 1,
+        "gas_price": 1,
+        "gas": 1,
+        "to": Address(b"\x00" * 20),
+        "value": 1,
+        "data": b"",
+    }
+
+    access_list_tx_values = merge(
+        legacy_tx_values,
+        {
+            "chain_id": 1,
+            "access_list": [],
+        },
+    )
+
+    dynamic_tx_values = merge(
+        access_list_tx_values,
+        {
+            "max_priority_fee_per_gas": 1,
+            "max_fee_per_gas": 1,
+        },
+    )
+    dynamic_tx_values.pop("gas_price")
+    blob_tx_values = merge(
+        dynamic_tx_values,
+        {
+            "max_fee_per_blob_gas": 1,
+            "blob_versioned_hashes": [],
+        },
+    )
+
+    unsigned_legacy = latest_txn_builder.create_unsigned_transaction(**legacy_tx_values)
+    # unsigned spoofed legacy transaction
+    unsigned_legacy_spoofed = SpoofTransaction(unsigned_legacy)
+    _validate_unsigned_spoofed(unsigned_legacy_spoofed)
+    # signed spoofed legacy transaction
+    signed_legacy_spoofed = SpoofTransaction(
+        unsigned_legacy, from_=Address(b"\x00" * 20)
+    )
+    _validate_signed_spoofed_common(signed_legacy_spoofed)
+    assert signed_legacy_spoofed.type_id is None
+
+    unsigned_access_list = latest_txn_builder.new_unsigned_access_list_transaction(**access_list_tx_values)  # type: ignore  # noqa: E501
+    # unsigned spoofed access list transaction
+    unsigned_access_list_spoofed = SpoofTransaction(unsigned_access_list)
+    _validate_unsigned_spoofed(unsigned_access_list_spoofed)
+    # signed spoofed access list transaction
+    signed_access_list_spoofed = SpoofTransaction(
+        unsigned_access_list, from_=Address(b"\x00" * 20)
+    )
+    _validate_signed_spoofed_common(signed_access_list_spoofed)
+    assert signed_access_list_spoofed.type_id == 1
+
+    unsigned_dynamic = latest_txn_builder.new_unsigned_dynamic_fee_transaction(**dynamic_tx_values)  # type: ignore  # noqa: E501
+    # unsigned spoofed dynamic fee transaction
+    unsigned_dynamic_spoofed = SpoofTransaction(unsigned_dynamic)
+    _validate_unsigned_spoofed(unsigned_dynamic_spoofed)
+    # signed spoofed dynamic fee transaction
+    signed_dynamic_spoofed = SpoofTransaction(
+        unsigned_dynamic, from_=Address(b"\x00" * 20)
+    )
+    _validate_signed_spoofed_common(signed_dynamic_spoofed)
+    assert signed_dynamic_spoofed.type_id == 2
+
+    unsigned_blob = latest_txn_builder.new_unsigned_blob_transaction(**blob_tx_values)  # type: ignore  # noqa: E501
+    # unsigned spoofed blob transaction
+    unsigned_blob_spoofed = SpoofTransaction(unsigned_blob)
+    _validate_unsigned_spoofed(unsigned_blob_spoofed)
+    # signed spoofed blob transaction
+    signed_blob_spoofed = SpoofTransaction(unsigned_blob, from_=Address(b"\x00" * 20))
+    _validate_signed_spoofed_common(signed_blob_spoofed)
+    assert signed_blob_spoofed.type_id == unsigned_blob._type_id == 3
+
+
+def _validate_signed_spoofed_common(signed_spoofed):
+    assert signed_spoofed.sender == Address(b"\x00" * 20)
+    assert signed_spoofed.r == DEFAULT_SPOOF_R
+    assert signed_spoofed.s == DEFAULT_SPOOF_S
+    assert signed_spoofed.y_parity == DEFAULT_SPOOF_Y_PARITY
+
+
+def _validate_unsigned_spoofed(unsigned_spoofed):
+    assert not hasattr(unsigned_spoofed, "sender")
+    assert not hasattr(unsigned_spoofed, "type_id")
+    assert not hasattr(unsigned_spoofed, "r")
+    assert not hasattr(unsigned_spoofed, "s")
+    assert not hasattr(unsigned_spoofed, "y_parity")


### PR DESCRIPTION
### What was wrong?

- A `SpoofTransaction` is usually used to turn an unsigned transaction into a "signed" transaction for estimating gas for example. *eth-tester* uses `SpoofTransaction` for these purposes and we need to make sure that it also accounts for a `type_id` which is a part of the `SignedTransactionAPI`.
- Quite a few transaction tests can be pulled in from general state tests.

### How was it fixed?

- Add proper `type_id` values to `SpoofTransaction` since it should use all attributes from the `SignedTransactionAPI`.
- Pull in transaction tests from some general state tests

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

prompt: `iterate on 'snakes transitioning from the Shanghai city life to a life in Cancun with a sign that says "Cancun"' but make 'transactions' a theme`

![Screenshot 2024-03-15 at 17 42 07](https://github.com/ethereum/py-evm/assets/3532824/eaa2f1cb-b390-4194-9779-85012e00c27f)