### PR TITLE
Update block fields check to use current vm's block header

### DIFF
--- a/eth/vm/base.py
+++ b/eth/vm/base.py
@@ -73,9 +73,6 @@ from eth.db.trie import (
 from eth.exceptions import (
     HeaderNotFound,
 )
-from eth.rlp.headers import (
-    BlockHeader,
-)
 from eth.rlp.sedes import (
     uint32,
 )
@@ -518,7 +515,7 @@ class VM(Configurable, VirtualMachineAPI):
             uncles = block.uncles
 
         provided_fields = set(kwargs.keys())
-        known_fields = set(BlockHeader._meta.field_names)
+        known_fields = set(self.get_header()._meta.field_names)  # type: ignore
         unknown_fields = provided_fields.difference(known_fields)
 
         if unknown_fields:

--- a/eth/vm/forks/cancun/__init__.py
+++ b/eth/vm/forks/cancun/__init__.py
@@ -101,5 +101,9 @@ class CancunVM(ShanghaiVM):
             raise ValidationError("Block exceeded maximum blob gas limit.")
 
         # ensure blob_gas_used matches header
-        if block.header.blob_gas_used != blob_gas_used:
-            raise ValidationError("Block blob gas used does not match actual usage.")
+        block_blob_gas_used = block.header.blob_gas_used
+        if block_blob_gas_used != blob_gas_used:
+            raise ValidationError(
+                f"Block blob gas used ({block_blob_gas_used}) does not match "
+                f"total blob gas used ({blob_gas_used})."
+            )

--- a/newsfragments/2165.bugfix.rst
+++ b/newsfragments/2165.bugfix.rst
@@ -1,0 +1,1 @@
+Use the current VM's header class to check valid fields for ``vm.pack_block()``.


### PR DESCRIPTION
### What was wrong?

- This is a minor change that is nice to have but also necessary for full *web3.py* <-> *eth-tester* <-> *py-evm* support in order to update fields that are meant to be coming from the consensus layer.

*Bonus: Instead of just copying the messages from the EIP, provider values in the error message when the calculated `blob_gas_used` doesn't match the block header blob gas used. This kind of helped track this down but also is just a nicety :)*

### How was it fixed?

- Use the current vm's header to check fields got `vm.pack_block()`

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="722" alt="Screenshot 2024-04-03 at 17 55 45" src="https://github.com/ethereum/py-evm/assets/3532824/d256d313-0437-49f3-b3e1-ec7df9e290da">

