### PR TITLE
Compare the first versioned hash byte by indexing

### DIFF
--- a/eth/vm/forks/cancun/state.py
+++ b/eth/vm/forks/cancun/state.py
@@ -221,7 +221,7 @@ class CancunState(ShanghaiState):
 
             # all versioned blob hashes must start with VERSIONED_HASH_VERSION_KZG
             for h in transaction.blob_versioned_hashes:
-                if h[0].to_bytes() != VERSIONED_HASH_VERSION_KZG:
+                if h[:1] != VERSIONED_HASH_VERSION_KZG:
                     raise ValidationError(
                         "Blob versioned hash does not start with expected "
                         f"KZG version: {VERSIONED_HASH_VERSION_KZG!r}"

--- a/newsfragments/2168.bugfix.rst
+++ b/newsfragments/2168.bugfix.rst
@@ -1,0 +1,1 @@
+``integer.to_bytes()`` requires size and byteorder below py311 and our fixture tests only use py311. Compare the first byte of versioned hashes by indexing instead.


### PR DESCRIPTION
### What was wrong?

- ``integer.to_bytes()`` requires size and byteorder below py311 and our fixture tests only use py311.

### How was it fixed?

- Compare the first byte of versioned hashes by indexing instead.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="1115" alt="Screenshot 2024-04-05 at 10 54 58" src="https://github.com/ethereum/py-evm/assets/3532824/5734dd3e-4fa0-4eeb-9564-cad64f555f2b">
