### PR TITLE
Add python 3.12 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,90 +108,90 @@ jobs:
         environment:
           TOXENV: docs
 
-  py311-native-blockchain-berlin:
+  py312-native-blockchain-berlin:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-berlin
-  py311-native-blockchain-byzantium:
+          TOXENV: py312-native-blockchain-berlin
+  py312-native-blockchain-byzantium:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-byzantium
-  py311-native-blockchain-cancun:
+          TOXENV: py312-native-blockchain-byzantium
+  py312-native-blockchain-cancun:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-cancun
-  py311-native-blockchain-constantinople:
+          TOXENV: py312-native-blockchain-cancun
+  py312-native-blockchain-constantinople:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-constantinople
-  py311-native-blockchain-frontier:
+          TOXENV: py312-native-blockchain-constantinople
+  py312-native-blockchain-frontier:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-frontier
-  py311-native-blockchain-homestead:
+          TOXENV: py312-native-blockchain-frontier
+  py312-native-blockchain-homestead:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-homestead
-  py311-native-blockchain-istanbul:
+          TOXENV: py312-native-blockchain-homestead
+  py312-native-blockchain-istanbul:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-istanbul
-  py311-native-blockchain-london:
+          TOXENV: py312-native-blockchain-istanbul
+  py312-native-blockchain-london:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-london
-  py311-native-blockchain-paris:
+          TOXENV: py312-native-blockchain-london
+  py312-native-blockchain-paris:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-paris
-  py311-native-blockchain-petersburg:
+          TOXENV: py312-native-blockchain-paris
+  py312-native-blockchain-petersburg:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-petersburg
-  py311-native-blockchain-shanghai:
+          TOXENV: py312-native-blockchain-petersburg
+  py312-native-blockchain-shanghai:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-shanghai
-  py311-native-blockchain-spurious_dragon:
+          TOXENV: py312-native-blockchain-shanghai
+  py312-native-blockchain-spurious_dragon:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-spurious_dragon
-  py311-native-blockchain-tangerine_whistle:
+          TOXENV: py312-native-blockchain-spurious_dragon
+  py312-native-blockchain-tangerine_whistle:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-tangerine_whistle
-  py311-native-blockchain-transition:
+          TOXENV: py312-native-blockchain-tangerine_whistle
+  py312-native-blockchain-transition:
     <<: *common
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
         environment:
-          TOXENV: py311-native-blockchain-transition
+          TOXENV: py312-native-blockchain-transition
 
   py38-core:
     <<: *common
@@ -364,56 +364,106 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-wheel
-  py311-wheel-windows:
+
+  py312-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-core
+  py312-database:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-database
+  py312-difficulty:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-difficulty
+  py312-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-lint
+  py312-transactions:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-transactions
+  py312-vm:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-vm
+  py312-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-wheel
+  py312-wheel-windows:
     <<: *windows_steps
     environment:
-      TOXENV: py311-wheel-windows
+      TOXENV: py312-wheel-windows
 
 workflows:
   version: 2
   test:
     jobs:
       - docs
-      - py311-native-blockchain-berlin
-      - py311-native-blockchain-byzantium
-      - py311-native-blockchain-cancun
-      - py311-native-blockchain-constantinople
-      - py311-native-blockchain-frontier
-      - py311-native-blockchain-homestead
-      - py311-native-blockchain-istanbul
-      - py311-native-blockchain-london
-      - py311-native-blockchain-paris
-      - py311-native-blockchain-petersburg
-      - py311-native-blockchain-shanghai
-      - py311-native-blockchain-spurious_dragon
-      - py311-native-blockchain-tangerine_whistle
-      - py311-native-blockchain-transition
+      - py312-native-blockchain-berlin
+      - py312-native-blockchain-byzantium
+      - py312-native-blockchain-cancun
+      - py312-native-blockchain-constantinople
+      - py312-native-blockchain-frontier
+      - py312-native-blockchain-homestead
+      - py312-native-blockchain-istanbul
+      - py312-native-blockchain-london
+      - py312-native-blockchain-paris
+      - py312-native-blockchain-petersburg
+      - py312-native-blockchain-shanghai
+      - py312-native-blockchain-spurious_dragon
+      - py312-native-blockchain-tangerine_whistle
+      - py312-native-blockchain-transition
       - py38-core
       - py39-core
       - py310-core
       - py311-core
+      - py312-core
       - py38-database
       - py39-database
       - py310-database
       - py311-database
+      - py312-database
       - py38-difficulty
       - py39-difficulty
       - py310-difficulty
       - py311-difficulty
+      - py312-difficulty
       - py38-lint
       - py39-lint
       - py310-lint
       - py311-lint
+      - py312-lint
       - py38-transactions
       - py39-transactions
       - py310-transactions
       - py311-transactions
+      - py312-transactions
       - py38-vm
       - py39-vm
       - py310-vm
       - py311-vm
+      - py312-vm
       - py38-wheel
       - py39-wheel
       - py310-wheel
       - py311-wheel
-      - py311-wheel-windows
+      - py312-wheel
+      - py312-wheel-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,28 +67,51 @@ common: &common
 orbs:
   win: circleci/windows@5.0.0
 
-windows_steps: &windows_steps
-  executor:
-    name: win/default
-    shell: bash.exe
-  working_directory: C:\Users\circleci\project\py-evm
-  steps:
-    - checkout
-    - restore_cache:
-        keys:
-          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-    - run:
-        name: install dependencies
-        command: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
-    - run:
-        name: run tox
-        command: python -m tox run -r
-    - save_cache:
-        paths:
-          - .tox
-        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+windows-wheel-steps:
+  windows-wheel-setup: &windows-wheel-setup
+    executor:
+      name: win/default
+      shell: bash.exe
+    working_directory: C:\Users\circleci\project\py-evm
+    environment:
+      TOXENV: windows-wheel
+  restore-cache-step: &restore-cache-step
+    restore_cache:
+      keys:
+        - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+  install-pyenv-step: &install-pyenv-step
+    run:
+      name: install pyenv
+      command: |
+        pip install pyenv-win --target $HOME/.pyenv
+        echo 'export PYENV="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+        echo 'export PYENV_ROOT="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+        echo 'export PYENV_USERPROFILE="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+        echo 'export PATH="$PATH:$HOME/.pyenv/pyenv-win/bin"' >> $BASH_ENV
+        echo 'export PATH="$PATH:$HOME/.pyenv/pyenv-win/shims"' >> $BASH_ENV
+        source $BASH_ENV
+        pyenv update
+  install-latest-python-step: &install-latest-python-step
+    run:
+      name: install latest python version and tox
+      command: |
+        LATEST_VERSION=$(pyenv install --list | grep -E "${MINOR_VERSION}\.[0-9]+$" | tail -1)
+        echo "installing python version $LATEST_VERSION"
+        pyenv install $LATEST_VERSION
+        pyenv global $LATEST_VERSION
+        python3 -m pip install --upgrade pip
+        python3 -m pip install tox
+  run-tox-step: &run-tox-step
+    run:
+      name: run tox
+      command: |
+        echo 'running tox with' $(python3 --version)
+        python3 -m tox run -r
+  save-cache-step: &save-cache-step
+    save_cache:
+      paths:
+        - .tox
+      key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 docs: &docs
   docker:
@@ -364,6 +387,18 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-wheel
+  py311-windows-wheel:
+    <<: *windows-wheel-setup
+    steps:
+      - checkout
+      - <<: *restore-cache-step
+      - <<: *install-pyenv-step
+      - run:
+          name: set minor version
+          command: echo "export MINOR_VERSION='3.11'" >> $BASH_ENV
+      - <<: *install-latest-python-step
+      - <<: *run-tox-step
+      - <<: *save-cache-step
 
   py312-core:
     <<: *common
@@ -407,10 +442,18 @@ jobs:
       - image: cimg/python:3.12
         environment:
           TOXENV: py312-wheel
-  py312-wheel-windows:
-    <<: *windows_steps
-    environment:
-      TOXENV: py312-wheel-windows
+  py312-windows-wheel:
+    <<: *windows-wheel-setup
+    steps:
+      - checkout
+      - <<: *restore-cache-step
+      - <<: *install-pyenv-step
+      - run:
+          name: set minor version
+          command: echo "export MINOR_VERSION='3.12'" >> $BASH_ENV
+      - <<: *install-latest-python-step
+      - <<: *run-tox-step
+      - <<: *save-cache-step
 
 workflows:
   version: 2
@@ -466,4 +509,5 @@ workflows:
       - py310-wheel
       - py311-wheel
       - py312-wheel
-      - py312-wheel-windows
+      - py311-windows-wheel
+      - py312-windows-wheel

--- a/eth/validation.py
+++ b/eth/validation.py
@@ -179,7 +179,7 @@ def validate_unique(values: Iterable[Any], title: str = "Value") -> None:
         )
         raise ValidationError(
             f"{title} does not contain unique items.  Duplicates: "
-            f"{', '.join((str(value) for value in duplicates))}"
+            f"{', '.join(str(value) for value in duplicates)}"
         )
 
 

--- a/newsfragments/2171.feature.rst
+++ b/newsfragments/2171.feature.rst
@@ -1,0 +1,1 @@
+Add support for python 3.12.

--- a/setup.py
+++ b/setup.py
@@ -99,5 +99,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require = {
     ],
     "test": [
         "factory-boy>=3.0.0",
-        "hypothesis>=5,<6",
+        "hypothesis>=6,<7",
         "pytest>=7.0.0",
         "pytest-asyncio>=0.20.0",
         "pytest-cov>=4.0.0",

--- a/tests/database/test_eth1_chaindb.py
+++ b/tests/database/test_eth1_chaindb.py
@@ -2,7 +2,9 @@ from eth_hash.auto import (
     keccak,
 )
 from hypothesis import (
+    HealthCheck,
     given,
+    settings,
     strategies as st,
 )
 import pytest
@@ -284,6 +286,7 @@ def test_chaindb_persist_header(chaindb, header):
 
 
 @given(seed=st.binary(min_size=32, max_size=32))
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 def test_chaindb_persist_header_unknown_parent(chaindb, header, seed):
     n_header = header.copy(parent_hash=keccak(seed))
     with pytest.raises(ParentNotFound):

--- a/tests/database/test_header_db.py
+++ b/tests/database/test_header_db.py
@@ -85,7 +85,7 @@ def mk_header_chain(base_header, length):
             timestamp=previous_header.timestamp + 1,
             gas_limit=previous_header.gas_limit,
             difficulty=previous_header.difficulty,
-            extra_data=keccak(random.randint(0, 1e18)),
+            extra_data=keccak(random.randint(0, 10**18)),
         )
         yield next_header
         previous_header = next_header

--- a/tests/database/test_journal_db.py
+++ b/tests/database/test_journal_db.py
@@ -2,6 +2,7 @@ from eth_utils import (
     ValidationError,
 )
 from hypothesis import (
+    HealthCheck,
     given,
     settings,
     strategies as st,
@@ -470,6 +471,7 @@ DO_RECORD = object()
         max_size=10,
     ),
 )
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 def test_journal_db_diff_application_mimics_persist(journal_db, memory_db, actions):
     memory_db.kv_store.clear()  # hypothesis not resetting other test-scoped fixtures
     for action in actions:

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist=
     py{38,39,310,311,312}-transactions
     py{38,39,310,311,312}-vm
     py{38,39,310,311,312}-wheel
-    py312-wheel-windows
+    windows-wheel
     docs
     py312-native-blockchain-{ \
         metropolis, transition, frontier, homestead, tangerine_whistle, \
@@ -47,6 +47,7 @@ commands=
 
 basepython =
     docs: python
+    windows-wheel: python
     py38: python3.8
     py39: python3.9
     py310: python3.10
@@ -79,13 +80,14 @@ commands=
     python -c "import eth"
 skip_install=true
 
-[testenv:py312-wheel-windows]
+[testenv:windows-wheel]
 deps=
     wheel
     build[virtualenv]
 allowlist_externals=
     bash.exe
 commands=
+    python --version
     python -m pip install --upgrade pip
     bash.exe -c "rm -rf build dist"
     python -m build

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist=
-    py{38,39,310,311}-core
-    py{38,39,310,311}-database
-    py{38,39,310,311}-difficulty
-    py{38,39,310,311}-lint
-    py{38,39,310,311}-transactions
-    py{38,39,310,311}-vm
-    py{38,39,310,311}-wheel
-    py311-wheel-windows
+    py{38,39,310,311,312}-core
+    py{38,39,310,311,312}-database
+    py{38,39,310,311,312}-difficulty
+    py{38,39,310,311,312}-lint
+    py{38,39,310,311,312}-transactions
+    py{38,39,310,311,312}-vm
+    py{38,39,310,311,312}-wheel
+    py312-wheel-windows
     docs
-    py311-native-blockchain-{ \
+    py312-native-blockchain-{ \
         metropolis, transition, frontier, homestead, tangerine_whistle, \
         spurious_dragon, byzantium, constantinople, petersburg, istanbul, \
         berlin, london, paris, shanghai, cancun \
@@ -51,19 +51,20 @@ basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 extras=
     docs
     eth-extra
     test
 allowlist_externals=make,pre-commit
 
-[testenv:py{38,39,310,311}-lint]
+[testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py{38,39,310,311}-wheel]
+[testenv:py{38,39,310,311,312}-wheel]
 deps=
     wheel
     build[virtualenv]
@@ -78,7 +79,7 @@ commands=
     python -c "import eth"
 skip_install=true
 
-[testenv:py311-wheel-windows]
+[testenv:py312-wheel-windows]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
### What was wrong?

closes #2169 

### How was it fixed?

- Add relevant Python 3.12 CI runs, copy the new windows CI setup from the template.
- Bump `hypothesis` to `>6,<7` (this is only for `tests` install extra, should be OK / non-breaking)
- Silence some minor warnings related to new hypothesis version. When `@given()` is used with a function-scoped fixture, it doesn't re-generate the values at the function level. I think this is OK for the tests that had this issue but double check to make sure I didn't miss anything.
- Use an `int` (`10**18`) instead of a `float` (`10e18`) for `random.randint()` as it now raises an exception.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="721" alt="Screenshot 2024-04-17 at 14 41 42" src="https://github.com/ethereum/py-evm/assets/3532824/69f05857-4326-4b0c-88f0-091fcc1d00e0">
