### PR TITLE
Update README to reflect repository status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-This repository has been archived, and is now read-only. For a Python implementation of the EVM, check out the [execution-specs](https://github.com/ethereum/execution-specs) repo. 
-
+> [!caution]
+> This repository has been archived, and is now read-only. For a Python implementation of the EVM, check out the [execution-specs](https://github.com/ethereum/execution-specs) repo.
 
 # Python Implementation of the Ethereum protocol
 
-[![Join the conversation on Discord](https://img.shields.io/discord/809793915578089484?color=blue&label=chat&logo=discord&logoColor=white)](https://discord.gg/GHryRvPB84)
-[![Build Status](https://circleci.com/gh/ethereum/py-evm.svg?style=shield)](https://circleci.com/gh/ethereum/py-evm)
 [![PyPI version](https://badge.fury.io/py/py-evm.svg)](https://badge.fury.io/py/py-evm)
 [![Python versions](https://img.shields.io/pypi/pyversions/py-evm.svg)](https://pypi.python.org/pypi/py-evm)
 [![Docs build](https://readthedocs.org/projects/py-evm/badge/?version=latest)](https://py-evm.readthedocs.io/en/latest/?badge=latest)

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,6 +1,10 @@
 Introduction
 ============
 
+.. warning::
+
+   Py-EVM has been archived, and is now read-only. The last supported fork is Prague.
+
 
 Py-EVM is an implementation of the Ethereum Virtual Machine (EVM) written in Python.
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+.. warning::
+
+   Py-EVM has been archived, and is now read-only. The last supported fork is Prague.
+
 .. towncrier release notes start
 
 py-evm v0.12.1-beta.1 (2025-05-14)


### PR DESCRIPTION
Removed Discord and build status badges from README.

### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/py-evm/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
