### PR TITLE
Remove scripts/__init__.py, don't include scripts dir in sdist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ linux-docs: build-docs
 	xdg-open docs/_build/html/index.html
 
 package: clean
-	python setup.py sdist bdist_wheel
+	python -m build
 	python scripts/release/test_package.py
 
 notes:
@@ -87,11 +87,11 @@ release: check-bump clean
 	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
 	git config commit.gpgSign true
 	bumpversion $(bump)
+	python -m build
 	git push upstream && git push upstream --tags
-	python setup.py sdist bdist_wheel
 	twine upload dist/*
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
 sdist: clean
-	python setup.py sdist bdist_wheel
+	python -m build
 	ls -l dist

--- a/newsfragments/2172.bugfix.rst
+++ b/newsfragments/2172.bugfix.rst
@@ -1,0 +1,1 @@
+Remove scripts/__init__.py so that scripts doesn't get imported as a package. Also removes the scripts/ directory from the wheel.

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     license="MIT",
     zip_safe=False,
     keywords="ethereum blockchain evm",
-    packages=find_packages(exclude=["scripts", "tests", "tests.*"]),
+    packages=find_packages(exclude=["scripts", "scripts.*", "tests", "tests.*"]),
     package_data={"eth": ["py.typed"]},
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
### What was wrong?
scripts was getting installed as a package because we added a `scripts/__init__.py`, but it really shouldn't be a package. 


### How was it fixed?
Removed `scripts/__init__.py`, and made sure it wasn't getting included in the wheel. It is still getting included in the source dist.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.firstcoastnews.com/assets/WTLV/images/600928980/600928980_750x422.png)
