### PR TITLE
Exclude `scripts` from wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include README.md
 
 include eth/_utils/kzg_trusted_setup.txt
 
+recursive-include scripts *
 recursive-include tests *
 global-include *.pyi
 

--- a/newsfragments/2170.internal.rst
+++ b/newsfragments/2170.internal.rst
@@ -1,0 +1,1 @@
+Exclude `scripts` when building the wheel.

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     license="MIT",
     zip_safe=False,
     keywords="ethereum blockchain evm",
-    packages=find_packages(exclude=["tests", "tests.*"]),
+    packages=find_packages(exclude=["scripts", "tests", "tests.*"]),
     package_data={"eth": ["py.typed"]},
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
### What was wrong?

Error importing when using pytest due to `scripts` being included as a package.

### How was it fixed?

Exclude `scripts` when building the wheel (setup.py)
Include `scripts` for the distribution (MANIFEST.in)

### Todo:

- [X] Clean up commit history
- [X] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="701" alt="Screen Shot 2024-04-16 at 11 04 05 AM" src="https://github.com/ethereum/py-evm/assets/435903/7a3e3622-ef4c-43d7-855e-bd59f1c0a608">
