### PR TITLE
Remove scripts dir instead of scripts module

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -50,7 +50,8 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
-	rm eth.* scripts.* tests.*
+	rm -rf scripts/
+	rm eth.* tests.*
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/newsfragments/2174.internal.rst
+++ b/newsfragments/2174.internal.rst
@@ -1,0 +1,1 @@
+Remove scripts/ directory on doc build


### PR DESCRIPTION
### What was wrong?
`make build-docs` (which calls `make docs clean`) was failing because we took out the `scripts/__init__.py` and it couldn't find the scripts files to rm. 

### How was it fixed?
Now we remove the scripts directory before the doc build on `make docs clean`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTgJCHKC-IZ-EjPTbuEWV6_9zuaTHgHz0EyLGyD4CKTxv7AQvvTr-EuDAJAKc65xuzWYvU&usqp=CAU)
