### PR TITLE
fix: cancun transaction executor

### DIFF
--- a/eth/abc.py
+++ b/eth/abc.py
@@ -2529,6 +2529,13 @@ class TransientStorageAPI(ABC):
         ...
 
     @abstractmethod
+    def clear(self) -> None:
+        """
+        Clear the transient storage.
+        """
+        ...
+
+    @abstractmethod
     def get_transient_storage(self, address: Address, slot: int) -> bytes:
         """
         Return the transient storage for ``address`` at slot ``slot``.
@@ -3249,9 +3256,9 @@ class StateAPI(ConfigurableAPI):
         ...
 
     @abstractmethod
-    def reset_transient_storage(self) -> None:
+    def clear_transient_storage(self) -> None:
         """
-        Reset the transient storage.
+        Clear the transient storage. Should be done at the start of every transaction
         """
         ...
 

--- a/eth/vm/state.py
+++ b/eth/vm/state.py
@@ -215,7 +215,7 @@ class BaseState(Configurable, StateAPI):
     def set_transient_storage(self, address: Address, slot: int, value: bytes) -> None:
         raise AttributeError("No transient_storage has been set for this State")
 
-    def reset_transient_storage(self) -> None:
+    def clear_transient_storage(self) -> None:
         raise AttributeError("No transient_storage has been set for this State")
 
     #

--- a/eth/vm/transient_storage.py
+++ b/eth/vm/transient_storage.py
@@ -55,3 +55,6 @@ class TransientStorage(TransientStorageAPI):
 
     def discard(self, checkpoint: JournalDBCheckpoint) -> None:
         self._db.discard(checkpoint)
+
+    def clear(self) -> None:
+        self._db.clear()

--- a/newsfragments/2159.bugfix.rst
+++ b/newsfragments/2159.bugfix.rst
@@ -1,0 +1,1 @@
+Clear existing transient storage db instead of resetting and creating a new one


### PR DESCRIPTION
in chain.estimate_gas(), the chain creates a snapshot, applies a transaction, then reverts the snapshot. the issue with this is applying a transaction creates a new JournalDB inside of the transient storage, so the checkpoint from the snapshot is no longer valid as soon as apply_transaction() is called. this commit cleans the transient storage db by calling JournalDB.clear() so that the checkpoint from the snapshot is still valid.

### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/py-evm/assets/5199899/6f17a31b-fac3-4532-8d14-6d2839566438)
