### PR TITLE
bugfix: use CancunReceiptBuilder in CancunBlock

### DIFF
--- a/eth/vm/forks/cancun/blocks.py
+++ b/eth/vm/forks/cancun/blocks.py
@@ -53,9 +53,6 @@ from eth.vm.forks.london.blocks import (
     LondonBlockHeader,
 )
 
-from ..london.receipts import (
-    LondonReceiptBuilder,
-)
 from ..shanghai.blocks import (
     ShanghaiBackwardsHeader,
     ShanghaiBlock,
@@ -63,6 +60,9 @@ from ..shanghai.blocks import (
 )
 from ..shanghai.withdrawals import (
     Withdrawal,
+)
+from .receipts import (
+    CancunReceiptBuilder,
 )
 from .transactions import (
     CancunTransactionBuilder,
@@ -200,7 +200,7 @@ class CancunBackwardsHeader(ShanghaiBackwardsHeader):
 
 class CancunBlock(ShanghaiBlock):
     transaction_builder: Type[TransactionBuilderAPI] = CancunTransactionBuilder
-    receipt_builder: Type[ReceiptBuilderAPI] = LondonReceiptBuilder
+    receipt_builder: Type[ReceiptBuilderAPI] = CancunReceiptBuilder
     fields = [
         ("header", CancunBlockHeader),
         ("transactions", CountableList(transaction_builder)),

--- a/newsfragments/2166.bugfix.rst
+++ b/newsfragments/2166.bugfix.rst
@@ -1,0 +1,1 @@
+Properly configure the ``CancunBlock`` class to use the ``CancunReceiptBuilder``.


### PR DESCRIPTION
### What was wrong?

Having plugged *web3.py* (via PR ethereum/web3.py#3332) through *eth-tester* (via ethereum/eth-tester#285), these seem to be that last few changes to fully support Cancun across the stack.

### How was it fixed?

- We are incorrectly not using the `CancunReceiptBuilder` for `CancunBlock`

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="1092" alt="Screenshot 2024-04-04 at 15 40 32" src="https://github.com/ethereum/py-evm/assets/3532824/debb3854-32fa-4b10-ab6c-01080f5870ff">
