### PR TITLE
Fix Docs CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,15 +113,33 @@ windows-wheel-steps:
         - .tox
       key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
+
 docs: &docs
-  docker:
-    - image: common
+  working_directory: ~/repo
   steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: install latexpdf dependencies
         command: |
           sudo apt-get update
           sudo apt-get install latexmk tex-gyre texlive-fonts-extra
+    - run:
+        name: run tox
+        command: python -m tox -r
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
   docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ docs: &docs
     - checkout
     - restore_cache:
         keys:
-          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "Makefile" }}
     - run:
         name: install dependencies
         command: |
@@ -139,7 +139,8 @@ docs: &docs
           - .tox
           - ~/.cache/pip
           - ~/.local
-        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - /var/lib/dpkg/info
+        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "Makefile" }}
 
 jobs:
   docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ docs: &docs
     - checkout
     - restore_cache:
         keys:
-          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "Makefile" }}
+          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
         command: |
@@ -133,14 +133,14 @@ docs: &docs
           sudo apt-get install latexmk tex-gyre texlive-fonts-extra
     - run:
         name: run tox
-        command: python -m tox -r
+        command: python -m tox run -r
     - save_cache:
         paths:
           - .tox
           - ~/.cache/pip
           - ~/.local
-          - /var/lib/dpkg/info
-        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "Makefile" }}
+        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+  resource_class: xlarge
 
 jobs:
   docs:

--- a/docs/guides/understanding_the_mining_process.rst
+++ b/docs/guides/understanding_the_mining_process.rst
@@ -386,7 +386,8 @@ zero value transfer transaction.
   ...     block.number,
   ...     block.header.mining_hash,
   ...     block.header.difficulty,
-  ... )  # doctest: +SKIP (takes too long for doctest to process)
+  ... )  # doctest: +SKIP
+  ... # (takes too long for doctest to process)
 
   >>> chain.mine_block(mix_hash=mix_hash, nonce=nonce)  # doctest: +SKIP
   <ByzantiumBlock(#Block #1-0xe372..385c)>

--- a/newsfragments/2175.internal.rst
+++ b/newsfragments/2175.internal.rst
@@ -1,0 +1,1 @@
+Ensure docs build on CI is running.


### PR DESCRIPTION
### What was wrong?

`docs` CI was only installing dependencies and exiting.


### How was it fixed?
Added the missing steps to the CI run.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.treehugger.com/thmb/tbkv-2sorps_nd6R9Ub2D8pNv9k=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__mnn__images__2014__04__pygmy-jeroba-c4249d0ea8df4a66924272480fc63c6a.jpeg)
