### PR TITLE
`PragueTransactionBuilder` is not building a `PragueTypedTransaction` as expected

### DIFF
--- a/eth/vm/forks/prague/transactions.py
+++ b/eth/vm/forks/prague/transactions.py
@@ -436,7 +436,7 @@ class PragueTransactionBuilder(CancunTransactionBuilder):
         )
 
     @classmethod
-    def new_signed_set_code_transaction(
+    def new_set_code_transaction(
         cls,
         chain_id: int,
         nonce: int,
@@ -447,17 +447,27 @@ class PragueTransactionBuilder(CancunTransactionBuilder):
         value: int,
         data: bytes,
         access_list: Sequence[Tuple[Address, Sequence[int]]],
-        authorization_list: Sequence[Authorization],
-    ) -> SetCodeTransaction:
-        return SetCodeTransaction(
+        authorization_list: Sequence[Union[AuthorizationDict, Authorization]],
+        y_parity: int,
+        r: int,
+        s: int,
+    ) -> PragueTypedTransaction:
+        transaction = SetCodeTransaction(
             chain_id=chain_id,
             nonce=nonce,
-            gas=gas,
             max_priority_fee_per_gas=max_priority_fee_per_gas,
             max_fee_per_gas=max_fee_per_gas,
+            gas=gas,
             to=to,
             value=value,
             data=data,
             access_list=access_list,
-            authorization_list=authorization_list,
+            authorization_list=[
+                Authorization(**auth) if isinstance(auth, dict) else auth
+                for auth in authorization_list
+            ],
+            y_parity=y_parity,
+            r=r,
+            s=s,
         )
+        return PragueTypedTransaction(SET_CODE_TRANSACTION_TYPE, transaction)

--- a/newsfragments/2211.bugfix.rst
+++ b/newsfragments/2211.bugfix.rst
@@ -1,0 +1,1 @@
+Rename ``new_signed_set_code_transaction()`` -> ``new_set_code_transaction()`` and make sure this returns a ``PragueTypedTransaction``, as is expected. It can also take dictionary auth lists, as was recently added to ``new_unsigned_set_code_transaction()``.

--- a/tests/core/transactions/test_transaction_builder.py
+++ b/tests/core/transactions/test_transaction_builder.py
@@ -3,10 +3,23 @@ import pytest
 from eth_keys.datatypes import (
     PrivateKey,
 )
+from eth_utils.toolz import (
+    merge,
+)
 
+from eth.chains.mainnet import (
+    MAINNET_VMS,
+)
+from eth.vm.forks import (
+    BerlinVM,
+    CancunVM,
+    LondonVM,
+    PragueVM,
+)
 from eth.vm.forks.prague.transactions import (
     Authorization,
     PragueTransactionBuilder,
+    PragueTypedTransaction,
 )
 
 AUTH1 = {
@@ -38,23 +51,84 @@ AUTH2 = {
 def test_prague_transaction_builder_set_code_transaction(authorization_list):
     builder = PragueTransactionBuilder()
 
-    unsigned = builder.new_unsigned_set_code_transaction(
-        **{
-            "chain_id": 1,
-            "nonce": 1,
-            "max_priority_fee_per_gas": 1,
-            "max_fee_per_gas": 1,
-            "gas": 1,
-            "to": b"\x00" * 20,
-            "value": 1,
-            "data": b"\x00" * 32 + b"\x01",
-            "access_list": [(b"\x00" * 20, [0])],
-            "authorization_list": authorization_list,
-        }
-    )
+    unsigned_tx_dict = {
+        "chain_id": 1,
+        "nonce": 1,
+        "max_priority_fee_per_gas": 1,
+        "max_fee_per_gas": 1,
+        "gas": 1,
+        "to": b"\x00" * 20,
+        "value": 1,
+        "data": b"\x00" * 32 + b"\x01",
+        "access_list": [(b"\x00" * 20, (0, 1))],
+        "authorization_list": authorization_list,
+    }
+    unsigned_set_code_tx = builder.new_unsigned_set_code_transaction(**unsigned_tx_dict)
 
     key = PrivateKey(b"\x01" * 32)
-    unsigned.as_signed_transaction(
+    set_code_tx = unsigned_set_code_tx.as_signed_transaction(
         private_key=key,
         chain_id=1,
     )
+    assert isinstance(set_code_tx, PragueTypedTransaction)
+
+    signed_set_code_dict = merge(
+        unsigned_tx_dict,
+        {
+            "y_parity": set_code_tx.y_parity,
+            "r": set_code_tx.r,
+            "s": set_code_tx.s,
+        },
+    )
+    built_set_code_tx = builder.new_set_code_transaction(**signed_set_code_dict)
+
+    assert set_code_tx == built_set_code_tx
+
+
+# mainnet VMs starting from Berlin (TypedTransaction introduced)
+@pytest.mark.parametrize("vm_class", MAINNET_VMS[8:])
+def test_transaction_builder_methods(vm_class):
+    builder = vm_class.get_transaction_builder()
+
+    builder_dir = dir(builder)
+    new_tx_methods = {
+        method
+        for method in builder_dir
+        if method.startswith("new") and callable(getattr(builder, method))
+    }
+    assert len(new_tx_methods) > 0, f"no builder methods for `{vm_class}`"
+
+    transaction_types = 0
+    if issubclass(vm_class, BerlinVM):
+        new_tx_methods.difference_update(
+            {
+                "new_transaction",  # legacy
+                "new_access_list_transaction",
+                "new_unsigned_access_list_transaction",
+            }
+        )
+        transaction_types += 1
+    if issubclass(vm_class, LondonVM):
+        new_tx_methods.difference_update(
+            {"new_dynamic_fee_transaction", "new_unsigned_dynamic_fee_transaction"}
+        )
+        transaction_types += 1
+    if issubclass(vm_class, CancunVM):
+        new_tx_methods.difference_update(
+            {"new_blob_transaction", "new_unsigned_blob_transaction"}
+        )
+        transaction_types += 1
+    if issubclass(vm_class, PragueVM):
+        new_tx_methods.difference_update(
+            {"new_set_code_transaction", "new_unsigned_set_code_transaction"}
+        )
+        transaction_types += 1
+
+    assert len(new_tx_methods) == 0
+
+    if len(builder.typed_transaction.decoders.keys()) != transaction_types:
+        # Add new methods and make sure `nex_x_transaction` method returns a
+        # `TypedTransaction`, following the pattern of the other VMs
+        raise AssertionError(
+            f"Likely missing new transaction methods in {vm_class} builder."
+        )


### PR DESCRIPTION
### What was wrong?

- `PragueTransactionBuilder.new_set_code_transaction()` should return a `PragueTypedTransaction` filled in appropriately with the transaction type and inner transaction.
- As we did with `new_unsigned_set_code_transaction`, open up the types to accept dictionary auths in the auth list and fill in `Authorization` classes via the method.

### How was it fixed?

- Return `PragueTypedTransaction`
- Accept dict auths in the auth list for `new_set_code_transaction`

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="410" alt="Screenshot 2025-04-22 at 14 02 13" src="https://github.com/user-attachments/assets/bc04d03b-b8ff-4237-bcae-2173806e5c26" />
